### PR TITLE
Update Azure Pipeline to Use WIF with azcli2 Integration

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -7,10 +7,12 @@ name: smoke-tests
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
-  pull_request_target:
-    branches: ["main"]
+  # These smoke tests have been moved to Azure DevOps so that we can use Workload Identity Flow (secretless) auth. 
+  # Disabled the GitHub trigger for now. If you want to run them on GitHub, re-enable this trigger.
+  # push:
+  #   branches: ["main"]
+  # pull_request_target:
+  #   branches: ["main"]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -16,8 +16,10 @@
 #     connection that uses Workload Identity Federation. A single AzureCLI@2
 #     task performs the federated (secret-free) login, pulls the secrets, and
 #     publishes AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE so
-#     the later plain test steps authenticate to Azure OpenAI through
-#     @azure/identity's WorkloadIdentityCredential. Nothing to rotate.
+#     the quick CLI smoke step authenticates to Azure OpenAI through
+#     @azure/identity's WorkloadIdentityCredential. The long-running shell and
+#     live suites each take a fresh per-step login instead (they can outlive this
+#     token). Nothing to rotate.
 #
 # Prerequisites:
 #   * GitHub service connection - created when you set up this pipeline via
@@ -114,17 +116,16 @@ jobs:
       # publish the three variables that @azure/identity's
       # WorkloadIdentityCredential (part of DefaultAzureCredential v4) reads —
       # AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE — so the
-      # later plain test steps reach Azure OpenAI without each needing its own
-      # AzureCLI task. getKeys runs here too, while az is signed in, and writes
+      # quick CLI smoke step reaches Azure OpenAI without its own AzureCLI task.
+      # getKeys runs here too, while az is signed in, and writes
       # ts/config.local.yaml. The connection's service principal needs
       # 'Key Vault Secrets User' on 'build-pipeline-kv' and 'Cognitive Services
       # OpenAI User' on the Azure OpenAI resource(s).
       #
-      # NOTE: the OIDC token is short-lived (~15 min). A step that first calls
-      # Azure OpenAI long after this one can see it expire. The quick CLI smoke
-      # and the shell suites call Azure OpenAI early enough to use this shared
-      # login; Live Tests run after the up-to-60-min shell suite, so they get
-      # their own AzureCLI@2 task (a fresh federated login) below.
+      # NOTE: the OIDC token is short-lived (~15 min). Only the immediate CLI
+      # smoke step relies on this shared login. Every long-running suite (the
+      # shell tests and Live Tests) can run past the token's lifetime, so each
+      # takes its own fresh AzureCLI@2 login below instead.
       - task: AzureCLI@2
         displayName: Azure login + Get Keys
         inputs:
@@ -149,34 +150,46 @@ jobs:
         displayName: Test CLI - smoke
         workingDirectory: $(buildDirectory)/packages/cli
 
-      - script: |
-          npm run shell:test
+      # Long-running suite: it can run past the shared login's ~15-min token
+      # window, so it takes its own AzureCLI@2 task for a fresh federated
+      # `az login`. We first clear the three published AZURE_* variables (they
+      # persist job-wide): otherwise DefaultAzureCredential would try
+      # WorkloadIdentityCredential against the now-stale token file, and a failed
+      # assertion exchange is a hard error that stops the chain before it reaches
+      # this task's fresh AzureCliCredential. Clearing them makes it fall through.
+      - task: AzureCLI@2
         displayName: Shell Tests - full (Windows)
-        workingDirectory: $(buildDirectory)/packages/shell
         timeoutInMinutes: 60
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+        inputs:
+          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          workingDirectory: $(buildDirectory)/packages/shell
+          inlineScript: |
+            'AZURE_CLIENT_ID','AZURE_TENANT_ID','AZURE_FEDERATED_TOKEN_FILE' | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
+            npm run shell:test
 
-      - bash: |
-          Xvfb :99 -screen 0 1600x1200x24 &
-          export DISPLAY=:99
-          npm run shell:smoke
+      # Own AzureCLI@2 login with the published AZURE_* vars cleared — same
+      # rationale as "Shell Tests - full" above.
+      - task: AzureCLI@2
         displayName: Shell Tests - smoke (Linux)
-        workingDirectory: $(buildDirectory)/packages/shell
         timeoutInMinutes: 60
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+        inputs:
+          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(buildDirectory)/packages/shell
+          inlineScript: |
+            unset AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_FEDERATED_TOKEN_FILE
+            Xvfb :99 -screen 0 1600x1200x24 &
+            export DISPLAY=:99
+            npm run shell:smoke
 
-      # Live Tests run after the up-to-60-min shell suite, by which point the
-      # federated token the "Azure login + Get Keys" step published (~15 min
-      # lifetime) is long expired. So this step gets its own AzureCLI@2 task,
-      # which performs a fresh federated `az login` at start.
-      #
-      # We first clear the three published AZURE_* variables for this step only.
-      # They persist as job-wide env vars, so without this DefaultAzureCredential
-      # would try WorkloadIdentityCredential against the stale token file — a
-      # failed assertion exchange is a hard error that stops the chain, so it
-      # would never reach the fresh AzureCliCredential from this task's az login.
-      # Unsetting them makes the chain fall through to AzureCliCredential.
-      # Non-blocking (continueOnError) so a late auth issue won't fail the run.
+      # Own AzureCLI@2 login with the published AZURE_* vars cleared — same
+      # rationale as "Shell Tests - full" above. Non-blocking (continueOnError)
+      # so a late auth issue won't fail the run.
       - task: AzureCLI@2
         displayName: Live Tests (Linux)
         timeoutInMinutes: 60

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -1,0 +1,177 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Live / smoke sanity tests for the TypeAgent TypeScript workspace.
+#
+# Azure DevOps port of .github/workflows/smoke-tests.yml. Differences from the
+# GitHub Actions version, and why:
+#   * The fork-PR permission gating (actions-cool/check-user-permission) is
+#     dropped. That check existed to protect secrets on the PUBLIC OSS repo;
+#     on an internal Azure DevOps project, Key Vault / secret access is already
+#     governed by project permissions and the service connection's RBAC.
+#   * "Setup Git LF" is dropped because .gitattributes already pins `* text
+#     eol=lf`, so checkout produces LF on every OS regardless of core.autocrlf.
+#   * dorny/paths-filter is replaced by the trigger `paths` filter below.
+#   * azure/login (OIDC) is replaced by a service-principal login: the CLIENT_ID
+#     / TENANT_ID / CLIENT_SECRET variables are passed to getKeys.mjs as AZURE_*
+#     env vars, which it consumes via DefaultAzureCredential ->
+#     EnvironmentCredential. A secret-free Workload Identity Federation variant
+#     is documented inline at the Get Keys step.
+#
+# Prerequisites:
+#   * GitHub service connection - created when you set up this pipeline via
+#     StartRight (per the eng.ms integrate-ado guide). It lets Azure Pipelines
+#     read the repo AND report each run's status back to the PR. No YAML needed.
+#   * Pipeline variables (define in the pipeline UI or a linked variable group;
+#     mark the credential ones as secret):
+#       - REGISTRY         npm registry URL used by include-prepare-repo.yml to
+#                          restore dependencies (internal Azure Artifacts feed).
+#       - CLIENT_ID        service principal (app) ID, its home
+#       - TENANT_ID        tenant, and target
+#       - SUBSCRIPTION_ID  subscription for reading 'build-pipeline-kv'.
+#       - CLIENT_SECRET    secret for that service principal. REQUIRED for a
+#                          silent CI login (see the Get Keys step); without it
+#                          getKeys falls back to interactive login and hangs.
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - ts/**
+      - pipelines/azure-smoke-tests.yml
+
+# Run on PRs targeting main so a failing smoke test blocks the PR. This
+# pipeline's source is a GitHub repo, so Azure Pipelines reports each PR run's
+# status back to GitHub automatically; make it blocking by adding it as a
+# required status check in the branch-protection rule for `main`.
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - ts/**
+      - pipelines/azure-smoke-tests.yml
+
+variables:
+  - name: buildDirectory
+    value: $(Build.SourcesDirectory)/ts
+  - name: nodeVersion
+    value: "22"
+  # Mirrors the GitHub workflow's env.NODE_OPTIONS. Non-secret pipeline variables
+  # are surfaced to every script step as environment variables; secret variables
+  # (CLIENT_ID / TENANT_ID / CLIENT_SECRET / SUBSCRIPTION_ID) must be mapped
+  # explicitly via `env:` (done at the Get Keys step).
+  - name: NODE_OPTIONS
+    value: --max_old_space_size=8192
+
+jobs:
+  - job: shell_and_cli
+    displayName: Shell & CLI smoke tests
+    # Generous cap: the Linux leg can run the shell smoke (60m) + live (60m)
+    # tests back to back. Requires purchased parallelism for hosted agents.
+    timeoutInMinutes: 150
+    strategy:
+      # Both legs run independently; one failing does not cancel the other
+      # (equivalent to the GitHub matrix's fail-fast: false).
+      matrix:
+        linux:
+          image: ubuntu-latest
+        windows:
+          image: windows-latest
+    pool:
+      vmImage: $(image)
+    steps:
+      # Checkout + internal npm registry auth + Node + pnpm install
+      # (--frozen-lockfile --strict-peer-dependencies).
+      - template: include-prepare-repo.yml
+        parameters:
+          buildDirectory: $(buildDirectory)
+          nodeVersion: $(nodeVersion)
+          registry: $(REGISTRY)
+
+      # keytar links against libsecret at runtime on Linux; install before any
+      # TypeAgent process (CLI / shell) loads the native module.
+      - script: |
+          sudo apt install libsecret-1-0
+        displayName: Install libsecret-1-0
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+      - script: |
+          pnpm exec playwright install --with-deps
+        displayName: Install Playwright Browsers
+        workingDirectory: $(buildDirectory)/packages/shell
+
+      - script: |
+          npm run build
+        displayName: Build
+        workingDirectory: $(buildDirectory)
+
+      # Azure login + secret retrieval. getKeys.mjs authenticates via
+      # DefaultAzureCredential -> EnvironmentCredential using the service
+      # principal below, then writes ts/config.local.yaml. The three IDs mirror
+      # the GitHub workflow's federated-login inputs; CLIENT_SECRET is required
+      # here for a silent login — without it getKeys launches an interactive
+      # browser login and this step hangs until it times out.
+      #
+      # Secret-free alternative (Workload Identity Federation; matches the
+      # original OIDC, nothing to rotate). Create an ARM service connection with
+      # WIF, then replace this whole step with:
+      #   - task: AzureCLI@2
+      #     displayName: Get Keys
+      #     inputs:
+      #       azureSubscription: <your-ARM-WIF-service-connection>
+      #       scriptType: pscore
+      #       scriptLocation: inlineScript
+      #       workingDirectory: $(buildDirectory)
+      #       inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+      - script: |
+          node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+        displayName: Get Keys
+        workingDirectory: $(buildDirectory)
+        env:
+          AZURE_CLIENT_ID: $(CLIENT_ID)
+          AZURE_TENANT_ID: $(TENANT_ID)
+          AZURE_CLIENT_SECRET: $(CLIENT_SECRET)
+          AZURE_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+
+      # pwsh gives consistent single-quote argument grouping on Windows and
+      # Linux (matches the default shells GitHub Actions used).
+      - pwsh: |
+          npm run start:dev 'prompt' 'why is the sky blue'
+        displayName: Test CLI - smoke
+        workingDirectory: $(buildDirectory)/packages/cli
+
+      - script: |
+          npm run shell:test
+        displayName: Shell Tests - full (Windows)
+        workingDirectory: $(buildDirectory)/packages/shell
+        timeoutInMinutes: 60
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+      - bash: |
+          Xvfb :99 -screen 0 1600x1200x24 &
+          export DISPLAY=:99
+          npm run shell:smoke
+        displayName: Shell Tests - smoke (Linux)
+        workingDirectory: $(buildDirectory)/packages/shell
+        timeoutInMinutes: 60
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+      - bash: |
+          npm run test:live
+        displayName: Live Tests (Linux)
+        workingDirectory: $(buildDirectory)
+        timeoutInMinutes: 60
+        continueOnError: true
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
+      # Remove provisioned secrets even if a prior step failed.
+      - pwsh: |
+          node -e "try{require('fs').unlinkSync('./.env');}catch(e){}"
+          node -e "try{require('fs').unlinkSync('./config.local.yaml');}catch(e){}"
+        displayName: Clean up Keys
+        workingDirectory: $(buildDirectory)
+        condition: always()

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -121,10 +121,10 @@ jobs:
       # OpenAI User' on the Azure OpenAI resource(s).
       #
       # NOTE: the OIDC token is short-lived (~15 min). A step that first calls
-      # Azure OpenAI long after this one (e.g. Live Tests, which start after the
-      # up-to-60-min shell suite) can see it expire; give such a step its own
-      # AzureCLI@2 task if it needs a guaranteed-fresh login. Live Tests are
-      # non-blocking (continueOnError) so a late expiry won't fail the run.
+      # Azure OpenAI long after this one can see it expire. The quick CLI smoke
+      # and the shell suites call Azure OpenAI early enough to use this shared
+      # login; Live Tests run after the up-to-60-min shell suite, so they get
+      # their own AzureCLI@2 task (a fresh federated login) below.
       - task: AzureCLI@2
         displayName: Azure login + Get Keys
         inputs:
@@ -165,13 +165,31 @@ jobs:
         timeoutInMinutes: 60
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-      - bash: |
-          npm run test:live
+      # Live Tests run after the up-to-60-min shell suite, by which point the
+      # federated token the "Azure login + Get Keys" step published (~15 min
+      # lifetime) is long expired. So this step gets its own AzureCLI@2 task,
+      # which performs a fresh federated `az login` at start.
+      #
+      # We first clear the three published AZURE_* variables for this step only.
+      # They persist as job-wide env vars, so without this DefaultAzureCredential
+      # would try WorkloadIdentityCredential against the stale token file — a
+      # failed assertion exchange is a hard error that stops the chain, so it
+      # would never reach the fresh AzureCliCredential from this task's az login.
+      # Unsetting them makes the chain fall through to AzureCliCredential.
+      # Non-blocking (continueOnError) so a late auth issue won't fail the run.
+      - task: AzureCLI@2
         displayName: Live Tests (Linux)
-        workingDirectory: $(buildDirectory)
         timeoutInMinutes: 60
         continueOnError: true
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+        inputs:
+          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(buildDirectory)
+          inlineScript: |
+            unset AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_FEDERATED_TOKEN_FILE
+            npm run test:live
 
       # Remove provisioned secrets even if a prior step failed.
       - pwsh: |

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -13,10 +13,11 @@
 #     eol=lf`, so checkout produces LF on every OS regardless of core.autocrlf.
 #   * dorny/paths-filter is replaced by the trigger `paths` filter below.
 #   * azure/login (OIDC) is preserved via an Azure Resource Manager service
-#     connection that uses Workload Identity Federation: the Get Keys step runs
-#     inside an AzureCLI@2 task, which performs the federated (secret-free)
-#     login. getKeys.mjs then authenticates via DefaultAzureCredential ->
-#     AzureCliCredential, reusing that session. Nothing to rotate.
+#     connection that uses Workload Identity Federation. A single AzureCLI@2
+#     task performs the federated (secret-free) login, pulls the secrets, and
+#     publishes AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE so
+#     the later plain test steps authenticate to Azure OpenAI through
+#     @azure/identity's WorkloadIdentityCredential. Nothing to rotate.
 #
 # Prerequisites:
 #   * GitHub service connection - created when you set up this pipeline via
@@ -61,8 +62,8 @@ variables:
     value: "22"
   # Mirrors the GitHub workflow's env.NODE_OPTIONS. Non-secret pipeline variables
   # are surfaced to every script step as environment variables. Azure auth no
-  # longer needs secret variables — the Get Keys step logs in through the WIF
-  # service connection (see below).
+  # longer needs secret variables — the "Azure login + Get Keys" step signs in
+  # through the WIF service connection (see below).
   - name: NODE_OPTIONS
     value: --max_old_space_size=8192
 
@@ -108,25 +109,41 @@ jobs:
         displayName: Build
         workingDirectory: $(buildDirectory)
 
-      # Azure login + secret retrieval, secret-free via Workload Identity
-      # Federation. The AzureCLI@2 task signs in to Azure using the WIF service
-      # connection (no stored secret/cert — it exchanges a short-lived OIDC
-      # token at runtime). getKeys.mjs then authenticates via
-      # DefaultAzureCredential -> AzureCliCredential, reusing that az session,
-      # and writes ts/config.local.yaml. Reading 'build-pipeline-kv' relies on
-      # the connection's service principal holding the 'Key Vault Secrets User'
-      # RBAC role on the vault.
+      # Single federated (WIF) login for the whole job. addSpnToEnvironment
+      # surfaces the service connection's OIDC token; we persist it to a file and
+      # publish the three variables that @azure/identity's
+      # WorkloadIdentityCredential (part of DefaultAzureCredential v4) reads —
+      # AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE — so the
+      # later plain test steps reach Azure OpenAI without each needing its own
+      # AzureCLI task. getKeys runs here too, while az is signed in, and writes
+      # ts/config.local.yaml. The connection's service principal needs
+      # 'Key Vault Secrets User' on 'build-pipeline-kv' and 'Cognitive Services
+      # OpenAI User' on the Azure OpenAI resource(s).
+      #
+      # NOTE: the OIDC token is short-lived (~15 min). A step that first calls
+      # Azure OpenAI long after this one (e.g. Live Tests, which start after the
+      # up-to-60-min shell suite) can see it expire; give such a step its own
+      # AzureCLI@2 task if it needs a guaranteed-fresh login. Live Tests are
+      # non-blocking (continueOnError) so a late expiry won't fail the run.
       - task: AzureCLI@2
-        displayName: Get Keys
+        displayName: Azure login + Get Keys
         inputs:
           azureSubscription: 'MSOCTO-ADO-Service-Connection'
           scriptType: pscore
           scriptLocation: inlineScript
+          addSpnToEnvironment: true
           workingDirectory: $(buildDirectory)
-          inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+          inlineScript: |
+            $tokenFile = Join-Path "$(Agent.TempDirectory)" "wif-federated-token.txt"
+            Set-Content -Path $tokenFile -Value "$env:idToken" -NoNewline
+            Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
+            Write-Host "##vso[task.setvariable variable=AZURE_TENANT_ID]$env:tenantId"
+            Write-Host "##vso[task.setvariable variable=AZURE_FEDERATED_TOKEN_FILE]$tokenFile"
+            node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
 
       # pwsh gives consistent single-quote argument grouping on Windows and
-      # Linux (matches the default shells GitHub Actions used).
+      # Linux. Authenticates to Azure OpenAI via the AZURE_* WIF variables the
+      # login step published.
       - pwsh: |
           npm run start:dev 'prompt' 'why is the sky blue'
         displayName: Test CLI - smoke

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -12,26 +12,25 @@
 #   * "Setup Git LF" is dropped because .gitattributes already pins `* text
 #     eol=lf`, so checkout produces LF on every OS regardless of core.autocrlf.
 #   * dorny/paths-filter is replaced by the trigger `paths` filter below.
-#   * azure/login (OIDC) is replaced by a service-principal login: the CLIENT_ID
-#     / TENANT_ID / CLIENT_SECRET variables are passed to getKeys.mjs as AZURE_*
-#     env vars, which it consumes via DefaultAzureCredential ->
-#     EnvironmentCredential. A secret-free Workload Identity Federation variant
-#     is documented inline at the Get Keys step.
+#   * azure/login (OIDC) is preserved via an Azure Resource Manager service
+#     connection that uses Workload Identity Federation: the Get Keys step runs
+#     inside an AzureCLI@2 task, which performs the federated (secret-free)
+#     login. getKeys.mjs then authenticates via DefaultAzureCredential ->
+#     AzureCliCredential, reusing that session. Nothing to rotate.
 #
 # Prerequisites:
 #   * GitHub service connection - created when you set up this pipeline via
 #     StartRight (per the eng.ms integrate-ado guide). It lets Azure Pipelines
 #     read the repo AND report each run's status back to the PR. No YAML needed.
-#   * Pipeline variables (define in the pipeline UI or a linked variable group;
-#     mark the credential ones as secret):
+#   * Azure Resource Manager service connection (Workload Identity Federation) -
+#     'MSOCTO-ADO-Service-Connection'. The Get Keys step's AzureCLI@2 task uses
+#     it to log in without any stored secret or certificate. Its backing service
+#     principal must hold the 'Key Vault Secrets User' RBAC role on the
+#     'build-pipeline-kv' vault (the vault uses RBAC authorization, not access
+#     policies). Authorize the pipeline to use the connection on first run.
+#   * Pipeline variables (define in the pipeline UI or a linked variable group):
 #       - REGISTRY         npm registry URL used by include-prepare-repo.yml to
 #                          restore dependencies (internal Azure Artifacts feed).
-#       - CLIENT_ID        service principal (app) ID, its home
-#       - TENANT_ID        tenant, and target
-#       - SUBSCRIPTION_ID  subscription for reading 'build-pipeline-kv'.
-#       - CLIENT_SECRET    secret for that service principal. REQUIRED for a
-#                          silent CI login (see the Get Keys step); without it
-#                          getKeys falls back to interactive login and hangs.
 
 trigger:
   branches:
@@ -61,9 +60,9 @@ variables:
   - name: nodeVersion
     value: "22"
   # Mirrors the GitHub workflow's env.NODE_OPTIONS. Non-secret pipeline variables
-  # are surfaced to every script step as environment variables; secret variables
-  # (CLIENT_ID / TENANT_ID / CLIENT_SECRET / SUBSCRIPTION_ID) must be mapped
-  # explicitly via `env:` (done at the Get Keys step).
+  # are surfaced to every script step as environment variables. Azure auth no
+  # longer needs secret variables — the Get Keys step logs in through the WIF
+  # service connection (see below).
   - name: NODE_OPTIONS
     value: --max_old_space_size=8192
 
@@ -109,33 +108,22 @@ jobs:
         displayName: Build
         workingDirectory: $(buildDirectory)
 
-      # Azure login + secret retrieval. getKeys.mjs authenticates via
-      # DefaultAzureCredential -> EnvironmentCredential using the service
-      # principal below, then writes ts/config.local.yaml. The three IDs mirror
-      # the GitHub workflow's federated-login inputs; CLIENT_SECRET is required
-      # here for a silent login — without it getKeys launches an interactive
-      # browser login and this step hangs until it times out.
-      #
-      # Secret-free alternative (Workload Identity Federation; matches the
-      # original OIDC, nothing to rotate). Create an ARM service connection with
-      # WIF, then replace this whole step with:
-      #   - task: AzureCLI@2
-      #     displayName: Get Keys
-      #     inputs:
-      #       azureSubscription: <your-ARM-WIF-service-connection>
-      #       scriptType: pscore
-      #       scriptLocation: inlineScript
-      #       workingDirectory: $(buildDirectory)
-      #       inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
-      - script: |
-          node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+      # Azure login + secret retrieval, secret-free via Workload Identity
+      # Federation. The AzureCLI@2 task signs in to Azure using the WIF service
+      # connection (no stored secret/cert — it exchanges a short-lived OIDC
+      # token at runtime). getKeys.mjs then authenticates via
+      # DefaultAzureCredential -> AzureCliCredential, reusing that az session,
+      # and writes ts/config.local.yaml. Reading 'build-pipeline-kv' relies on
+      # the connection's service principal holding the 'Key Vault Secrets User'
+      # RBAC role on the vault.
+      - task: AzureCLI@2
         displayName: Get Keys
-        workingDirectory: $(buildDirectory)
-        env:
-          AZURE_CLIENT_ID: $(CLIENT_ID)
-          AZURE_TENANT_ID: $(TENANT_ID)
-          AZURE_CLIENT_SECRET: $(CLIENT_SECRET)
-          AZURE_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+        inputs:
+          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          workingDirectory: $(buildDirectory)
+          inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
 
       # pwsh gives consistent single-quote argument grouping on Windows and
       # Linux (matches the default shells GitHub Actions used).

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -119,23 +119,23 @@ jobs:
       # Secret-free alternative (Workload Identity Federation; matches the
       # original OIDC, nothing to rotate). Create an ARM service connection with
       # WIF, then replace this whole step with:
-      #   - task: AzureCLI@2
-      #     displayName: Get Keys
-      #     inputs:
-      #       azureSubscription: <your-ARM-WIF-service-connection>
-      #       scriptType: pscore
-      #       scriptLocation: inlineScript
-      #       workingDirectory: $(buildDirectory)
-      #       inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
-      - script: |
-          node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+      - task: AzureCLI@2
         displayName: Get Keys
-        workingDirectory: $(buildDirectory)
-        env:
-          AZURE_CLIENT_ID: $(CLIENT_ID)
-          AZURE_TENANT_ID: $(TENANT_ID)
-          AZURE_CLIENT_SECRET: $(CLIENT_SECRET)
-          AZURE_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+        inputs:
+          azureSubscription: <your-ARM-WIF-service-connection>
+          scriptType: pscore
+          scriptLocation: inlineScript
+          workingDirectory: $(buildDirectory)
+          inlineScript: node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+      # - script: |
+      #     node tools/scripts/getKeys.mjs --vault build-pipeline-kv --commit
+      #   displayName: Get Keys
+      #   workingDirectory: $(buildDirectory)
+      #   env:
+      #     AZURE_CLIENT_ID: $(CLIENT_ID)
+      #     AZURE_TENANT_ID: $(TENANT_ID)
+      #     AZURE_CLIENT_SECRET: $(CLIENT_SECRET)
+      #     AZURE_SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
 
       # pwsh gives consistent single-quote argument grouping on Windows and
       # Linux (matches the default shells GitHub Actions used).


### PR DESCRIPTION
This pull request adds a new Azure DevOps pipeline configuration for running smoke and live tests on the TypeAgent workspace. The pipeline mirrors the functionality of the existing GitHub Actions workflow but adapts it for Azure DevOps, with changes to authentication, permissions, and environment setup to fit the Azure environment.

**Azure DevOps pipeline for smoke and live tests:**

* Adds a new pipeline file, `pipelines/azure-smoke-tests.yml`, which defines jobs to run shell and CLI smoke tests, as well as long-running live tests, on both Linux and Windows agents.

**Key features and adaptations:**

* Uses Azure Resource Manager service connection with Workload Identity Federation for secure, secret-free authentication to Azure resources and Key Vault.
* Implements path-based triggers to only run the pipeline for changes in the TypeScript workspace or the pipeline config itself.
* Installs necessary dependencies (such as `libsecret-1-0` and Playwright browsers) and manages environment variables for Node.js and Azure authentication.
* Ensures long-running test suites each perform a fresh Azure login to avoid token expiration issues, and cleans up provisioned secrets at the end of the run.