### PR TITLE
A server-side heartbeat for agent-side websocket server

### DIFF
--- a/ts/docs/architecture/browserRpc.md
+++ b/ts/docs/architecture/browserRpc.md
@@ -82,9 +82,29 @@ Call IDs are monotonically increasing integers, unique per endpoint.
 
 ### 5. Keep-alive for MV3
 
-WebSocket keep-alive pings every 20 seconds prevent the MV3 service
-worker from going idle. The ping is counted as activity, resetting the
-30-second idle timer.
+Liveness is maintained from three independent angles:
+
+1. **Application keep-alive (client → agent).** The extension sends a
+   `keepAlive` JSON message every 20 seconds. The agent ignores its
+   contents; the point is to count as activity and reset the service
+   worker's 30-second idle timer.
+2. **Service-worker wake (`chrome.alarms`).** A persisted alarm fires
+   every 30 seconds (the shortest interval Chrome allows). Because an
+   alarm resurrects a _dormant_ service worker — not just a live one —
+   its `onAlarm` handler calls `ensureWebsocketConnected()`, so the
+   worker reconnects without waiting for a user gesture. The 20s
+   application keep-alive only helps while the worker is still alive;
+   the alarm is what recovers it after Chrome has reaped it.
+3. **Server-side heartbeat (agent → client).** The agent's WebSocket
+   server pings each client on a 30-second sweep (RFC 6455 ping/pong)
+   and `terminate()`s any socket that misses the previous sweep's pong.
+   This reaps half-open sockets (sleep/wake, VPN flip, a killed service
+   worker) within ~60 seconds instead of waiting on the OS TCP timeout,
+   so the server's client map and readiness probes reflect reality and
+   the extension's `onclose`-driven reconnect fires promptly. Browsers
+   answer protocol pings automatically, so no extension code is
+   involved. Implemented by `attachHeartbeat` in
+   `@typeagent/websocket-channel-server`.
 
 > **Why this matters:** Without keep-alive, the service worker would
 > terminate during idle periods, dropping the WebSocket connection. The

--- a/ts/packages/agents/browser/package.json
+++ b/ts/packages/agents/browser/package.json
@@ -107,6 +107,7 @@
     "typechat": "^0.1.1",
     "typescript": "~5.4.5",
     "website-memory": "workspace:*",
+    "websocket-channel-server": "workspace:*",
     "ws": "^8.21.0",
     "xss": "^1.0.15",
     "yaml": "^2.8.3",

--- a/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
+++ b/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
@@ -10,6 +10,7 @@ import {
     type ChannelProviderAdapter,
 } from "@typeagent/agent-rpc/channel";
 import { createRpc } from "@typeagent/agent-rpc/rpc";
+import { attachHeartbeat } from "websocket-channel-server";
 import type {
     BrowserAgentInvokeFunctions,
     BrowserAgentCallFunctions,
@@ -57,6 +58,7 @@ interface SessionHandlers {
 export class AgentWebSocketServer {
     private clients = new Map<string, Map<string, BrowserClient>>();
     private sessionHandlers = new Map<string, SessionHandlers>();
+    private readonly stopHeartbeat: () => void;
 
     /**
      * @param server The underlying ws server, already bound and listening.
@@ -72,6 +74,7 @@ export class AgentWebSocketServer {
         public readonly port: number,
     ) {
         this.setupHandlers();
+        this.stopHeartbeat = attachHeartbeat(server);
         debug(`Agent WebSocket server listening on port ${port}`);
     }
 
@@ -596,6 +599,7 @@ export class AgentWebSocketServer {
      */
     public close(): Promise<void> {
         debug("Closing AgentWebSocketServer");
+        this.stopHeartbeat();
         for (const sessionMap of this.clients.values()) {
             for (const client of sessionMap.values()) {
                 if (client.channelProvider) {

--- a/ts/packages/agents/browser/src/extension/manifest.json
+++ b/ts/packages/agents/browser/src/extension/manifest.json
@@ -93,6 +93,7 @@
   ],
   "permissions": [
     "activeTab",
+    "alarms",
     "tts",
     "search",
     "storage",

--- a/ts/packages/agents/browser/src/extension/serviceWorker/index.ts
+++ b/ts/packages/agents/browser/src/extension/serviceWorker/index.ts
@@ -30,6 +30,12 @@ const debugError = registerDebug("typeagent:browser:serviceWorker:error");
 
 const debugWebAgentProxy = registerDebug("typeagent:webAgent:proxy");
 
+// MV3 service workers are reaped after ~30s idle, destroying the
+// WebSocket and its reconnect timer. A persisted alarm resurrects the
+// worker on the shortest interval Chrome allows (30s) so it can
+// re-establish the connection without a user gesture.
+const KEEPALIVE_ALARM_NAME = "typeagent-keepalive";
+
 let serviceWorkerHandlers: ReturnType<typeof createAllHandlers> | undefined;
 
 /**
@@ -301,6 +307,24 @@ function setupEventListeners(): void {
             }
         } catch (error) {
             console.error("Error on browser startup:", error);
+            reconnectWebSocket();
+        }
+    });
+
+    // Service-worker keepalive: resurrect a dormant worker and re-heal a
+    // dropped WebSocket on a 30s cadence without waiting for user input.
+    chrome.alarms.create(KEEPALIVE_ALARM_NAME, { periodInMinutes: 0.5 });
+    chrome.alarms.onAlarm.addListener(async (alarm) => {
+        if (alarm.name !== KEEPALIVE_ALARM_NAME) {
+            return;
+        }
+        try {
+            const connected = await ensureWebsocketConnected();
+            if (!connected) {
+                reconnectWebSocket();
+            }
+        } catch (error) {
+            debugError("Error on keepalive alarm:", error);
             reconnectWebSocket();
         }
     });

--- a/ts/packages/agents/browser/test/jest-setup.js
+++ b/ts/packages/agents/browser/test/jest-setup.js
@@ -14,6 +14,15 @@ global.chrome = {
             removeListener: jest.fn(),
         },
     },
+    alarms: {
+        create: jest.fn(),
+        clear: jest.fn(),
+        onAlarm: {
+            addListener: jest.fn(),
+            hasListeners: jest.fn(),
+            removeListener: jest.fn(),
+        },
+    },
     contextMenus: {
         create: jest.fn(),
         remove: jest.fn(),

--- a/ts/packages/agents/browser/test/unit/agentWebSocketServer.test.ts
+++ b/ts/packages/agents/browser/test/unit/agentWebSocketServer.test.ts
@@ -7,6 +7,7 @@ jest.mock("ws", () => {
     const listeningHandlers: Function[] = [];
     let lastVerifyClient: any;
     const mockWss: any = {
+        clients: new Set(),
         on: jest.fn((event: string, handler: Function) => {
             if (event === "connection") connectionHandlers.push(handler);
             if (event === "error") errorHandlers.push(handler);

--- a/ts/packages/agents/code/package.json
+++ b/ts/packages/agents/code/package.json
@@ -50,6 +50,7 @@
     "chalk": "^5.4.1",
     "debug": "^4.4.0",
     "telemetry": "workspace:*",
+    "websocket-channel-server": "workspace:*",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/ts/packages/agents/code/src/codeAgentWebSocketServer.ts
+++ b/ts/packages/agents/code/src/codeAgentWebSocketServer.ts
@@ -5,12 +5,14 @@ import { WebSocketServer, WebSocket } from "ws";
 import { AddressInfo } from "net";
 import registerDebug from "debug";
 import { isAllowedAgentOrigin } from "./originAllowlist.js";
+import { attachHeartbeat } from "websocket-channel-server";
 
 const debug = registerDebug("typeagent:code:websocket");
 
 export class CodeAgentWebSocketServer {
     private clients: Map<string, WebSocket> = new Map();
     private clientIdCounter = 0;
+    private readonly stopHeartbeat: () => void;
     public onMessage?: (message: string) => void;
     /**
      * Fired after the {@link clients} map mutation completes for any
@@ -36,6 +38,7 @@ export class CodeAgentWebSocketServer {
         public readonly port: number,
     ) {
         this.setupHandlers();
+        this.stopHeartbeat = attachHeartbeat(server);
         debug(`CodeAgentWebSocketServer listening on port ${port}`);
     }
 
@@ -212,6 +215,7 @@ export class CodeAgentWebSocketServer {
      */
     public close(): Promise<void> {
         debug("Closing CodeAgentWebSocketServer");
+        this.stopHeartbeat();
         for (const [, client] of this.clients.entries()) {
             if (client.readyState === WebSocket.OPEN) {
                 client.close();

--- a/ts/packages/utils/webSocketChannelServer/jest.config.cjs
+++ b/ts/packages/utils/webSocketChannelServer/jest.config.cjs
@@ -1,5 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export * from "./server.js";
-export * from "./heartbeat.js";
+module.exports = require("../../../jest.config.js");

--- a/ts/packages/utils/webSocketChannelServer/package.json
+++ b/ts/packages/utils/webSocketChannelServer/package.json
@@ -22,9 +22,12 @@
   "scripts": {
     "build": "npm run tsc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
+    "jest-esm": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
-    "tsc": "tsc -b"
+    "test": "npm run test:local",
+    "test:local": "pnpm run jest-esm --testPathPattern=\".*[.]spec[.]js\"",
+    "tsc": "tsc -b src test"
   },
   "dependencies": {
     "@typeagent/agent-rpc": "workspace:*",
@@ -33,8 +36,11 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/debug": "^4.1.12",
+    "@types/jest": "^29.5.7",
     "@types/ws": "^8.5.10",
+    "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"

--- a/ts/packages/utils/webSocketChannelServer/src/heartbeat.ts
+++ b/ts/packages/utils/webSocketChannelServer/src/heartbeat.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { WebSocket, WebSocketServer } from "ws";
+import registerDebug from "debug";
+
+const debug = registerDebug("typeagent:transport:heartbeat");
+
+export interface HeartbeatOptions {
+    /**
+     * Milliseconds between liveness sweeps. A client that has not
+     * answered the previous sweep's ping is terminated on the next one,
+     * so a dead peer is detected in `intervalMs`..`2 * intervalMs`.
+     * Default 30000 (detection within 30–60s).
+     */
+    intervalMs?: number;
+    /**
+     * Invoked with the socket about to be terminated for failing the
+     * liveness check, just before `terminate()`. A seam for diagnostics
+     * or scrubbing cached per-client state during self-recovery.
+     */
+    onStale?: (ws: WebSocket) => void;
+}
+
+// Per-socket liveness flag. A Symbol avoids colliding with any property
+// the consuming server may set on its sockets.
+const ALIVE = Symbol("heartbeatAlive");
+
+/**
+ * Attach RFC 6455 ping/pong liveness to every client of `wss`.
+ *
+ * Each sweep terminates any socket that did not pong since the previous
+ * sweep, then pings the survivors. `terminate()` surfaces the drop to
+ * the server's existing `close` handler immediately, so half-open
+ * sockets (sleep/wake, VPN flip, a killed MV3 service worker) are
+ * reaped in seconds instead of waiting on the OS TCP timeout.
+ *
+ * Browsers answer protocol pings automatically, so no client change is
+ * required. Returns a stop function; the sweep is also stopped when
+ * `wss` emits `close`.
+ */
+export function attachHeartbeat(
+    wss: WebSocketServer,
+    options: HeartbeatOptions = {},
+): () => void {
+    const intervalMs = options.intervalMs ?? 30000;
+
+    const track = (ws: WebSocket) => {
+        (ws as any)[ALIVE] = true;
+        ws.on("pong", () => {
+            (ws as any)[ALIVE] = true;
+        });
+    };
+
+    for (const ws of wss.clients) {
+        track(ws);
+    }
+    wss.on("connection", track);
+
+    const timer = setInterval(() => {
+        for (const ws of wss.clients) {
+            try {
+                if ((ws as any)[ALIVE] === false) {
+                    debug("terminating unresponsive client");
+                    options.onStale?.(ws);
+                    ws.terminate();
+                    continue;
+                }
+                (ws as any)[ALIVE] = false;
+                ws.ping();
+            } catch (e) {
+                // A socket mid-close (or a throwing onStale) must not
+                // abort the sweep for the remaining clients, nor escalate
+                // to an uncaught exception out of the timer callback.
+                debug("heartbeat sweep error: %o", e);
+            }
+        }
+    }, intervalMs);
+
+    // Never hold the process open solely for the heartbeat.
+    if (typeof timer.unref === "function") {
+        timer.unref();
+    }
+
+    let stopped = false;
+    const stop = () => {
+        if (stopped) {
+            return;
+        }
+        stopped = true;
+        clearInterval(timer);
+    };
+    wss.on("close", stop);
+    return stop;
+}

--- a/ts/packages/utils/webSocketChannelServer/src/server.ts
+++ b/ts/packages/utils/webSocketChannelServer/src/server.ts
@@ -8,6 +8,7 @@ import {
 import WebSocket, { WebSocketServer } from "ws";
 import registerDebug from "debug";
 import { createPromiseWithResolvers } from "@typeagent/common-utils";
+import { attachHeartbeat } from "./heartbeat.js";
 
 const debugWss = registerDebug("typeagent:transport:wss");
 const debugWssError = registerDebug("typeagent:transport:wss:error");
@@ -80,6 +81,7 @@ export async function createWebSocketChannelServer(
               }
             : wsOptions;
     const wss = new WebSocketServer(wssOptions);
+    attachHeartbeat(wss);
     wss.on("connection", (ws) => {
         const id = nextId++;
         const debugId = `typeagent:transport:wss:ws-${id}`;

--- a/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import WebSocket, { AddressInfo, WebSocketServer } from "ws";
+
+import { attachHeartbeat } from "../src/heartbeat.js";
+
+// Short sweep so the deadline (2 intervals) elapses quickly. A stale
+// peer is reaped in `intervalMs`..`2 * intervalMs`.
+const INTERVAL_MS = 40;
+
+const openServers: WebSocketServer[] = [];
+const openClients: WebSocket[] = [];
+const stops: Array<() => void> = [];
+
+async function startServer(): Promise<{ wss: WebSocketServer; url: string }> {
+    const wss = new WebSocketServer({ port: 0 });
+    openServers.push(wss);
+    await new Promise<void>((resolve, reject) => {
+        wss.once("listening", () => resolve());
+        wss.once("error", reject);
+    });
+    const addr = wss.address() as AddressInfo;
+    return { wss, url: `ws://localhost:${addr.port}` };
+}
+
+function connect(url: string, options?: WebSocket.ClientOptions): WebSocket {
+    const ws = new WebSocket(url, options);
+    openClients.push(ws);
+    return ws;
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+    return new Promise((resolve, reject) => {
+        ws.once("open", () => resolve());
+        ws.once("error", reject);
+    });
+}
+
+function waitForClose(ws: WebSocket, timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error("client did not close in time")),
+            timeoutMs,
+        );
+        ws.once("close", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+    });
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+    predicate: () => boolean,
+    timeoutMs: number,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+        if (Date.now() > deadline) {
+            throw new Error("condition not met in time");
+        }
+        await delay(5);
+    }
+}
+
+afterEach(async () => {
+    for (const stop of stops.splice(0)) {
+        stop();
+    }
+    for (const ws of openClients.splice(0)) {
+        try {
+            ws.terminate();
+        } catch {
+            // already closed
+        }
+    }
+    for (const wss of openServers.splice(0)) {
+        await new Promise<void>((resolve) => wss.close(() => resolve()));
+    }
+});
+
+describe("attachHeartbeat", () => {
+    it("terminates a client that never answers a ping", async () => {
+        const { wss, url } = await startServer();
+        stops.push(attachHeartbeat(wss, { intervalMs: INTERVAL_MS }));
+
+        // autoPong:false makes ws ignore incoming pings — simulates a
+        // half-open / dormant peer.
+        const client = connect(url, { autoPong: false });
+        await waitForOpen(client);
+
+        await waitForClose(client, INTERVAL_MS * 10);
+        // The server-side `close` (and its `wss.clients` removal) may
+        // land a tick after the client observes the drop.
+        await waitFor(() => wss.clients.size === 0, INTERVAL_MS * 10);
+        expect(wss.clients.size).toBe(0);
+    });
+
+    it("keeps a responsive client connected across many sweeps", async () => {
+        const { wss, url } = await startServer();
+        stops.push(attachHeartbeat(wss, { intervalMs: INTERVAL_MS }));
+
+        const client = connect(url); // default autoPong:true
+        await waitForOpen(client);
+
+        await delay(INTERVAL_MS * 6);
+        expect(client.readyState).toBe(WebSocket.OPEN);
+        expect(wss.clients.size).toBe(1);
+    });
+
+    it("invokes onStale before terminating a dead client", async () => {
+        const { wss, url } = await startServer();
+        let staleCount = 0;
+        stops.push(
+            attachHeartbeat(wss, {
+                intervalMs: INTERVAL_MS,
+                onStale: () => {
+                    staleCount++;
+                },
+            }),
+        );
+
+        const client = connect(url, { autoPong: false });
+        await waitForOpen(client);
+
+        await waitForClose(client, INTERVAL_MS * 10);
+        expect(staleCount).toBe(1);
+    });
+
+    it("stops sweeping after the returned stop() is called", async () => {
+        const { wss, url } = await startServer();
+        const stop = attachHeartbeat(wss, { intervalMs: INTERVAL_MS });
+        stop();
+
+        // With the sweep stopped, even a non-ponging client is left alone.
+        const client = connect(url, { autoPong: false });
+        await waitForOpen(client);
+
+        await delay(INTERVAL_MS * 6);
+        expect(client.readyState).toBe(WebSocket.OPEN);
+        expect(wss.clients.size).toBe(1);
+    });
+});

--- a/ts/packages/utils/webSocketChannelServer/test/tsconfig.json
+++ b/ts/packages/utils/webSocketChannelServer/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../dist/test",
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*"],
+  "ts-node": {
+    "esm": true
+  },
+  "references": [{ "path": "../src" }]
+}

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -577,7 +577,7 @@ importers:
         version: 24.37.5(typescript@5.4.5)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@22.19.21)(typescript@5.4.5)
+        version: 10.9.2(@types/node@25.9.1)(typescript@5.4.5)
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -1944,6 +1944,9 @@ importers:
       website-memory:
         specifier: workspace:*
         version: link:../../memory/website
+      websocket-channel-server:
+        specifier: workspace:*
+        version: link:../../utils/webSocketChannelServer
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -2163,6 +2166,9 @@ importers:
       telemetry:
         specifier: workspace:*
         version: link:../../telemetry
+      websocket-channel-server:
+        specifier: workspace:*
+        version: link:../../utils/webSocketChannelServer
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -3890,7 +3896,7 @@ importers:
         version: link:../telemetry
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@22.19.21)(typescript@5.4.5)
+        version: 10.9.2(@types/node@25.9.1)(typescript@5.4.5)
       typechat-utils:
         specifier: workspace:*
         version: link:../utils/typechatUtils
@@ -3909,7 +3915,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -3918,7 +3924,7 @@ importers:
         version: 6.0.1
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.4.9(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5)))(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -5483,7 +5489,7 @@ importers:
     devDependencies:
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
-        version: 1.0.1(@types/node@22.19.21)
+        version: 1.0.1(@types/node@25.9.1)
       '@fontsource/lato':
         specifier: ^5.2.5
         version: 5.2.5
@@ -5519,10 +5525,10 @@ importers:
         version: 26.8.1(dmg-builder@26.8.1)
       electron-vite:
         specifier: ^4.0.1
-        version: 4.0.1(vite@6.4.3(@types/node@22.19.21)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.0.1(vite@6.4.3(@types/node@25.9.1)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
       less:
         specifier: ^4.2.0
         version: 4.3.0
@@ -5540,7 +5546,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^6.4.3
-        version: 6.4.3(@types/node@22.19.21)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.3(@types/node@25.9.1)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/telemetry:
     dependencies:
@@ -5872,12 +5878,21 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      '@types/jest':
+        specifier: ^29.5.7
+        version: 29.5.14
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -9469,9 +9484,6 @@ packages:
 
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
-
-  '@types/node@22.19.21':
-    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -18121,9 +18133,9 @@ snapshots:
     dependencies:
       electron: 40.8.5
 
-  '@electron-toolkit/tsconfig@1.0.1(@types/node@22.19.21)':
+  '@electron-toolkit/tsconfig@1.0.1(@types/node@25.9.1)':
     dependencies:
-      '@types/node': 22.19.21
+      '@types/node': 25.9.1
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -18949,41 +18961,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.19.19
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -21323,10 +21300,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.19.21':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -21334,7 +21307,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -23100,21 +23072,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5)):
     dependencies:
       '@jest/types': 29.6.3
@@ -23773,7 +23730,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@4.0.1(vite@6.4.3(@types/node@22.19.21)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)):
+  electron-vite@4.0.1(vite@6.4.3(@types/node@25.9.1)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.4)
@@ -23781,7 +23738,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.17
       picocolors: 1.1.1
-      vite: 6.4.3(@types/node@22.19.21)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.3(@types/node@25.9.1)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -25608,25 +25565,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
@@ -25739,37 +25677,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.19
-      ts-node: 10.9.2(@types/node@22.19.21)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.28.4
@@ -25797,37 +25704,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
       ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.21
-      ts-node: 10.9.2(@types/node@22.19.21)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26117,18 +25993,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -29510,12 +29374,12 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.4)
 
-  ts-jest@29.4.9(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.4.9(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -29588,24 +29452,6 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.19.21)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.21
-      acorn: 8.15.0
-      acorn-walk: 8.3.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   ts-node@10.9.2(@types/node@25.9.1)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -29623,7 +29469,6 @@ snapshots:
       typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   tslib@1.14.1: {}
 
@@ -29765,8 +29610,7 @@ snapshots:
 
   undici-types@7.24.4: {}
 
-  undici-types@7.24.6:
-    optional: true
+  undici-types@7.24.6: {}
 
   undici@6.25.0: {}
 
@@ -29931,23 +29775,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.15.18
-      fsevents: 2.3.3
-      jiti: 2.5.1
-      less: 4.3.0
-      terser: 5.39.2
-      tsx: 4.21.0
-      yaml: 2.8.3
-
-  vite@6.4.3(@types/node@22.19.21)(jiti@2.5.1)(less@4.3.0)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.21
       fsevents: 2.3.3
       jiti: 2.5.1
       less: 4.3.0


### PR DESCRIPTION
## Summary
 
 Agents that rely on an out-of-process worker (the Chrome/Edge browser extension and the VS Code "Coda" extension) could appear "suddenly disconnected" after a laptop sleep, a Wi-Fi/VPN change, or Chrome shutting down its idle extension. In these cases the agent kept believing the worker was still connected for a minute or two, so requests were sent to a dead connection and quietly hung — often only fixable by restarting the agent-server.
 
 This change makes the agent detect a gone worker quickly and recover on its own.
 
 ## What changed
 
 - **Faster detection of dead connections.** The agent now actively checks that each connected worker is still responsive and drops it within seconds instead of waiting on long network timeouts. This keeps the agent's "is my browser/editor connected?" status honest, so it stops sending work into a void.
 
 - **Automatic browser reconnect.** The browser extension now wakes itself on a short schedule and re-establishes its connection without needing the user to click anything — closing the gap where a dormant extension would otherwise stay disconnected until the next manual interaction.
 
 ## Impact
 
 - Fewer "your browser/editor isn't connected" errors after sleep, network changes, or idle periods.
 - In most cases recovery is automatic, removing the need to restart the agent-server to get things working again.
 - No user-facing configuration changes.