### PR TITLE
VS Code reuse and rebind rpc across reconnects

### DIFF
--- a/ts/packages/agentRpc/README.md
+++ b/ts/packages/agentRpc/README.md
@@ -2,6 +2,90 @@
 
 This package contains code to support remoting TypeAgent SDK interfaces via an abstract RpcChannel interface.
 
+## Connection convention: prefer `rpc.rebind` over recreate
+
+**Decision (adopted):** rpc connection clients should be built as a **durable
+session that rebinds its transport on reconnect**, not as an object that is thrown
+away and rebuilt on every drop.
+
+Concretely, a client that owns a reconnecting transport should:
+
+1. Create its rpc **once**, with `createRpc(..., { rebindable: true })`.
+2. On reconnect, reopen the transport and call `rpc.rebind(newChannel)` (reusing the
+   same rpc/connection object), rather than calling `createRpc(...)` again.
+
+```ts
+// On (re)connect:
+if (rpc) {
+  rpc.rebind(channelProvider.createChannel(name)); // reuse — stable identity
+} else {
+  rpc = createRpc(
+    name,
+    channelProvider.createChannel(name),
+    invokeHandlers,
+    callHandlers,
+    {
+      rebindable: true,
+    },
+  );
+}
+```
+
+### Why — benefits
+
+- **Connection safety (the main reason).** A non-rebindable rpc is _permanently
+  poisoned_ the first time its channel disconnects: `invoke`/`send` are swapped for
+  error stubs, so any reference to it is dead after a single drop. A rebindable rpc
+  instead rejects in-flight calls, **fail-fasts** with a clear error while
+  disconnected, and **resumes** after `rebind`. The object stays usable across the
+  whole connection lifetime.
+
+- **Pit of success — caching/injecting the rpc is safe by default.** Because the
+  object survives reconnects, you can hold it in a field, inject it into a service's
+  constructor, capture it in a closure, or hand it to a webview, and it keeps working
+  after a drop. With recreate, every such holder is a latent bug: it works until the
+  first reconnect, then silently breaks unless the author _remembered_ to re-fetch
+  from a getter. Rebind makes the obvious thing (keep the reference) the correct
+  thing, instead of relying on a "never cache, always re-fetch" rule no compiler
+  enforces.
+
+- **Stable identity → cleaner consumers.** Consumers can call `rpc.invoke(...)`
+  directly instead of threading a `getRpc()` getter and null-checking at every call
+  site. This is the classic DI shape (a dependency passed as a plain object), which is
+  more decoupled and more testable than reaching for a module-level accessor — and it
+  works across process/webview boundaries where you can only pass an object, not a
+  getter.
+
+- **Logical / correct domain model.** A connection _has_ a transport (an ephemeral
+  socket) rather than _is_ one. Modeling reconnect as "re-point the transport of a
+  durable session" matches the domain better than "throw the session away and build a
+  new one," and keeps continuity of per-rpc state (registered handlers, the call-id
+  sequence) across reconnects.
+
+- **Consistency.** One pattern for every connection-owning client means one mental
+  model to learn, review, and maintain — rather than a mix of recreate-and-refetch and
+  rebind across the codebase.
+
+> Honest scope note: for the connection clients that exist **today**, every consumer
+> already re-fetches, so the immediate, measurable benefit is small — these are
+> lateral refactors. The value above is mostly **forward-looking** (it pays off as
+> more/longer-lived consumers cache or inject the rpc). We adopt it as a convention so
+> that future code is safe by construction, not because it fixes a present bug.
+
+### Notes / caveats
+
+- The rebindable behavior is **opt-in** (`{ rebindable: true }`); existing
+  non-rebindable consumers are unchanged.
+- This is a convention for **connection-owning** clients (those with a reconnect
+  loop). One-shot clients (connect → invoke → close) and servers (one rpc per inbound
+  socket) don't need it.
+- Reconnect orchestration (backoff, badges, re-subscribe, re-join) stays
+  transport-specific per client — only the create-once/rebind kernel is shared.
+- Adopted clients: browser extension (`agentRpc`), studio `StudioServiceConnection`,
+  agent-server `connectAgentServer`. See the design doc
+  `docs/plans/.../rpc-rebindable-channel-design.md` (where maintained) for the full
+  rationale and the per-consumer assessment.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft

--- a/ts/packages/typeagent-studio/src/studioServiceClient.ts
+++ b/ts/packages/typeagent-studio/src/studioServiceClient.ts
@@ -35,11 +35,13 @@ import type { SandboxStatus } from "@typeagent/core/sandbox";
  */
 export class StudioServiceClient {
     private constructor(
-        private readonly socket: WebSocket,
+        private socket: WebSocket,
         private readonly rpc: ReturnType<
             typeof createRpc<StudioServiceInvokeFunctions>
         >,
         private readonly repoRoot: string | undefined,
+        private readonly endpoint: string,
+        private readonly token: string | undefined,
     ) {}
 
     /**
@@ -91,8 +93,36 @@ export class StudioServiceClient {
             createWebSocketRpcChannel(socket),
             undefined,
             callHandlers,
+            { rebindable: true },
         );
-        return new StudioServiceClient(socket, rpc, options.repoRoot);
+        return new StudioServiceClient(
+            socket,
+            rpc,
+            options.repoRoot,
+            options.endpoint,
+            options.token,
+        );
+    }
+
+    /**
+     * Reopen the service socket and rebind the existing rpc onto it, so this
+     * client (and its rpc reference) survives a reconnect instead of being
+     * recreated. `onClose` is wired to the new socket. Returns false when the
+     * socket can't be reopened (service gone / bad token) — caller retries.
+     */
+    async reconnect(onClose: () => void): Promise<boolean> {
+        const attempt = await StudioServiceClient.openSocket(
+            this.endpoint,
+            this.token,
+        );
+        if (attempt.socket === undefined) {
+            return false;
+        }
+        const socket = attempt.socket;
+        socket.on("close", onClose);
+        this.rpc.rebind(createWebSocketRpcChannel(socket));
+        this.socket = socket;
+        return true;
     }
 
     /**

--- a/ts/packages/typeagent-studio/src/studioServiceConnection.ts
+++ b/ts/packages/typeagent-studio/src/studioServiceConnection.ts
@@ -84,7 +84,10 @@ export class StudioServiceConnection {
 
     /** The live client, or `undefined` when not connected. */
     getClient(): StudioServiceClient | undefined {
-        return this.client;
+        // The client is kept across reconnects (its rpc is rebound onto the new
+        // socket), so only surface it when actually connected — preserving the
+        // "undefined while disconnected" contract callers and tests rely on.
+        return this.state === "connected" ? this.client : undefined;
     }
 
     /**
@@ -128,7 +131,7 @@ export class StudioServiceConnection {
         if (this.disposed) {
             return Promise.resolve(false);
         }
-        if (this.client) {
+        if (this.client && this.state === "connected") {
             return Promise.resolve(true);
         }
         if (this.connecting) {
@@ -138,22 +141,33 @@ export class StudioServiceConnection {
         const gen = ++this.generation;
         this.setState("connecting");
         this.connecting = (async () => {
-            const client = await StudioServiceClient.connect({
-                ...(this.repoRoot !== undefined
-                    ? { repoRoot: this.repoRoot }
-                    : {}),
-                ...(this.endpoint !== undefined
-                    ? { endpoint: this.endpoint }
-                    : {}),
-                ...(this.token !== undefined ? { token: this.token } : {}),
-                onEvent: (event) => this.fanout(event),
-                onClose: () => this.handleClose(gen),
-            });
-            // Superseded (disposed or a newer generation, e.g. setTarget) —
-            // drop this client. The superseding change may not have started its
-            // own attempt (connect() coalesces onto this in-flight one), so when
-            // auto-retry is on, schedule a fresh attempt for the new target;
-            // otherwise the connection can stall with nothing pending.
+            const existing = this.client;
+            let client: StudioServiceClient | undefined;
+            if (existing !== undefined) {
+                // Reuse the cached client across a reconnect: reopen the socket
+                // and rebind its rpc rather than recreating the client.
+                client = (await existing.reconnect(() => this.handleClose(gen)))
+                    ? existing
+                    : undefined;
+            } else {
+                client = await StudioServiceClient.connect({
+                    ...(this.repoRoot !== undefined
+                        ? { repoRoot: this.repoRoot }
+                        : {}),
+                    ...(this.endpoint !== undefined
+                        ? { endpoint: this.endpoint }
+                        : {}),
+                    ...(this.token !== undefined ? { token: this.token } : {}),
+                    onEvent: (event) => this.fanout(event),
+                    onClose: () => this.handleClose(gen),
+                });
+            }
+            // Superseded (disposed or a newer generation, e.g. setTarget). The
+            // superseding op (setTarget/dispose) already cleared this.client, so
+            // whatever we just (re)opened is now an orphan — close it (for a
+            // reused client this closes its freshly-rebound socket). The
+            // superseding change may not have started its own attempt, so when
+            // auto-retry is on, schedule one for the new target.
             if (this.disposed || gen !== this.generation) {
                 client?.close();
                 if (!this.disposed && this.client === undefined) {
@@ -190,7 +204,9 @@ export class StudioServiceConnection {
         if (gen !== this.generation || this.disposed) {
             return; // a stale client closing, or we're shutting down
         }
-        this.client = undefined;
+        // Keep this.client: its rpc is rebindable and gets re-pointed at a fresh
+        // socket on reconnect. getClient() gates on state, so callers still see
+        // "undefined" while disconnected.
         this.setState("disconnected");
         if (this.autoRetry) {
             this.scheduleRetry();

--- a/ts/packages/typeagent-studio/src/test/studioServiceConnection.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioServiceConnection.spec.ts
@@ -20,6 +20,7 @@ import {
 async function startStubServer(): Promise<{
     endpoint: string;
     push: (e: StudioEvent) => void;
+    dropSockets: () => void;
     close: () => Promise<void>;
 }> {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
@@ -42,12 +43,27 @@ async function startStubServer(): Promise<{
     return {
         endpoint: `ws://127.0.0.1:${port}`,
         push: (e) => pushers.forEach((p) => p(e)),
+        // Drop connected sockets but keep the server listening, so a client's
+        // retry reconnects (and rebinds) instead of failing.
+        dropSockets: () => {
+            for (const c of server.clients) c.terminate();
+        },
         close: () =>
             new Promise<void>((resolve) => {
                 for (const c of server.clients) c.terminate();
                 server.close(() => resolve());
             }),
     };
+}
+
+async function waitFor(
+    predicate: () => boolean,
+    timeoutMs = 2000,
+): Promise<void> {
+    const start = Date.now();
+    while (!predicate() && Date.now() - start < timeoutMs) {
+        await new Promise((r) => setTimeout(r, 10));
+    }
 }
 
 test("connects, transitions state, and fans out events", async () => {
@@ -131,5 +147,107 @@ test("connect() resolves false when unreachable", async () => {
         assert.equal(connection.currentState, "disconnected");
     } finally {
         connection.dispose();
+    }
+});
+
+test("reuses the same client across a reconnect (rebind, not recreate)", async () => {
+    const stub = await startStubServer();
+    const connection = new StudioServiceConnection(undefined, {
+        endpoint: stub.endpoint,
+        backoffMs: [50],
+    });
+    try {
+        assert.equal(await connection.connect(), true);
+        const client1 = connection.getClient();
+        assert.ok(client1);
+
+        // Drop the socket; the server stays listening so the retry reconnects.
+        stub.dropSockets();
+        await waitFor(() => connection.currentState === "disconnected");
+        // Contract preserved: no client surfaced while disconnected.
+        assert.equal(connection.getClient(), undefined);
+
+        await waitFor(() => connection.currentState === "connected");
+        const client2 = connection.getClient();
+        assert.ok(client2);
+        // Same object, rebound to a fresh socket (reaching "connected" also
+        // proves subscribeEvents was re-invoked over the rebound rpc).
+        assert.equal(client2, client1);
+    } finally {
+        connection.dispose();
+        await stub.close();
+    }
+});
+
+test("delivers events over the rebound socket after a reconnect", async () => {
+    const stub = await startStubServer();
+    const connection = new StudioServiceConnection(undefined, {
+        endpoint: stub.endpoint,
+        backoffMs: [50],
+    });
+    const received: StudioEvent[] = [];
+    connection.onEvent((e) => received.push(e));
+    try {
+        assert.equal(await connection.connect(), true);
+
+        stub.dropSockets();
+        await waitFor(() => connection.currentState === "disconnected");
+        await waitFor(() => connection.currentState === "connected");
+
+        stub.push({ type: "collision.detected", ts: 2 } as StudioEvent);
+        await waitFor(() => received.length >= 1);
+        assert.equal(received.length >= 1, true);
+    } finally {
+        connection.dispose();
+        await stub.close();
+    }
+});
+
+test("keeps the same client across multiple sequential reconnects", async () => {
+    const stub = await startStubServer();
+    const connection = new StudioServiceConnection(undefined, {
+        endpoint: stub.endpoint,
+        backoffMs: [50],
+    });
+    try {
+        assert.equal(await connection.connect(), true);
+        const client1 = connection.getClient();
+        assert.ok(client1);
+
+        for (let i = 0; i < 3; i++) {
+            stub.dropSockets();
+            await waitFor(() => connection.currentState === "disconnected");
+            await waitFor(() => connection.currentState === "connected");
+            assert.equal(connection.getClient(), client1);
+        }
+    } finally {
+        connection.dispose();
+        await stub.close();
+    }
+});
+
+test("setTarget connects a fresh client to the new endpoint (no stale reuse)", async () => {
+    const stubA = await startStubServer();
+    const stubB = await startStubServer();
+    const connection = new StudioServiceConnection(undefined, {
+        endpoint: stubA.endpoint,
+        backoffMs: [50],
+    });
+    try {
+        assert.equal(await connection.connect(), true);
+        const clientA = connection.getClient();
+        assert.ok(clientA);
+
+        // Re-point at a different service; the old client stored the old
+        // endpoint, so it must not be reused — a fresh client connects to B.
+        connection.setTarget({ endpoint: stubB.endpoint, token: "" });
+        await waitFor(() => connection.currentState === "connected");
+        const clientB = connection.getClient();
+        assert.ok(clientB);
+        assert.notEqual(clientB, clientA);
+    } finally {
+        connection.dispose();
+        await stubA.close();
+        await stubB.close();
     }
 });


### PR DESCRIPTION
 ## Studio service client: rebind on reconnect + adopt the pattern as a convention
 
 ### What
 - Reworks the Studio service client (`StudioServiceConnection` / `StudioServiceClient`) so it **reuses one client and rebinds its rpc** on reconnect, instead of building a brand-new client each time. External behavior is unchanged — the "no client while disconnected" contract is preserved.
 - Documents this as the standard going forward: rpc connection clients should be a **durable session that rebinds its transport** (`createRpc({ rebindable: true })` once + `rpc.rebind` on reconnect) rather than recreate-and-refetch. Captured in the `@typeagent/agent-rpc` README.
 
 ### Why
 - **Connection safety / pit of success:** a rebindable rpc survives a drop (fail-fast then resume) instead of being permanently poisoned, so holding or injecting the client is safe by default — no "always re-fetch" rule to remember.
 - **Cleaner model:** a connection *has* a transport rather than *is* one, giving it stable identity across reconnects.
 
 ### Notes
 - Reconnect itself already worked; this is a behavior-preserving refactor plus a forward-looking convention, not a bug fix.
 - Adds tests covering reuse-across-reconnect, the disconnected-state contract, and event delivery after a reconnect.