### PR TITLE
Implement dev-tunnel discovery, URL resolver, and management scripts

### DIFF
--- a/ts/packages/agentServer/client/src/discovery.ts
+++ b/ts/packages/agentServer/client/src/discovery.ts
@@ -44,12 +44,24 @@ export type DiscoverPortOptions = {
     url?: string;
     /** Per-attempt timeout in milliseconds. Default 5_000. */
     timeoutMs?: number;
+    /**
+     * Ask the server to answer with a remote-realm (tunnel) URL when one is
+     * configured and live. Set by clients connecting from another device; a
+     * local client leaves it unset and keeps getting localhost. See the
+     * dev-tunnel discovery design.
+     */
+    remote?: boolean;
 };
 
 /** What `discoverPort` returns. */
 export type DiscoverPortResult =
-    /** Agent has registered a port for `(agentName, role)`. */
-    | { kind: "found"; port: number }
+    /**
+     * Agent has registered a port for `(agentName, role)`. `url`, when
+     * present, is a fully-qualified address (e.g. a `wss://…devtunnels.ms`
+     * tunnel URL) to connect to instead of `ws://localhost:<port>`; when
+     * absent, build the localhost URL from `port` as before.
+     */
+    | { kind: "found"; port: number; url?: string }
     /** Discovery channel reached but no live allocation found. */
     | { kind: "not-registered" }
     /** Discovery channel could not be reached (agentServer down, etc). */
@@ -165,14 +177,27 @@ export async function discoverPort(
                 "discovery:client",
                 channel.createChannel(DiscoveryChannelName),
             );
-            const params =
-                role === undefined ? { agentName } : { agentName, role };
+            const params: {
+                agentName: string;
+                role?: string;
+                remote?: boolean;
+            } = { agentName };
+            if (role !== undefined) params.role = role;
+            if (options?.remote) params.remote = true;
             rpc.invoke("lookupPort", params).then(
                 (result) => {
                     if (result.port === null) {
                         settle({ kind: "not-registered" });
                     } else {
-                        settle({ kind: "found", port: result.port });
+                        settle(
+                            result.url === undefined
+                                ? { kind: "found", port: result.port }
+                                : {
+                                      kind: "found",
+                                      port: result.port,
+                                      url: result.url,
+                                  },
+                        );
                     }
                 },
                 (e: unknown) => {

--- a/ts/packages/agentServer/protocol/src/protocol.ts
+++ b/ts/packages/agentServer/protocol/src/protocol.ts
@@ -127,7 +127,25 @@ export type DiscoveryInvokeFunctions = {
     lookupPort: (param: {
         agentName: string;
         role?: string;
-    }) => Promise<{ port: number | null }>;
+        /**
+         * Hint that the request originates from a remote (non-loopback)
+         * client, so the server should answer with a tunnel `url` (when one
+         * is configured and live) rather than a localhost realm. Optional and
+         * backward compatible — omitted by local clients, which only ever
+         * need the port. See the dev-tunnel discovery design.
+         */
+        remote?: boolean;
+    }) => Promise<{
+        port: number | null;
+        /**
+         * A fully-qualified WebSocket URL (e.g. a `wss://…devtunnels.ms`
+         * tunnel address) the caller should connect to instead of
+         * `ws://localhost:<port>`. Present only when the server resolved a
+         * live tunnel mapping for `port` and the request was remote-realm.
+         * Absent → fall back to the localhost realm using `port`.
+         */
+        url?: string;
+    }>;
 };
 
 /**
@@ -146,11 +164,29 @@ export type DiscoveryInvokeFunctions = {
  */
 export function createDiscoveryHandlers(
     lookup: (agentName: string, role?: string) => number | undefined,
+    /**
+     * Optional URL resolver. When supplied and it returns a string for the
+     * resolved `(agentName, port, remote)`, that URL is attached to the
+     * response so remote clients connect to a tunnel address instead of
+     * localhost. Hosts that don't support tunneling (e.g. the standalone
+     * shell) simply omit it and behavior is unchanged. Wiring the real
+     * tunnel resolver is done by the agent-server (dev-tunnel H2).
+     */
+    resolveUrl?: (
+        agentName: string,
+        port: number,
+        remote?: boolean,
+    ) => string | undefined,
 ): DiscoveryInvokeFunctions {
     return {
-        lookupPort: async ({ agentName, role }) => ({
-            port: lookup(agentName, role) ?? null,
-        }),
+        lookupPort: async ({ agentName, role, remote }) => {
+            const port = lookup(agentName, role) ?? null;
+            if (port === null) {
+                return { port };
+            }
+            const url = resolveUrl?.(agentName, port, remote);
+            return url === undefined ? { port } : { port, url };
+        },
     };
 }
 

--- a/ts/packages/agentServer/protocol/src/protocol.ts
+++ b/ts/packages/agentServer/protocol/src/protocol.ts
@@ -169,8 +169,8 @@ export function createDiscoveryHandlers(
      * resolved `(agentName, port, remote)`, that URL is attached to the
      * response so remote clients connect to a tunnel address instead of
      * localhost. Hosts that don't support tunneling (e.g. the standalone
-     * shell) simply omit it and behavior is unchanged. Wiring the real
-     * tunnel resolver is done by the agent-server (dev-tunnel H2).
+     * shell) simply omit it and behavior is unchanged. The agent-server supplies
+     * a resolver that reads the dev-tunnel config and checks host liveness.
      */
     resolveUrl?: (
         agentName: string,

--- a/ts/packages/agentServer/protocol/src/protocol.ts
+++ b/ts/packages/agentServer/protocol/src/protocol.ts
@@ -176,7 +176,7 @@ export function createDiscoveryHandlers(
         agentName: string,
         port: number,
         remote?: boolean,
-    ) => string | undefined,
+    ) => string | undefined | Promise<string | undefined>,
 ): DiscoveryInvokeFunctions {
     return {
         lookupPort: async ({ agentName, role, remote }) => {
@@ -184,8 +184,8 @@ export function createDiscoveryHandlers(
             if (port === null) {
                 return { port };
             }
-            const url = resolveUrl?.(agentName, port, remote);
-            return url === undefined ? { port } : { port, url };
+            const url = await resolveUrl?.(agentName, port, remote);
+            return url ? { port, url } : { port };
         },
     };
 }

--- a/ts/packages/agentServer/server/src/connectionHandler.ts
+++ b/ts/packages/agentServer/server/src/connectionHandler.ts
@@ -19,6 +19,7 @@ import {
 import type { Dispatcher } from "agent-dispatcher";
 import type { PortRegistrar } from "agent-dispatcher";
 import type { ConversationManager } from "./conversationManager.js";
+import { resolveTunnelUrlForDiscovery } from "./tunnelResolver.js";
 
 /**
  * Per-connection handler signature expected by transports (the WebSocket
@@ -247,8 +248,12 @@ export function createAgentServerConnectionHandler(
             createRpc(
                 "agent-server:discovery",
                 channelProvider.createChannel(DiscoveryChannelName),
-                createDiscoveryHandlers((agentName, role) =>
-                    portRegistrar.lookup(agentName, role),
+                createDiscoveryHandlers(
+                    (agentName, role) => portRegistrar.lookup(agentName, role),
+                    // Remote clients get a live dev-tunnel URL when one is
+                    // configured; local clients (and a down/absent tunnel) fall
+                    // back to localhost. See tunnelResolver.ts.
+                    resolveTunnelUrlForDiscovery,
                 ),
             );
         }

--- a/ts/packages/agentServer/server/src/tunnelResolver.ts
+++ b/ts/packages/agentServer/server/src/tunnelResolver.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Dev-tunnel URL resolver for the discovery channel (dev-tunnel H2).
+//
+// When a remote client looks up a port, the agent-server can answer with a
+// public `wss://…devtunnels.ms` URL instead of `ws://localhost:<port>`, so the
+// client reaches the service across devices. A tunnel URL is only valid while a
+// host process is connected (Dev Tunnels is a pure relay — no store-and-forward),
+// so we verify host liveness (`devtunnel show --json` → `tunnel.hostConnections`)
+// before handing one out and degrade to localhost otherwise.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+    readDevTunnelConfig,
+    type DevTunnelConfig,
+} from "agent-dispatcher";
+import registerDebug from "debug";
+
+const debug = registerDebug("agent-server:tunnel");
+
+const execFileAsync = promisify(execFile);
+
+// Liveness is cached briefly so we don't shell out to `devtunnel` on every
+// lookup; discovery is infrequent but bursty (a client may probe several ports).
+const LIVENESS_TTL_MS = 5_000;
+const livenessCache = new Map<string, { at: number; live: boolean }>();
+
+/**
+ * The CLI reports `tunnelId` as `<id>.<cluster>`, but the public URL uses the
+ * bare `<id>`. Tolerate either form being stored in the config.
+ */
+function bareTunnelId(config: DevTunnelConfig): string {
+    const { tunnelId, cluster } = config;
+    if (cluster && tunnelId.endsWith(`.${cluster}`)) {
+        return tunnelId.slice(0, -(cluster.length + 1));
+    }
+    const dot = tunnelId.indexOf(".");
+    return dot > 0 ? tunnelId.slice(0, dot) : tunnelId;
+}
+
+/** Derive the relay WebSocket URL for a port. Pure (no I/O). */
+export function deriveTunnelUrl(config: DevTunnelConfig, port: number): string {
+    const baseDomain = config.baseDomain ?? "devtunnels.ms";
+    return `wss://${bareTunnelId(config)}-${port}.${config.cluster}.${baseDomain}`;
+}
+
+/**
+ * Is a host currently connected to the tunnel? Cached for {@link LIVENESS_TTL_MS}.
+ * Any failure (CLI missing, not logged in, tunnel gone, unparseable output) is
+ * treated as "down" so discovery degrades to localhost rather than handing out a
+ * dead URL.
+ */
+async function isTunnelHostLive(tunnelId: string): Promise<boolean> {
+    const cached = livenessCache.get(tunnelId);
+    const now = Date.now();
+    if (cached !== undefined && now - cached.at < LIVENESS_TTL_MS) {
+        return cached.live;
+    }
+    let live = false;
+    try {
+        const { stdout } = await execFileAsync(
+            "devtunnel",
+            ["show", tunnelId, "--json"],
+            { timeout: 4_000 },
+        );
+        const info: any = JSON.parse(stdout);
+        const count = info?.tunnel?.hostConnections ?? info?.hostConnections;
+        live = typeof count === "number" && count > 0;
+    } catch (e) {
+        debug(`liveness probe failed for ${tunnelId}, treating as down: ${e}`);
+        live = false;
+    }
+    livenessCache.set(tunnelId, { at: now, live });
+    return live;
+}
+
+/**
+ * Discovery `resolveUrl` callback: returns a tunnel URL for `(port)` only when
+ * the request is remote-realm, a tunnel mapping for that port exists, and the
+ * tunnel host is live. Otherwise `undefined` → caller falls back to localhost.
+ *
+ * Pass this to `createDiscoveryHandlers(lookup, resolveTunnelUrlForDiscovery)`.
+ */
+export async function resolveTunnelUrlForDiscovery(
+    _agentName: string,
+    port: number,
+    remote?: boolean,
+): Promise<string | undefined> {
+    if (!remote) {
+        return undefined; // local client → localhost realm
+    }
+    const config = readDevTunnelConfig();
+    if (config === undefined) {
+        return undefined; // no tunnel configured
+    }
+    if (config.ports[String(port)] === undefined) {
+        debug(`port ${port} not in tunnel config; no tunnel URL`);
+        return undefined; // port isn't forwarded by the tunnel
+    }
+    if (!(await isTunnelHostLive(config.tunnelId))) {
+        debug(`tunnel ${config.tunnelId} host down; degrading to localhost`);
+        return undefined; // relay has no live host → don't hand out a dead URL
+    }
+    const url = deriveTunnelUrl(config, port);
+    debug(`resolved remote ${url} for port ${port}`);
+    return url;
+}
+
+/** Test seam: clear the liveness cache. */
+export function _resetTunnelLivenessCacheForTest() {
+    livenessCache.clear();
+}

--- a/ts/packages/agentServer/server/src/tunnelResolver.ts
+++ b/ts/packages/agentServer/server/src/tunnelResolver.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Dev-tunnel URL resolver for the discovery channel (dev-tunnel H2).
+// Dev-tunnel URL resolver for the discovery channel.
 //
 // When a remote client looks up a port, the agent-server can answer with a
 // public `wss://…devtunnels.ms` URL instead of `ws://localhost:<port>`, so the

--- a/ts/packages/agentServer/server/src/tunnelResolver.ts
+++ b/ts/packages/agentServer/server/src/tunnelResolver.ts
@@ -12,10 +12,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-    readDevTunnelConfig,
-    type DevTunnelConfig,
-} from "agent-dispatcher";
+import { readDevTunnelConfig, type DevTunnelConfig } from "agent-dispatcher";
 import registerDebug from "debug";
 
 const debug = registerDebug("agent-server:tunnel");

--- a/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts
@@ -101,12 +101,18 @@ async function resolveBrowserEndpoint(
         url: agentServerUrl,
     });
     if (result.kind === "found") {
-        // Browser agent's WS server binds to the same host as the
+        const query = `channel=browser&role=client&clientId=${chrome.runtime.id}&sessionId=${sessionId}`;
+        // A discovered remote (tunnel) URL takes precedence; append our query.
+        if (result.url) {
+            const sep = result.url.includes("?") ? "&" : "?";
+            return `${result.url}${sep}${query}`;
+        }
+        // Otherwise the browser agent's WS server binds to the same host as the
         // agent-server (single-process), so we reuse the host portion of
         // agentServerUrl and swap in the discovered port.
         try {
             const u = new URL(agentServerUrl);
-            return `${u.protocol}//${u.hostname}:${result.port}/?channel=browser&role=client&clientId=${chrome.runtime.id}&sessionId=${sessionId}`;
+            return `${u.protocol}//${u.hostname}:${result.port}/?${query}`;
         } catch (e) {
             debugWebSocketError("Invalid agentServerHost URL: %s", e);
             return undefined;

--- a/ts/packages/coda/src/webSocket.ts
+++ b/ts/packages/coda/src/webSocket.ts
@@ -30,7 +30,9 @@ async function resolveCodeEndpoint(): Promise<string | undefined> {
         url: process.env["AGENT_SERVER_URL"],
     });
     if (result.kind === "found") {
-        return `ws://localhost:${result.port}`;
+        // Honor a discovered remote (tunnel) URL when the agent-server hands
+        // one back; otherwise dial the local port.
+        return result.url ?? `ws://localhost:${result.port}`;
     }
     if (result.kind === "not-registered") {
         // Agent server is running but the `code` agent isn't enabled

--- a/ts/packages/dispatcher/dispatcher/src/helpers/userData.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/userData.ts
@@ -150,10 +150,7 @@ function getDevTunnelConfigFilePath() {
  */
 export function readDevTunnelConfig(): DevTunnelConfig | undefined {
     try {
-        const content = fs.readFileSync(
-            getDevTunnelConfigFilePath(),
-            "utf-8",
-        );
+        const content = fs.readFileSync(getDevTunnelConfigFilePath(), "utf-8");
         const data: any = JSON.parse(content);
         if (
             data &&

--- a/ts/packages/dispatcher/dispatcher/src/helpers/userData.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/userData.ts
@@ -119,6 +119,64 @@ async function lockUserDataAsync<T>(fn: () => T | Promise<T>): Promise<T> {
     }
 }
 
+/**
+ * Cross-device access config written to `~/.typeagent/devtunnel.json`. Maps the
+ * agent-server (and, in a future Option B, sub-agent) ports onto a Microsoft
+ * Dev Tunnel so remote clients can reach the service. The per-port URL is
+ * *derived* (`wss://<tunnelId>-<port>.<cluster>.<baseDomain>`), not stored, so
+ * the same file supports later dynamic-forwarding work. See the dev-tunnel
+ * discovery design.
+ */
+export interface DevTunnelConfig {
+    /** Tunnel id from `devtunnel create` (e.g. "typeagent-xxxx"). */
+    tunnelId: string;
+    /** Tunnel cluster/region id (e.g. "usw2"). */
+    cluster: string;
+    /** Base domain; defaults to "devtunnels.ms" when absent. */
+    baseDomain?: string;
+    /** Forwarded port → label (e.g. `{ "8999": "agent-server" }`). */
+    ports: { [port: string]: string };
+    /** Tunnel access model; informational for discovery/degradation. */
+    access?: "private" | "anonymous";
+}
+
+function getDevTunnelConfigFilePath() {
+    return path.join(getUserDataDir(), "devtunnel.json");
+}
+
+/**
+ * Read the dev-tunnel config, or `undefined` when the file is missing or
+ * malformed. Unlocked (a plain read), mirroring `readGlobalUserConfig`.
+ */
+export function readDevTunnelConfig(): DevTunnelConfig | undefined {
+    try {
+        const content = fs.readFileSync(
+            getDevTunnelConfigFilePath(),
+            "utf-8",
+        );
+        const data: any = JSON.parse(content);
+        if (
+            data &&
+            typeof data.tunnelId === "string" &&
+            typeof data.cluster === "string" &&
+            data.ports &&
+            typeof data.ports === "object"
+        ) {
+            return data as DevTunnelConfig;
+        }
+    } catch {}
+    return undefined;
+}
+
+/** Write the dev-tunnel config under the user-data lock. */
+export function saveDevTunnelConfig(config: DevTunnelConfig) {
+    lockUserData(() => {
+        const content = JSON.stringify(config, null, 2);
+        ensureUserDataDir();
+        fs.writeFileSync(getDevTunnelConfigFilePath(), content);
+    });
+}
+
 function getInstancesDir() {
     return path.join(ensureUserDataDir(), "profiles");
 }

--- a/ts/packages/dispatcher/dispatcher/src/index.ts
+++ b/ts/packages/dispatcher/dispatcher/src/index.ts
@@ -25,3 +25,8 @@ export type {
 export { DefaultIndexingServiceRegistry } from "./context/indexingServiceRegistry.js";
 export * from "@typeagent/dispatcher-types";
 export { StorageProvider } from "./storageProvider/storageProvider.js";
+export {
+    readDevTunnelConfig,
+    saveDevTunnelConfig,
+} from "./helpers/userData.js";
+export type { DevTunnelConfig } from "./helpers/userData.js";

--- a/ts/tools/scripts/deployAgentServer.mjs
+++ b/ts/tools/scripts/deployAgentServer.mjs
@@ -178,11 +178,18 @@ function main() {
         copyInto(sample, path.join(toolsOut, "config.sample.yaml"));
     }
 
-    // 4. Copy the bootstrap launcher to the artifact root.
+    // 4. Copy the bootstrap launcher to the artifact root, plus the dev-tunnel
+    //    helpers (setup-devtunnel / list-tunnels) for optional remote access.
     copyInto(
         path.join(scriptsDir, "typeagent-serve.mjs"),
         path.join(args.out, "typeagent-serve.mjs"),
     );
+    for (const tunnelScript of ["setup-devtunnel.mjs", "list-tunnels.mjs"]) {
+        copyInto(
+            path.join(scriptsDir, tunnelScript),
+            path.join(args.out, tunnelScript),
+        );
+    }
 
     console.log(
         `\nArtifact ready at ${args.out}\n` +

--- a/ts/tools/scripts/install-typeagent.ps1
+++ b/ts/tools/scripts/install-typeagent.ps1
@@ -19,6 +19,8 @@
     4. (Optional) installs the Copilot CLI plugin from -PluginSource.
     5. Runs config provisioning (getKeys, browser login) and starts the daemon
        via the artifact's typeagent-serve.mjs.
+    6. (Optional, -DevTunnel) sets up a Microsoft Dev Tunnel and hosts it so a
+       client on another device can reach the service.
 
   Azure CLI (with az login) is used to download from the feed. This is the
   install-time exception; runtime config provisioning still uses getKeys'
@@ -27,6 +29,7 @@
 .EXAMPLE
   pwsh ./install-typeagent.ps1
   pwsh ./install-typeagent.ps1 -Variant full -Version 0.0.1-12345
+  pwsh ./install-typeagent.ps1 -DevTunnel   # also expose the service via a Dev Tunnel
 #>
 
 [CmdletBinding()]
@@ -39,7 +42,13 @@ param(
     [string]$Project = "AI_Systems",
     [string]$Feed = "typeagent",
     [string]$PluginSource = "",
-    [switch]$NoStart
+    [switch]$NoStart,
+    # Opt-in: set up a Microsoft Dev Tunnel so another device (e.g. a phone) can
+    # reach this agent-server, and start the tunnel host alongside the daemon.
+    [switch]$DevTunnel,
+    # With -DevTunnel: allow anonymous client access (WARNING: removes the only
+    # access control on the otherwise-unauthenticated service). Default private.
+    [switch]$DevTunnelAnonymous
 )
 
 $ErrorActionPreference = "Stop"
@@ -126,9 +135,30 @@ Write-Step "Provisioning config (getKeys, browser login)"
 & node $serve provision
 if ($LASTEXITCODE -ne 0) { Fail "Config provisioning failed." }
 
+# --- 6. Optional: set up + host a Dev Tunnel for cross-device access ----------
+if ($DevTunnel) {
+    Write-Step "Setting up Dev Tunnel (cross-device access)"
+    if (-not (Test-Command devtunnel)) {
+        Write-Host "  Installing devtunnel CLI (winget install Microsoft.devtunnel)"
+        & winget install Microsoft.devtunnel --accept-source-agreements --accept-package-agreements 2>$null
+        if (-not (Test-Command devtunnel)) {
+            Fail "devtunnel CLI not found after install. Install it manually and re-run with -DevTunnel."
+        }
+    }
+    $setup = Join-Path $InstallDir "setup-devtunnel.mjs"
+    $setupArgs = @($setup)
+    if ($DevTunnelAnonymous) { $setupArgs += "--anonymous" }
+    & node @setupArgs
+    if ($LASTEXITCODE -ne 0) { Fail "Dev Tunnel setup failed." }
+    # Bring the tunnel host up with the daemon (start below honors --tunnel).
+    $env:TYPEAGENT_TUNNEL = "1"
+}
+
 if (-not $NoStart) {
     Write-Step "Starting agent-server"
-    & node $serve start
+    $startArgs = @($serve, "start")
+    if ($DevTunnel) { $startArgs += "--tunnel" }
+    & node @startArgs
 }
 
 Write-Host ""
@@ -136,3 +166,6 @@ Write-Host "TypeAgent agent-server installed at $InstallDir" -ForegroundColor Gr
 Write-Host "  Start:    node `"$serve`" start"
 Write-Host "  Status:   node `"$serve`" status"
 Write-Host "  Stop:     node `"$serve`" stop"
+if ($DevTunnel) {
+    Write-Host "  Tunnel:   node `"$serve`" tunnel status   (list-tunnels.mjs shows the client URL + token)"
+}

--- a/ts/tools/scripts/list-tunnels.mjs
+++ b/ts/tools/scripts/list-tunnels.mjs
@@ -67,7 +67,10 @@ function dt(args, { json = false, check = true } = {}) {
 function readLocalConfig() {
     try {
         return JSON.parse(
-            fs.readFileSync(path.join(userDataDir(), "devtunnel.json"), "utf-8"),
+            fs.readFileSync(
+                path.join(userDataDir(), "devtunnel.json"),
+                "utf-8",
+            ),
         );
     } catch {
         return undefined;
@@ -127,7 +130,9 @@ function main() {
     }
 
     if (rows.length === 0) {
-        console.log("No Dev Tunnels found. Run setup-devtunnel.mjs to create one.");
+        console.log(
+            "No Dev Tunnels found. Run setup-devtunnel.mjs to create one.",
+        );
         return;
     }
     for (const r of rows) {

--- a/ts/tools/scripts/list-tunnels.mjs
+++ b/ts/tools/scripts/list-tunnels.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// List the user's Dev Tunnels with their derived agent-server client URLs and
+// live/down state, and flag which one matches the local `devtunnel.json`. Answers
+// "what's my tunnel URL and is a host running?" in one command.
+//
+// Usage:
+//   node list-tunnels.mjs [options]
+//     --json     Machine-readable output.
+//     --token    Also print a connect token for the configured tunnel.
+
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+function parseArgs(argv) {
+    const args = { json: false, token: false };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--json") args.json = true;
+        else if (a === "--token") args.token = true;
+        else if (a === "-h" || a === "--help") {
+            console.log(fs.readFileSync(new URL(import.meta.url)).toString());
+            process.exit(0);
+        } else {
+            console.error(`Unknown argument: ${a}`);
+            process.exit(1);
+        }
+    }
+    return args;
+}
+
+function userDataDir() {
+    return (
+        process.env.TYPEAGENT_USER_DATA_DIR ??
+        path.join(os.homedir(), ".typeagent")
+    );
+}
+
+function dt(args, { json = false, check = true } = {}) {
+    const finalArgs = json ? [...args, "--json"] : args;
+    const res = spawnSync("devtunnel", finalArgs, { encoding: "utf-8" });
+    if (res.error?.code === "ENOENT") {
+        console.error(
+            "devtunnel CLI not found (install: winget install Microsoft.devtunnel / brew install --cask devtunnel).",
+        );
+        process.exit(1);
+    }
+    if (check && res.status !== 0) {
+        throw new Error(
+            `devtunnel ${finalArgs.join(" ")} failed (${res.status}): ${res.stderr ?? ""}`,
+        );
+    }
+    if (json) {
+        try {
+            return JSON.parse(res.stdout);
+        } catch {
+            return undefined;
+        }
+    }
+    return res.stdout;
+}
+
+function readLocalConfig() {
+    try {
+        return JSON.parse(
+            fs.readFileSync(path.join(userDataDir(), "devtunnel.json"), "utf-8"),
+        );
+    } catch {
+        return undefined;
+    }
+}
+
+function deriveWssUrl(fullTunnelId, cluster, port) {
+    const bareId =
+        cluster && fullTunnelId.endsWith(`.${cluster}`)
+            ? fullTunnelId.slice(0, -(cluster.length + 1))
+            : fullTunnelId;
+    return `wss://${bareId}-${port}.${cluster}.devtunnels.ms`;
+}
+
+function main() {
+    const args = parseArgs(process.argv);
+
+    const loginStatus = spawnSync("devtunnel", ["user", "show"], {
+        encoding: "utf-8",
+    });
+    if (loginStatus.error?.code === "ENOENT") dt(["--version"]);
+    if (!(loginStatus.stdout ?? "").toLowerCase().includes("logged in")) {
+        console.error("Not signed in. Run `devtunnel user login` first.");
+        process.exit(1);
+    }
+
+    const local = readLocalConfig();
+    const listed = dt(["list"], { json: true, check: false });
+    const tunnels = listed?.tunnels ?? [];
+
+    const rows = [];
+    for (const t of tunnels) {
+        const id = t.tunnelId; // "<id>.<cluster>"
+        const cluster = id.includes(".") ? id.slice(id.indexOf(".") + 1) : "";
+        // Per-tunnel details for ports + live host state.
+        const info = dt(["show", id], { json: true, check: false });
+        const tunnel = info?.tunnel ?? t;
+        const live = (tunnel.hostConnections ?? 0) > 0;
+        const ports = (tunnel.ports ?? []).map((p) => p.portNumber);
+        rows.push({
+            tunnelId: id,
+            cluster,
+            labels: tunnel.labels ?? [],
+            ports,
+            live,
+            urls: ports.map((p) => ({
+                port: p,
+                url: deriveWssUrl(id, cluster, p),
+            })),
+            configured: local?.tunnelId === id,
+        });
+    }
+
+    if (args.json) {
+        console.log(JSON.stringify({ tunnels: rows, local }, null, 2));
+        return;
+    }
+
+    if (rows.length === 0) {
+        console.log("No Dev Tunnels found. Run setup-devtunnel.mjs to create one.");
+        return;
+    }
+    for (const r of rows) {
+        const mark = r.configured ? " (configured)" : "";
+        console.log(
+            `\n${r.tunnelId}${mark}  [${r.live ? "LIVE" : "host down"}]` +
+                (r.labels.length ? `  labels: ${r.labels.join(",")}` : ""),
+        );
+        for (const u of r.urls) {
+            console.log(`  ${u.port}: ${u.url}`);
+        }
+    }
+
+    if (args.token) {
+        const id = local?.tunnelId ?? rows[0].tunnelId;
+        console.log(`\nConnect token for ${id}:`);
+        process.stdout.write(dt(["token", id, "--scopes", "connect"]));
+    }
+}
+
+main();

--- a/ts/tools/scripts/setup-devtunnel.mjs
+++ b/ts/tools/scripts/setup-devtunnel.mjs
@@ -89,7 +89,10 @@ function dt(args, { json = false, check = true } = {}) {
 
 // devtunnel ids: lowercase alphanumeric + dashes, 3-60 chars.
 function defaultTunnelName() {
-    const host = os.hostname().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+    const host = os
+        .hostname()
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, "-");
     return `typeagent-${host}`.slice(0, 60).replace(/-+$/, "");
 }
 
@@ -111,7 +114,9 @@ function main() {
     if (loginStatus.error?.code === "ENOENT") {
         dt(["--version"]); // triggers the install-guidance path + exit
     }
-    const signedIn = (loginStatus.stdout ?? "").toLowerCase().includes("logged in");
+    const signedIn = (loginStatus.stdout ?? "")
+        .toLowerCase()
+        .includes("logged in");
     if (!signedIn) {
         if (!args.login) {
             console.error(
@@ -119,7 +124,9 @@ function main() {
             );
             process.exit(1);
         }
-        console.log("Signing in to Dev Tunnels (a browser window will open)...");
+        console.log(
+            "Signing in to Dev Tunnels (a browser window will open)...",
+        );
         const login = spawnSync("devtunnel", ["user", "login"], {
             stdio: "inherit",
         });

--- a/ts/tools/scripts/setup-devtunnel.mjs
+++ b/ts/tools/scripts/setup-devtunnel.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Create (or reuse) a Microsoft Dev Tunnel that forwards the agent-server port
+// so a client on another device can reach the service, and write the mapping to
+// `~/.typeagent/devtunnel.json` for the agent-server's discovery resolver.
+//
+// The tunnel is a pure relay with no store-and-forward: traffic only flows while
+// a host process is connected (`devtunnel host <id>`), so this script sets up the
+// tunnel and prints the host command (or runs it with --host).
+//
+// Usage:
+//   node setup-devtunnel.mjs [options]
+//     --port <n>      Agent-server port to forward (default 8999)
+//     --name <id>     Tunnel id (default typeagent-<hostname>)
+//     --anonymous     Allow anonymous client access (WARNING: removes the only
+//                     auth on an otherwise unauthenticated service). Default is
+//                     private (clients present a connect token).
+//     --host          Start `devtunnel host` in the foreground after setup.
+//     --no-login      Don't attempt an interactive login if not signed in.
+
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+function parseArgs(argv) {
+    const args = {
+        port: 8999,
+        name: undefined,
+        anonymous: false,
+        host: false,
+        login: true,
+    };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--port") args.port = parseInt(argv[++i], 10);
+        else if (a === "--name") args.name = argv[++i];
+        else if (a === "--anonymous") args.anonymous = true;
+        else if (a === "--host") args.host = true;
+        else if (a === "--no-login") args.login = false;
+        else if (a === "-h" || a === "--help") {
+            console.log(fs.readFileSync(new URL(import.meta.url)).toString());
+            process.exit(0);
+        } else {
+            console.error(`Unknown argument: ${a}`);
+            process.exit(1);
+        }
+    }
+    return args;
+}
+
+function userDataDir() {
+    return (
+        process.env.TYPEAGENT_USER_DATA_DIR ??
+        path.join(os.homedir(), ".typeagent")
+    );
+}
+
+// Run devtunnel, returning stdout (or parsed JSON with {json:true}). When the
+// CLI is missing, print install guidance and exit.
+function dt(args, { json = false, check = true } = {}) {
+    const finalArgs = json ? [...args, "--json"] : args;
+    const res = spawnSync("devtunnel", finalArgs, { encoding: "utf-8" });
+    if (res.error && res.error.code === "ENOENT") {
+        console.error(
+            "devtunnel CLI not found. Install it:\n" +
+                "  Windows: winget install Microsoft.devtunnel\n" +
+                "  macOS:   brew install --cask devtunnel\n" +
+                "  Linux:   curl -sL https://aka.ms/DevTunnelCliInstall | bash",
+        );
+        process.exit(1);
+    }
+    if (check && res.status !== 0) {
+        throw new Error(
+            `devtunnel ${finalArgs.join(" ")} failed (${res.status}): ${res.stderr ?? ""}`,
+        );
+    }
+    if (json) {
+        try {
+            return JSON.parse(res.stdout);
+        } catch {
+            return undefined;
+        }
+    }
+    return res.stdout;
+}
+
+// devtunnel ids: lowercase alphanumeric + dashes, 3-60 chars.
+function defaultTunnelName() {
+    const host = os.hostname().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+    return `typeagent-${host}`.slice(0, 60).replace(/-+$/, "");
+}
+
+function deriveWssUrl(fullTunnelId, cluster, port) {
+    const bareId = fullTunnelId.endsWith(`.${cluster}`)
+        ? fullTunnelId.slice(0, -(cluster.length + 1))
+        : fullTunnelId;
+    return `wss://${bareId}-${port}.${cluster}.devtunnels.ms`;
+}
+
+function main() {
+    const args = parseArgs(process.argv);
+    const name = args.name ?? defaultTunnelName();
+
+    // Login check (devtunnel user show exits non-zero when signed out).
+    const loginStatus = spawnSync("devtunnel", ["user", "show"], {
+        encoding: "utf-8",
+    });
+    if (loginStatus.error?.code === "ENOENT") {
+        dt(["--version"]); // triggers the install-guidance path + exit
+    }
+    const signedIn = (loginStatus.stdout ?? "").toLowerCase().includes("logged in");
+    if (!signedIn) {
+        if (!args.login) {
+            console.error(
+                "Not signed in to devtunnel. Run `devtunnel user login` (Entra/Microsoft) first, or omit --no-login.",
+            );
+            process.exit(1);
+        }
+        console.log("Signing in to Dev Tunnels (a browser window will open)...");
+        const login = spawnSync("devtunnel", ["user", "login"], {
+            stdio: "inherit",
+        });
+        if (login.status !== 0) {
+            console.error("devtunnel login failed.");
+            process.exit(1);
+        }
+    }
+
+    // Create or reuse the tunnel.
+    let info = dt(["show", name], { json: true, check: false });
+    if (info?.tunnel === undefined) {
+        console.log(`Creating tunnel "${name}"...`);
+        const createArgs = ["create", name, "--labels", "typeagent"];
+        if (args.anonymous) createArgs.push("--allow-anonymous");
+        info = dt(createArgs, { json: true });
+    } else {
+        console.log(`Reusing existing tunnel "${name}".`);
+    }
+    const fullTunnelId = info.tunnel.tunnelId; // "<id>.<cluster>"
+    const cluster = fullTunnelId.includes(".")
+        ? fullTunnelId.slice(fullTunnelId.indexOf(".") + 1)
+        : "";
+
+    // Ensure the port is forwarded (idempotent — ignore "already exists").
+    const ports = info.tunnel.ports ?? [];
+    const hasPort = ports.some((p) => p.portNumber === args.port);
+    if (!hasPort) {
+        console.log(`Forwarding port ${args.port}...`);
+        dt(["port", "create", name, "-p", String(args.port)], { check: false });
+    }
+
+    // Write the discovery mapping.
+    const dir = userDataDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const configPath = path.join(dir, "devtunnel.json");
+    const config = {
+        tunnelId: fullTunnelId,
+        cluster,
+        ports: { [String(args.port)]: "agent-server" },
+        access: args.anonymous ? "anonymous" : "private",
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    console.log(`Wrote ${configPath}`);
+
+    const wss = deriveWssUrl(fullTunnelId, cluster, args.port);
+    console.log(`\nTunnel ready. Client URL: ${wss}`);
+    if (args.anonymous) {
+        console.warn(
+            "WARNING: anonymous access is enabled — anyone with the URL can reach the\n" +
+                "agent-server, which has no auth of its own. Prefer private + a connect token.",
+        );
+    } else {
+        console.log(
+            `Private tunnel — clients need a connect token:\n  devtunnel token ${name} --scopes connect`,
+        );
+    }
+
+    if (args.host) {
+        console.log(`\nStarting host (Ctrl+C to stop)...`);
+        spawnSync("devtunnel", ["host", name], { stdio: "inherit" });
+    } else {
+        console.log(
+            `\nTo serve traffic, run (keep it running):\n  devtunnel host ${name}`,
+        );
+    }
+}
+
+main();

--- a/ts/tools/scripts/typeagent-serve.mjs
+++ b/ts/tools/scripts/typeagent-serve.mjs
@@ -21,15 +21,19 @@
  *   node typeagent-serve.mjs provision # run getKeys to write config.local.yaml
  *   node typeagent-serve.mjs status    # report whether the daemon is listening
  *   node typeagent-serve.mjs stop       # stop the daemon (best effort)
+ *   node typeagent-serve.mjs tunnel [start|stop|status]  # manage the dev-tunnel
+ *                                       # host so remote devices can reach the service
  * Options: --port <n> (default $TYPEAGENT_PORT / $AGENT_SERVER_PORT / 8999),
- *          --idle-timeout <seconds>.
+ *          --idle-timeout <seconds>,
+ *          --tunnel (with start: also bring up the dev-tunnel host; or set
+ *          $TYPEAGENT_TUNNEL=1). Requires a tunnel configured via setup-devtunnel.
  */
 
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const artifactDir = path.dirname(fileURLToPath(import.meta.url));
@@ -150,6 +154,12 @@ async function cmdStart() {
     spawnDaemon(port);
     if (await waitForPort(port)) {
         console.log(`Agent server is up at ws://localhost:${port}.`);
+        // Opt-in: also bring up the dev-tunnel host so remote devices can reach
+        // the service. Only when --tunnel/$TYPEAGENT_TUNNEL is set AND a tunnel
+        // has been configured (setup-devtunnel wrote devtunnel.json).
+        if (tunnelOptIn() && readDevTunnel() !== undefined) {
+            await cmdTunnel("start");
+        }
         return 0;
     }
     console.error(
@@ -171,6 +181,174 @@ async function cmdProvision() {
     // Pass through any extra args after the subcommand (e.g. --vault, --verbose).
     const passthrough = process.argv.slice(3).filter((a) => a !== "--port");
     return runInline(getKeysEntry, passthrough);
+}
+
+// ---- Dev-tunnel host management ----------------------------------------
+// devtunnel.json (written by setup-devtunnel) and the host pidfile live in the
+// user data dir — the same location the agent-server's discovery resolver reads.
+
+function userDataDir() {
+    return (
+        process.env.TYPEAGENT_USER_DATA_DIR ??
+        path.join(os.homedir(), ".typeagent")
+    );
+}
+
+function readDevTunnel() {
+    try {
+        return JSON.parse(
+            fs.readFileSync(path.join(userDataDir(), "devtunnel.json"), "utf8"),
+        );
+    } catch {
+        return undefined;
+    }
+}
+
+// The CLI reports tunnelId as "<id>.<cluster>"; `devtunnel host` wants the id.
+function bareTunnelId(cfg) {
+    const { tunnelId, cluster } = cfg;
+    if (cluster && tunnelId.endsWith(`.${cluster}`)) {
+        return tunnelId.slice(0, -(cluster.length + 1));
+    }
+    const dot = tunnelId.indexOf(".");
+    return dot > 0 ? tunnelId.slice(0, dot) : tunnelId;
+}
+
+function deriveWss(cfg) {
+    const port = Object.keys(cfg.ports ?? {})[0] ?? "8999";
+    return `wss://${bareTunnelId(cfg)}-${port}.${cfg.cluster}.devtunnels.ms`;
+}
+
+function tunnelPidFile() {
+    return path.join(userDataDir(), "devtunnel-host.pid");
+}
+
+function pidAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function readTunnelPid() {
+    try {
+        return parseInt(fs.readFileSync(tunnelPidFile(), "utf8").trim(), 10);
+    } catch {
+        return undefined;
+    }
+}
+
+// Does the relay report a connected host? (Liveness, independent of our pidfile.)
+function tunnelRelayLive(cfg) {
+    const res = spawnSync("devtunnel", ["show", cfg.tunnelId, "--json"], {
+        encoding: "utf-8",
+    });
+    if (res.status !== 0) return false;
+    try {
+        return (JSON.parse(res.stdout)?.tunnel?.hostConnections ?? 0) > 0;
+    } catch {
+        return false;
+    }
+}
+
+async function cmdTunnel(actionArg) {
+    const action =
+        actionArg ??
+        (process.argv[3] && !process.argv[3].startsWith("--")
+            ? process.argv[3]
+            : "status");
+    const cfg = readDevTunnel();
+    if (cfg === undefined) {
+        console.error(
+            "No tunnel configured. Run setup-devtunnel.mjs to create one.",
+        );
+        return 1;
+    }
+    const id = bareTunnelId(cfg);
+    switch (action) {
+        case "start": {
+            const existing = readTunnelPid();
+            if (existing !== undefined && pidAlive(existing)) {
+                console.log(`Tunnel host already running (pid ${existing}).`);
+                return 0;
+            }
+            console.log(`Starting tunnel host for ${id}...`);
+            // `devtunnel host` exits if its stdout/stderr are the null device, so
+            // direct them to a log file (which also aids debugging). Close our
+            // copy of the fd after spawn — the detached child keeps its own.
+            const logPath = path.join(userDataDir(), "devtunnel-host.log");
+            const out = fs.openSync(logPath, "a");
+            const child = spawn("devtunnel", ["host", id], {
+                // Fully detach so the host outlives this short-lived launcher
+                // (a non-detached child is terminated when its parent exits on
+                // Windows). windowsHide keeps it from popping a console window.
+                detached: true,
+                windowsHide: true,
+                stdio: ["ignore", out, out],
+            });
+            fs.closeSync(out);
+            if (child.pid === undefined) {
+                console.error(
+                    "Failed to start devtunnel host (is the CLI installed and are you logged in?).",
+                );
+                return 1;
+            }
+            child.unref();
+            fs.writeFileSync(tunnelPidFile(), String(child.pid));
+            console.log(
+                `Tunnel host started (pid ${child.pid}); log: ${logPath}`,
+            );
+            console.log(`Client URL: ${deriveWss(cfg)}`);
+            return 0;
+        }
+        case "stop": {
+            const pid = readTunnelPid();
+            if (pid === undefined || !pidAlive(pid)) {
+                console.log("Tunnel host not running.");
+                try {
+                    fs.rmSync(tunnelPidFile(), { force: true });
+                } catch {}
+                return 0;
+            }
+            try {
+                if (process.platform === "win32") {
+                    spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"]);
+                } else {
+                    process.kill(pid, "SIGTERM");
+                }
+            } catch {}
+            try {
+                fs.rmSync(tunnelPidFile(), { force: true });
+            } catch {}
+            console.log(`Tunnel host stopped (pid ${pid}).`);
+            return 0;
+        }
+        case "status": {
+            const pid = readTunnelPid();
+            const running = pid !== undefined && pidAlive(pid);
+            const live = tunnelRelayLive(cfg);
+            console.log(
+                `Tunnel ${cfg.tunnelId}: host process ${running ? `running (pid ${pid})` : "not running"}, relay ${live ? "LIVE" : "down"}.`,
+            );
+            console.log(`Client URL: ${deriveWss(cfg)}`);
+            return live ? 0 : 1;
+        }
+        default:
+            console.error(
+                `Unknown tunnel action '${action}'. Use start|stop|status.`,
+            );
+            return 1;
+    }
+}
+
+function tunnelOptIn() {
+    const env = process.env.TYPEAGENT_TUNNEL;
+    return (
+        process.argv.includes("--tunnel") ||
+        (env !== undefined && env !== "0" && env !== "false" && env !== "")
+    );
 }
 
 async function cmdStatus() {
@@ -198,6 +376,8 @@ async function main() {
             return cmdProvision();
         case "status":
             return cmdStatus();
+        case "tunnel":
+            return cmdTunnel();
         case "stop": {
             // Best-effort: defer to the deployed control utility if present.
             const stop = path.join(artifactDir, "dist", "stop.js");


### PR DESCRIPTION
This pull request introduces cross-device access to the agent-server via Microsoft Dev Tunnels, allowing remote clients to discover and connect through a public tunnel URL when available. The changes add support for tunnel-aware port discovery, remote/localhost fallback, and scripts to simplify tunnel setup and deployment. It also updates the installation process to optionally configure and host a Dev Tunnel for remote access.

**Agent-server discovery and protocol enhancements:**

* Added a `remote` option to the `DiscoverPortOptions` and protocol so clients can request a tunnel URL when connecting from another device; the server responds with a `url` field when a live tunnel is available. (`ts/packages/agentServer/client/src/discovery.ts`, `ts/packages/agentServer/protocol/src/protocol.ts`) [[1]](diffhunk://#diff-ff09970ec6b31acb61d5d5c598085dc11d4e42bc60cca41b15597e4001cd6f5bR47-R64) [[2]](diffhunk://#diff-9d96b7e904765a11b9911d9fb883203064cf8f4faa9744d3d460c44586ef1be3L130-R148)
* Updated the discovery handler to accept an optional `resolveUrl` callback, which provides a tunnel URL only when the tunnel is live and the request is remote; otherwise, it falls back to localhost. (`ts/packages/agentServer/protocol/src/protocol.ts`, `ts/packages/agentServer/server/src/connectionHandler.ts`) [[1]](diffhunk://#diff-9d96b7e904765a11b9911d9fb883203064cf8f4faa9744d3d460c44586ef1be3R167-R189) [[2]](diffhunk://#diff-de3c317cfa127b5f7d5274a61b9aedcf7308fe03b1fc0b2d861ddfeebba4ffccL250-R256)

**Dev Tunnel configuration and runtime support:**

* Added `DevTunnelConfig` definition, read/write helpers, and export from dispatcher for managing tunnel metadata and port mappings. (`ts/packages/dispatcher/dispatcher/src/helpers/userData.ts`, `ts/packages/dispatcher/dispatcher/src/index.ts`) [[1]](diffhunk://#diff-506d319ee10822813fbd341146ee941a3828b1d103e46c2393513a30ea910b9fR122-R176) [[2]](diffhunk://#diff-eead37706f686ace4c9ad367f892b2975cdab52935cd57da37bd30c492dac99fR28-R32)
* Implemented a tunnel resolver (`tunnelResolver.ts`) that checks tunnel liveness, derives tunnel URLs, and caches host status to avoid unnecessary CLI calls. (`ts/packages/agentServer/server/src/tunnelResolver.ts`)

**Client and agent updates for tunnel discovery:**

* Updated browser and coda agents to honor the discovered tunnel URL when present, ensuring clients connect via the tunnel if available, otherwise defaulting to localhost. (`ts/packages/agents/browser/src/extension/serviceWorker/websocket.ts`, `ts/packages/coda/src/webSocket.ts`) [[1]](diffhunk://#diff-07674280105a5532cb8f34b2141275afb66c755e12e6496795a0141cf6dc16b7L104-R115) [[2]](diffhunk://#diff-3d0fbc81bf8a80dcfa999f1d1d5f165bc0e33ea6a02de40a8780df9ef6736f75L33-R35)

**Deployment and installation improvements:**

* Modified deployment scripts to include new tunnel setup helpers and updated the PowerShell installer to optionally configure and host a Dev Tunnel, including support for anonymous access and integration with the devtunnel CLI. (`ts/tools/scripts/deployAgentServer.mjs`, `ts/tools/scripts/install-typeagent.ps1`) [[1]](diffhunk://#diff-7dd1fd29ed63c774bf31be46acae5be1eb43b2aa42edbb390ae36ad9ab446498L181-R192) [[2]](diffhunk://#diff-db1a511fea45df284c67e813a9c4bb2208aaf52a1b55e255a89b63ba9b7eb607R22-R23) [[3]](diffhunk://#diff-db1a511fea45df284c67e813a9c4bb2208aaf52a1b55e255a89b63ba9b7eb607R32) [[4]](diffhunk://#diff-db1a511fea45df284c67e813a9c4bb2208aaf52a1b55e255a89b63ba9b7eb607L42-R51) [[5]](diffhunk://#diff-db1a511fea45df284c67e813a9c4bb2208aaf52a1b55e255a89b63ba9b7eb607R138-R171)

These changes enable seamless cross-device connectivity for the agent-server, with robust fallback and simple setup for both local and remote clients.