### PR TITLE
Switch to per-user install and fix script execution issues

### DIFF
--- a/pipelines/azure-build-package-agent-server-msi.yml
+++ b/pipelines/azure-build-package-agent-server-msi.yml
@@ -51,7 +51,6 @@ parameters:
     default: win32-x64
     values:
       - win32-x64
-      - win32-arm64
     displayName: "RID (Runtime ID)"
 
 jobs:

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -110,9 +110,9 @@
 
     <!-- Pass the PowerShell command as CustomActionData to the deferred CA -->
     <SetProperty Id="RegisterCopilotPlugin"
-                 Before="RegisterCopilotPlugin"
-                 Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\cmd.exe&quot; /c &quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -InstallDir &quot;[TYPEAGENTROOT]&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
+           Before="RegisterCopilotPlugin"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
 
     <CustomAction Id="RegisterCopilotPlugin"
                   BinaryKey="WixCA"
@@ -123,9 +123,9 @@
 
     <!-- Unregister on uninstall -->
     <SetProperty Id="UnregisterCopilotPlugin"
-                 Before="UnregisterCopilotPlugin"
-                 Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\cmd.exe&quot; /c &quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -Uninstall -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
+           Before="UnregisterCopilotPlugin"
+           Sequence="execute"
+           Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -Uninstall -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
 
     <CustomAction Id="UnregisterCopilotPlugin"
                   BinaryKey="WixCA"

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -3,7 +3,7 @@
 
 <!--
   TypeAgent MSI — installs:
-    C:\Program Files\TypeAgent\
+    %LOCALAPPDATA%\TypeAgent\
       agent-server\       ← agent-server.<rid> artifact (all files from heat)
       copilot-plugin\     ← typeagent-copilot-plugin artifact (all files from heat)
       .github\plugin\marketplace.json  ← for `copilot plugin marketplace add`
@@ -29,7 +29,7 @@
     <Package
       InstallerVersion="500"
       Compressed="yes"
-      InstallScope="perMachine"
+      InstallScope="perUser"
       Platform="x64"
       Description="TypeAgent — AI agent server and GitHub Copilot CLI integration"
       Manufacturer="Microsoft Corporation" />
@@ -43,8 +43,8 @@
          Directory layout
          ═══════════════════════════════════════════════ -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFiles64Folder">
-        <Directory Id="TYPEAGENTFOLDER" Name="TypeAgent">
+      <Directory Id="LocalAppDataFolder">
+        <Directory Id="TYPEAGENTROOT" Name="TypeAgent">
           <Directory Id="INSTALLFOLDER" Name="agent-server" />
           <Directory Id="PLUGINFOLDER" Name="copilot-plugin" />
           <Directory Id="GITHUBFOLDER" Name=".github">
@@ -71,7 +71,7 @@
          Static components
          ═══════════════════════════════════════════════ -->
 
-    <!-- marketplace.json — enables `copilot plugin marketplace add <TYPEAGENTFOLDER>` -->
+    <!-- marketplace.json — enables `copilot plugin marketplace add <TYPEAGENTROOT>` -->
     <DirectoryRef Id="PLUGINREGFOLDER">
       <Component Id="MarketplaceJsonComponent" Guid="*">
         <File Id="MarketplaceJson" Name="marketplace.json"
@@ -82,19 +82,19 @@
     </DirectoryRef>
 
     <!-- register-plugin.ps1 — helper for post-install Copilot CLI registration -->
-    <DirectoryRef Id="TYPEAGENTFOLDER">
+    <DirectoryRef Id="TYPEAGENTROOT">
       <Component Id="RegisterScriptComponent" Guid="*">
         <File Id="RegisterPluginPs1" Name="register-plugin.ps1"
               Source="$(var.InstallerSourceDir)\register-plugin.ps1" />
-        <RemoveFolder Id="RemoveTypeAgentFolder" Directory="TYPEAGENTFOLDER" On="uninstall" />
+        <RemoveFolder Id="RemoveTypeAgentFolder" Directory="TYPEAGENTROOT" On="uninstall" />
       </Component>
     </DirectoryRef>
 
-    <!-- HKLM registry entries for config and tool discovery -->
+    <!-- HKCU registry entries for config and tool discovery -->
     <DirectoryRef Id="TARGETDIR">
       <Component Id="RegistryComponent" Guid="*">
-        <RegistryKey Root="HKLM" Key="Software\Microsoft\TypeAgent">
-          <RegistryValue Name="InstallDir"        Value="[TYPEAGENTFOLDER]" Type="string" KeyPath="yes" />
+        <RegistryKey Root="HKCU" Key="Software\Microsoft\TypeAgent">
+          <RegistryValue Name="InstallDir"        Value="[TYPEAGENTROOT]" Type="string" KeyPath="yes" />
           <RegistryValue Name="AgentServerDir"    Value="[INSTALLFOLDER]"   Type="string" />
           <RegistryValue Name="CopilotPluginDir"  Value="[PLUGINFOLDER]"    Type="string" />
           <RegistryValue Name="Version"           Value="$(var.ProductVersion)" Type="string" />
@@ -105,15 +105,14 @@
     <!-- ═══════════════════════════════════════════════
          Custom actions — Copilot CLI plugin registration
          Runs register-plugin.ps1 as the installing user.
-         Return="ignore" so install succeeds even if the
-         Copilot CLI is not present on this machine.
+          Registration failures are fatal.
          ═══════════════════════════════════════════════ -->
 
     <!-- Pass the PowerShell command as CustomActionData to the deferred CA -->
     <SetProperty Id="RegisterCopilotPlugin"
                  Before="RegisterCopilotPlugin"
                  Sequence="execute"
-                 Value="[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NonInteractive -File &quot;[TYPEAGENTFOLDER]register-plugin.ps1&quot; -InstallDir &quot;[TYPEAGENTFOLDER]&quot;" />
+                 Value="&quot;[WindowsFolder]System32\cmd.exe&quot; /c &quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -InstallDir &quot;[TYPEAGENTROOT]&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
 
     <CustomAction Id="RegisterCopilotPlugin"
                   BinaryKey="WixCA"
@@ -126,7 +125,7 @@
     <SetProperty Id="UnregisterCopilotPlugin"
                  Before="UnregisterCopilotPlugin"
                  Sequence="execute"
-                 Value="[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NonInteractive -File &quot;[TYPEAGENTFOLDER]register-plugin.ps1&quot; -Uninstall" />
+                 Value="&quot;[WindowsFolder]System32\cmd.exe&quot; /c &quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -Uninstall -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
 
     <CustomAction Id="UnregisterCopilotPlugin"
                   BinaryKey="WixCA"
@@ -136,7 +135,7 @@
                   Impersonate="yes" />
 
     <InstallExecuteSequence>
-      <Custom Action="RegisterCopilotPlugin"   After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="RegisterCopilotPlugin"   After="InstallFiles">NOT REMOVE~="ALL"</Custom>
       <Custom Action="UnregisterCopilotPlugin" Before="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
 

--- a/ts/tools/installers/wix/register-plugin.ps1
+++ b/ts/tools/installers/wix/register-plugin.ps1
@@ -9,14 +9,14 @@
     Called automatically by the TypeAgent MSI installer as a deferred custom
     action.  Can also be run manually after installing the Copilot CLI.
 
-    Registration mechanism (mirrors install-plugin.mjs):
-      1. `copilot plugin marketplace add <InstallDir>` — registers the directory
-         that contains .github/plugin/marketplace.json as a local marketplace.
-      2. `copilot plugin install typeagent@typeagent-local` — installs the plugin
-         from that marketplace into ~/.copilot/installed-plugins/.
+     Registration mechanism (mirrors install-typeagent.ps1):
+        1. Build/update local marketplace payload under
+            ~/.copilot/marketplaces/typeagent-local.
+        2. Ensure marketplace registration with Copilot CLI.
+        3. Install typeagent@typeagent-local.
 
-    If `copilot` is not on PATH the script exits 0 (non-fatal), so the MSI
-    install always succeeds even on machines without the Copilot CLI.
+     On install/upgrade this script is strict: failures return non-zero and
+     should block MSI completion.
 
 .PARAMETER InstallDir
     Path to the TypeAgent install root (default: the directory this script
@@ -24,13 +24,128 @@
 
 .PARAMETER Uninstall
     When set, unregisters the plugin instead of registering it.
+
+.PARAMETER LogPath
+    Path to log file for registration diagnostics.
 #>
 param(
     [string]$InstallDir = $PSScriptRoot,
-    [switch]$Uninstall
+    [switch]$Uninstall,
+    [string]$LogPath = "$env:LOCALAPPDATA\TypeAgent\logs\msi-register-plugin.log"
 )
 
-$ErrorActionPreference = "Continue"
+$ErrorActionPreference = "Stop"
+
+function Write-Log {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    $timestamp = (Get-Date).ToString("s")
+    $line = "[$timestamp] $Message"
+    Write-Host $line
+    Add-Content -Path $LogPath -Value $line
+}
+
+function Invoke-Copilot {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Args,
+        [switch]$AllowFailure
+    )
+
+    Write-Log "Running: copilot $($Args -join ' ')"
+    $output = & copilot @Args 2>&1
+    $exitCode = $LASTEXITCODE
+    foreach ($line in @($output)) {
+        Write-Log "copilot> $line"
+    }
+
+    if (-not $AllowFailure -and $exitCode -ne 0) {
+        throw "Copilot command failed with exit code $exitCode: copilot $($Args -join ' ')"
+    }
+
+    return ($output | Out-String)
+}
+
+function Ensure-LocalPluginMarketplace {
+    param(
+        [Parameter(Mandatory = $true)][string]$MarketplaceRoot,
+        [Parameter(Mandatory = $true)][string]$PluginName,
+        [Parameter(Mandatory = $true)][string]$PluginSourceDir,
+        [Parameter(Mandatory = $true)][string]$PluginDescription,
+        [Parameter(Mandatory = $true)][string]$PluginVersion
+    )
+
+    $manifestDir = Join-Path $MarketplaceRoot ".github\plugin"
+    $manifestPath = Join-Path $manifestDir "marketplace.json"
+    $pluginsRoot = Join-Path $MarketplaceRoot "plugins"
+    $marketplacePluginDir = Join-Path $pluginsRoot $PluginName
+
+    New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $pluginsRoot | Out-Null
+
+    if (Test-Path $marketplacePluginDir) {
+        Remove-Item -Recurse -Force $marketplacePluginDir
+    }
+    Copy-Item -Path $PluginSourceDir -Destination $pluginsRoot -Recurse -Force
+
+    $manifest = $null
+    if (Test-Path $manifestPath) {
+        try {
+            $manifest = Get-Content -Raw -Path $manifestPath | ConvertFrom-Json -Depth 20
+        }
+        catch {
+            Write-Log "Existing marketplace.json is invalid JSON; recreating."
+            $manifest = $null
+        }
+    }
+
+    if ($null -eq $manifest) {
+        $manifest = [ordered]@{
+            name = "typeagent-local"
+            owner = [ordered]@{
+                name = "Microsoft"
+            }
+            metadata = [ordered]@{
+                description = "Local TypeAgent plugin marketplace"
+                version = "1.0.0"
+            }
+            plugins = @()
+        }
+    }
+
+    $existingPlugins = @()
+    if ($manifest.plugins) {
+        foreach ($entry in @($manifest.plugins)) {
+            if ($entry.name -ne $PluginName) {
+                $existingPlugins += $entry
+            }
+        }
+    }
+
+    $pluginEntry = [ordered]@{
+        name = $PluginName
+        description = $PluginDescription
+        version = $PluginVersion
+        source = "plugins/$PluginName"
+    }
+    $existingPlugins += $pluginEntry
+
+    $manifest.name = "typeagent-local"
+    if (-not $manifest.owner -or -not $manifest.owner.name) {
+        $manifest.owner = [ordered]@{ name = "Microsoft" }
+    }
+    if (-not $manifest.metadata) {
+        $manifest.metadata = [ordered]@{}
+    }
+    if (-not $manifest.metadata.description) {
+        $manifest.metadata.description = "Local TypeAgent plugin marketplace"
+    }
+    if (-not $manifest.metadata.version) {
+        $manifest.metadata.version = "1.0.0"
+    }
+    $manifest.plugins = $existingPlugins
+
+    $manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $manifestPath -Encoding UTF8
+    return $manifestPath
+}
 
 function Find-CopilotCli {
     try {
@@ -42,64 +157,86 @@ function Find-CopilotCli {
 }
 
 $copilotPath = Find-CopilotCli
-if (-not $copilotPath) {
-    Write-Host "[TypeAgent] GitHub Copilot CLI not found on PATH — skipping plugin registration."
-    Write-Host "[TypeAgent] After installing Copilot CLI, re-run this script to register:"
-    Write-Host "[TypeAgent]   powershell -File `"$PSCommandPath`" -InstallDir `"$InstallDir`""
-    exit 0
-}
+New-Item -ItemType Directory -Force -Path (Split-Path -Path $LogPath -Parent) | Out-Null
+Set-Content -Path $LogPath -Value ""
 
-Write-Host "[TypeAgent] Found Copilot CLI: $copilotPath"
+try {
+    Write-Log "TypeAgent register-plugin starting"
+    Write-Log "InstallDir: $InstallDir"
+    Write-Log "Uninstall: $Uninstall"
 
-# ── Uninstall path ─────────────────────────────────────────────────────────────
-if ($Uninstall) {
-    Write-Host "[TypeAgent] Unregistering TypeAgent Copilot CLI plugin..."
-    try {
-        & copilot plugin uninstall typeagent 2>&1 | ForEach-Object { Write-Host $_ }
-    } catch {
-        Write-Host "[TypeAgent] Note: uninstall skipped (plugin may not have been registered). $_"
+    if (-not $copilotPath) {
+        throw "GitHub Copilot CLI not found on PATH."
     }
-    try {
-        & copilot plugin marketplace remove typeagent-local 2>&1 | ForEach-Object { Write-Host $_ }
-    } catch {
-        Write-Host "[TypeAgent] Note: marketplace remove skipped. $_"
+
+    Write-Log "Found Copilot CLI: $copilotPath"
+
+    if ($Uninstall) {
+        Write-Log "Uninstall mode: removing plugin and marketplace"
+        Invoke-Copilot -Args @("plugin", "uninstall", "typeagent") -AllowFailure | Out-Null
+        Invoke-Copilot -Args @("plugin", "marketplace", "remove", "typeagent-local") -AllowFailure | Out-Null
+        Write-Log "Uninstall mode completed"
+        exit 0
     }
-    Write-Host "[TypeAgent] Done."
-    exit 0
-}
 
-# ── Install path ───────────────────────────────────────────────────────────────
-$marketplaceRoot = $InstallDir.TrimEnd('\').TrimEnd('/')
-$marketplaceJson = Join-Path $marketplaceRoot ".github\plugin\marketplace.json"
+    $pluginSourceDir = Join-Path $InstallDir "copilot-plugin"
+    if (-not (Test-Path $pluginSourceDir)) {
+        throw "Plugin source directory not found: $pluginSourceDir"
+    }
 
-if (-not (Test-Path $marketplaceJson)) {
-    Write-Host "[TypeAgent] marketplace.json not found at: $marketplaceJson"
-    Write-Host "[TypeAgent] TypeAgent installation may be incomplete — skipping plugin registration."
-    exit 0
-}
+    $pluginJsonPath = Join-Path $pluginSourceDir "plugin.json"
+    $pluginVersion = "0.0.1"
+    if (Test-Path $pluginJsonPath) {
+        $pluginJson = Get-Content -Raw -Path $pluginJsonPath | ConvertFrom-Json
+        if ($pluginJson.version) {
+            $pluginVersion = [string]$pluginJson.version
+        }
+    }
 
-Write-Host "[TypeAgent] Registering plugin from: $marketplaceRoot"
+    $marketplaceRoot = Join-Path $env:USERPROFILE ".copilot\marketplaces\typeagent-local"
+    Write-Log "Updating local marketplace at: $marketplaceRoot"
+    $manifestPath = Ensure-LocalPluginMarketplace \
+        -MarketplaceRoot $marketplaceRoot \
+        -PluginName "typeagent" \
+        -PluginSourceDir $pluginSourceDir \
+        -PluginDescription "TypeAgent integration for Copilot CLI" \
+        -PluginVersion $pluginVersion
+    Write-Log "Marketplace manifest updated: $manifestPath"
 
-# 1. Register (or refresh) the local marketplace
-$mpList = & copilot plugin marketplace list 2>&1 | Out-String
-if ($mpList -match "typeagent-local") {
-    Write-Host "[TypeAgent] Marketplace 'typeagent-local' already registered."
-    Write-Host "[TypeAgent] Updating plugin..."
-    & copilot plugin update typeagent 2>&1 | ForEach-Object { Write-Host $_ }
-} else {
-    Write-Host "[TypeAgent] Adding marketplace..."
-    & copilot plugin marketplace add "$marketplaceRoot" 2>&1 | ForEach-Object { Write-Host $_ }
+    $mpList = Invoke-Copilot -Args @("plugin", "marketplace", "list")
+    if ($mpList -notmatch "typeagent-local") {
+        Write-Log "Adding marketplace typeagent-local"
+        Invoke-Copilot -Args @("plugin", "marketplace", "add", $marketplaceRoot) | Out-Null
+    }
 
-    # 2. Install the plugin from the marketplace
-    $pluginList = & copilot plugin list 2>&1 | Out-String
+    Write-Log "Refreshing marketplace index"
+    Invoke-Copilot -Args @("plugin", "marketplace", "update", "typeagent-local") | Out-Null
+
+    $pluginList = Invoke-Copilot -Args @("plugin", "list")
     if ($pluginList -match "typeagent@typeagent-local") {
-        Write-Host "[TypeAgent] Plugin already installed, updating..."
-        & copilot plugin update typeagent 2>&1 | ForEach-Object { Write-Host $_ }
-    } else {
-        Write-Host "[TypeAgent] Installing plugin..."
-        & copilot plugin install "typeagent@typeagent-local" 2>&1 | ForEach-Object { Write-Host $_ }
+        Write-Log "Plugin already installed; reinstalling to refresh content"
+        Invoke-Copilot -Args @("plugin", "uninstall", "typeagent") -AllowFailure | Out-Null
     }
-}
 
-Write-Host "[TypeAgent] Plugin registration complete."
-exit 0
+    Write-Log "Installing typeagent@typeagent-local"
+    Invoke-Copilot -Args @("plugin", "install", "typeagent@typeagent-local") | Out-Null
+
+    $verifyList = Invoke-Copilot -Args @("plugin", "list")
+    if ($verifyList -notmatch "typeagent@typeagent-local") {
+        throw "Plugin verification failed: typeagent@typeagent-local missing from 'copilot plugin list'"
+    }
+
+    Write-Log "Plugin registration complete"
+    exit 0
+}
+catch {
+    $message = $_.Exception.Message
+    if (-not [string]::IsNullOrWhiteSpace($message)) {
+        Write-Log "ERROR: $message"
+    }
+    else {
+        Write-Log "ERROR: Unknown registration failure"
+    }
+    Write-Host "[TypeAgent] Registration failed. See log: $LogPath"
+    exit 1
+}

--- a/ts/tools/installers/wix/register-plugin.ps1
+++ b/ts/tools/installers/wix/register-plugin.ps1
@@ -36,6 +36,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Test-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
 function Write-Log {
     param([Parameter(Mandatory = $true)][string]$Message)
     $timestamp = (Get-Date).ToString("s")
@@ -165,32 +170,77 @@ function Ensure-LocalPluginMarketplace {
     return $manifestPath
 }
 
+function Test-VsCodeCopilotShimPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $shimRoot = Join-Path $env:APPDATA "Code\User\globalStorage\github.copilot-chat\copilotCli"
+    try {
+        $resolvedPath = (Resolve-Path -Path $Path -ErrorAction SilentlyContinue).Path
+        $resolvedShimRoot = (Resolve-Path -Path $shimRoot -ErrorAction SilentlyContinue).Path
+        if ($resolvedPath -and $resolvedShimRoot) {
+            return $resolvedPath.StartsWith($resolvedShimRoot, [System.StringComparison]::OrdinalIgnoreCase)
+        }
+    }
+    catch {
+        # If resolution fails, fall back to string test below.
+    }
+
+    return $Path -like "*$([IO.Path]::DirectorySeparatorChar)Code$([IO.Path]::DirectorySeparatorChar)User$([IO.Path]::DirectorySeparatorChar)globalStorage$([IO.Path]::DirectorySeparatorChar)github.copilot-chat$([IO.Path]::DirectorySeparatorChar)copilotCli*"
+}
+
 function Find-CopilotCli {
     $candidates = @()
+    $rejectedShimPaths = @()
 
     try {
-        # VS Code Copilot Chat installs shims here; prefer .bat on Windows.
-        $candidates += (Join-Path $env:APPDATA "Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.bat")
-        $candidates += (Join-Path $env:APPDATA "Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.ps1")
+        # 1) Optional explicit override for deterministic installs.
+        if ($env:COPILOT_CLI_PATH) {
+            $candidates += $env:COPILOT_CLI_PATH
+        }
 
+        # 2) Typical npm global shims on Windows.
+        $candidates += (Join-Path $env:APPDATA "npm\copilot.cmd")
+        $candidates += (Join-Path $env:APPDATA "npm\copilot.ps1")
+
+        # 2b) Winget links location (common for copilot.exe installs).
+        $candidates += (Join-Path $env:LOCALAPPDATA "Microsoft\\WinGet\\Links\\copilot.exe")
+
+        # 3) PATH discovery, similar to install-typeagent.ps1.
         $cmd = Get-Command copilot -ErrorAction SilentlyContinue
         if ($cmd) {
             $candidates += $cmd.Source
         }
 
         foreach ($candidate in ($candidates | Select-Object -Unique)) {
-            if (-not [string]::IsNullOrWhiteSpace($candidate) -and (Test-Path $candidate)) {
-                return $candidate
+            if ([string]::IsNullOrWhiteSpace($candidate)) {
+                continue
             }
+
+            if (-not (Test-Path $candidate)) {
+                continue
+            }
+
+            if (Test-VsCodeCopilotShimPath -Path $candidate) {
+                $rejectedShimPaths += $candidate
+                continue
+            }
+
+            return $candidate
         }
 
-        # Final fallback: resolve from PATH at runtime.
-        $null = & copilot --version 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            return "copilot"
+        # Final fallback: if command exists and is not a VS Code shim, use it by name.
+        if (Test-Command -Name "copilot") {
+            $pathResolved = (Get-Command copilot -ErrorAction SilentlyContinue).Source
+            if (-not [string]::IsNullOrWhiteSpace($pathResolved) -and -not (Test-VsCodeCopilotShimPath -Path $pathResolved)) {
+                return "copilot"
+            }
         }
     } catch {
         # Fall through and report not found.
+    }
+
+    if ($rejectedShimPaths.Count -gt 0) {
+        Write-Log "Rejected VS Code wrapper path(s) for MSI context: $($rejectedShimPaths -join '; ')"
     }
 
     return $null
@@ -207,7 +257,7 @@ try {
     Write-Log "Uninstall: $Uninstall"
 
     if (-not $copilotPath) {
-        throw "GitHub Copilot CLI not found on PATH."
+        throw "GitHub Copilot CLI not found in MSI-safe locations. Install @github/copilot globally (for example at %APPDATA%\\npm\\copilot.cmd) or set COPILOT_CLI_PATH."
     }
 
     Write-Log "Found Copilot CLI: $copilotPath"

--- a/ts/tools/installers/wix/register-plugin.ps1
+++ b/ts/tools/installers/wix/register-plugin.ps1
@@ -58,7 +58,7 @@ function Invoke-Copilot {
     }
 
     if (-not $AllowFailure -and $exitCode -ne 0) {
-        throw "Copilot command failed with exit code $exitCode: copilot $($Args -join ' ')"
+        throw "Copilot command failed with exit code ${exitCode}: copilot $($Args -join ' ')"
     }
 
     return ($output | Out-String)
@@ -84,7 +84,12 @@ function Ensure-LocalPluginMarketplace {
     if (Test-Path $marketplacePluginDir) {
         Remove-Item -Recurse -Force $marketplacePluginDir
     }
+    # Copy the source directory to the plugins directory, then rename to plugin name
+    $tempCopyPath = Join-Path $pluginsRoot (Split-Path -Leaf $PluginSourceDir)
     Copy-Item -Path $PluginSourceDir -Destination $pluginsRoot -Recurse -Force
+    if ($tempCopyPath -ne $marketplacePluginDir -and (Test-Path $tempCopyPath)) {
+        Rename-Item -Path $tempCopyPath -NewName (Split-Path -Leaf $marketplacePluginDir) -Force
+    }
 
     $manifest = $null
     if (Test-Path $manifestPath) {
@@ -149,11 +154,21 @@ function Ensure-LocalPluginMarketplace {
 
 function Find-CopilotCli {
     try {
+        # Try to get the command; if it exists, return its source
         $cmd = Get-Command copilot -ErrorAction SilentlyContinue
-        return $cmd?.Source
+        if ($cmd) {
+            return $cmd.Source
+        }
+        # If not found via Get-Command (e.g., when running with -NoProfile),
+        # try invoking it to see if it's available on PATH
+        $testOutput = & copilot --version 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            return "copilot (on PATH)"
+        }
     } catch {
-        return $null
+        # Silently ignore
     }
+    return $null
 }
 
 $copilotPath = Find-CopilotCli
@@ -195,11 +210,11 @@ try {
 
     $marketplaceRoot = Join-Path $env:USERPROFILE ".copilot\marketplaces\typeagent-local"
     Write-Log "Updating local marketplace at: $marketplaceRoot"
-    $manifestPath = Ensure-LocalPluginMarketplace \
-        -MarketplaceRoot $marketplaceRoot \
-        -PluginName "typeagent" \
-        -PluginSourceDir $pluginSourceDir \
-        -PluginDescription "TypeAgent integration for Copilot CLI" \
+    $manifestPath = Ensure-LocalPluginMarketplace `
+        -MarketplaceRoot $marketplaceRoot `
+        -PluginName "typeagent" `
+        -PluginSourceDir $pluginSourceDir `
+        -PluginDescription "TypeAgent integration for Copilot CLI" `
         -PluginVersion $pluginVersion
     Write-Log "Marketplace manifest updated: $manifestPath"
 

--- a/ts/tools/installers/wix/register-plugin.ps1
+++ b/ts/tools/installers/wix/register-plugin.ps1
@@ -50,15 +50,26 @@ function Invoke-Copilot {
         [switch]$AllowFailure
     )
 
-    Write-Log "Running: copilot $($Args -join ' ')"
-    $output = & copilot @Args 2>&1
+    if (-not $script:CopilotCommand) {
+        throw "Copilot CLI command path is not initialized."
+    }
+
+    $copilotCmdText = "$script:CopilotCommand $($Args -join ' ')"
+    Write-Log "Running: $copilotCmdText"
+
+    if ($script:CopilotCommand -like "*.ps1") {
+        $output = & pwsh -NoProfile -ExecutionPolicy Bypass -File $script:CopilotCommand @Args 2>&1
+    }
+    else {
+        $output = & $script:CopilotCommand @Args 2>&1
+    }
     $exitCode = $LASTEXITCODE
     foreach ($line in @($output)) {
         Write-Log "copilot> $line"
     }
 
     if (-not $AllowFailure -and $exitCode -ne 0) {
-        throw "Copilot command failed with exit code ${exitCode}: copilot $($Args -join ' ')"
+        throw "Copilot command failed with exit code ${exitCode}: $script:CopilotCommand $($Args -join ' ')"
     }
 
     return ($output | Out-String)
@@ -148,30 +159,45 @@ function Ensure-LocalPluginMarketplace {
     }
     $manifest.plugins = $existingPlugins
 
-    $manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $manifestPath -Encoding UTF8
+    $manifestJson = $manifest | ConvertTo-Json -Depth 20
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($manifestPath, $manifestJson, $utf8NoBom)
     return $manifestPath
 }
 
 function Find-CopilotCli {
+    $candidates = @()
+
     try {
-        # Try to get the command; if it exists, return its source
+        # VS Code Copilot Chat installs shims here; prefer .bat on Windows.
+        $candidates += (Join-Path $env:APPDATA "Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.bat")
+        $candidates += (Join-Path $env:APPDATA "Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.ps1")
+
         $cmd = Get-Command copilot -ErrorAction SilentlyContinue
         if ($cmd) {
-            return $cmd.Source
+            $candidates += $cmd.Source
         }
-        # If not found via Get-Command (e.g., when running with -NoProfile),
-        # try invoking it to see if it's available on PATH
-        $testOutput = & copilot --version 2>&1
+
+        foreach ($candidate in ($candidates | Select-Object -Unique)) {
+            if (-not [string]::IsNullOrWhiteSpace($candidate) -and (Test-Path $candidate)) {
+                return $candidate
+            }
+        }
+
+        # Final fallback: resolve from PATH at runtime.
+        $null = & copilot --version 2>&1
         if ($LASTEXITCODE -eq 0) {
-            return "copilot (on PATH)"
+            return "copilot"
         }
     } catch {
-        # Silently ignore
+        # Fall through and report not found.
     }
+
     return $null
 }
 
 $copilotPath = Find-CopilotCli
+$script:CopilotCommand = $copilotPath
 New-Item -ItemType Directory -Force -Path (Split-Path -Path $LogPath -Parent) | Out-Null
 Set-Content -Path $LogPath -Value ""
 

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -54,6 +54,13 @@ console.log(`   Output:         ${outputDir}`);
 if (stagedAgentDir) console.log(`   Agent dir:      ${stagedAgentDir}`);
 if (stagedPluginDir) console.log(`   Plugin dir:     ${stagedPluginDir}`);
 
+if (rid !== "win32-x64") {
+    console.error(
+        `❌ Unsupported RID for MSI build: ${rid}. Currently supported: win32-x64`,
+    );
+    process.exit(1);
+}
+
 // ── Paths ─────────────────────────────────────────────────────────────────────
 const wxsDir = path.resolve(__dirname, "../installers/wix");
 const wxsFile = path.join(wxsDir, "TypeAgent-AgentServer.wxs");
@@ -249,8 +256,8 @@ if (!skipDownload) {
 // ── Step 2: Generate marketplace.json ─────────────────────────────────────────
 console.log(`\n📝 Generating marketplace.json...`);
 fs.mkdirSync(marketplaceDir, { recursive: true });
-const semverVersion =
-    version
+const pluginSemverVersion =
+    pluginVersion
         .replace(/[^0-9.]/g, ".")
         .replace(/\.{2,}/g, ".")
         .replace(/\.$/, "") || "0.0.1";
@@ -286,13 +293,13 @@ const marketplace = {
     owner: { name: "Microsoft", email: "typeagent@microsoft.com" },
     metadata: {
         description: "TypeAgent Copilot CLI plugin",
-        version: semverVersion,
+        version: pluginSemverVersion,
     },
     plugins: [
         {
             name: "typeagent",
             description: "TypeAgent integration for Copilot CLI",
-            version: semverVersion,
+            version: pluginSemverVersion,
             source: "./copilot-plugin",
         },
     ],


### PR DESCRIPTION
This pull request makes significant improvements to the TypeAgent MSI installer and Copilot plugin registration process, with a focus on switching to per-user installation, hardening plugin registration, and improving logging and error handling. It also restricts MSI builds to `win32-x64` and refines the plugin marketplace generation logic.

**Installer packaging and installation scope:**

* The MSI now installs TypeAgent under `%LOCALAPPDATA%\TypeAgent` rather than `C:\Program Files\TypeAgent`, switching from a per-machine to a per-user installation (`InstallScope="perUser"`, directory changes, registry moved to `HKCU`). [[1]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL6-R6) [[2]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL32-R32) [[3]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL46-R47) [[4]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL85-R97) [[5]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL74-R74) [[6]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL85-R97)
* The MSI is now only built for `win32-x64`; other RIDs such as `win32-arm64` are no longer supported, and the build script enforces this. [[1]](diffhunk://#diff-00491f3c05eb13079c23f8476077907568c35080a0110a26e011a8ef3b34d000L54) [[2]](diffhunk://#diff-c22b0b88ab487de50f95d90e3d5baaa0521c7984bc91f300d5b445fdce962d4bR57-R63)

**Copilot plugin registration and logging:**

* The `register-plugin.ps1` script is completely rewritten to:
    - Fail the MSI install on registration errors (registration failures are now fatal).
    - Log all actions and errors to a file for diagnostics.
    - Use a robust, explicit search for the Copilot CLI executable, avoiding VS Code extension shims.
    - Build or update a local plugin marketplace in the user's profile, ensuring the plugin is always registered and up-to-date.
    - Support uninstall mode that properly removes both plugin and marketplace. [[1]](diffhunk://#diff-e660dc9dc2ebb763257c9cd6f4b1cbf19320a2e6a9a0f845b588113f79b9cff0L12-R333) [[2]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL108-R115) [[3]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL129-R128) [[4]](diffhunk://#diff-37aecd3f240a2e5a142008983e2992441b64da9f551a48df5fe549c925f7e7ccL139-R138)

**Marketplace and plugin manifest generation:**

* The build script for the MSI (`build-msi.mjs`) now uses the plugin version (not the agent version) for the marketplace manifest, ensuring the correct version is reflected. [[1]](diffhunk://#diff-c22b0b88ab487de50f95d90e3d5baaa0521c7984bc91f300d5b445fdce962d4bL252-R260) [[2]](diffhunk://#diff-c22b0b88ab487de50f95d90e3d5baaa0521c7984bc91f300d5b445fdce962d4bL289-R302)

These changes collectively improve the reliability, user experience, and maintainability of the TypeAgent MSI installer and Copilot CLI plugin integration.