### PR TITLE
Make agent-rpc channel rebindable

### DIFF
--- a/ts/packages/agentRpc/jest.config.cjs
+++ b/ts/packages/agentRpc/jest.config.cjs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+module.exports = {
+    ...require("../../jest.config.js"),
+};

--- a/ts/packages/agentRpc/package.json
+++ b/ts/packages/agentRpc/package.json
@@ -21,8 +21,11 @@
   "scripts": {
     "build": "npm run tsc",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
+    "jest-esm": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
+    "test": "npm run test:local",
+    "test:local": "pnpm run jest-esm --testPathPattern=\".*[.]spec[.]js\"",
     "tsc": "tsc -b"
   },
   "dependencies": {

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -23,7 +23,15 @@ type RpcReturn<
     InvokeTargetFunctions extends RpcInvokeFunctions,
     CallTargetFunctions extends RpcCallFunctions,
 > = RpcFuncTypes<"invoke", InvokeTargetFunctions> &
-    RpcFuncTypes<"send", CallTargetFunctions>;
+    RpcFuncTypes<"send", CallTargetFunctions> & {
+        rebind(channel: RpcChannel): void;
+    };
+
+export type RpcOptions = {
+    // When true, a disconnect rejects in-flight calls but leaves invoke/send
+    // intact so the rpc can be reattached to a fresh channel via rebind().
+    rebindable?: boolean;
+};
 
 export function createRpc<
     InvokeTargetFunctions extends RpcInvokeFunctions = {},
@@ -35,6 +43,7 @@ export function createRpc<
     channel: RpcChannel,
     invokeHandlers?: InvokeHandlers,
     callHandlers?: CallHandlers,
+    options?: RpcOptions,
 ): RpcReturn<InvokeTargetFunctions, CallTargetFunctions> {
     const debugIn = registerDebug(`typeagent:${name}:rpc:in`);
     const debugOut = registerDebug(`typeagent:${name}:rpc:out`);
@@ -47,12 +56,26 @@ export function createRpc<
         }
     >();
 
+    const rebindable = options?.rebindable ?? false;
+    let currentChannel: RpcChannel = channel;
+    let connected = true;
+    let bindGeneration = 0;
+    const errorFunc = () => {
+        throw new Error("Agent channel disconnected");
+    };
+    const rejectAllPending = (reason: string) => {
+        for (const r of pending.values()) {
+            r.reject(new Error(reason));
+        }
+        pending.clear();
+    };
+
     const out = (
         message: RpcMessage,
         cbErr: (err: Error | null) => void = (e) => {},
     ) => {
         debugOut(message);
-        channel.send(message, cbErr);
+        currentChannel.send(message, cbErr);
     };
     const cb = (message: any) => {
         debugIn(message);
@@ -125,20 +148,26 @@ export function createRpc<
             r.reject(new Error(message.error));
         }
     };
-    channel.on("message", cb);
-    channel.once("disconnect", () => {
-        debugError("disconnect");
-        channel.off("message", cb);
-        const errorFunc = () => {
-            throw new Error("Agent channel disconnected");
-        };
-        for (const r of pending.values()) {
-            r.reject(new Error("Agent channel disconnected"));
-        }
-        pending.clear();
-        rpc.invoke = errorFunc;
-        rpc.send = errorFunc;
-    });
+    const bindChannel = (newChannel: RpcChannel) => {
+        currentChannel = newChannel;
+        connected = true;
+        const generation = ++bindGeneration;
+        newChannel.on("message", cb);
+        newChannel.once("disconnect", () => {
+            // Ignore a superseded binding: a later rebind already moved on.
+            if (generation !== bindGeneration) {
+                return;
+            }
+            debugError("disconnect");
+            newChannel.off("message", cb);
+            connected = false;
+            rejectAllPending("Agent channel disconnected");
+            if (!rebindable) {
+                rpc.invoke = errorFunc;
+                rpc.send = errorFunc;
+            }
+        });
+    };
 
     let nextCallId = 0;
     const rpc = {
@@ -146,6 +175,11 @@ export function createRpc<
             name: keyof InvokeTargetFunctions,
             ...args: any[]
         ): Promise<any> {
+            // Fail fast in a rebindable rpc's disconnected window (a poisoned
+            // rpc never reaches here — invoke is replaced outright).
+            if (!connected) {
+                throw new Error("Agent channel disconnected");
+            }
             const message: InvokeMessage = {
                 type: "invoke",
                 callId: nextCallId++,
@@ -164,6 +198,9 @@ export function createRpc<
             });
         },
         send: (name: keyof CallTargetFunctions, ...args: any[]) => {
+            if (!connected) {
+                throw new Error("Agent channel disconnected");
+            }
             out(
                 {
                     type: "call",
@@ -178,7 +215,16 @@ export function createRpc<
                 },
             );
         },
+        rebind: (newChannel: RpcChannel) => {
+            if (!rebindable) {
+                throw new Error("rpc was not created as rebindable");
+            }
+            currentChannel.off("message", cb);
+            rejectAllPending("Agent channel rebound");
+            bindChannel(newChannel);
+        },
     } as RpcReturn<InvokeTargetFunctions, CallTargetFunctions>;
+    bindChannel(channel);
     return rpc;
 }
 

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createRpc } from "../src/rpc.js";
+import type { RpcChannel } from "../src/common.js";
+
+type FakeChannel = RpcChannel & {
+    deliver(message: any): void;
+    fireDisconnect(): void;
+    setPeer(peer: FakeChannel): void;
+    sent: any[];
+};
+
+function remove<T>(arr: T[], item: T) {
+    const i = arr.indexOf(item);
+    if (i >= 0) {
+        arr.splice(i, 1);
+    }
+}
+
+function createFakeChannel(): FakeChannel {
+    const messageHandlers: ((m: any) => void)[] = [];
+    const onceMessage: ((m: any) => void)[] = [];
+    const disconnectHandlers: (() => void)[] = [];
+    const onceDisconnect: (() => void)[] = [];
+    let peer: FakeChannel | undefined;
+    const sent: any[] = [];
+
+    const channel: FakeChannel = {
+        on(event: "message" | "disconnect", cb: any) {
+            (event === "message" ? messageHandlers : disconnectHandlers).push(
+                cb,
+            );
+        },
+        once(event: "message" | "disconnect", cb: any) {
+            (event === "message" ? onceMessage : onceDisconnect).push(cb);
+        },
+        off(event: "message" | "disconnect", cb: any) {
+            if (event === "message") {
+                remove(messageHandlers, cb);
+                remove(onceMessage, cb);
+            } else {
+                remove(disconnectHandlers, cb);
+                remove(onceDisconnect, cb);
+            }
+        },
+        send(message: any, cb?: (err: Error | null) => void) {
+            sent.push(message);
+            if (peer) {
+                queueMicrotask(() => peer!.deliver(message));
+            }
+            cb?.(null);
+        },
+        deliver(message: any) {
+            for (const h of [...messageHandlers]) {
+                h(message);
+            }
+            const onces = onceMessage.splice(0);
+            for (const h of onces) {
+                h(message);
+            }
+        },
+        fireDisconnect() {
+            for (const h of [...disconnectHandlers]) {
+                h();
+            }
+            const onces = onceDisconnect.splice(0);
+            for (const h of onces) {
+                h();
+            }
+        },
+        setPeer(p: FakeChannel) {
+            peer = p;
+        },
+        sent,
+    };
+    return channel;
+}
+
+function connect(a: FakeChannel, b: FakeChannel) {
+    a.setPeer(b);
+    b.setPeer(a);
+}
+
+type EchoInvoke = { echo: (x: number) => Promise<number> };
+type Notify = { notify: (x: number) => void };
+
+// options is the 5th positional arg of createRpc; this keeps the rebindable
+// client calls below readable and avoids passing the wrong positional slot.
+function createRebindableClient<
+    I extends Record<string, (...args: any[]) => any> = {},
+    C extends Record<string, (...args: any[]) => any> = {},
+>(name: string, channel: RpcChannel) {
+    return createRpc<I, C>(name, channel, undefined, undefined, {
+        rebindable: true,
+    });
+}
+
+function createEchoServer(name: string, channel: RpcChannel, offset = 0) {
+    return createRpc<{}, {}, EchoInvoke>(name, channel, {
+        echo: async (x: number) => x + offset,
+    });
+}
+
+function flushMicrotasks() {
+    return new Promise((r) => queueMicrotask(() => r(undefined)));
+}
+
+describe("createRpc default (non-rebindable)", () => {
+    it("round-trips invoke results", async () => {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+
+        const clientRpc = createRpc<EchoInvoke>("client", client);
+        createRpc<{}, {}, EchoInvoke>("server", server, {
+            echo: async (x: number) => x * 2,
+        });
+
+        await expect(clientRpc.invoke("echo", 21)).resolves.toBe(42);
+    });
+
+    it("rejects in-flight invokes on disconnect", async () => {
+        const client = createFakeChannel();
+        const clientRpc = createRpc<EchoInvoke>("client", client);
+
+        const inflight = clientRpc.invoke("echo", 1);
+        client.fireDisconnect();
+
+        await expect(inflight).rejects.toThrow("Agent channel disconnected");
+    });
+
+    it("poisons invoke and send after disconnect", () => {
+        const client = createFakeChannel();
+        const clientRpc = createRpc<EchoInvoke, Notify>("client", client);
+
+        client.fireDisconnect();
+
+        expect(() => clientRpc.invoke("echo", 1)).toThrow(
+            "Agent channel disconnected",
+        );
+        expect(() => clientRpc.send("notify", 1)).toThrow(
+            "Agent channel disconnected",
+        );
+    });
+
+    it("throws when rebind is called on a non-rebindable rpc", () => {
+        const client = createFakeChannel();
+        const next = createFakeChannel();
+        const clientRpc = createRpc<EchoInvoke>("client", client);
+
+        expect(() => clientRpc.rebind(next)).toThrow(
+            "rpc was not created as rebindable",
+        );
+    });
+});
+
+describe("createRpc rebindable", () => {
+    it("fails fast while disconnected and recovers after rebind", async () => {
+        const client1 = createFakeChannel();
+        const clientRpc = createRebindableClient<EchoInvoke, Notify>(
+            "client",
+            client1,
+        );
+
+        const inflight = clientRpc.invoke("echo", 1);
+        client1.fireDisconnect();
+        await expect(inflight).rejects.toThrow("Agent channel disconnected");
+
+        // New calls during the disconnected window fail fast rather than hang,
+        // and the rpc is not poisoned (it recovers after rebind).
+        await expect(clientRpc.invoke("echo", 2)).rejects.toThrow(
+            "Agent channel disconnected",
+        );
+        expect(() => clientRpc.send("notify", 1)).toThrow(
+            "Agent channel disconnected",
+        );
+
+        const client2 = createFakeChannel();
+        const server2 = createFakeChannel();
+        connect(client2, server2);
+        createEchoServer("server", server2);
+        clientRpc.rebind(client2);
+
+        await expect(clientRpc.invoke("echo", 9)).resolves.toBe(9);
+        expect(() => clientRpc.send("notify", 1)).not.toThrow();
+    });
+
+    it("round-trips invokes on a new channel after rebind", async () => {
+        const client1 = createFakeChannel();
+        const clientRpc = createRebindableClient<EchoInvoke>("client", client1);
+
+        client1.fireDisconnect();
+
+        const client2 = createFakeChannel();
+        const server2 = createFakeChannel();
+        connect(client2, server2);
+        createEchoServer("server", server2, 100);
+
+        clientRpc.rebind(client2);
+
+        await expect(clientRpc.invoke("echo", 5)).resolves.toBe(105);
+    });
+
+    it("round-trips sends on a new channel after rebind", async () => {
+        const client1 = createFakeChannel();
+        const clientRpc = createRebindableClient<{}, Notify>("client", client1);
+
+        const client2 = createFakeChannel();
+        const server2 = createFakeChannel();
+        connect(client2, server2);
+        const received: number[] = [];
+        createRpc<{}, {}, {}, Notify>("server", server2, undefined, {
+            notify: (x: number) => {
+                received.push(x);
+            },
+        });
+
+        clientRpc.rebind(client2);
+        clientRpc.send("notify", 7);
+
+        await flushMicrotasks();
+        expect(received).toEqual([7]);
+    });
+
+    it("rejects in-flight invokes on the old channel when rebinding", async () => {
+        const client1 = createFakeChannel();
+        // No peer: the server never answers, so the call stays in-flight.
+        const clientRpc = createRebindableClient<EchoInvoke>("client", client1);
+
+        const inflight = clientRpc.invoke("echo", 1);
+        const client2 = createFakeChannel();
+        clientRpc.rebind(client2);
+
+        await expect(inflight).rejects.toThrow("Agent channel rebound");
+    });
+
+    it("ignores a stale channel disconnect after rebind", async () => {
+        const client1 = createFakeChannel();
+        const clientRpc = createRebindableClient<EchoInvoke, Notify>(
+            "client",
+            client1,
+        );
+
+        const client2 = createFakeChannel();
+        const server2 = createFakeChannel();
+        connect(client2, server2);
+        createEchoServer("server", server2);
+
+        clientRpc.rebind(client2);
+        // The abandoned channel fires disconnect; the live channel must be
+        // unaffected (no poison, no rejection of its calls).
+        client1.fireDisconnect();
+
+        await expect(clientRpc.invoke("echo", 9)).resolves.toBe(9);
+        expect(() => clientRpc.send("notify", 1)).not.toThrow();
+    });
+
+    it("survives multiple sequential rebinds", async () => {
+        const client1 = createFakeChannel();
+        const clientRpc = createRebindableClient<EchoInvoke>("client", client1);
+
+        for (let i = 0; i < 3; i++) {
+            const c = createFakeChannel();
+            const s = createFakeChannel();
+            connect(c, s);
+            createEchoServer(`server${i}`, s, i);
+            clientRpc.rebind(c);
+            await expect(clientRpc.invoke("echo", 10)).resolves.toBe(10 + i);
+        }
+    });
+});

--- a/ts/packages/agentRpc/test/tsconfig.json
+++ b/ts/packages/agentRpc/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../dist/test",
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*"],
+  "ts-node": {
+    "esm": true
+  },
+  "references": [{ "path": "../src" }]
+}

--- a/ts/packages/agentRpc/tsconfig.json
+++ b/ts/packages/agentRpc/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true
   },
   "include": [],
-  "references": [{ "path": "./src" }],
+  "references": [{ "path": "./src" }, { "path": "./test" }],
   "ts-node": {
     "esm": true
   }


### PR DESCRIPTION
## Make `agent-rpc` channels rebindable (opt-in)
 
 ### Why
 Today, the first time an RPC channel disconnects, its `createRpc` instance is permanently disabled — every later call throws, even after the worker reconnects. Any agent that caches an rpc reference (browser, dispatcher, discovery, etc.) is stuck until a full restart. This is a leading cause of "the agent is suddenly disconnected" issues.
 
 ### What
 Adds an opt-in `rebindable` mode to `createRpc` plus a `rebind(channel)` method, so a cached rpc can reattach to a fresh channel after a reconnect instead of dying.
 
 The new behavior is **strictly opt-in** — existing consumers are unchanged. This is the foundational first step; individual agents will move onto it in follow-up PRs.
 
 ### Scope
 - Touches only `@typeagent/agent-rpc`; no consumer behavior changes yet.
 - Backward-compatible: all dependent packages build clean.
 - Includes unit tests for the new disconnect/rebind lifecycle.