### PR TITLE
TypeAgent Studio: Impact Report redesign + connection UX

### DIFF
--- a/ts/packages/cache/src/explanation/schemaInfoProvider.ts
+++ b/ts/packages/cache/src/explanation/schemaInfoProvider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import crypto from "node:crypto";
 import { ParamSpec } from "@typeagent/action-schema";
 import { ExecutableAction, FullAction } from "./requestAction.js";
 
@@ -55,6 +56,33 @@ export function getNamespaceForCache(
     }
 
     return schemaName;
+}
+
+/**
+ * Compute the schema-file hash that keys a schema's construction-cache
+ * namespace (`${schemaName},${hash}`). A construction only matches while this
+ * hash still equals the current schema's (see {@link isValidActionSchemaFileHash}),
+ * so editing or rebuilding a schema invalidates its cached constructions.
+ *
+ * The hash digests, in order, the JSON-serialized schema type, the schema
+ * source, and the optional sidecar paramSpec config (omitted when falsy, e.g.
+ * built `.pas.json` schemas that carry no sidecar). This is the single source of
+ * truth for the hash; producers (the dispatcher's schema cache) and consumers
+ * (cache-namespace validation, replay tooling) must share it so the namespace
+ * key stays consistent.
+ */
+export function computeActionSchemaFileHash(
+    schemaType: unknown,
+    source: string,
+    config?: string,
+): string {
+    const hash = crypto.createHash("sha256");
+    hash.update(JSON.stringify(schemaType));
+    hash.update(source);
+    if (config) {
+        hash.update(config);
+    }
+    return hash.digest("base64");
 }
 
 export function isValidActionSchemaFileHash(

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -54,6 +54,7 @@ export {
 export { AgentCacheFactory, getDefaultExplainerName } from "./cache/factory.js";
 export type { MatchResult, GrammarStore } from "./cache/types.js";
 export { GrammarStoreImpl } from "./cache/grammarStore.js";
+export { computeActionSchemaFileHash } from "./explanation/schemaInfoProvider.js";
 export { WildcardMode } from "./constructions/constructions.js";
 
 // Testing

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaFileCache.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaFileCache.ts
@@ -17,9 +17,8 @@ import {
 import { AppAction, SchemaFormat, SchemaTypeNames } from "@typeagent/agent-sdk";
 import { DeepPartialUndefined, simpleStarRegex } from "@typeagent/common-utils";
 import fs from "node:fs";
-import crypto from "node:crypto";
 import registerDebug from "debug";
-import { SchemaInfoProvider } from "agent-cache";
+import { SchemaInfoProvider, computeActionSchemaFileHash } from "agent-cache";
 import {
     getActionSchemaTypeName,
     getActivitySchemaTypeName,
@@ -29,13 +28,6 @@ import { getActionSchema } from "./actionSchemaUtils.js";
 
 const debug = registerDebug("typeagent:dispatcher:schema:cache");
 const debugError = registerDebug("typeagent:dispatcher:schema:cache:error");
-function hashStrings(...str: string[]) {
-    const hash = crypto.createHash("sha256");
-    for (const s of str) {
-        hash.update(s);
-    }
-    return hash.digest("base64");
-}
 
 const ActionSchemaFileCacheVersion = 3;
 
@@ -187,9 +179,11 @@ export class ActionSchemaFileCache {
             this.getSchemaSource(actionConfig);
 
         const schemaTypeString = JSON.stringify(actionConfig.schemaType);
-        const hash = config
-            ? hashStrings(schemaTypeString, source, config)
-            : hashStrings(schemaTypeString, source);
+        const hash = computeActionSchemaFileHash(
+            actionConfig.schemaType,
+            source,
+            config,
+        );
         const cacheKey = `${format}|${actionConfig.schemaName}|${schemaTypeString}|${fullPath ?? ""}`;
         const lastCached = this.prevSaved.get(cacheKey);
         if (lastCached !== undefined) {

--- a/ts/packages/dispatcher/dispatcher/test/actionSchemaFileCache.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/actionSchemaFileCache.spec.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import crypto from "node:crypto";
 import { ActionSchemaFileCache } from "../src/translation/actionSchemaFileCache.js";
 import { ActionConfig } from "../src/translation/actionConfig.js";
 import { SchemaContent } from "@typeagent/agent-sdk";
+import { computeActionSchemaFileHash } from "agent-cache";
 
 function makePasActionConfig(content: string): ActionConfig {
     const schemaFile: SchemaContent = {
@@ -181,29 +181,23 @@ describe("ActionSchemaFileCache", () => {
         });
 
         it("should produce different hashes when config differs", () => {
-            // This test verifies the consequence of the bug fix:
-            // when config is correctly included, the hash changes
-            // when config content changes, ensuring proper cache invalidation.
-
-            function hashStrings(...str: string[]) {
-                const hash = crypto.createHash("sha256");
-                for (const s of str) {
-                    hash.update(s);
-                }
-                return hash.digest("base64");
-            }
-
+            // The schema-file hash must include the sidecar paramSpec config so
+            // a config change invalidates the cache; folding config into the
+            // hash is what makes a stale config produce a different key.
             const schemaType = JSON.stringify("TestAction");
             const source = 'export type TestAction = { actionName: "test"; }';
             const config = '{"configKey": "configValue"}';
 
-            // With the fix: config is included in the hash
-            const hashWithConfig = hashStrings(schemaType, source, config);
-            const hashWithoutConfig = hashStrings(schemaType, source);
+            const hashWithConfig = computeActionSchemaFileHash(
+                schemaType,
+                source,
+                config,
+            );
+            const hashWithoutConfig = computeActionSchemaFileHash(
+                schemaType,
+                source,
+            );
 
-            // The hashes must differ - if config was dropped (the bug),
-            // both would be identical and config changes wouldn't
-            // invalidate the cache
             expect(hashWithConfig).not.toBe(hashWithoutConfig);
         });
     });

--- a/ts/packages/studio-service/src/studioServiceServer.ts
+++ b/ts/packages/studio-service/src/studioServiceServer.ts
@@ -5,8 +5,8 @@ import { WebSocketServer, WebSocket } from "ws";
 import { AddressInfo } from "node:net";
 import registerDebug from "debug";
 import { createRpc } from "@typeagent/agent-rpc/rpc";
-import type { RpcChannel } from "@typeagent/agent-rpc/channel";
 import { createAgentOriginAllowlist } from "@typeagent/websocket-utils/originAllowlist";
+import { createWebSocketRpcChannel } from "@typeagent/websocket-utils/rpcChannel";
 import type {
     StudioRuntime,
     StudioClientCallFunctions,
@@ -222,49 +222,4 @@ function parseBearerToken(
 }
 
 /** Adapt a `ws` WebSocket to the `agent-rpc` {@link RpcChannel} interface. */
-export function createWebSocketRpcChannel(socket: WebSocket): RpcChannel {
-    const messageHandlers = new Set<(message: any) => void>();
-    const disconnectHandlers = new Set<() => void>();
-    const onceMessage = new Set<(message: any) => void>();
-    const onceDisconnect = new Set<() => void>();
-
-    socket.on("message", (data) => {
-        let message: unknown;
-        try {
-            message = JSON.parse(data.toString());
-        } catch {
-            return; // ignore non-JSON frames
-        }
-        for (const h of messageHandlers) h(message);
-        for (const h of onceMessage.values()) {
-            onceMessage.delete(h);
-            h(message);
-        }
-    });
-    socket.on("close", () => {
-        for (const h of disconnectHandlers) h();
-        for (const h of onceDisconnect.values()) {
-            onceDisconnect.delete(h);
-            h();
-        }
-    });
-
-    return {
-        on(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? messageHandlers : disconnectHandlers).add(
-                cb,
-            );
-        },
-        once(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? onceMessage : onceDisconnect).add(cb);
-        },
-        off(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? messageHandlers : disconnectHandlers).delete(
-                cb,
-            );
-        },
-        send(message: unknown, cb?: (err: Error | null) => void) {
-            socket.send(JSON.stringify(message), (err) => cb?.(err ?? null));
-        },
-    };
-}
+export { createWebSocketRpcChannel };

--- a/ts/packages/typeagent-core/package.json
+++ b/ts/packages/typeagent-core/package.json
@@ -23,6 +23,7 @@
     "./replay": "./dist/replay/index.js",
     "./replayResolver": "./dist/replay/grammarResolver.js",
     "./onboardingBridge": "./dist/onboardingBridge/index.js",
+    "./webview": "./dist/webview/index.js",
     "./runtime": "./dist/runtime/index.js"
   },
   "types": "./dist/index.d.ts",

--- a/ts/packages/typeagent-core/src/index.ts
+++ b/ts/packages/typeagent-core/src/index.ts
@@ -12,3 +12,4 @@ export * as health from "./health/index.js";
 export * as collisions from "./collisions/index.js";
 export * as replay from "./replay/index.js";
 export * as onboardingBridge from "./onboardingBridge/index.js";
+export * as webview from "./webview/index.js";

--- a/ts/packages/typeagent-core/src/replay/constructionCacheResolver.ts
+++ b/ts/packages/typeagent-core/src/replay/constructionCacheResolver.ts
@@ -29,9 +29,9 @@
  * is `absent` and the resolver degrades cleanly to the grammar match.
  */
 
-import crypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import {
+    computeActionSchemaFileHash,
     loadConstructionCacheFile,
     type ConstructionCache,
     type MatchResult,
@@ -57,19 +57,17 @@ export interface SchemaHashInput {
 }
 
 /**
- * Recompute the dispatcher's schema-file `sourceHash`. Must match
- * `hashStrings(schemaTypeString, source[, config])` in
- * `dispatcher/.../actionSchemaFileCache.ts` byte-for-byte so the resulting
- * namespace key equals the one the dispatcher stamped into the cache.
+ * Recompute the dispatcher's schema-file `sourceHash` so the resulting namespace
+ * key equals the one the dispatcher stamped into the cache. Delegates to the
+ * shared {@link computeActionSchemaFileHash}, the single source of truth the
+ * dispatcher's schema cache also uses, so the two cannot drift.
  */
 export function reproduceSchemaSourceHash(input: SchemaHashInput): string {
-    const hash = crypto.createHash("sha256");
-    hash.update(JSON.stringify(input.schemaType));
-    hash.update(input.source);
-    if (input.config !== undefined) {
-        hash.update(input.config);
-    }
-    return hash.digest("base64");
+    return computeActionSchemaFileHash(
+        input.schemaType,
+        input.source,
+        input.config,
+    );
 }
 
 export type ConstructionCacheStatus =

--- a/ts/packages/typeagent-core/src/replay/grammarResolver.ts
+++ b/ts/packages/typeagent-core/src/replay/grammarResolver.ts
@@ -242,7 +242,15 @@ async function readFileAtVersion(
         .join("/");
     const { stdout } = await execFileAsync(
         "git",
-        ["-C", gitRoot, "show", `${version.ref}:${relPath}`],
+        // `--end-of-options` stops a ref that begins with `-` from being parsed
+        // as a `git show` option (e.g. `--output=…` would write a file).
+        [
+            "-C",
+            gitRoot,
+            "show",
+            "--end-of-options",
+            `${version.ref}:${relPath}`,
+        ],
         { maxBuffer: 16 * 1024 * 1024 },
     );
     return stdout;

--- a/ts/packages/typeagent-core/src/sandbox/agentRef.ts
+++ b/ts/packages/typeagent-core/src/sandbox/agentRef.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Resolve an agent reference (a bare name, a `packages/agents/<name>` path, or
+ * an arbitrary directory/file path) to the agent's package name.
+ */
+export function resolveAgentName(agentRef: string): string {
+    let normalized = agentRef.replace(/\\/g, "/");
+    while (normalized.endsWith("/")) {
+        normalized = normalized.slice(0, -1);
+    }
+    const marker = "packages/agents/";
+    const markerAt = normalized.lastIndexOf(marker);
+    if (markerAt >= 0) {
+        const rest = normalized.slice(markerAt + marker.length);
+        const name = rest.split("/")[0];
+        if (name) {
+            return name;
+        }
+    }
+    const tail = normalized.split("/").pop() ?? agentRef;
+    return tail.replace(/\.[^.]+$/, "") || agentRef;
+}

--- a/ts/packages/typeagent-core/src/sandbox/agentRef.ts
+++ b/ts/packages/typeagent-core/src/sandbox/agentRef.ts
@@ -2,14 +2,47 @@
 // Licensed under the MIT License.
 
 /**
- * Resolve an agent reference (a bare name, a `packages/agents/<name>` path, or
- * an arbitrary directory/file path) to the agent's package name.
+ * Resolve an agent reference (a bare name, a path under a configured agent
+ * root, a conventional `packages/agents/<name>` path, or an arbitrary
+ * directory/file path) to the agent's package name.
+ *
+ * When the configured {@link agentRoots} are supplied, a reference that sits
+ * under one of them resolves to the first path segment after that root — so the
+ * name is correct for any configured source, not just the default monorepo
+ * layout. The hard-coded `packages/agents/` marker is only a fallback for
+ * references that don't match a known root (e.g. a path captured before roots
+ * were configured); a bare name passes through unchanged.
  */
-export function resolveAgentName(agentRef: string): string {
+export function resolveAgentName(
+    agentRef: string,
+    agentRoots?: readonly string[],
+): string {
     let normalized = agentRef.replace(/\\/g, "/");
     while (normalized.endsWith("/")) {
         normalized = normalized.slice(0, -1);
     }
+
+    // Prefer deriving the name relative to a configured agent root: the first
+    // segment after the root is the agent's package dir. Try the longest (most
+    // specific) matching root so nested roots resolve correctly.
+    if (agentRoots && agentRoots.length > 0) {
+        const roots = [...agentRoots]
+            .map((r) => r.replace(/\\/g, "/").replace(/\/+$/, ""))
+            .filter((r) => r.length > 0)
+            .sort((a, b) => b.length - a.length);
+        for (const root of roots) {
+            const prefix = `${root}/`;
+            if (normalized.startsWith(prefix)) {
+                const name = normalized.slice(prefix.length).split("/")[0];
+                if (name) {
+                    return name;
+                }
+            }
+        }
+    }
+
+    // Fallback for the conventional monorepo layout when no configured root
+    // matched.
     const marker = "packages/agents/";
     const markerAt = normalized.lastIndexOf(marker);
     if (markerAt >= 0) {

--- a/ts/packages/typeagent-core/src/sandbox/agentRef.ts
+++ b/ts/packages/typeagent-core/src/sandbox/agentRef.ts
@@ -17,17 +17,14 @@ export function resolveAgentName(
     agentRef: string,
     agentRoots?: readonly string[],
 ): string {
-    let normalized = agentRef.replace(/\\/g, "/");
-    while (normalized.endsWith("/")) {
-        normalized = normalized.slice(0, -1);
-    }
+    const normalized = stripTrailingSlashes(agentRef.replace(/\\/g, "/"));
 
     // Prefer deriving the name relative to a configured agent root: the first
     // segment after the root is the agent's package dir. Try the longest (most
     // specific) matching root so nested roots resolve correctly.
     if (agentRoots && agentRoots.length > 0) {
         const roots = [...agentRoots]
-            .map((r) => r.replace(/\\/g, "/").replace(/\/+$/, ""))
+            .map((r) => stripTrailingSlashes(r.replace(/\\/g, "/")))
             .filter((r) => r.length > 0)
             .sort((a, b) => b.length - a.length);
         for (const root of roots) {
@@ -54,4 +51,13 @@ export function resolveAgentName(
     }
     const tail = normalized.split("/").pop() ?? agentRef;
     return tail.replace(/\.[^.]+$/, "") || agentRef;
+}
+
+/** Strip any trailing `/` characters without a backtracking-prone regex. */
+function stripTrailingSlashes(p: string): string {
+    let end = p.length;
+    while (end > 0 && p[end - 1] === "/") {
+        end--;
+    }
+    return p.slice(0, end);
 }

--- a/ts/packages/typeagent-core/src/sandbox/inMemorySandboxManager.ts
+++ b/ts/packages/typeagent-core/src/sandbox/inMemorySandboxManager.ts
@@ -18,6 +18,7 @@ import {
     type SandboxManager,
     type SandboxStatus,
 } from "./types.js";
+import { resolveAgentName } from "./agentRef.js";
 
 export interface InMemorySandboxManagerOptions {
     /** Event sink for sandbox lifecycle events. */
@@ -40,7 +41,7 @@ interface InternalSandbox {
  * string. Real dispatcher integration replaces this in a later chunk.
  */
 const defaultAgentLoader: AgentLoader = async (_sandboxId, agentRef) => {
-    const name = deriveAgentName(agentRef);
+    const name = resolveAgentName(agentRef);
     return {
         name,
         schemaHash: "stub",
@@ -49,12 +50,6 @@ const defaultAgentLoader: AgentLoader = async (_sandboxId, agentRef) => {
         sourcePath: agentRef,
     };
 };
-
-function deriveAgentName(agentRef: string): string {
-    const normalized = agentRef.replace(/\\/g, "/");
-    const tail = normalized.split("/").pop() ?? agentRef;
-    return tail.replace(/\.[^.]+$/, "") || agentRef;
-}
 
 /**
  * In-memory implementation of `SandboxManager`.

--- a/ts/packages/typeagent-core/src/sandbox/repoAgentLoader.ts
+++ b/ts/packages/typeagent-core/src/sandbox/repoAgentLoader.ts
@@ -10,7 +10,10 @@ import {
     type HealthFinding,
     type HealthService,
 } from "../health/index.js";
+import { resolveAgentName } from "./agentRef.js";
 import type { AgentLoader, HealthStatus, SandboxAgentInfo } from "./types.js";
+
+export { resolveAgentName };
 
 export interface RepoAgentLoaderOptions {
     /** Repository root that contains `packages/agents/<name>`. */
@@ -30,28 +33,6 @@ export interface RepoAgentLoaderOptions {
 }
 
 const NO_FILES_HASH = "none";
-
-/**
- * Resolve an agent reference (a bare name, a `packages/agents/<name>` path, or
- * an arbitrary directory/file path) to the agent's package name.
- */
-export function resolveAgentName(agentRef: string): string {
-    let normalized = agentRef.replace(/\\/g, "/");
-    while (normalized.endsWith("/")) {
-        normalized = normalized.slice(0, -1);
-    }
-    const marker = "packages/agents/";
-    const markerAt = normalized.lastIndexOf(marker);
-    if (markerAt >= 0) {
-        const rest = normalized.slice(markerAt + marker.length);
-        const name = rest.split("/")[0];
-        if (name) {
-            return name;
-        }
-    }
-    const tail = normalized.split("/").pop() ?? agentRef;
-    return tail.replace(/\.[^.]+$/, "") || agentRef;
-}
 
 /**
  * Map a set of health findings to the coarse badge used by sandbox status.

--- a/ts/packages/typeagent-core/src/sandbox/repoAgentLoader.ts
+++ b/ts/packages/typeagent-core/src/sandbox/repoAgentLoader.ts
@@ -73,8 +73,8 @@ export function createRepoAgentLoader(
         _sandboxId: string,
         agentRef: string,
     ): Promise<Omit<SandboxAgentInfo, "loadedAt">> => {
-        const name = resolveAgentName(agentRef);
         const agentRoots = resolveAgentRoots(options.agentRoots, repoRoot);
+        const name = resolveAgentName(agentRef, agentRoots);
         const files = await discoverAgentFiles(agentRoots, name);
 
         const located =

--- a/ts/packages/typeagent-core/src/webview/index.ts
+++ b/ts/packages/typeagent-core/src/webview/index.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Shared helpers for VS Code webview hosts. Kept free of `vscode`/DOM so they
+ * can be reused by any extension surface and unit-tested in isolation.
+ */
+
+import { randomBytes } from "node:crypto";
+
+/**
+ * Generate a per-load nonce (base64) for a webview's Content-Security-Policy
+ * `script-src`/`style-src`. Uses a cryptographically strong random source so
+ * the nonce cannot be predicted by injected content; the value is unique per
+ * call and is meant to be regenerated on every webview render.
+ */
+export function createWebviewNonce(): string {
+    return randomBytes(16).toString("base64");
+}

--- a/ts/packages/typeagent-core/test/repoAgentLoader.spec.ts
+++ b/ts/packages/typeagent-core/test/repoAgentLoader.spec.ts
@@ -85,6 +85,42 @@ describe("resolveAgentName", () => {
     it("ignores a trailing slash", () => {
         expect(resolveAgentName("packages/agents/photo/")).toBe("photo");
     });
+
+    it("derives the name relative to a configured agent root", () => {
+        expect(
+            resolveAgentName("/custom/agents/weather/src", ["/custom/agents"]),
+        ).toBe("weather");
+    });
+
+    it("uses a configured root over the packages/agents marker", () => {
+        // The ref also contains `packages/agents`, but the configured root is
+        // more specific and wins.
+        expect(
+            resolveAgentName("/work/packages/agents/extra/email/src/manifest", [
+                "/work/packages/agents/extra",
+            ]),
+        ).toBe("email");
+    });
+
+    it("prefers the longest matching configured root", () => {
+        expect(resolveAgentName("/a/b/c/calendar/src", ["/a", "/a/b/c"])).toBe(
+            "calendar",
+        );
+    });
+
+    it("matches a configured root regardless of path separators", () => {
+        expect(
+            resolveAgentName("C:\\custom\\agents\\notes", ["C:/custom/agents"]),
+        ).toBe("notes");
+    });
+
+    it("falls back to the marker when no configured root matches", () => {
+        expect(
+            resolveAgentName("C:/repo/ts/packages/agents/calendar/src", [
+                "/some/other/root",
+            ]),
+        ).toBe("calendar");
+    });
 });
 
 describe("summarizeFindingsToHealth", () => {

--- a/ts/packages/typeagent-studio/.gitignore
+++ b/ts/packages/typeagent-studio/.gitignore
@@ -1,0 +1,2 @@
+# Generated icon font, copied from @vscode/codicons at build time (esbuild.mjs).
+media/codicon.ttf

--- a/ts/packages/typeagent-studio/README.md
+++ b/ts/packages/typeagent-studio/README.md
@@ -25,7 +25,6 @@ pnpm run build
 
 Current command palette surface:
 
-- TypeAgent Studio: Hello (skeleton)
 - TypeAgent Studio: Start onboarding session
 - TypeAgent Studio: Ask TypeAgent about this...
 - TypeAgent Studio: Install latest onboarding session to sandbox

--- a/ts/packages/typeagent-studio/esbuild.mjs
+++ b/ts/packages/typeagent-studio/esbuild.mjs
@@ -36,6 +36,30 @@ function copyRuntimeAssets() {
         "../actionGrammar/src/builtInEntities.agr",
     );
     fs.copyFileSync(builtInEntities, "dist/builtInEntities.agr");
+    copyCodiconFont();
+}
+
+/**
+ * Copy the codicon icon font next to the webview stylesheet so the Impact Report
+ * can render VS Code's native icon set. `media/` is a `localResourceRoot`, so the
+ * webview can load the font under the existing `font-src ${cspSource}` policy; the
+ * stylesheet `@font-face`s it by the relative `codicon.ttf` path. The `.ttf` is
+ * generated (gitignored) and shipped in the `.vsix` from disk by vsce.
+ */
+function copyCodiconFont() {
+    const candidates = [
+        path.resolve("node_modules/@vscode/codicons/dist/codicon.ttf"),
+        path.resolve("../../node_modules/@vscode/codicons/dist/codicon.ttf"),
+    ];
+    const src = candidates.find((p) => fs.existsSync(p));
+    if (src) {
+        fs.mkdirSync("media", { recursive: true });
+        fs.copyFileSync(src, "media/codicon.ttf");
+    } else {
+        console.warn(
+            "typeagent-studio: codicon.ttf not found; icons will fall back to text.",
+        );
+    }
 }
 
 /** @type {import('esbuild').BuildOptions} */

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -524,7 +524,7 @@ td.resolution {
 td.latency {
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
-  text-align: right;
+  text-align: left;
   font-variant-numeric: tabular-nums;
 }
 

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -193,9 +193,15 @@ td {
   vertical-align: top;
 }
 
-td.detail {
+td.resolution {
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
+}
+
+td.latency {
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+  text-align: right;
 }
 
 .status-equal {
@@ -249,7 +255,16 @@ td.detail {
 }
 
 .filter-chip.is-empty {
-  opacity: 0.5;
+  opacity: 0.45;
+  cursor: default;
+}
+
+.filter-chip:disabled {
+  cursor: default;
+}
+
+.filter-chip:disabled:hover {
+  border-color: var(--vscode-panel-border);
 }
 
 .empty-state {

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -18,50 +18,6 @@ body {
   display: none !important;
 }
 
-.context-header {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding: 6px 10px;
-  margin-bottom: 10px;
-  font-size: 12px;
-  border: 1px solid var(--vscode-panel-border);
-  border-radius: 2px;
-  background: var(
-    --vscode-editorWidget-background,
-    var(--vscode-editor-background)
-  );
-}
-
-.context-header:empty {
-  display: none;
-}
-
-.context-item {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  cursor: help;
-}
-
-.context-label {
-  color: var(--vscode-descriptionForeground);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 10px;
-}
-
-.context-value {
-  color: var(--vscode-foreground);
-  font-weight: 600;
-}
-
-.context-sep {
-  color: var(--vscode-descriptionForeground);
-  opacity: 0.6;
-}
-
 .toolbar {
   display: flex;
   align-items: center;
@@ -88,6 +44,12 @@ body {
   cursor: default;
 }
 
+.icon-button {
+  padding: 3px 9px;
+  font-size: 14px;
+  line-height: 1;
+}
+
 .agent-select {
   color: var(--vscode-dropdown-foreground);
   background: var(--vscode-dropdown-background);
@@ -98,18 +60,8 @@ body {
 
 .version-field {
   display: inline-flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 4px;
-}
-
-.version-method {
-  flex-basis: 100%;
-  text-align: right;
-  color: var(--vscode-descriptionForeground);
-  font-size: 11px;
-  font-style: italic;
-  min-height: 13px;
 }
 
 .version-label {
@@ -126,24 +78,9 @@ body {
   border-radius: 2px;
 }
 
-.comparison {
-  color: var(--vscode-descriptionForeground);
-  font-size: 12px;
-  margin-bottom: 8px;
-}
-
-.comparison:empty {
-  display: none;
-}
-
 .status {
   color: var(--vscode-descriptionForeground);
   margin-left: auto;
-}
-
-.summary {
-  font-weight: 600;
-  margin-bottom: 8px;
 }
 
 .banner {
@@ -156,12 +93,6 @@ body {
 
 .banner:empty {
   display: none;
-}
-
-.banner-note {
-  color: var(--vscode-descriptionForeground);
-  background: var(--vscode-textBlockQuote-background);
-  border-left-color: var(--vscode-charts-yellow);
 }
 
 .banner-error {

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -10,6 +10,14 @@ body {
   margin: 0;
 }
 
+/* Class display rules (e.g. `.filters { display: flex }`) outrank the UA
+   `[hidden] { display: none }` by specificity, so an explicit rule is needed
+   for `el.hidden` to actually hide flex containers (the CSP forbids inline
+   `style=""`, so visibility is toggled via the hidden attribute). */
+[hidden] {
+  display: none !important;
+}
+
 .context-header {
   display: flex;
   align-items: center;
@@ -210,4 +218,58 @@ td.detail {
   color: var(--vscode-descriptionForeground);
   font-style: italic;
   margin-top: 8px;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 10px 0 4px;
+}
+
+.filter-chip {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 2px 10px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+}
+
+.filter-chip:hover {
+  border-color: var(--vscode-focusBorder);
+}
+
+.filter-chip.is-active {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  border-color: var(--vscode-badge-background);
+}
+
+.filter-chip.is-empty {
+  opacity: 0.5;
+}
+
+.empty-state {
+  border: 1px dashed var(--vscode-panel-border);
+  border-radius: 4px;
+  padding: 18px 16px;
+  margin-top: 12px;
+  background: var(
+    --vscode-editorWidget-background,
+    var(--vscode-editor-background)
+  );
+}
+
+.empty-state-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.empty-state-hint {
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+  line-height: 1.5;
 }

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -1,125 +1,412 @@
 /* Copyright (c) Microsoft Corporation.
    Licensed under the MIT License. */
 
+/* The codicon icon font ships next to this stylesheet (copied from
+   @vscode/codicons at build time) so the report can use VS Code's native icon
+   set under the webview's font-src policy. */
+@font-face {
+  font-family: "codicon";
+  font-display: block;
+  src: url("codicon.ttf") format("truetype");
+}
+
+:root {
+  --ta-gap: 6px;
+  --ta-radius: 4px;
+  --ta-row-height: 22px;
+}
+
+html,
+body {
+  height: 100%;
+}
+
 body {
   font-family: var(--vscode-font-family);
   font-size: var(--vscode-font-size);
   color: var(--vscode-foreground);
   background: var(--vscode-editor-background);
-  padding: 12px;
+  padding: 0;
   margin: 0;
 }
 
-/* Class display rules (e.g. `.filters { display: flex }`) outrank the UA
-   `[hidden] { display: none }` by specificity, so an explicit rule is needed
-   for `el.hidden` to actually hide flex containers (the CSP forbids inline
-   `style=""`, so visibility is toggled via the hidden attribute). */
+#root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* Class display rules outrank the UA `[hidden] { display: none }` by
+   specificity, so an explicit rule is needed for `el.hidden` to hide flex
+   containers (the CSP forbids inline `style=""`). */
 [hidden] {
   display: none !important;
 }
 
-.toolbar {
+/* --- Codicon base -------------------------------------------------------- */
+.codicon {
+  font: normal normal normal 16px/1 codicon;
+  display: inline-block;
+  text-decoration: none;
+  text-rendering: auto;
+  text-align: center;
+  vertical-align: middle;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+}
+
+.codicon-play::before {
+  content: "\eb2c";
+}
+.codicon-refresh::before {
+  content: "\eb37";
+}
+.codicon-arrow-swap::before {
+  content: "\ebcb";
+}
+.codicon-chevron-down::before {
+  content: "\eab4";
+}
+.codicon-close::before {
+  content: "\ea76";
+}
+.codicon-diff-added::before {
+  content: "\eadc";
+}
+.codicon-diff-modified::before {
+  content: "\eade";
+}
+.codicon-diff-removed::before {
+  content: "\eadf";
+}
+.codicon-pass::before {
+  content: "\eba4";
+}
+.codicon-error::before {
+  content: "\ea87";
+}
+.codicon-warning::before {
+  content: "\ea6c";
+}
+.codicon-arrow-right::before {
+  content: "\ea9c";
+}
+.codicon-list-filter::before {
+  content: "\eb83";
+}
+.codicon-git-compare::before {
+  content: "\eafd";
+}
+.codicon-library::before {
+  content: "\eb9c";
+}
+
+/* --- Action bar (the native editor toolbar) ------------------------------ */
+.action-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--ta-gap);
   flex-wrap: wrap;
-  margin-bottom: 12px;
+  padding: 6px 10px;
+  background: var(--vscode-editor-background);
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex: 0 0 auto;
 }
 
-.toolbar button {
-  color: var(--vscode-button-foreground);
-  background: var(--vscode-button-background);
-  border: none;
-  padding: 4px 12px;
-  border-radius: 2px;
-  cursor: pointer;
-}
-
-.toolbar button:hover:not(:disabled) {
-  background: var(--vscode-button-hoverBackground);
-}
-
-.toolbar button:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.icon-button {
-  padding: 3px 9px;
-  font-size: 14px;
-  line-height: 1;
-}
-
-.picker-field {
+.bar-group {
   display: inline-flex;
   align-items: center;
   gap: 4px;
 }
 
-.picker-label {
+.bar-spacer {
+  flex: 1 1 auto;
+}
+
+.bar-sep {
+  width: 1px;
+  align-self: stretch;
+  margin: 2px 4px;
+  background: var(--vscode-panel-border);
+}
+
+.bar-prefix {
   color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* The read-only agent label: the report's subject, paired with a library icon
+   in the action bar (also reflected in the panel tab title). */
+.agent-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--vscode-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 18em;
+}
+
+.bar-group > .codicon-library {
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Picker controls read as native dropdowns: value + trailing chevron. */
+.picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 20em;
+  min-width: 6em;
+  height: 24px;
+  padding: 0 6px 0 8px;
+  color: var(--vscode-dropdown-foreground);
+  background: var(--vscode-dropdown-background);
+  border: 1px solid var(--vscode-dropdown-border, transparent);
+  border-radius: var(--ta-radius);
+  cursor: pointer;
+  font-family: inherit;
   font-size: 12px;
 }
 
-/* Picker buttons read as dropdowns, not primary actions, so override the
-   .toolbar button fill with the dropdown palette. */
-.toolbar button.picker-button {
-  color: var(--vscode-dropdown-foreground);
-  background: var(--vscode-dropdown-background);
-  border: 1px solid var(--vscode-dropdown-border);
-  padding: 3px 8px;
-  min-width: 7em;
-  max-width: 18em;
-  text-align: left;
-}
-
-.toolbar button.picker-button:hover:not(:disabled) {
+.picker:hover:not(:disabled) {
   background: var(
     --vscode-list-hoverBackground,
     var(--vscode-dropdown-background)
   );
 }
 
+.picker:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.picker:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .picker-value {
-  display: inline-block;
-  max-width: 16em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  vertical-align: bottom;
+}
+
+.picker .codicon-chevron-down {
+  font-size: 12px;
+  margin-left: auto;
+  color: var(--vscode-descriptionForeground);
+}
+
+.picker-side {
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Toolbar icon buttons (run, swap, reconnect, close). */
+.tool-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 24px;
+  min-width: 24px;
+  padding: 0 6px;
+  color: var(--vscode-foreground);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--ta-radius);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.tool-button:hover:not(:disabled) {
+  background: var(
+    --vscode-toolbar-hoverBackground,
+    var(--vscode-list-hoverBackground)
+  );
+}
+
+.tool-button:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.tool-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* The Run button is the one primary action, so it carries the button fill. */
+.tool-button.is-primary {
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+  padding: 0 12px;
+  font-weight: 600;
+}
+
+.tool-button.is-primary:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground);
+}
+
+/* --- Sub-bar: provenance + run status ------------------------------------ */
+.sub-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px;
+  min-height: 22px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  flex: 0 0 auto;
+  font-size: 12px;
+}
+
+.sub-bar:empty {
+  display: none;
+}
+
+.provenance {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--vscode-descriptionForeground);
+  font-family: var(--vscode-editor-font-family, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.provenance .codicon-arrow-right {
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .status {
   color: var(--vscode-descriptionForeground);
   margin-left: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.banner {
-  margin-bottom: 8px;
-  padding: 6px 10px;
-  border-radius: 2px;
-  border-left: 3px solid transparent;
+/* --- Inline notification (errors) ---------------------------------------- */
+.notification {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 8px 12px 0;
+  padding: 8px 10px;
+  border-radius: var(--ta-radius);
+  border: 1px solid
+    var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+  background: var(--vscode-inputValidation-errorBackground);
+  color: var(
+    --vscode-inputValidation-errorForeground,
+    var(--vscode-foreground)
+  );
   font-size: 12px;
 }
 
-.banner:empty {
+.notification:empty {
   display: none;
 }
 
-.banner-error {
-  color: var(
-    --vscode-inputValidation-errorForeground,
-    var(--vscode-errorForeground)
-  );
-  background: var(--vscode-inputValidation-errorBackground);
-  border-left-color: var(--vscode-errorForeground);
+.notification .codicon {
+  color: var(--vscode-errorForeground);
+  flex: 0 0 auto;
 }
 
-.banner-provenance {
+/* --- Scrolling content area ---------------------------------------------- */
+.content {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 0 0 16px;
+}
+
+/* --- Filter segmented control -------------------------------------------- */
+.filters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 12px 4px;
+}
+
+.filters-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 4px;
   color: var(--vscode-descriptionForeground);
-  background: var(--vscode-textBlockQuote-background);
-  border-left-color: var(--vscode-textLink-foreground);
-  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: inherit;
+  font-size: 11px;
+  height: 20px;
+  padding: 0 9px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+}
+
+.filter-chip:hover:not(:disabled) {
+  border-color: var(--vscode-focusBorder);
+}
+
+.filter-chip:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+}
+
+.filter-chip .chip-count {
+  color: var(--vscode-descriptionForeground);
+  font-variant-numeric: tabular-nums;
+}
+
+.filter-chip.is-active {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  border-color: var(--vscode-badge-background);
+}
+
+.filter-chip.is-active .chip-count {
+  color: var(--vscode-badge-foreground);
+}
+
+.filter-chip.is-empty {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.filter-chip:disabled {
+  cursor: default;
+}
+
+/* A status dot mirrors the row status colour on each chip. The status-* classes
+   set the text colour; the dot fills from currentColor. */
+.chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: currentColor;
+}
+
+/* --- Results list (styled like a native tree/list) ----------------------- */
+.table-wrap {
+  padding: 4px 0 0;
 }
 
 table {
@@ -128,29 +415,63 @@ table {
   font-size: 13px;
 }
 
-th {
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   text-align: left;
   color: var(--vscode-descriptionForeground);
+  background: var(--vscode-editor-background);
   border-bottom: 1px solid var(--vscode-panel-border);
-  padding: 4px 8px;
+  padding: 4px 10px;
   font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
 }
 
-td {
-  padding: 3px 8px;
-  border-bottom: 1px solid var(--vscode-panel-border);
-  vertical-align: top;
+tbody td {
+  padding: 0 10px;
+  height: var(--ta-row-height);
+  border: none;
+  vertical-align: middle;
+}
+
+tbody tr {
+  border-bottom: 1px solid transparent;
+}
+
+tbody tr:hover td {
+  background: var(--vscode-list-hoverBackground);
+}
+
+td.col-status {
+  white-space: nowrap;
+}
+
+.status-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.status-cell .codicon {
+  font-size: 14px;
 }
 
 td.resolution {
-  color: var(--vscode-descriptionForeground);
+  color: var(--vscode-foreground);
   white-space: nowrap;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 12px;
 }
 
 td.latency {
   color: var(--vscode-descriptionForeground);
   white-space: nowrap;
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .status-equal {
@@ -173,9 +494,9 @@ tr.row-clickable {
   cursor: pointer;
 }
 
-tr.row-clickable:hover td,
-tr.row-clickable:focus-visible td {
-  background: var(--vscode-list-hoverBackground);
+tr.row-clickable:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 tr.row-open td {
@@ -183,21 +504,29 @@ tr.row-open td {
   color: var(--vscode-list-activeSelectionForeground);
 }
 
+tr.row-open td.resolution,
+tr.row-open td.latency {
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* --- Detail pane (a peek-style action diff) ------------------------------ */
 .detail-pane {
-  margin-top: 12px;
+  margin: 10px 12px 0;
   border: 1px solid var(--vscode-panel-border);
-  border-radius: 4px;
+  border-radius: var(--ta-radius);
   background: var(
     --vscode-editorWidget-background,
     var(--vscode-editor-background)
   );
+  box-shadow: 0 2px 8px var(--vscode-widget-shadow, transparent);
+  overflow: hidden;
 }
 
 .detail-header {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 6px 10px;
+  padding: 6px 8px 6px 12px;
   border-bottom: 1px solid var(--vscode-panel-border);
 }
 
@@ -209,9 +538,24 @@ tr.row-open td {
 }
 
 .detail-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.detail-meta .added {
+  color: var(
+    --vscode-charts-green,
+    var(--vscode-gitDecoration-addedResourceForeground)
+  );
+}
+
+.detail-meta .removed {
+  color: var(--vscode-errorForeground);
 }
 
 .detail-close {
@@ -219,23 +563,28 @@ tr.row-open td {
 }
 
 .detail-legend {
-  padding: 4px 10px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px 0;
   color: var(--vscode-descriptionForeground);
   font-size: 11px;
 }
 
 .detail-diff {
   margin: 0;
-  padding: 8px 10px;
+  padding: 8px 12px 10px;
   overflow-x: auto;
   font-family: var(--vscode-editor-font-family, monospace);
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 .diff-line {
   display: block;
   white-space: pre;
+  padding: 0 4px;
+  border-radius: 2px;
 }
 
 .diff-added {
@@ -261,68 +610,34 @@ tr.row-open td {
 .truncation {
   color: var(--vscode-descriptionForeground);
   font-style: italic;
-  margin-top: 8px;
+  padding: 8px 12px 0;
 }
 
-.filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin: 10px 0 4px;
-}
-
-.filter-chip {
-  font-family: inherit;
-  font-size: 11px;
-  padding: 2px 10px;
-  border: 1px solid var(--vscode-panel-border);
-  border-radius: 10px;
-  background: transparent;
-  color: var(--vscode-descriptionForeground);
-  cursor: pointer;
-}
-
-.filter-chip:hover {
-  border-color: var(--vscode-focusBorder);
-}
-
-.filter-chip.is-active {
-  background: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
-  border-color: var(--vscode-badge-background);
-}
-
-.filter-chip.is-empty {
-  opacity: 0.45;
-  cursor: default;
-}
-
-.filter-chip:disabled {
-  cursor: default;
-}
-
-.filter-chip:disabled:hover {
-  border-color: var(--vscode-panel-border);
-}
-
+/* --- Empty state (first-run guidance) ------------------------------------ */
 .empty-state {
-  border: 1px dashed var(--vscode-panel-border);
-  border-radius: 4px;
-  padding: 18px 16px;
-  margin-top: 12px;
-  background: var(
-    --vscode-editorWidget-background,
-    var(--vscode-editor-background)
-  );
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  max-width: 36em;
+  margin: 48px auto 0;
+  padding: 24px;
+}
+
+.empty-state .codicon {
+  font-size: 38px;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.5;
 }
 
 .empty-state-title {
   font-weight: 600;
-  margin-bottom: 6px;
+  font-size: 14px;
 }
 
 .empty-state-hint {
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.6;
 }

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -50,32 +50,43 @@ body {
   line-height: 1;
 }
 
-.agent-select {
-  color: var(--vscode-dropdown-foreground);
-  background: var(--vscode-dropdown-background);
-  border: 1px solid var(--vscode-dropdown-border);
-  padding: 3px 6px;
-  border-radius: 2px;
-}
-
-.version-field {
+.picker-field {
   display: inline-flex;
   align-items: center;
   gap: 4px;
 }
 
-.version-label {
+.picker-label {
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
 }
 
-.version-input {
-  width: 9em;
-  color: var(--vscode-input-foreground);
-  background: var(--vscode-input-background);
-  border: 1px solid var(--vscode-input-border, var(--vscode-dropdown-border));
-  padding: 3px 6px;
-  border-radius: 2px;
+/* Picker buttons read as dropdowns, not primary actions, so override the
+   .toolbar button fill with the dropdown palette. */
+.toolbar button.picker-button {
+  color: var(--vscode-dropdown-foreground);
+  background: var(--vscode-dropdown-background);
+  border: 1px solid var(--vscode-dropdown-border);
+  padding: 3px 8px;
+  min-width: 7em;
+  max-width: 18em;
+  text-align: left;
+}
+
+.toolbar button.picker-button:hover:not(:disabled) {
+  background: var(
+    --vscode-list-hoverBackground,
+    var(--vscode-dropdown-background)
+  );
+}
+
+.picker-value {
+  display: inline-block;
+  max-width: 16em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 .status {
@@ -102,6 +113,13 @@ body {
   );
   background: var(--vscode-inputValidation-errorBackground);
   border-left-color: var(--vscode-errorForeground);
+}
+
+.banner-provenance {
+  color: var(--vscode-descriptionForeground);
+  background: var(--vscode-textBlockQuote-background);
+  border-left-color: var(--vscode-textLink-foreground);
+  font-family: var(--vscode-editor-font-family, monospace);
 }
 
 table {
@@ -149,6 +167,95 @@ td.latency {
 
 .status-lost-match {
   color: var(--vscode-errorForeground);
+}
+
+tr.row-clickable {
+  cursor: pointer;
+}
+
+tr.row-clickable:hover td,
+tr.row-clickable:focus-visible td {
+  background: var(--vscode-list-hoverBackground);
+}
+
+tr.row-open td {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+.detail-pane {
+  margin-top: 12px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 4px;
+  background: var(
+    --vscode-editorWidget-background,
+    var(--vscode-editor-background)
+  );
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.detail-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-meta {
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.detail-close {
+  margin-left: auto;
+}
+
+.detail-legend {
+  padding: 4px 10px 0;
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+}
+
+.detail-diff {
+  margin: 0;
+  padding: 8px 10px;
+  overflow-x: auto;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.diff-line {
+  display: block;
+  white-space: pre;
+}
+
+.diff-added {
+  color: var(
+    --vscode-charts-green,
+    var(--vscode-gitDecoration-addedResourceForeground)
+  );
+  background: var(--vscode-diffEditor-insertedTextBackground, transparent);
+}
+
+.diff-removed {
+  color: var(
+    --vscode-errorForeground,
+    var(--vscode-gitDecoration-deletedResourceForeground)
+  );
+  background: var(--vscode-diffEditor-removedTextBackground, transparent);
+}
+
+.diff-context {
+  color: var(--vscode-descriptionForeground);
 }
 
 .truncation {

--- a/ts/packages/typeagent-studio/media/impactReport.css
+++ b/ts/packages/typeagent-studio/media/impactReport.css
@@ -101,6 +101,12 @@ body {
 .codicon-library::before {
   content: "\eb9c";
 }
+.codicon-circle-filled::before {
+  content: "\ea71";
+}
+.codicon-sync::before {
+  content: "\ea77";
+}
 
 /* --- Action bar (the native editor toolbar) ------------------------------ */
 .action-bar {
@@ -152,6 +158,54 @@ body {
 
 .bar-group > .codicon-library {
   color: var(--vscode-descriptionForeground);
+}
+
+/* Single connection indicator (replaces a manual reconnect button). Colour
+   tracks state; the icon spins while (re)connecting to signal auto-retry. */
+.conn-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 999px;
+  white-space: nowrap;
+  color: var(--vscode-descriptionForeground);
+  background: var(--vscode-badge-background);
+}
+
+.conn-pill .codicon {
+  font-size: 13px;
+}
+
+.conn-connected {
+  color: var(--vscode-foreground);
+}
+
+.conn-connected .codicon-circle-filled {
+  color: var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+}
+
+.conn-connecting .codicon-sync,
+.conn-disconnected .codicon-sync {
+  color: var(--vscode-descriptionForeground);
+  animation: conn-spin 1.4s linear infinite;
+}
+
+@keyframes conn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conn-pill .codicon-sync {
+    animation: none;
+  }
 }
 
 /* Picker controls read as native dropdowns: value + trailing chevron. */

--- a/ts/packages/typeagent-studio/package.json
+++ b/ts/packages/typeagent-studio/package.json
@@ -31,7 +31,7 @@
     "commands": [
       {
         "command": "typeagent-studio.connectStudioService",
-        "title": "Connect Event Log to studio service",
+        "title": "Connect to Studio service",
         "category": "TypeAgent Studio"
       },
       {
@@ -39,11 +39,6 @@
         "title": "Open Impact Report",
         "category": "TypeAgent Studio",
         "icon": "$(graph)"
-      },
-      {
-        "command": "typeagent-studio.hello",
-        "title": "Hello (skeleton)",
-        "category": "TypeAgent Studio"
       },
       {
         "command": "typeagent-studio.startOnboardingSession",
@@ -483,7 +478,6 @@
     "onView:typeagentStudioCollisions",
     "onCommand:typeagent-studio.connectStudioService",
     "onCommand:typeagent-studio.openImpactReport",
-    "onCommand:typeagent-studio.hello",
     "onCommand:typeagent-studio.startOnboardingSession",
     "onCommand:typeagent-studio.ask",
     "onCommand:typeagent-studio.installToSandbox",

--- a/ts/packages/typeagent-studio/package.json
+++ b/ts/packages/typeagent-studio/package.json
@@ -454,22 +454,22 @@
     "viewsWelcome": [
       {
         "view": "typeagentStudioSandboxes",
-        "contents": "The TypeAgent Studio service isn't connected, so sandboxes can't be shown yet.\n[Connect to Studio service](command:typeagent-studio.connectStudioService)\nOr open this workspace so Studio can launch it, or run `typeagent-studio serve`.",
+        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state. If it never connects, open this workspace's `ts` folder or run `typeagent-studio serve`.",
         "when": "!typeagentStudio.serviceConnected"
       },
       {
         "view": "typeagentStudioCorpora",
-        "contents": "The TypeAgent Studio service isn't connected, so corpora can't be shown yet.\n[Connect to Studio service](command:typeagent-studio.connectStudioService)\nOr open this workspace so Studio can launch it, or run `typeagent-studio serve`.",
+        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
         "when": "!typeagentStudio.serviceConnected"
       },
       {
         "view": "typeagentStudioEvents",
-        "contents": "The TypeAgent Studio service isn't connected, so events can't be shown yet.\n[Connect to Studio service](command:typeagent-studio.connectStudioService)\nOr open this workspace so Studio can launch it, or run `typeagent-studio serve`.",
+        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
         "when": "!typeagentStudio.serviceConnected"
       },
       {
         "view": "typeagentStudioCollisions",
-        "contents": "The TypeAgent Studio service isn't connected, so grammar collisions can't be analyzed yet.\n[Connect to Studio service](command:typeagent-studio.connectStudioService)\nOr open this workspace so Studio can launch it, or run `typeagent-studio serve`.",
+        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
         "when": "!typeagentStudio.serviceConnected"
       }
     ]

--- a/ts/packages/typeagent-studio/package.json
+++ b/ts/packages/typeagent-studio/package.json
@@ -311,6 +311,10 @@
         {
           "command": "typeagent-studio.focusSandboxes",
           "when": "false"
+        },
+        {
+          "command": "typeagent-studio.openImpactReport",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -323,11 +327,6 @@
           "command": "typeagent-studio.refreshSandboxes",
           "when": "view == typeagentStudioSandboxes",
           "group": "navigation@2"
-        },
-        {
-          "command": "typeagent-studio.openImpactReport",
-          "when": "view == typeagentStudioCorpora",
-          "group": "navigation@0"
         },
         {
           "command": "typeagent-studio.refreshCorpora",
@@ -408,6 +407,11 @@
         },
         {
           "command": "typeagent-studio.addExternalCorpus",
+          "when": "view == typeagentStudioCorpora && viewItem == corpusAgent",
+          "group": "inline@1"
+        },
+        {
+          "command": "typeagent-studio.openImpactReport",
           "when": "view == typeagentStudioCorpora && viewItem == corpusAgent",
           "group": "inline@0"
         },
@@ -527,6 +531,7 @@
     "@types/debug": "^4.1.0",
     "@types/vscode": "^1.90.0",
     "@types/ws": "^8.5.10",
+    "@vscode/codicons": "^0.0.42",
     "@vscode/vsce": "^3.2.1",
     "esbuild": "^0.28.1",
     "mkdirp": "^3.0.1",

--- a/ts/packages/typeagent-studio/package.json
+++ b/ts/packages/typeagent-studio/package.json
@@ -450,29 +450,7 @@
           "icon": "$(beaker)"
         }
       ]
-    },
-    "viewsWelcome": [
-      {
-        "view": "typeagentStudioSandboxes",
-        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state. If it never connects, open this workspace's `ts` folder or run `typeagent-studio serve`.",
-        "when": "!typeagentStudio.serviceConnected"
-      },
-      {
-        "view": "typeagentStudioCorpora",
-        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
-        "when": "!typeagentStudio.serviceConnected"
-      },
-      {
-        "view": "typeagentStudioEvents",
-        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
-        "when": "!typeagentStudio.serviceConnected"
-      },
-      {
-        "view": "typeagentStudioCollisions",
-        "contents": "Connecting to the TypeAgent Studio service…\nThis is automatic — the **Studio** item in the status bar shows the live connection state.",
-        "when": "!typeagentStudio.serviceConnected"
-      }
-    ]
+    }
   },
   "activationEvents": [
     "onStartupFinished",

--- a/ts/packages/typeagent-studio/src/baseTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/baseTreeProvider.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from "vscode";
+
+/**
+ * The descriptor fields every Studio tree row/node shares. Each view's
+ * presentation module produces nodes with at least these; view-specific extras
+ * (icon ids, navigation targets, expandability) live on the concrete node type.
+ */
+export interface StudioTreeNode {
+    /** Stable identifier, unique across the displayed tree. */
+    id: string;
+    label: string;
+    description?: string;
+    tooltip?: string;
+    contextValue?: string;
+}
+
+/**
+ * Shared scaffolding for the extension's VS Code tree views (Event Log,
+ * Collisions, Sandboxes, Corpora). It owns the parts every provider repeated
+ * verbatim — the change emitter, the `connected` flag and its `setConnected`
+ * gate, `refresh`, and the descriptor→`TreeItem` field mapping — so concrete
+ * providers only supply what actually differs: how children are resolved
+ * ({@link getChildren}), how a node collapses ({@link collapsibleState}), and
+ * how it's decorated with an icon/command ({@link decorate}).
+ *
+ * Providers that hold a source subscription override {@link dispose} to tear it
+ * down and then call `super.dispose()`.
+ */
+export abstract class BaseStudioTreeProvider<TNode extends StudioTreeNode>
+    implements vscode.TreeDataProvider<TNode>, vscode.Disposable
+{
+    protected readonly emitter = new vscode.EventEmitter<TNode | undefined>();
+    readonly onDidChangeTreeData = this.emitter.event;
+    protected connected = false;
+
+    /** Reflect the studio service connection state (drives the empty view). */
+    setConnected(connected: boolean): void {
+        if (connected === this.connected) {
+            return;
+        }
+        this.connected = connected;
+        this.refresh();
+    }
+
+    refresh(): void {
+        this.emitter.fire(undefined);
+    }
+
+    getTreeItem(node: TNode): vscode.TreeItem {
+        const item = new vscode.TreeItem(
+            node.label,
+            this.collapsibleState(node),
+        );
+        item.id = node.id;
+        item.description = node.description;
+        item.tooltip = node.tooltip;
+        item.contextValue = node.contextValue;
+        this.decorate(item, node);
+        return item;
+    }
+
+    abstract getChildren(node?: TNode): vscode.ProviderResult<TNode[]>;
+
+    /** Leaf by default; expandable views override per node. */
+    protected collapsibleState(_node: TNode): vscode.TreeItemCollapsibleState {
+        return vscode.TreeItemCollapsibleState.None;
+    }
+
+    /** Apply the icon and (optionally) an activation command for a node. */
+    protected decorate(_item: vscode.TreeItem, _node: TNode): void {}
+
+    dispose(): void {
+        this.emitter.dispose();
+    }
+}

--- a/ts/packages/typeagent-studio/src/baseTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/baseTreeProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as vscode from "vscode";
+import type { TooltipModel } from "./tooltipModel.js";
 
 /**
  * The descriptor fields every Studio tree row/node shares. Each view's
@@ -13,7 +14,7 @@ export interface StudioTreeNode {
     id: string;
     label: string;
     description?: string;
-    tooltip?: string;
+    tooltip?: TooltipModel;
     contextValue?: string;
 }
 
@@ -80,7 +81,9 @@ export abstract class BaseStudioTreeProvider<TNode extends StudioTreeNode>
         );
         item.id = node.id;
         item.description = node.description;
-        item.tooltip = node.tooltip;
+        item.tooltip = node.tooltip
+            ? renderMarkdownTooltip(node.tooltip)
+            : undefined;
         item.contextValue = node.contextValue;
         this.decorate(item, node);
         return item;
@@ -110,4 +113,41 @@ function newGate(): { promise: Promise<void>; resolve: () => void } {
         resolve = r;
     });
     return { promise, resolve };
+}
+
+/**
+ * Render a {@link TooltipModel} into a VS Code hover card: an optional bold
+ * title, one `**Label:** value` row per field (values in `code` when `mono`),
+ * and an optional trailing italic hint. Rows use a hard line break so the card
+ * stays compact rather than double-spaced.
+ */
+function renderMarkdownTooltip(model: TooltipModel): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.supportThemeIcons = true;
+    const lines: string[] = [];
+    if (model.title) {
+        lines.push(`**${escapeMarkdown(model.title)}**`);
+    }
+    for (const field of model.fields) {
+        const value = field.mono
+            ? `\`${escapeInlineCode(field.value)}\``
+            : escapeMarkdown(field.value);
+        lines.push(`**${escapeMarkdown(field.label)}:** ${value}`);
+    }
+    if (model.hint) {
+        lines.push(`_${escapeMarkdown(model.hint)}_`);
+    }
+    // Two trailing spaces force a hard break without a blank paragraph between.
+    md.appendMarkdown(lines.join("  \n"));
+    return md;
+}
+
+/** Escape the markdown control characters that would otherwise format a value. */
+function escapeMarkdown(text: string): string {
+    return text.replace(/([\\`*_{}\[\]()#+\-.!|<>])/g, "\\$1");
+}
+
+/** Backticks can't appear inside an inline code span, so neutralize them. */
+function escapeInlineCode(text: string): string {
+    return text.replace(/`/g, "'");
 }

--- a/ts/packages/typeagent-studio/src/baseTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/baseTreeProvider.ts
@@ -36,13 +36,37 @@ export abstract class BaseStudioTreeProvider<TNode extends StudioTreeNode>
     readonly onDidChangeTreeData = this.emitter.event;
     protected connected = false;
 
+    // While disconnected, the root `getChildren` awaits this gate so VS Code
+    // keeps the view's native loading bar showing (rather than a premature
+    // empty view). It resolves on connect and re-arms on disconnect.
+    private connectGate = newGate();
+
     /** Reflect the studio service connection state (drives the empty view). */
     setConnected(connected: boolean): void {
         if (connected === this.connected) {
             return;
         }
         this.connected = connected;
+        if (connected) {
+            this.connectGate.resolve();
+        } else {
+            // Re-arm so a dropped connection re-shows the loading bar.
+            this.connectGate = newGate();
+        }
         this.refresh();
+    }
+
+    /**
+     * Hold the native loading bar until the service connects. Call this at the
+     * root of {@link getChildren} (before fetching) so every view shows a
+     * consistent "loading" state while connecting instead of a stale empty view.
+     * Resolves immediately once connected (or on dispose).
+     */
+    protected async whenConnected(): Promise<void> {
+        if (this.connected) {
+            return;
+        }
+        await this.connectGate.promise;
     }
 
     refresh(): void {
@@ -73,6 +97,17 @@ export abstract class BaseStudioTreeProvider<TNode extends StudioTreeNode>
     protected decorate(_item: vscode.TreeItem, _node: TNode): void {}
 
     dispose(): void {
+        // Release anyone awaiting the gate so pending getChildren settle.
+        this.connectGate.resolve();
         this.emitter.dispose();
     }
+}
+
+/** A one-shot resolvable promise used to gate the loading bar on connection. */
+function newGate(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+        resolve = r;
+    });
+    return { promise, resolve };
 }

--- a/ts/packages/typeagent-studio/src/collisionsPresentation.ts
+++ b/ts/packages/typeagent-studio/src/collisionsPresentation.ts
@@ -13,6 +13,11 @@ import type {
     CollisionKind,
 } from "@typeagent/core/events";
 import type { GrammarScanSkip } from "@typeagent/core/collisionScanner";
+import {
+    noteTooltip,
+    type TooltipField,
+    type TooltipModel,
+} from "./tooltipModel.js";
 
 export type CollisionRowKind =
     | "collision"
@@ -34,7 +39,7 @@ export interface CollisionRow {
     id: string;
     label: string;
     description?: string;
-    tooltip?: string;
+    tooltip?: TooltipModel;
     contextValue?: string;
     /** Codicon id (no `$()` wrapper) for the tree item. */
     icon: string;
@@ -69,22 +74,29 @@ export function formatCollisionSummary(event: CollisionDetectedEvent): string {
     return `${event.kind}: ${formatParticipants(event)}`;
 }
 
-function formatCollisionTooltip(event: CollisionDetectedEvent): string {
-    const lines = [
-        `Kind: ${event.kind}`,
-        `Detected at: ${event.detectionPoint}`,
-        `Sandbox: ${event.sandboxId}`,
+function formatCollisionTooltip(event: CollisionDetectedEvent): TooltipModel {
+    const fields: TooltipField[] = [
+        { label: "Kind", value: event.kind },
+        { label: "Detected at", value: event.detectionPoint },
+        { label: "Sandbox", value: event.sandboxId, mono: true },
     ];
     if (event.experimentId !== undefined) {
-        lines.push(`Experiment: ${event.experimentId}`);
+        fields.push({
+            label: "Experiment",
+            value: event.experimentId,
+            mono: true,
+        });
     }
     if (event.requestId !== undefined) {
-        lines.push(`Request: ${event.requestId}`);
+        fields.push({ label: "Request", value: event.requestId, mono: true });
     }
     if (event.exemplarUtterances && event.exemplarUtterances.length > 0) {
-        lines.push(`Exemplars: ${event.exemplarUtterances.length}`);
+        fields.push({
+            label: "Exemplars",
+            value: String(event.exemplarUtterances.length),
+        });
     }
-    return lines.join("\n");
+    return { fields };
 }
 
 /** Map provider entries (expected newest-first) into top-level rows. */
@@ -100,8 +112,9 @@ export function buildCollisionRows(
             id: "collision:skipped",
             label: `Skipped (${skipped.length})`,
             description: "Agents excluded from the most recent scan",
-            tooltip:
+            tooltip: noteTooltip(
                 "Agents whose grammars couldn't be scanned (no compiled grammar, parse error, or compile error). Click to expand.",
+            ),
             contextValue: "studioCollisionSkippedGroup",
             icon: "circle-slash",
             hasChildren: true,
@@ -173,13 +186,15 @@ export function buildSkippedRows(
             skip.reason === "grammar-not-built" && skip.compilable === false
                 ? "grammar source not compiled (no build step)"
                 : reasonLabel;
-        const tooltipLines = [`Schema: ${skip.schemaName}`];
-        if (ownerSuffix !== "") {
-            tooltipLines.push(`Agent: ${skip.agentName}`);
+        const tooltipFields: TooltipField[] = [
+            { label: "Schema", value: skip.schemaName },
+        ];
+        if (ownerSuffix !== "" && skip.agentName !== undefined) {
+            tooltipFields.push({ label: "Agent", value: skip.agentName });
         }
-        tooltipLines.push(`Reason: ${reasonText}`);
+        tooltipFields.push({ label: "Reason", value: reasonText });
         if (skip.error !== undefined) {
-            tooltipLines.push(`Detail: ${skip.error}`);
+            tooltipFields.push({ label: "Detail", value: skip.error });
         }
         return {
             kind: "skipped",
@@ -189,7 +204,7 @@ export function buildSkippedRows(
                 skip.error !== undefined
                     ? `${reasonText} — ${skip.error}`
                     : reasonText,
-            tooltip: tooltipLines.join("\n"),
+            tooltip: { fields: tooltipFields },
             contextValue: buildable
                 ? "studioCollisionSkippedBuildable"
                 : "studioCollisionSkipped",
@@ -205,17 +220,32 @@ export function buildSkippedRows(
 /** Child rows (participants then exemplar utterances) for one collision. */
 export function buildCollisionChildRows(entry: CollisionEntry): CollisionRow[] {
     const { seq, event } = entry;
-    const rows: CollisionRow[] = event.participants.map((p, index) => ({
-        kind: "participant" as const,
-        id: `collision:${seq}:participant:${index}`,
-        label: p.actionType || p.agent,
-        description: `${p.file}:${p.range[0]}`,
-        tooltip: `${p.agent}\n${p.file} [${p.range[0]}-${p.range[1]}]`,
-        contextValue: "studioCollisionParticipant",
-        icon: "symbol-class",
-        hasChildren: false,
-        ...(isNavigablePath(p.file) ? { openPath: p.file } : {}),
-    }));
+    const rows: CollisionRow[] = event.participants.map((p, index) => {
+        const navigable = isNavigablePath(p.file);
+        return {
+            kind: "participant" as const,
+            id: `collision:${seq}:participant:${index}`,
+            label: p.actionType || p.agent,
+            description: `${p.file}:${p.range[0]}`,
+            tooltip: {
+                fields: [
+                    { label: "Agent", value: p.agent },
+                    {
+                        label: "Location",
+                        value: `${p.file} [${p.range[0]}-${p.range[1]}]`,
+                        mono: true,
+                    },
+                ],
+                ...(navigable
+                    ? { hint: "Click to open the grammar source." }
+                    : {}),
+            },
+            contextValue: "studioCollisionParticipant",
+            icon: "symbol-class",
+            hasChildren: false,
+            ...(navigable ? { openPath: p.file } : {}),
+        };
+    });
 
     for (const [index, utterance] of (
         event.exemplarUtterances ?? []
@@ -224,7 +254,6 @@ export function buildCollisionChildRows(entry: CollisionEntry): CollisionRow[] {
             kind: "exemplar",
             id: `collision:${seq}:exemplar:${index}`,
             label: utterance,
-            description: "exemplar",
             contextValue: "studioCollisionExemplar",
             icon: "quote",
             hasChildren: false,

--- a/ts/packages/typeagent-studio/src/collisionsTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/collisionsTreeProvider.ts
@@ -11,6 +11,7 @@ import {
     type CollisionEntry,
     type CollisionRow,
 } from "./collisionsPresentation.js";
+import { BaseStudioTreeProvider } from "./baseTreeProvider.js";
 import type { CollisionsSource } from "./collisionsSource.js";
 
 /** View id contributed in package.json. */
@@ -30,12 +31,9 @@ export const COLLISIONS_CAPACITY = 200;
  * in-flight reload or late collision event can't repopulate the tree.
  */
 export class CollisionsTreeProvider
-    implements vscode.TreeDataProvider<CollisionRow>, vscode.Disposable
+    extends BaseStudioTreeProvider<CollisionRow>
+    implements vscode.Disposable
 {
-    private readonly emitter = new vscode.EventEmitter<
-        CollisionRow | undefined
-    >();
-    readonly onDidChangeTreeData = this.emitter.event;
     private source: CollisionsSource;
     private subscription: { dispose(): void } | undefined;
     private entries: CollisionEntry[] = [];
@@ -43,20 +41,11 @@ export class CollisionsTreeProvider
     private skipped: GrammarScanSkip[] = [];
     private seq = 0;
     private generation = 0;
-    private connected = false;
 
     constructor(source: CollisionsSource) {
+        super();
         this.source = source;
         this.install(++this.generation);
-    }
-
-    /** Reflect the studio service connection state (drives the empty view). */
-    setConnected(connected: boolean): void {
-        if (connected === this.connected) {
-            return;
-        }
-        this.connected = connected;
-        this.refresh();
     }
 
     /**
@@ -73,10 +62,6 @@ export class CollisionsTreeProvider
         this.refresh();
         this.source = source;
         this.install(++this.generation);
-    }
-
-    refresh(): void {
-        this.emitter.fire(undefined);
     }
 
     /** Re-read collisions from the active source (e.g. after a scan). */
@@ -102,17 +87,15 @@ export class CollisionsTreeProvider
         this.refresh();
     }
 
-    getTreeItem(row: CollisionRow): vscode.TreeItem {
-        const item = new vscode.TreeItem(
-            row.label,
-            row.hasChildren
-                ? vscode.TreeItemCollapsibleState.Collapsed
-                : vscode.TreeItemCollapsibleState.None,
-        );
-        item.id = row.id;
-        item.description = row.description;
-        item.tooltip = row.tooltip;
-        item.contextValue = row.contextValue;
+    protected collapsibleState(
+        row: CollisionRow,
+    ): vscode.TreeItemCollapsibleState {
+        return row.hasChildren
+            ? vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.None;
+    }
+
+    protected decorate(item: vscode.TreeItem, row: CollisionRow): void {
         item.iconPath = new vscode.ThemeIcon(row.icon);
         if (row.openPath !== undefined) {
             item.command = {
@@ -121,7 +104,6 @@ export class CollisionsTreeProvider
                 arguments: [vscode.Uri.file(row.openPath)],
             };
         }
-        return item;
     }
 
     getChildren(row?: CollisionRow): CollisionRow[] {
@@ -191,7 +173,7 @@ export class CollisionsTreeProvider
         this.generation++; // invalidate any in-flight reload
         this.subscription?.dispose();
         this.subscription = undefined;
-        this.emitter.dispose();
+        super.dispose();
     }
 }
 

--- a/ts/packages/typeagent-studio/src/collisionsTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/collisionsTreeProvider.ts
@@ -106,12 +106,11 @@ export class CollisionsTreeProvider
         }
     }
 
-    getChildren(row?: CollisionRow): CollisionRow[] {
+    async getChildren(row?: CollisionRow): Promise<CollisionRow[]> {
         if (!row) {
-            // Disconnected with nothing to show: render nothing so the view's
-            // welcome content ("connect to the Studio service") shows instead
-            // of a misleading "No collisions detected" check — nothing was
-            // actually scanned.
+            // Show the native loading bar while connecting; once connected,
+            // render scanned collisions (or the "no collisions" placeholder).
+            await this.whenConnected();
             if (
                 !this.connected &&
                 this.entries.length === 0 &&

--- a/ts/packages/typeagent-studio/src/corpusTreePresentation.ts
+++ b/ts/packages/typeagent-studio/src/corpusTreePresentation.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT License.
 
 import type { CorpusEntry, CorpusSource } from "@typeagent/core/corpus";
+import type { FeedbackRating } from "@typeagent/core/events";
 import { collapseAndTruncate } from "./textFormatting.js";
+import {
+    noteTooltip,
+    type TooltipField,
+    type TooltipModel,
+} from "./tooltipModel.js";
 
 /**
  * Pure, vscode-free mapping from federated corpus entries to tree-node
@@ -19,7 +25,7 @@ export interface CorpusTreeNode {
     id: string;
     label: string;
     description?: string;
-    tooltip?: string;
+    tooltip?: TooltipModel;
     contextValue?: string;
     /** Present on `agent`, `source`, and `entry` nodes. */
     agent?: string;
@@ -27,6 +33,8 @@ export interface CorpusTreeNode {
     source?: CorpusSource;
     /** Present on `entry` nodes. */
     entryId?: string;
+    /** Present on `entry` nodes that carry feedback; drives the row icon. */
+    feedbackRating?: FeedbackRating;
     /** Whether the node should render as expandable. */
     hasChildren: boolean;
 }
@@ -52,8 +60,9 @@ export function buildCorpusAgentNodes(
                 id: "corpus:empty",
                 label: "No corpora available",
                 description: "Load an agent into a sandbox",
-                tooltip:
+                tooltip: noteTooltip(
                     "Corpora are listed per agent loaded into a running sandbox.",
+                ),
                 hasChildren: false,
             },
         ];
@@ -88,7 +97,9 @@ export function buildCorpusSourceNodes(
                 id: `corpus:agent:${agent}:empty`,
                 label: "Seed in-repo corpus\u2026",
                 description: "No entries yet — click to create a corpus file",
-                tooltip: `Click to create corpus/${agent}.utterances.jsonl and open it so you can add labelled utterances for ${agent}.`,
+                tooltip: noteTooltip(
+                    `Click to create corpus/${agent}.utterances.jsonl and open it so you can add labelled utterances for ${agent}.`,
+                ),
                 contextValue: "corpusAgentSeed",
                 agent,
                 hasChildren: false,
@@ -123,14 +134,16 @@ export function buildCorpusEntryNodes(
             kind: "entry" as const,
             id: `corpus:entry:${entry.id}`,
             label: truncateUtterance(entry.utterance),
-            description: entry.feedback
-                ? formatFeedbackBadge(entry.feedback.rating)
-                : undefined,
+            // Feedback is conveyed by the row icon (thumbs up/down), so no
+            // description badge is needed.
             tooltip: buildEntryTooltip(entry),
             contextValue: "corpusEntry",
             agent,
             source,
             entryId: entry.id,
+            ...(entry.feedback
+                ? { feedbackRating: entry.feedback.rating }
+                : {}),
             hasChildren: false,
         }));
 }
@@ -164,28 +177,27 @@ function countBySource(
     return counts;
 }
 
-function formatFeedbackBadge(rating: string): string {
-    return `feedback: ${rating}`;
-}
-
-function buildEntryTooltip(entry: CorpusEntry): string {
-    const lines = [
-        entry.utterance,
-        `Agent: ${entry.agent}`,
-        `Source: ${formatCorpusSource(entry.source)}`,
-        `Origin: ${entry.provenance.sourceUri}`,
+function buildEntryTooltip(entry: CorpusEntry): TooltipModel {
+    const fields: TooltipField[] = [
+        { label: "Agent", value: entry.agent },
+        { label: "Source", value: formatCorpusSource(entry.source) },
+        { label: "Origin", value: entry.provenance.sourceUri, mono: true },
     ];
     if (entry.provenance.requestId) {
-        lines.push(`Request: ${entry.provenance.requestId}`);
+        fields.push({
+            label: "Request",
+            value: entry.provenance.requestId,
+            mono: true,
+        });
     }
     if (entry.feedback) {
-        lines.push(`Feedback: ${entry.feedback.rating}`);
+        fields.push({ label: "Feedback", value: entry.feedback.rating });
         if (entry.feedback.comment) {
-            lines.push(`Comment: ${entry.feedback.comment}`);
+            fields.push({ label: "Comment", value: entry.feedback.comment });
         }
     }
     if (entry.tags && entry.tags.length > 0) {
-        lines.push(`Tags: ${entry.tags.join(", ")}`);
+        fields.push({ label: "Tags", value: entry.tags.join(", ") });
     }
-    return lines.join("\n");
+    return { title: entry.utterance, fields };
 }

--- a/ts/packages/typeagent-studio/src/corpusTreePresentation.ts
+++ b/ts/packages/typeagent-studio/src/corpusTreePresentation.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type { CorpusEntry, CorpusSource } from "@typeagent/core/corpus";
+import { collapseAndTruncate } from "./textFormatting.js";
 
 /**
  * Pure, vscode-free mapping from federated corpus entries to tree-node
@@ -150,11 +151,7 @@ export function formatCorpusSource(source: CorpusSource): string {
 }
 
 export function truncateUtterance(utterance: string): string {
-    const collapsed = utterance.replace(/\s+/g, " ").trim();
-    if (collapsed.length <= MAX_UTTERANCE_LENGTH) {
-        return collapsed;
-    }
-    return `${collapsed.slice(0, MAX_UTTERANCE_LENGTH - 1)}\u2026`;
+    return collapseAndTruncate(utterance, MAX_UTTERANCE_LENGTH);
 }
 
 function countBySource(

--- a/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
@@ -93,6 +93,18 @@ function iconForNode(node: CorpusTreeNode): vscode.ThemeIcon | undefined {
         case "source":
             return new vscode.ThemeIcon("folder");
         case "entry":
+            if (node.feedbackRating === "up") {
+                return new vscode.ThemeIcon(
+                    "thumbsup",
+                    new vscode.ThemeColor("testing.iconPassed"),
+                );
+            }
+            if (node.feedbackRating === "down") {
+                return new vscode.ThemeIcon(
+                    "thumbsdown",
+                    new vscode.ThemeColor("testing.iconFailed"),
+                );
+            }
             return new vscode.ThemeIcon("comment");
         case "empty":
             return new vscode.ThemeIcon(

--- a/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
@@ -61,9 +61,9 @@ export class CorpusTreeProvider
 
     async getChildren(node?: CorpusTreeNode): Promise<CorpusTreeNode[]> {
         if (!node) {
-            // Disconnected: render nothing so the view's welcome content
-            // ("connect to the Studio service") shows instead of a misleading
-            // "No corpora available" placeholder.
+            // Show the native loading bar while connecting; once connected,
+            // fetch and render rows (or the "no corpora" placeholder).
+            await this.whenConnected();
             if (!this.connected) {
                 return [];
             }

--- a/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/corpusTreeProvider.ts
@@ -9,6 +9,7 @@ import {
     buildCorpusSourceNodes,
     type CorpusTreeNode,
 } from "./corpusTreePresentation.js";
+import { BaseStudioTreeProvider } from "./baseTreeProvider.js";
 
 /** View id contributed in package.json. */
 export const CORPUS_VIEW_ID = "typeagentStudioCorpora";
@@ -19,47 +20,30 @@ export const CORPUS_VIEW_ID = "typeagentStudioCorpora";
  * resolves children from the runtime and maps descriptors to `TreeItem`s.
  */
 export class CorpusTreeProvider
-    implements vscode.TreeDataProvider<CorpusTreeNode>, vscode.Disposable
+    extends BaseStudioTreeProvider<CorpusTreeNode>
+    implements vscode.Disposable
 {
-    private readonly emitter = new vscode.EventEmitter<
-        CorpusTreeNode | undefined
-    >();
-    readonly onDidChangeTreeData = this.emitter.event;
     private readonly subscription: { dispose(): void };
-    private connected = false;
 
     constructor(private readonly source: CorpusSource) {
+        super();
         // Loaded-agent set drives the agent rows, so refresh on sandbox
         // lifecycle changes (agent load/unload) as well as manual refresh.
         this.subscription = source.onSandboxChanged(() => this.refresh());
     }
 
-    /** Reflect the studio service connection state (drives the empty view). */
-    setConnected(connected: boolean): void {
-        if (connected === this.connected) {
-            return;
+    protected collapsibleState(
+        node: CorpusTreeNode,
+    ): vscode.TreeItemCollapsibleState {
+        if (!node.hasChildren) {
+            return vscode.TreeItemCollapsibleState.None;
         }
-        this.connected = connected;
-        this.refresh();
+        return node.kind === "agent"
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.Collapsed;
     }
 
-    refresh(): void {
-        this.emitter.fire(undefined);
-    }
-
-    getTreeItem(node: CorpusTreeNode): vscode.TreeItem {
-        const item = new vscode.TreeItem(
-            node.label,
-            node.hasChildren
-                ? node.kind === "agent"
-                    ? vscode.TreeItemCollapsibleState.Expanded
-                    : vscode.TreeItemCollapsibleState.Collapsed
-                : vscode.TreeItemCollapsibleState.None,
-        );
-        item.id = node.id;
-        item.description = node.description;
-        item.tooltip = node.tooltip;
-        item.contextValue = node.contextValue;
+    protected decorate(item: vscode.TreeItem, node: CorpusTreeNode): void {
         item.iconPath = iconForNode(node);
         // The seed empty-state row is clickable: selecting it runs the same
         // seed command as its inline button. The command shows a modal
@@ -73,7 +57,6 @@ export class CorpusTreeProvider
                 arguments: [node],
             };
         }
-        return item;
     }
 
     async getChildren(node?: CorpusTreeNode): Promise<CorpusTreeNode[]> {
@@ -99,7 +82,7 @@ export class CorpusTreeProvider
 
     dispose(): void {
         this.subscription.dispose();
-        this.emitter.dispose();
+        super.dispose();
     }
 }
 

--- a/ts/packages/typeagent-studio/src/eventLogPresentation.ts
+++ b/ts/packages/typeagent-studio/src/eventLogPresentation.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type { StudioEvent, StudioEventType } from "@typeagent/core/events";
+import { collapseAndTruncate } from "./textFormatting.js";
 
 /**
  * Pure, vscode-free mapping from structured events to event-log row
@@ -179,8 +180,5 @@ function buildEventTooltip(event: StudioEvent): string {
 }
 
 function quote(value: string): string {
-    const collapsed = value.replace(/\s+/g, " ").trim();
-    const capped =
-        collapsed.length > 60 ? `${collapsed.slice(0, 59)}\u2026` : collapsed;
-    return `"${capped}"`;
+    return `"${collapseAndTruncate(value, 60)}"`;
 }

--- a/ts/packages/typeagent-studio/src/eventLogPresentation.ts
+++ b/ts/packages/typeagent-studio/src/eventLogPresentation.ts
@@ -3,6 +3,7 @@
 
 import type { StudioEvent, StudioEventType } from "@typeagent/core/events";
 import { collapseAndTruncate } from "./textFormatting.js";
+import { type TooltipField, type TooltipModel } from "./tooltipModel.js";
 
 /**
  * Pure, vscode-free mapping from structured events to event-log row
@@ -25,7 +26,7 @@ export interface EventLogRow {
     id: string;
     label: string;
     description?: string;
-    tooltip?: string;
+    tooltip?: TooltipModel;
     contextValue?: string;
     eventType?: StudioEventType;
     hasChildren: boolean;
@@ -162,21 +163,21 @@ function formatEventDescription(event: StudioEvent): string {
     return event.agent ? `${time} · ${event.agent}` : time;
 }
 
-function buildEventTooltip(event: StudioEvent): string {
-    const lines: string[] = [
-        `${event.type} @ ${new Date(event.ts).toISOString()}`,
-        `sandbox: ${event.sandboxId}`,
+function buildEventTooltip(event: StudioEvent): TooltipModel {
+    const fields: TooltipField[] = [
+        { label: "Time", value: new Date(event.ts).toISOString(), mono: true },
+        { label: "Sandbox", value: event.sandboxId, mono: true },
     ];
     if (event.agent) {
-        lines.push(`agent: ${event.agent}`);
+        fields.push({ label: "Agent", value: event.agent });
     }
     if (event.requestId) {
-        lines.push(`requestId: ${event.requestId}`);
+        fields.push({ label: "Request", value: event.requestId, mono: true });
     }
     if (event.runId) {
-        lines.push(`runId: ${event.runId}`);
+        fields.push({ label: "Run", value: event.runId, mono: true });
     }
-    return lines.join("\n");
+    return { title: event.type, fields };
 }
 
 function quote(value: string): string {

--- a/ts/packages/typeagent-studio/src/eventLogTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/eventLogTreeProvider.ts
@@ -71,13 +71,13 @@ export class EventLogTreeProvider
         );
     }
 
-    getChildren(row?: EventLogRow): EventLogRow[] {
+    async getChildren(row?: EventLogRow): Promise<EventLogRow[]> {
         if (row) {
             return [];
         }
-        // Disconnected with nothing buffered: render nothing so the view's
-        // welcome content ("connect to the Studio service") shows instead of a
-        // misleading "No events yet" placeholder.
+        // Show the native loading bar while connecting; once connected, render
+        // buffered events (or the "no events yet" placeholder).
+        await this.whenConnected();
         if (!this.connected && this.entries.length === 0) {
             return [];
         }

--- a/ts/packages/typeagent-studio/src/eventLogTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/eventLogTreeProvider.ts
@@ -9,6 +9,7 @@ import {
     type EventLogEntry,
     type EventLogRow,
 } from "./eventLogPresentation.js";
+import { BaseStudioTreeProvider } from "./baseTreeProvider.js";
 import type { EventLogSource } from "./eventLogSource.js";
 
 /** View id contributed in package.json. */
@@ -29,30 +30,18 @@ export const EVENT_LOG_CAPACITY = 200;
  * repopulate the tree after it's been replaced.
  */
 export class EventLogTreeProvider
-    implements vscode.TreeDataProvider<EventLogRow>, vscode.Disposable
+    extends BaseStudioTreeProvider<EventLogRow>
+    implements vscode.Disposable
 {
-    private readonly emitter = new vscode.EventEmitter<
-        EventLogRow | undefined
-    >();
-    readonly onDidChangeTreeData = this.emitter.event;
     private subscription: { dispose(): void } | undefined;
     private readonly entries: EventLogEntry[] = [];
     private readonly eventById = new Map<string, StudioEvent>();
     private seq = 0;
     private generation = 0;
-    private connected = false;
 
     constructor(source: EventLogSource) {
+        super();
         this.install(source, ++this.generation);
-    }
-
-    /** Reflect the studio service connection state (drives the empty view). */
-    setConnected(connected: boolean): void {
-        if (connected === this.connected) {
-            return;
-        }
-        this.connected = connected;
-        this.refresh();
     }
 
     /**
@@ -69,30 +58,17 @@ export class EventLogTreeProvider
         this.install(source, ++this.generation);
     }
 
-    refresh(): void {
-        this.emitter.fire(undefined);
-    }
-
     clear(): void {
         this.entries.length = 0;
         this.eventById.clear();
         this.refresh();
     }
 
-    getTreeItem(row: EventLogRow): vscode.TreeItem {
-        const item = new vscode.TreeItem(
-            row.label,
-            vscode.TreeItemCollapsibleState.None,
-        );
-        item.id = row.id;
-        item.description = row.description;
-        item.tooltip = row.tooltip;
-        item.contextValue = row.contextValue;
+    protected decorate(item: vscode.TreeItem, row: EventLogRow): void {
         const event = this.eventById.get(row.id);
         item.iconPath = new vscode.ThemeIcon(
             row.kind === "event" && event ? iconForEvent(event) : "info",
         );
-        return item;
     }
 
     getChildren(row?: EventLogRow): EventLogRow[] {
@@ -174,6 +150,6 @@ export class EventLogTreeProvider
         this.generation++; // invalidate any in-flight seed
         this.subscription?.dispose();
         this.subscription = undefined;
-        this.emitter.dispose();
+        super.dispose();
     }
 }

--- a/ts/packages/typeagent-studio/src/extension.ts
+++ b/ts/packages/typeagent-studio/src/extension.ts
@@ -5,7 +5,6 @@ import * as vscode from "vscode";
 import { randomUUID } from "node:crypto";
 import * as path from "node:path";
 import { readFile } from "node:fs/promises";
-import { VERSION } from "@typeagent/core";
 import { registerStudioCommands } from "./commands.js";
 import { createStudioRuntime } from "./studioRuntime.js";
 import { ensureStudioService } from "./studioServiceLauncher.js";
@@ -882,14 +881,6 @@ export function activate(context: vscode.ExtensionContext): void {
             connection.startAutoConnect();
         }
     })();
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("typeagent-studio.hello", () => {
-            vscode.window.showInformationMessage(
-                `TypeAgent Studio skeleton (typeagent-core ${VERSION}).`,
-            );
-        }),
-    );
 }
 
 async function resolveSandboxId(

--- a/ts/packages/typeagent-studio/src/extension.ts
+++ b/ts/packages/typeagent-studio/src/extension.ts
@@ -517,7 +517,33 @@ export function activate(context: vscode.ExtensionContext): void {
         99,
     );
     serviceStatusBar.command = SERVICE_CONNECT_COMMAND;
+    // While disconnected the connection auto-retries on a backoff; a 1s ticker
+    // refreshes the countdown ("reconnecting in Ns…"). It's the single, global
+    // place that surfaces connection state — the views render nothing until
+    // connected rather than repeating a per-view "connecting" message.
+    let countdownTimer: ReturnType<typeof setInterval> | undefined;
+    const stopCountdown = () => {
+        if (countdownTimer !== undefined) {
+            clearInterval(countdownTimer);
+            countdownTimer = undefined;
+        }
+    };
+    const renderReconnecting = () => {
+        const at = connection.nextRetryAt;
+        const secs =
+            at !== undefined
+                ? Math.max(0, Math.ceil((at - Date.now()) / 1000))
+                : 0;
+        serviceStatusBar.text =
+            secs > 0
+                ? `$(sync~spin) Studio: reconnecting in ${secs}s…`
+                : "$(sync~spin) Studio: reconnecting…";
+        serviceStatusBar.tooltip =
+            "Studio service unavailable — reconnecting automatically. Click to retry now (or run `typeagent-studio serve`).";
+        serviceStatusBar.show();
+    };
     const renderServiceStatus = (state: StudioConnectionState) => {
+        stopCountdown();
         if (state === "connected") {
             serviceStatusBar.text = "$(plug) Studio: connected";
             serviceStatusBar.tooltip =
@@ -527,10 +553,9 @@ export function activate(context: vscode.ExtensionContext): void {
             serviceStatusBar.tooltip = "Connecting to the Studio service…";
         } else {
             // Disconnected always schedules an auto-retry (backoff), so frame it
-            // as reconnecting rather than a dead end needing a manual button.
-            serviceStatusBar.text = "$(sync~spin) Studio: reconnecting…";
-            serviceStatusBar.tooltip =
-                "Studio service unavailable — reconnecting automatically. Click to retry now (or run `typeagent-studio serve`).";
+            // as reconnecting (with a live countdown) rather than a dead end.
+            renderReconnecting();
+            countdownTimer = setInterval(renderReconnecting, 1000);
         }
         serviceStatusBar.show();
     };
@@ -548,6 +573,7 @@ export function activate(context: vscode.ExtensionContext): void {
         eventLog,
         eventLogView,
         serviceStatusBar,
+        { dispose: stopCountdown },
         { dispose: () => connection.dispose() },
         vscode.commands.registerCommand("typeagent-studio.refreshEvents", () =>
             eventLog.refresh(),
@@ -826,14 +852,9 @@ export function activate(context: vscode.ExtensionContext): void {
             renderServiceStatus(state);
             const connected = state === "connected";
 
-            // Drive the views' connection-aware empty states: when disconnected
-            // each tree renders nothing so its `viewsWelcome` "connect" content
-            // shows instead of a misleading "no data" placeholder.
-            void vscode.commands.executeCommand(
-                "setContext",
-                "typeagentStudio.serviceConnected",
-                connected,
-            );
+            // Each tree provider gates its own loading bar / empty state on the
+            // connection (see BaseStudioTreeProvider.whenConnected); the global
+            // status bar item carries the user-facing connection state.
             corpusTree.setConnected(connected);
             eventLog.setConnected(connected);
             collisions.setConnected(connected);
@@ -842,8 +863,7 @@ export function activate(context: vscode.ExtensionContext): void {
             if (connected && !sandboxesRestored) {
                 sandboxesRestored = true;
                 // Replay the service's persisted sandboxes once connected, then
-                // release the Sandbox view's loading bar (whether restore
-                // succeeded or failed) so it renders the restored rows.
+                // refresh so the view renders the restored rows.
                 void sandboxSource
                     .restoreSandboxes()
                     .then(() => sandboxTree.refresh())
@@ -852,8 +872,7 @@ export function activate(context: vscode.ExtensionContext): void {
                             "[typeagent-studio] Failed to restore sandboxes:",
                             describeError(err),
                         ),
-                    )
-                    .finally(() => sandboxTree.markReady());
+                    );
             }
         }),
         vscode.commands.registerCommand(SERVICE_CONNECT_COMMAND, async () => {

--- a/ts/packages/typeagent-studio/src/extension.ts
+++ b/ts/packages/typeagent-studio/src/extension.ts
@@ -554,15 +554,40 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand("typeagent-studio.clearEvents", () =>
             eventLog.clear(),
         ),
-        // Open the Impact Report webview — the first greenfield client of the
-        // service channel (replay over the channel; webview never opens a
-        // socket).
+        // Open a per-agent Impact Report. Launched from the graph icon on a
+        // Corpora agent row (the node carries the agent); when invoked without a
+        // row, fall back to a quick pick so a keybinding still works.
         vscode.commands.registerCommand(
             "typeagent-studio.openImpactReport",
-            () =>
-                openImpactReport(context, repoRootInfo.repoRoot, () =>
-                    connection.getTarget(),
-                ),
+            async (node?: { agent?: string }) => {
+                let agent = node?.agent;
+                if (!agent) {
+                    const agents = await serviceRuntime.listCorpusAgents();
+                    if (agents.length === 0) {
+                        vscode.window.showInformationMessage(
+                            "No agents have a corpus to replay. Load an agent into a sandbox first.",
+                        );
+                        return;
+                    }
+                    agent =
+                        agents.length === 1
+                            ? agents[0]
+                            : await vscode.window.showQuickPick(agents, {
+                                  title: "Open Impact Report",
+                                  placeHolder:
+                                      "Select an agent to open a report for",
+                              });
+                    if (!agent) {
+                        return;
+                    }
+                }
+                openImpactReport(
+                    context,
+                    repoRootInfo.repoRoot,
+                    () => connection.getTarget(),
+                    agent,
+                );
+            },
         ),
     );
 

--- a/ts/packages/typeagent-studio/src/extension.ts
+++ b/ts/packages/typeagent-studio/src/extension.ts
@@ -524,12 +524,13 @@ export function activate(context: vscode.ExtensionContext): void {
                 "Connected to the standalone Studio service for this workspace.";
         } else if (state === "connecting") {
             serviceStatusBar.text = "$(sync~spin) Studio: connecting…";
-            serviceStatusBar.tooltip =
-                "Launching / connecting to the Studio service…";
+            serviceStatusBar.tooltip = "Connecting to the Studio service…";
         } else {
-            serviceStatusBar.text = "$(debug-disconnect) Studio: disconnected";
+            // Disconnected always schedules an auto-retry (backoff), so frame it
+            // as reconnecting rather than a dead end needing a manual button.
+            serviceStatusBar.text = "$(sync~spin) Studio: reconnecting…";
             serviceStatusBar.tooltip =
-                "Studio service not connected. Click to retry (or run `typeagent-studio serve`).";
+                "Studio service unavailable — reconnecting automatically. Click to retry now (or run `typeagent-studio serve`).";
         }
         serviceStatusBar.show();
     };
@@ -584,7 +585,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 openImpactReport(
                     context,
                     repoRootInfo.repoRoot,
-                    () => connection.getTarget(),
+                    connection,
                     agent,
                 );
             },

--- a/ts/packages/typeagent-studio/src/gitRefProvider.ts
+++ b/ts/packages/typeagent-studio/src/gitRefProvider.ts
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Host-side git ref enumeration for the Impact Report version pickers.
+ *
+ * The webview never shells out to git (the security boundary); the extension
+ * host enumerates branches/tags/commits here and offers them through a native
+ * VS Code QuickPick. Every git call is read-only (`rev-parse`, `for-each-ref`,
+ * `log`). The exec function is injected so the parsing is unit-testable without
+ * a real repository.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { VersionSpec } from "@typeagent/core/replay";
+import type {
+    ResolvedVersion,
+    VersionProvenance,
+} from "./webviewKit/replayViewModel.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Runs `git -C <repoRoot> <args>` and resolves with raw stdout. */
+export type GitExec = (args: string[]) => Promise<string>;
+
+/** A real git runner rooted at `repoRoot`. */
+export function defaultGitExec(repoRoot: string): GitExec {
+    return async (args) => {
+        const { stdout } = await execFileAsync(
+            "git",
+            ["-C", repoRoot, ...args],
+            {
+                maxBuffer: 16 * 1024 * 1024,
+            },
+        );
+        return stdout;
+    };
+}
+
+/** Cap recent-commit enumeration so a deep history stays a snappy QuickPick. */
+const RECENT_COMMIT_LIMIT = 30;
+/** Field separator embedded in git format strings (ASCII unit separator). */
+const FS = "\u001f";
+
+function lines(stdout: string): string[] {
+    return stdout
+        .split("\n")
+        .map((l) => l.trimEnd())
+        .filter((l) => l.length > 0);
+}
+
+/** Run a git command, resolving with its stdout or `undefined` if it fails, so
+ *  one unreadable section never sinks the whole enumeration. */
+async function tryExec(
+    exec: GitExec,
+    args: string[],
+): Promise<string | undefined> {
+    try {
+        return await exec(args);
+    } catch {
+        return undefined;
+    }
+}
+
+/** Pull the current branch name out of a `git log %D` decoration, e.g.
+ *  "HEAD -> main, origin/main, tag: v1" → "main". A detached HEAD ("HEAD, …")
+ *  has no `HEAD -> ` segment and yields undefined. */
+function parseCurrentBranch(
+    decoration: string | undefined,
+): string | undefined {
+    if (!decoration) {
+        return undefined;
+    }
+    const head = decoration
+        .split(",")
+        .map((s) => s.trim())
+        .find((s) => s.startsWith("HEAD -> "));
+    return head ? head.slice("HEAD -> ".length).trim() : undefined;
+}
+
+const WORKING_TREE: ResolvedVersion = {
+    spec: { kind: "workingTree" },
+    label: "working tree",
+    tooltip: "Your uncommitted edits in the working tree.",
+};
+
+/**
+ * Enumerate the local versions a user can compare, ordered for the QuickPick:
+ * working tree, HEAD, the current branch, other branches (most-recent first),
+ * tags, then recent commits. Remote-tracking branches are intentionally excluded
+ * (see {@link listRemoteRefs}) to keep this fast and the list short.
+ *
+ * Spawning git is the dominant cost (each process is expensive), so this issues
+ * exactly **two** parallel calls: one `git log` that yields HEAD + the current
+ * branch + recent commits, and one `git for-each-ref` that yields branches and
+ * tags together. Resilient — a call that fails is skipped and the working tree
+ * is always offered.
+ */
+export async function listVersionRefs(
+    exec: GitExec,
+): Promise<ResolvedVersion[]> {
+    const [headLog, refRows] = await Promise.all([
+        // First line is HEAD (its %D decoration names the current branch); all
+        // lines are the recent-commit list.
+        tryExec(exec, [
+            "log",
+            "-n",
+            String(RECENT_COMMIT_LIMIT),
+            `--format=%h${FS}%s${FS}%D`,
+        ]),
+        // Branches and tags in one pass; the full %(refname) classifies each.
+        tryExec(exec, [
+            "for-each-ref",
+            "--sort=-committerdate",
+            `--format=%(refname)${FS}%(refname:short)${FS}%(objectname:short)${FS}%(contents:subject)`,
+            "refs/heads",
+            "refs/tags",
+        ]),
+    ]);
+
+    const refs: ResolvedVersion[] = [WORKING_TREE];
+
+    const commitLines = headLog !== undefined ? lines(headLog) : [];
+    let currentBranch: string | undefined;
+    if (commitLines.length > 0) {
+        const [sha, subject, decoration] = commitLines[0].split(FS);
+        currentBranch = parseCurrentBranch(decoration);
+        refs.push({
+            spec: { kind: "git", ref: "HEAD" },
+            label: currentBranch ? `HEAD (${currentBranch})` : "HEAD",
+            tooltip: currentBranch
+                ? `Last commit on ${currentBranch} \u2014 ${sha} ${subject ?? ""}`.trim()
+                : `Last commit (detached) \u2014 ${sha} ${subject ?? ""}`.trim(),
+        });
+    }
+
+    const branches: { name: string; sha: string; subject: string }[] = [];
+    const tags: { name: string; sha: string; subject: string }[] = [];
+    if (refRows !== undefined) {
+        for (const line of lines(refRows)) {
+            const [fullRef, name, sha, subject] = line.split(FS);
+            if (!name) continue;
+            const entry = { name, sha, subject: subject ?? "" };
+            if (fullRef.startsWith("refs/heads/")) {
+                branches.push(entry);
+            } else if (fullRef.startsWith("refs/tags/")) {
+                tags.push(entry);
+            }
+        }
+    }
+
+    // Current branch first so the most likely pick is at the top.
+    branches.sort((a, b) => {
+        if (a.name === currentBranch) return -1;
+        if (b.name === currentBranch) return 1;
+        return 0;
+    });
+    for (const b of branches) {
+        const isCurrent = b.name === currentBranch;
+        refs.push({
+            spec: { kind: "git", ref: b.name },
+            label: isCurrent ? `${b.name} (current)` : b.name,
+            tooltip: `Branch ${b.name} \u2014 ${b.sha} ${b.subject}`.trim(),
+        });
+    }
+    for (const t of tags) {
+        refs.push({
+            spec: { kind: "git", ref: t.name },
+            label: t.name,
+            tooltip: `Tag ${t.name} \u2014 ${t.sha} ${t.subject}`.trim(),
+        });
+    }
+
+    for (const line of commitLines) {
+        const [sha, subject] = line.split(FS);
+        if (!sha) continue;
+        const subj = subject ?? "";
+        refs.push({
+            spec: { kind: "git", ref: sha },
+            label: subj ? `${sha} ${subj}` : sha,
+            tooltip: `Commit ${sha} \u2014 ${subj}`.trim(),
+        });
+    }
+
+    return refs;
+}
+
+/**
+ * Enumerate remote-tracking branches (`refs/remotes`) the repo already knows
+ * about — local-only, no network `git fetch`. Loaded on demand (and cached by
+ * the caller) because a busy remote can have hundreds of branches that would
+ * bloat and slow the default version list. The symbolic `<remote>/HEAD` pointer
+ * is filtered out.
+ */
+export async function listRemoteRefs(
+    exec: GitExec,
+): Promise<ResolvedVersion[]> {
+    const out = await tryExec(exec, [
+        "for-each-ref",
+        "--sort=-committerdate",
+        `--format=%(refname:short)${FS}%(objectname:short)${FS}%(contents:subject)`,
+        "refs/remotes",
+    ]);
+    if (out === undefined) {
+        return [];
+    }
+    const refs: ResolvedVersion[] = [];
+    for (const line of lines(out)) {
+        const [name, sha, subject] = line.split(FS);
+        if (!name || name.endsWith("/HEAD")) {
+            // Skip the symbolic origin/HEAD pointer.
+            continue;
+        }
+        refs.push({
+            spec: { kind: "git", ref: name },
+            label: name,
+            tooltip:
+                `Remote branch ${name} \u2014 ${sha} ${subject ?? ""}`.trim(),
+        });
+    }
+    return refs;
+}
+
+/**
+ * Validate and resolve a free-form ref the user typed (a commit SHA, tag, branch,
+ * or a relative ref like `HEAD~3`). Returns a {@link ResolvedVersion} pinned to
+ * the entered ref, or `undefined` if git can't resolve it to a commit. The
+ * `^{commit}` peel makes annotated tags resolve to their commit; `--` guards
+ * against a ref that collides with a path name. A single git spawn does both the
+ * existence check and the subject lookup.
+ */
+export async function resolveRef(
+    exec: GitExec,
+    ref: string,
+): Promise<ResolvedVersion | undefined> {
+    const input = ref.trim();
+    if (input.length === 0) {
+        return undefined;
+    }
+    const out = await tryExec(exec, [
+        "log",
+        "-n",
+        "1",
+        `--format=%h${FS}%s`,
+        `${input}^{commit}`,
+        "--",
+    ]);
+    if (out === undefined) {
+        return undefined;
+    }
+    const [first] = lines(out);
+    if (!first) {
+        return undefined;
+    }
+    const [sha, subject] = first.split(FS);
+    if (!sha) {
+        return undefined;
+    }
+    const subj = subject ?? "";
+    return {
+        spec: { kind: "git", ref: input },
+        label: subj ? `${input} \u2014 ${subj}` : input,
+        tooltip: `Commit ${sha} \u2014 ${subj}`.trim(),
+    };
+}
+
+/**
+ * Resolve the concrete identity a side will run against, captured at run time.
+ * A git ref is pinned to its short SHA (so a later branch move doesn't make the
+ * report lie); the working tree records the HEAD it sits on plus the live marker.
+ * Resolution failures degrade to a label-only provenance rather than throwing.
+ */
+export async function resolveVersionProvenance(
+    spec: VersionSpec,
+    exec: GitExec,
+): Promise<VersionProvenance> {
+    if (spec.kind === "workingTree") {
+        const base: VersionProvenance = {
+            label: "working tree",
+            workingTree: true,
+        };
+        try {
+            const sha = (await exec(["rev-parse", "--short", "HEAD"])).trim();
+            return sha ? { ...base, sha } : base;
+        } catch {
+            return base;
+        }
+    }
+    const base: VersionProvenance = { label: spec.ref, workingTree: false };
+    try {
+        const sha = (await exec(["rev-parse", "--short", spec.ref])).trim();
+        return sha ? { ...base, sha } : base;
+    } catch {
+        return base;
+    }
+}

--- a/ts/packages/typeagent-studio/src/gitRefProvider.ts
+++ b/ts/packages/typeagent-studio/src/gitRefProvider.ts
@@ -243,6 +243,10 @@ export async function resolveRef(
         "-n",
         "1",
         `--format=%h${FS}%s`,
+        // `--end-of-options` stops git from parsing a ref that begins with `-`
+        // (e.g. a typed `--output=…`) as an option; `--` then guards against a
+        // ref that collides with a path name.
+        "--end-of-options",
         `${input}^{commit}`,
         "--",
     ]);
@@ -289,7 +293,11 @@ export async function resolveVersionProvenance(
     }
     const base: VersionProvenance = { label: spec.ref, workingTree: false };
     try {
-        const sha = (await exec(["rev-parse", "--short", spec.ref])).trim();
+        // `--end-of-options` keeps a webview-supplied ref that starts with `-`
+        // from being parsed as a git option.
+        const sha = (
+            await exec(["rev-parse", "--short", "--end-of-options", spec.ref])
+        ).trim();
         return sha ? { ...base, sha } : base;
     } catch {
         return base;

--- a/ts/packages/typeagent-studio/src/impactReportView.ts
+++ b/ts/packages/typeagent-studio/src/impactReportView.ts
@@ -6,8 +6,19 @@ import { WebviewKitPanel } from "./webviewKit/host.js";
 import {
     parseWebviewMessage,
     type HostToWebviewMessage,
+    type ReplaySide,
 } from "./webviewKit/protocol.js";
-import { parseVersionInput } from "./webviewKit/replayViewModel.js";
+import type {
+    ResolvedVersion,
+    RunProvenance,
+} from "./webviewKit/replayViewModel.js";
+import {
+    defaultGitExec,
+    listVersionRefs,
+    listRemoteRefs,
+    resolveRef,
+    resolveVersionProvenance,
+} from "./gitRefProvider.js";
 import { StudioServiceClient } from "./studioServiceClient.js";
 import type { StudioReplayResult } from "@typeagent/core/runtime";
 
@@ -32,8 +43,18 @@ export function openImpactReport(
     // panel is `retainContextWhenHidden: false`, so hidden panels drop posts) is
     // recovered on reveal — the webview dedupes by request id.
     let lastResult:
-        | { requestId: number; payload: StudioReplayResult }
+        | {
+              requestId: number;
+              payload: StudioReplayResult;
+              provenance?: RunProvenance;
+          }
         | undefined;
+    // Per-panel ref caches so re-opening a version picker is instant. The local
+    // list is invalidated on each run (a commit or branch switch may have moved
+    // HEAD); the remote-tracking list is enumerated on demand and kept for the
+    // panel's lifetime (re-open the panel to refresh it).
+    let localRefsCache: ResolvedVersion[] | undefined;
+    let remoteRefsCache: ResolvedVersion[] | undefined;
 
     const panel = WebviewKitPanel.createOrReveal(context, {
         viewType: VIEW_TYPE,
@@ -98,8 +119,188 @@ export function openImpactReport(
                 type: "result",
                 requestId: lastResult.requestId,
                 payload: lastResult.payload,
+                ...(lastResult.provenance
+                    ? { provenance: lastResult.provenance }
+                    : {}),
             });
         }
+    };
+
+    const WORKING_TREE_REF: ResolvedVersion = {
+        spec: { kind: "workingTree" },
+        label: "working tree",
+        tooltip: "Your uncommitted edits in the working tree.",
+    };
+
+    // Sentinel for the "show remote branches" affordance. It carries no resolved
+    // version; selecting it enumerates remote-tracking refs and re-opens the pick.
+    type VersionItem = vscode.QuickPickItem & { resolved?: ResolvedVersion };
+    const SHOW_REMOTES_ITEM: VersionItem = {
+        label: "$(cloud) Show remote branches…",
+        description: "List remote-tracking branches (no fetch)",
+        alwaysShow: true,
+    };
+    // Sentinel for free-form entry of a commit SHA or any other ref (e.g.
+    // HEAD~3). Selecting it opens an InputBox validated against git on the host.
+    const ENTER_REF_ITEM: VersionItem = {
+        label: "$(edit) Enter a commit or ref…",
+        description: "Type a commit SHA, tag, or branch",
+        alwaysShow: true,
+    };
+
+    // Prompt for a free-form ref and validate it against git. Loops on an
+    // unresolvable ref so a typo doesn't drop the user back to the start; an
+    // empty input (Esc) cancels and returns undefined.
+    const promptForRef = async (
+        exec: ReturnType<typeof defaultGitExec> | undefined,
+    ): Promise<ResolvedVersion | undefined> => {
+        if (!exec) {
+            return undefined;
+        }
+        let prefill = "";
+        for (;;) {
+            const input = await vscode.window.showInputBox({
+                title: "Impact Report — enter a commit or ref",
+                prompt: "Commit SHA, tag, branch, or relative ref (e.g. HEAD~3)",
+                placeHolder: "e.g. a1b2c3d or v1.2 or HEAD~3",
+                value: prefill,
+                ignoreFocusOut: true,
+            });
+            if (input === undefined || input.trim().length === 0) {
+                return undefined;
+            }
+            const resolved = await resolveRef(exec, input);
+            if (resolved) {
+                return resolved;
+            }
+            prefill = input;
+            void vscode.window.showWarningMessage(
+                `Git couldn't resolve "${input.trim()}" to a commit. Try again.`,
+            );
+        }
+    };
+
+    // The webview can't shell out to git (the security boundary), so version
+    // selection runs as a native QuickPick here. Local refs are cached per panel
+    // (invalidated on each run); remote-tracking refs are enumerated lazily and
+    // appended only when the user asks for them. An empty selection (Esc) leaves
+    // the webview's current choice untouched — no message is posted.
+    const pickVersion = async (side: ReplaySide): Promise<void> => {
+        const exec =
+            repoRoot !== undefined ? defaultGitExec(repoRoot) : undefined;
+        if (localRefsCache === undefined) {
+            if (exec) {
+                try {
+                    localRefsCache = await listVersionRefs(exec);
+                } catch {
+                    localRefsCache = [WORKING_TREE_REF];
+                }
+            } else {
+                localRefsCache = [WORKING_TREE_REF];
+            }
+        }
+
+        const title = `Impact Report — ${side === "a" ? "base (A)" : "compare (B)"} version`;
+        const toItems = (refs: ResolvedVersion[]): VersionItem[] =>
+            refs.map((r) => ({
+                label: r.label,
+                description: r.tooltip,
+                resolved: r,
+            }));
+
+        // Re-open loop: selecting the sentinel enumerates remotes and re-renders
+        // with them appended; any other choice resolves (or Esc cancels).
+        let showRemotes = remoteRefsCache !== undefined;
+        for (;;) {
+            const items: VersionItem[] = toItems(localRefsCache);
+            if (exec) {
+                items.push(ENTER_REF_ITEM);
+            }
+            if (!showRemotes && exec) {
+                items.push(SHOW_REMOTES_ITEM);
+            }
+            if (showRemotes && remoteRefsCache && remoteRefsCache.length > 0) {
+                items.push({
+                    label: "remote branches",
+                    kind: vscode.QuickPickItemKind.Separator,
+                });
+                items.push(...toItems(remoteRefsCache));
+            }
+            const choice = await vscode.window.showQuickPick(items, {
+                title,
+                placeHolder: "Select a version to compare",
+                matchOnDescription: true,
+            });
+            if (!choice) {
+                return;
+            }
+            if (choice === ENTER_REF_ITEM) {
+                const resolved = await promptForRef(exec);
+                if (resolved) {
+                    post({ type: "versionPicked", side, resolved });
+                    return;
+                }
+                // Cancelled the input box — fall back to the version list.
+                continue;
+            }
+            if (choice === SHOW_REMOTES_ITEM) {
+                if (remoteRefsCache === undefined && exec) {
+                    try {
+                        remoteRefsCache = await listRemoteRefs(exec);
+                    } catch {
+                        remoteRefsCache = [];
+                    }
+                }
+                if (!remoteRefsCache || remoteRefsCache.length === 0) {
+                    void vscode.window.showInformationMessage(
+                        "No remote-tracking branches were found.",
+                    );
+                    showRemotes = false;
+                    continue;
+                }
+                showRemotes = true;
+                continue;
+            }
+            if (choice.resolved) {
+                post({
+                    type: "versionPicked",
+                    side,
+                    resolved: choice.resolved,
+                });
+            }
+            return;
+        }
+    };
+
+    const pickAgent = async (): Promise<void> => {
+        const c = await ensureClient();
+        if (!c) {
+            post({
+                type: "error",
+                message: "Not connected to the studio service.",
+            });
+            return;
+        }
+        let agents: string[] = [];
+        try {
+            agents = await c.listCorpusAgents();
+        } catch {
+            // Listing failed; nothing to pick.
+        }
+        if (agents.length === 0) {
+            void vscode.window.showInformationMessage(
+                "No corpus agents are available to replay.",
+            );
+            return;
+        }
+        const choice = await vscode.window.showQuickPick(agents, {
+            title: "Impact Report — agent",
+            placeHolder: "Select an agent corpus to replay",
+        });
+        if (!choice) {
+            return;
+        }
+        post({ type: "agentPicked", agent: choice });
     };
 
     const handleMessage = async (raw: unknown): Promise<void> => {
@@ -115,7 +316,18 @@ export function openImpactReport(
             await sendInit();
             return;
         }
+        if (msg.type === "pickVersion") {
+            await pickVersion(msg.side);
+            return;
+        }
+        if (msg.type === "pickAgent") {
+            await pickAgent();
+            return;
+        }
         // msg.type === "run"
+        // A run may follow a commit or branch switch, so the cached local refs
+        // could be stale — drop them so the next picker re-enumerates HEAD.
+        localRefsCache = undefined;
         try {
             const c = await ensureClient();
             if (!c) {
@@ -126,6 +338,19 @@ export function openImpactReport(
                 });
                 return;
             }
+            // Pin each side to the concrete commit it ran against (a bare
+            // HEAD/branch label goes stale when the branch moves), captured now
+            // so the report stays self-describing.
+            const exec =
+                repoRoot !== undefined ? defaultGitExec(repoRoot) : undefined;
+            let provenance: RunProvenance | undefined;
+            if (exec) {
+                const [a, b] = await Promise.all([
+                    resolveVersionProvenance(msg.versionA, exec),
+                    resolveVersionProvenance(msg.versionB, exec),
+                ]);
+                provenance = { a, b, runAt: Date.now() };
+            }
             const payload = await c.replayCorpus({
                 agent: msg.agent,
                 // The launch controls choose the two versions to compare
@@ -133,12 +358,21 @@ export function openImpactReport(
                 // journey). The static-grammar resolver builds each side and
                 // the deterministic `needs-explanation` policy keeps the run
                 // free of LLM calls.
-                versionA: parseVersionInput(msg.versionA),
-                versionB: parseVersionInput(msg.versionB),
+                versionA: msg.versionA,
+                versionB: msg.versionB,
                 missPolicy: "needs-explanation",
             });
-            post({ type: "result", requestId: msg.requestId, payload });
-            lastResult = { requestId: msg.requestId, payload };
+            post({
+                type: "result",
+                requestId: msg.requestId,
+                payload,
+                ...(provenance ? { provenance } : {}),
+            });
+            lastResult = {
+                requestId: msg.requestId,
+                payload,
+                ...(provenance ? { provenance } : {}),
+            };
         } catch (e) {
             post({
                 type: "error",

--- a/ts/packages/typeagent-studio/src/impactReportView.ts
+++ b/ts/packages/typeagent-studio/src/impactReportView.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as vscode from "vscode";
-import * as path from "node:path";
 import { WebviewKitPanel } from "./webviewKit/host.js";
 import {
     parseWebviewMessage,
@@ -35,10 +34,6 @@ export function openImpactReport(
     let lastResult:
         | { requestId: number; payload: StudioReplayResult }
         | undefined;
-
-    const repoName =
-        repoRoot !== undefined ? path.basename(repoRoot) : undefined;
-    const repoField = repoName !== undefined ? { repoName } : {};
 
     const panel = WebviewKitPanel.createOrReveal(context, {
         viewType: VIEW_TYPE,
@@ -87,7 +82,7 @@ export function openImpactReport(
         post({ type: "status", text: "Connecting to the studio service…" });
         const c = await ensureClient();
         if (!c) {
-            post({ type: "init", agents: [], connected: false, ...repoField });
+            post({ type: "init", agents: [], connected: false });
             return;
         }
         let agents: string[] = [];
@@ -96,7 +91,7 @@ export function openImpactReport(
         } catch {
             // Connected but listing failed; surface an empty agent list.
         }
-        post({ type: "init", agents, connected: true, ...repoField });
+        post({ type: "init", agents, connected: true });
         // Recover a result computed while the panel was hidden/reloaded.
         if (lastResult) {
             post({

--- a/ts/packages/typeagent-studio/src/impactReportView.ts
+++ b/ts/packages/typeagent-studio/src/impactReportView.ts
@@ -25,16 +25,19 @@ import type { StudioReplayResult } from "@typeagent/core/runtime";
 const VIEW_TYPE = "typeagentStudio.impactReport";
 
 /**
- * Open (or reveal) the Impact Report webview — the first greenfield client of
- * the `studio` service channel. The webview never opens a socket: it asks the
- * extension host (here) to run a replay, and the host drives the agent's runtime
- * over the channel (`listCorpusAgents` / `replayCorpus`) and posts typed results
+ * Open (or reveal) the Impact Report webview for a single `agent` — the first
+ * greenfield client of the `studio` service channel. One panel exists per agent
+ * (keyed by `instanceKey`), so reports for different agents open as separate
+ * tabs the user can place side-by-side. The webview never opens a socket: it
+ * asks the extension host (here) to run a replay, and the host drives the
+ * agent's runtime over the channel (`replayCorpus`) and posts typed results
  * back. The channel client is owned per-panel and closed on dispose.
  */
 export function openImpactReport(
     context: vscode.ExtensionContext,
     repoRoot: string | undefined,
     getTarget: () => { endpoint: string; token: string } | undefined,
+    agent: string,
 ): void {
     let client: StudioServiceClient | undefined;
     let connecting: Promise<StudioServiceClient | undefined> | undefined;
@@ -58,7 +61,8 @@ export function openImpactReport(
 
     const panel = WebviewKitPanel.createOrReveal(context, {
         viewType: VIEW_TYPE,
-        title: "Studio Impact Report",
+        instanceKey: agent,
+        title: `Impact Report — ${agent}`,
         scriptPath: ["dist", "webview", "impactReport.js"],
         stylePath: ["media", "impactReport.css"],
         onMessage: (raw) => void handleMessage(raw),
@@ -103,16 +107,19 @@ export function openImpactReport(
         post({ type: "status", text: "Connecting to the studio service…" });
         const c = await ensureClient();
         if (!c) {
-            post({ type: "init", agents: [], connected: false });
+            post({ type: "init", agent, connected: false, available: false });
             return;
         }
-        let agents: string[] = [];
+        // Confirm this agent still has a corpus to replay so the webview can
+        // explain an empty/unavailable state rather than failing a run blindly.
+        let available = false;
         try {
-            agents = await c.listCorpusAgents();
+            const agents = await c.listCorpusAgents();
+            available = agents.includes(agent);
         } catch {
-            // Connected but listing failed; surface an empty agent list.
+            // Connected but listing failed; treat as unavailable for now.
         }
-        post({ type: "init", agents, connected: true });
+        post({ type: "init", agent, connected: true, available });
         // Recover a result computed while the panel was hidden/reloaded.
         if (lastResult) {
             post({
@@ -272,37 +279,6 @@ export function openImpactReport(
         }
     };
 
-    const pickAgent = async (): Promise<void> => {
-        const c = await ensureClient();
-        if (!c) {
-            post({
-                type: "error",
-                message: "Not connected to the studio service.",
-            });
-            return;
-        }
-        let agents: string[] = [];
-        try {
-            agents = await c.listCorpusAgents();
-        } catch {
-            // Listing failed; nothing to pick.
-        }
-        if (agents.length === 0) {
-            void vscode.window.showInformationMessage(
-                "No corpus agents are available to replay.",
-            );
-            return;
-        }
-        const choice = await vscode.window.showQuickPick(agents, {
-            title: "Impact Report — agent",
-            placeHolder: "Select an agent corpus to replay",
-        });
-        if (!choice) {
-            return;
-        }
-        post({ type: "agentPicked", agent: choice });
-    };
-
     const handleMessage = async (raw: unknown): Promise<void> => {
         const msg = parseWebviewMessage(raw);
         if (!msg) {
@@ -318,10 +294,6 @@ export function openImpactReport(
         }
         if (msg.type === "pickVersion") {
             await pickVersion(msg.side);
-            return;
-        }
-        if (msg.type === "pickAgent") {
-            await pickAgent();
             return;
         }
         // msg.type === "run"
@@ -352,7 +324,9 @@ export function openImpactReport(
                 provenance = { a, b, runAt: Date.now() };
             }
             const payload = await c.replayCorpus({
-                agent: msg.agent,
+                // The panel is scoped to a single agent; use that authoritative
+                // agent rather than trusting the webview's echoed value.
+                agent,
                 // The launch controls choose the two versions to compare
                 // (default: HEAD → working tree, the "find a regression"
                 // journey). The static-grammar resolver builds each side and

--- a/ts/packages/typeagent-studio/src/impactReportView.ts
+++ b/ts/packages/typeagent-studio/src/impactReportView.ts
@@ -20,9 +20,21 @@ import {
     resolveVersionProvenance,
 } from "./gitRefProvider.js";
 import { StudioServiceClient } from "./studioServiceClient.js";
+import type { StudioConnectionState } from "./studioServiceConnection.js";
 import type { StudioReplayResult } from "@typeagent/core/runtime";
 
 const VIEW_TYPE = "typeagentStudio.impactReport";
+
+/** The slice of the shared {@link StudioServiceConnection} the report needs: the
+ *  service target for its dedicated replay client, plus the live connection
+ *  state so the webview can show one connection indicator and auto-reconnect. */
+export interface ImpactReportConnection {
+    getTarget(): { endpoint: string; token: string } | undefined;
+    readonly currentState: StudioConnectionState;
+    onStateChanged(listener: (state: StudioConnectionState) => void): {
+        dispose(): void;
+    };
+}
 
 /**
  * Open (or reveal) the Impact Report webview for a single `agent` — the first
@@ -36,11 +48,16 @@ const VIEW_TYPE = "typeagentStudio.impactReport";
 export function openImpactReport(
     context: vscode.ExtensionContext,
     repoRoot: string | undefined,
-    getTarget: () => { endpoint: string; token: string } | undefined,
+    connection: ImpactReportConnection,
     agent: string,
 ): void {
     let client: StudioServiceClient | undefined;
     let connecting: Promise<StudioServiceClient | undefined> | undefined;
+    // Set once the webview has loaded and asked for state; until then, posts are
+    // dropped (the iframe isn't listening yet) so we defer to the `ready` pull.
+    let webviewReady = false;
+    // Subscription to the shared connection's state, disposed with the panel.
+    let stateSub: { dispose(): void } | undefined;
     // The last completed result + its request id. Re-posted whenever the webview
     // signals `ready` so a run that finished while the iframe was torn down (the
     // panel is `retainContextWhenHidden: false`, so hidden panels drop posts) is
@@ -67,6 +84,8 @@ export function openImpactReport(
         stylePath: ["media", "impactReport.css"],
         onMessage: (raw) => void handleMessage(raw),
         onDispose: () => {
+            stateSub?.dispose();
+            stateSub = undefined;
             client?.close();
             client = undefined;
             connecting = undefined;
@@ -85,7 +104,7 @@ export function openImpactReport(
             // Reach the same standalone service the shared connection uses (the
             // agent no longer serves the runtime, so there is no discovery
             // fallback); a dedicated client keeps heavy replay off the shared one.
-            const target = getTarget();
+            const target = connection.getTarget();
             connecting = StudioServiceClient.connect({
                 ...(repoRoot !== undefined ? { repoRoot } : {}),
                 ...(target !== undefined
@@ -284,12 +303,19 @@ export function openImpactReport(
         if (!msg) {
             return;
         }
-        if (msg.type === "ready" || msg.type === "reconnect") {
-            if (msg.type === "reconnect") {
+        if (msg.type === "ready") {
+            // The webview is now listening: report the live connection state and,
+            // when connected, dial a fresh client and push init. Disconnected /
+            // connecting states leave the controls off — the shared connection's
+            // auto-reconnect drives the next init (no manual button).
+            webviewReady = true;
+            postConnection(connection.currentState);
+            if (connection.currentState === "connected") {
                 client?.close();
                 client = undefined;
+                connecting = undefined;
+                await sendInit();
             }
-            await sendInit();
             return;
         }
         if (msg.type === "pickVersion") {
@@ -355,4 +381,26 @@ export function openImpactReport(
             });
         }
     };
+
+    const postConnection = (state: StudioConnectionState): void => {
+        post({ type: "connection", state });
+    };
+
+    // Mirror the shared connection so the webview shows a single connection
+    // indicator and reconnects without a button. On each (re)connect, drop the
+    // dedicated replay client so the next init/run dials a fresh socket to the
+    // live service. The immediate fire on subscribe lands before the webview is
+    // ready (guarded), so the `ready` pull seeds the first state.
+    stateSub = connection.onStateChanged((state) => {
+        if (!webviewReady) {
+            return;
+        }
+        postConnection(state);
+        if (state === "connected") {
+            client?.close();
+            client = undefined;
+            connecting = undefined;
+            void sendInit();
+        }
+    });
 }

--- a/ts/packages/typeagent-studio/src/replayPresentation.ts
+++ b/ts/packages/typeagent-studio/src/replayPresentation.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ActionDelta, ReplaySummary } from "@typeagent/core/replay";
+import { collapseAndTruncate } from "./textFormatting.js";
 
 export type ReplayRowStatus = "equal" | "changed" | "new-match" | "lost-match";
 
@@ -52,10 +53,7 @@ export function classifyReplayRow(row: ActionDelta): ReplayRowStatus {
 }
 
 function truncate(text: string, max = 80): string {
-    const collapsed = text.replace(/\s+/g, " ").trim();
-    return collapsed.length > max
-        ? `${collapsed.slice(0, max - 1)}\u2026`
-        : collapsed;
+    return collapseAndTruncate(text, max);
 }
 
 export function formatReplayRow(row: ActionDelta): ReplayRowView {

--- a/ts/packages/typeagent-studio/src/sandboxTreePresentation.ts
+++ b/ts/packages/typeagent-studio/src/sandboxTreePresentation.ts
@@ -7,6 +7,11 @@ import type {
     SandboxStatus,
 } from "@typeagent/core/sandbox";
 import type { SandboxState } from "@typeagent/core/events";
+import {
+    noteTooltip,
+    type TooltipField,
+    type TooltipModel,
+} from "./tooltipModel.js";
 
 /**
  * Pure, vscode-free mapping from sandbox status to tree-node descriptors.
@@ -24,7 +29,7 @@ export interface SandboxTreeNode {
     id: string;
     label: string;
     description?: string;
-    tooltip?: string;
+    tooltip?: TooltipModel;
     /** Drives `when` clauses for context-menu contributions. */
     contextValue?: string;
     /** Present on `sandbox` and `agent` nodes. */
@@ -50,7 +55,9 @@ export function buildSandboxRootNodes(
                 id: EMPTY_ROOT_ID,
                 label: "No sandboxes running",
                 description: "Start one to begin",
-                tooltip: "Use “TypeAgent Studio: Start sandbox” to create one.",
+                tooltip: noteTooltip(
+                    "Use \u201cTypeAgent Studio: Start sandbox\u201d to create one.",
+                ),
                 hasChildren: false,
             },
         ];
@@ -110,12 +117,13 @@ function toAgentNode(
     agent: SandboxAgentInfo,
 ): SandboxTreeNode {
     const fingerprint = formatHashFingerprint(agent.schemaHash);
-    const health = formatHealth(agent.health);
     return {
         kind: "agent",
         id: `agent:${sandboxId}:${agent.name}`,
         label: agent.name,
-        description: fingerprint ? `${health} \u00b7 ${fingerprint}` : health,
+        // Health is conveyed by the row icon's colour, so the description carries
+        // just the schema fingerprint (when the agent has one on disk).
+        description: fingerprint,
         tooltip: buildAgentTooltip(agent),
         contextValue: "sandboxAgent",
         sandboxId,
@@ -156,36 +164,50 @@ export function formatHealth(health: HealthStatus): string {
     }
 }
 
-function buildSandboxTooltip(sandbox: SandboxStatus): string {
-    const lines = [
-        `Sandbox: ${sandbox.id}`,
-        `Mode: ${sandbox.mode}`,
-        `State: ${formatSandboxState(sandbox.state)}`,
-        `Agents: ${sandbox.agents.length}`,
+function buildSandboxTooltip(sandbox: SandboxStatus): TooltipModel {
+    const fields: TooltipField[] = [
+        { label: "Sandbox", value: sandbox.id, mono: true },
+        { label: "Mode", value: sandbox.mode },
+        { label: "State", value: formatSandboxState(sandbox.state) },
+        { label: "Agents", value: String(sandbox.agents.length) },
     ];
     if (sandbox.pid !== undefined) {
-        lines.push(`PID: ${sandbox.pid}`);
+        fields.push({ label: "PID", value: String(sandbox.pid), mono: true });
     }
     if (sandbox.startedAt !== undefined) {
-        lines.push(`Started: ${new Date(sandbox.startedAt).toISOString()}`);
+        fields.push({
+            label: "Started",
+            value: new Date(sandbox.startedAt).toISOString(),
+        });
     }
-    return lines.join("\n");
+    return { fields };
 }
 
-function buildAgentTooltip(agent: SandboxAgentInfo): string {
-    const lines = [
-        `Agent: ${agent.name}`,
-        `Health: ${formatHealth(agent.health)}`,
-        `Schema: ${formatHashFull(agent.schemaHash)}`,
-        `Grammar: ${formatHashFull(agent.grammarHash)}`,
+function buildAgentTooltip(agent: SandboxAgentInfo): TooltipModel {
+    const fields: TooltipField[] = [
+        { label: "Agent", value: agent.name },
+        { label: "Health", value: formatHealth(agent.health) },
+        {
+            label: "Schema",
+            value: formatHashFull(agent.schemaHash),
+            mono: true,
+        },
+        {
+            label: "Grammar",
+            value: formatHashFull(agent.grammarHash),
+            mono: true,
+        },
     ];
     if (agent.sourcePath) {
-        lines.push(`Source: ${agent.sourcePath}`);
+        fields.push({ label: "Source", value: agent.sourcePath, mono: true });
     }
     if (agent.loadedAt !== undefined) {
-        lines.push(`Loaded: ${new Date(agent.loadedAt).toISOString()}`);
+        fields.push({
+            label: "Loaded",
+            value: new Date(agent.loadedAt).toISOString(),
+        });
     }
-    return lines.join("\n");
+    return { fields };
 }
 
 /**

--- a/ts/packages/typeagent-studio/src/sandboxTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/sandboxTreeProvider.ts
@@ -27,41 +27,9 @@ export class SandboxTreeProvider
 {
     private readonly subscription: { dispose(): void };
 
-    // Initial-load gate: until the first connect + sandbox restore settles, the
-    // root `getChildren` awaits this so VS Code keeps the view's native loading
-    // bar showing — rather than resolving to an empty list and flashing a blank
-    // view before the persisted sandboxes come back. A safety timer resolves it
-    // so a service that never connects can't spin the bar forever.
-    private ready = false;
-    private resolveReady!: () => void;
-    private readonly readyGate = new Promise<void>((resolve) => {
-        this.resolveReady = resolve;
-    });
-    private readyTimer: ReturnType<typeof setTimeout> | undefined;
-
     constructor(private readonly source: SandboxSource) {
         super();
         this.subscription = source.onSandboxChanged(() => this.refresh());
-        this.readyTimer = setTimeout(() => this.markReady(), 20_000);
-        this.readyTimer.unref?.();
-    }
-
-    /**
-     * Signal that the initial connect + sandbox restore has settled (or timed
-     * out), so the view stops holding the loading bar and renders real rows.
-     * Idempotent.
-     */
-    markReady(): void {
-        if (this.ready) {
-            return;
-        }
-        this.ready = true;
-        if (this.readyTimer !== undefined) {
-            clearTimeout(this.readyTimer);
-            this.readyTimer = undefined;
-        }
-        this.resolveReady();
-        this.refresh();
     }
 
     protected collapsibleState(
@@ -78,14 +46,10 @@ export class SandboxTreeProvider
 
     async getChildren(node?: SandboxTreeNode): Promise<SandboxTreeNode[]> {
         if (!node) {
-            // Hold the native loading bar until the first connect + restore
-            // settles, so the view doesn't flash empty before sandboxes return.
-            if (!this.ready) {
-                await this.readyGate;
-            }
+            // Show the native loading bar while connecting; once connected,
+            // fetch and render rows (or the "no sandboxes" placeholder).
+            await this.whenConnected();
             if (!this.connected) {
-                // Empty when disconnected — the status-bar item shows the
-                // connection state; it doesn't belong as a sandbox row.
                 return [];
             }
             return buildSandboxRootNodes(await this.source.listSandboxes());
@@ -99,11 +63,6 @@ export class SandboxTreeProvider
     }
 
     dispose(): void {
-        if (this.readyTimer !== undefined) {
-            clearTimeout(this.readyTimer);
-            this.readyTimer = undefined;
-        }
-        this.resolveReady();
         this.subscription.dispose();
         super.dispose();
     }

--- a/ts/packages/typeagent-studio/src/sandboxTreeProvider.ts
+++ b/ts/packages/typeagent-studio/src/sandboxTreeProvider.ts
@@ -7,6 +7,7 @@ import {
     buildSandboxRootNodes,
     type SandboxTreeNode,
 } from "./sandboxTreePresentation.js";
+import { BaseStudioTreeProvider } from "./baseTreeProvider.js";
 import type { SandboxSource } from "./sandboxSource.js";
 
 /** View id contributed in package.json. */
@@ -21,14 +22,10 @@ export const SANDBOX_VIEW_ID = "typeagentStudioSandboxes";
  * surfaced by the dedicated status-bar item, not as a row here).
  */
 export class SandboxTreeProvider
-    implements vscode.TreeDataProvider<SandboxTreeNode>, vscode.Disposable
+    extends BaseStudioTreeProvider<SandboxTreeNode>
+    implements vscode.Disposable
 {
-    private readonly emitter = new vscode.EventEmitter<
-        SandboxTreeNode | undefined
-    >();
-    readonly onDidChangeTreeData = this.emitter.event;
     private readonly subscription: { dispose(): void };
-    private connected = false;
 
     // Initial-load gate: until the first connect + sandbox restore settles, the
     // root `getChildren` awaits this so VS Code keeps the view's native loading
@@ -43,18 +40,10 @@ export class SandboxTreeProvider
     private readyTimer: ReturnType<typeof setTimeout> | undefined;
 
     constructor(private readonly source: SandboxSource) {
+        super();
         this.subscription = source.onSandboxChanged(() => this.refresh());
         this.readyTimer = setTimeout(() => this.markReady(), 20_000);
         this.readyTimer.unref?.();
-    }
-
-    /** Reflect the studio service connection state (drives the empty view). */
-    setConnected(connected: boolean): void {
-        if (connected === this.connected) {
-            return;
-        }
-        this.connected = connected;
-        this.refresh();
     }
 
     /**
@@ -75,23 +64,16 @@ export class SandboxTreeProvider
         this.refresh();
     }
 
-    refresh(): void {
-        this.emitter.fire(undefined);
+    protected collapsibleState(
+        node: SandboxTreeNode,
+    ): vscode.TreeItemCollapsibleState {
+        return node.hasChildren
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.None;
     }
 
-    getTreeItem(node: SandboxTreeNode): vscode.TreeItem {
-        const item = new vscode.TreeItem(
-            node.label,
-            node.hasChildren
-                ? vscode.TreeItemCollapsibleState.Expanded
-                : vscode.TreeItemCollapsibleState.None,
-        );
-        item.id = node.id;
-        item.description = node.description;
-        item.tooltip = node.tooltip;
-        item.contextValue = node.contextValue;
+    protected decorate(item: vscode.TreeItem, node: SandboxTreeNode): void {
         item.iconPath = iconForNode(node);
-        return item;
     }
 
     async getChildren(node?: SandboxTreeNode): Promise<SandboxTreeNode[]> {
@@ -123,7 +105,7 @@ export class SandboxTreeProvider
         }
         this.resolveReady();
         this.subscription.dispose();
-        this.emitter.dispose();
+        super.dispose();
     }
 }
 

--- a/ts/packages/typeagent-studio/src/studioServiceClient.ts
+++ b/ts/packages/typeagent-studio/src/studioServiceClient.ts
@@ -4,7 +4,7 @@
 import WebSocket from "ws";
 import { attachClientHeartbeat } from "@typeagent/websocket-utils/heartbeat";
 import { createRpc } from "@typeagent/agent-rpc/rpc";
-import type { RpcChannel } from "@typeagent/agent-rpc/channel";
+import { createWebSocketRpcChannel } from "@typeagent/websocket-utils/rpcChannel";
 import type {
     StudioInfo,
     StudioServiceInvokeFunctions,
@@ -319,49 +319,4 @@ export class StudioServiceClient {
 }
 
 /** Adapt a `ws` WebSocket to the `agent-rpc` {@link RpcChannel} interface. */
-export function createWebSocketRpcChannel(socket: WebSocket): RpcChannel {
-    const messageHandlers = new Set<(message: any) => void>();
-    const disconnectHandlers = new Set<() => void>();
-    const onceMessage = new Set<(message: any) => void>();
-    const onceDisconnect = new Set<() => void>();
-
-    socket.on("message", (data: WebSocket.RawData) => {
-        let message: unknown;
-        try {
-            message = JSON.parse(data.toString());
-        } catch {
-            return;
-        }
-        for (const h of messageHandlers) h(message);
-        for (const h of onceMessage.values()) {
-            onceMessage.delete(h);
-            h(message);
-        }
-    });
-    socket.on("close", () => {
-        for (const h of disconnectHandlers) h();
-        for (const h of onceDisconnect.values()) {
-            onceDisconnect.delete(h);
-            h();
-        }
-    });
-
-    return {
-        on(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? messageHandlers : disconnectHandlers).add(
-                cb,
-            );
-        },
-        once(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? onceMessage : onceDisconnect).add(cb);
-        },
-        off(event: "message" | "disconnect", cb: any) {
-            (event === "message" ? messageHandlers : disconnectHandlers).delete(
-                cb,
-            );
-        },
-        send(message: unknown, cb?: (err: Error | null) => void) {
-            socket.send(JSON.stringify(message), (err) => cb?.(err ?? null));
-        },
-    };
-}
+export { createWebSocketRpcChannel };

--- a/ts/packages/typeagent-studio/src/studioServiceConnection.ts
+++ b/ts/packages/typeagent-studio/src/studioServiceConnection.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 import type { StudioEvent } from "@typeagent/core/events";
+import {
+    createBackoff,
+    type Backoff,
+} from "@typeagent/websocket-utils/backoff";
 import { StudioServiceClient } from "./studioServiceClient.js";
 
 export type StudioConnectionState = "disconnected" | "connecting" | "connected";
@@ -28,7 +32,7 @@ export class StudioServiceConnection {
     private generation = 0;
     private connecting: Promise<boolean> | undefined;
     private retryTimer: ReturnType<typeof setTimeout> | undefined;
-    private retryAttempt = 0;
+    private readonly backoff: Backoff;
     private autoRetry = false;
     private disposed = false;
     private readonly eventListeners = new Set<(event: StudioEvent) => void>();
@@ -36,27 +40,23 @@ export class StudioServiceConnection {
         (state: StudioConnectionState) => void
     >();
 
-    private readonly backoffMs: number[];
-
     constructor(
         private readonly repoRoot: string | undefined,
         private readonly options: {
-            /** Retry backoff in ms, capped at the last value. */
-            backoffMs?: number[];
+            /** First retry delay / exponential base in ms. Default 2000. */
+            baseBackoffMs?: number;
+            /** Upper bound applied to every retry delay in ms. Default 15000. */
+            maxBackoffMs?: number;
             /** Explicit `ws://host:port` (tests); bypasses discovery. */
             endpoint?: string;
             /** Capability token presented on connect (with `endpoint`). */
             token?: string;
         } = {},
     ) {
-        const DEFAULT_BACKOFF = [2000, 4000, 8000, 15000];
-        // Guard against an empty array: a 0-length backoff would index to -1 →
-        // `undefined` delay → `setTimeout(_, undefined)` fires immediately,
-        // spinning reconnect in a tight CPU loop.
-        this.backoffMs =
-            options.backoffMs && options.backoffMs.length > 0
-                ? options.backoffMs
-                : DEFAULT_BACKOFF;
+        this.backoff = createBackoff({
+            baseMs: options.baseBackoffMs ?? 2000,
+            maxMs: options.maxBackoffMs ?? 15000,
+        });
         this.endpoint = options.endpoint;
         this.token = options.token;
     }
@@ -198,7 +198,7 @@ export class StudioServiceConnection {
                 this.scheduleRetry();
                 return false;
             }
-            this.retryAttempt = 0;
+            this.backoff.reset();
             this.setState("connected");
             return true;
         })().finally(() => {
@@ -224,11 +224,7 @@ export class StudioServiceConnection {
         if (this.disposed || this.retryTimer !== undefined || !this.autoRetry) {
             return;
         }
-        const delay =
-            this.backoffMs[
-                Math.min(this.retryAttempt, this.backoffMs.length - 1)
-            ];
-        this.retryAttempt += 1;
+        const delay = this.backoff.next();
         this.retryTimer = setTimeout(() => {
             this.retryTimer = undefined;
             void this.connect();

--- a/ts/packages/typeagent-studio/src/studioServiceConnection.ts
+++ b/ts/packages/typeagent-studio/src/studioServiceConnection.ts
@@ -32,6 +32,8 @@ export class StudioServiceConnection {
     private generation = 0;
     private connecting: Promise<boolean> | undefined;
     private retryTimer: ReturnType<typeof setTimeout> | undefined;
+    /** Epoch ms of the next scheduled reconnect attempt (while disconnected). */
+    private nextRetryAtMs: number | undefined;
     private readonly backoff: Backoff;
     private autoRetry = false;
     private disposed = false;
@@ -87,6 +89,12 @@ export class StudioServiceConnection {
 
     get currentState(): StudioConnectionState {
         return this.state;
+    }
+
+    /** When disconnected and auto-retrying, the epoch ms of the next attempt;
+     *  otherwise undefined. Lets a status indicator show a live countdown. */
+    get nextRetryAt(): number | undefined {
+        return this.state === "disconnected" ? this.nextRetryAtMs : undefined;
     }
 
     /** The live client, or `undefined` when not connected. */
@@ -225,13 +233,16 @@ export class StudioServiceConnection {
             return;
         }
         const delay = this.backoff.next();
+        this.nextRetryAtMs = Date.now() + delay;
         this.retryTimer = setTimeout(() => {
             this.retryTimer = undefined;
+            this.nextRetryAtMs = undefined;
             void this.connect();
         }, delay);
     }
 
     private cancelRetry(): void {
+        this.nextRetryAtMs = undefined;
         if (this.retryTimer !== undefined) {
             clearTimeout(this.retryTimer);
             this.retryTimer = undefined;

--- a/ts/packages/typeagent-studio/src/test/backoff.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/backoff.spec.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createBackoff } from "@typeagent/websocket-utils/backoff";
+
+test("doubles from the base and clamps at the ceiling", () => {
+    const backoff = createBackoff({ baseMs: 2000, maxMs: 15000 });
+    assert.equal(backoff.next(), 2000);
+    assert.equal(backoff.next(), 4000);
+    assert.equal(backoff.next(), 8000);
+    // 16000 would exceed the cap → clamped, and stays there afterwards.
+    assert.equal(backoff.next(), 15000);
+    assert.equal(backoff.next(), 15000);
+});
+
+test("tracks the attempt count", () => {
+    const backoff = createBackoff({ baseMs: 1000, maxMs: 30000 });
+    assert.equal(backoff.attempt, 0);
+    backoff.next();
+    assert.equal(backoff.attempt, 1);
+    backoff.next();
+    assert.equal(backoff.attempt, 2);
+});
+
+test("reset returns to the first delay", () => {
+    const backoff = createBackoff({ baseMs: 2000, maxMs: 30000 });
+    backoff.next();
+    backoff.next();
+    backoff.reset();
+    assert.equal(backoff.attempt, 0);
+    assert.equal(backoff.next(), 2000);
+});
+
+test("a max below the base clamps the first delay too", () => {
+    const backoff = createBackoff({ baseMs: 5000, maxMs: 3000 });
+    assert.equal(backoff.next(), 3000);
+});

--- a/ts/packages/typeagent-studio/src/test/collisionsPresentation.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/collisionsPresentation.spec.ts
@@ -192,7 +192,12 @@ test("buildSkippedRows formats reason and surfaces error detail in description",
     assert.equal(rows[0].icon, "circle-outline");
     assert.equal(rows[1].description, "compile error — unknown variable t");
     assert.equal(rows[1].icon, "error");
-    assert.equal(rows[1].tooltip?.includes("Detail: unknown variable t"), true);
+    assert.equal(
+        rows[1].tooltip?.fields.some(
+            (f) => f.label === "Detail" && f.value === "unknown variable t",
+        ),
+        true,
+    );
     assert.equal(rows[2].icon, "warning");
 });
 
@@ -272,8 +277,16 @@ test("buildSkippedRows annotates sub-schemas with their owning agent", () => {
     ]);
     // Sub-schema name differs from agent -> show "(browser)" suffix.
     assert.equal(rows[0].label, "crossword (browser)");
-    assert.equal(rows[0].tooltip?.includes("Agent: browser"), true);
+    assert.equal(
+        rows[0].tooltip?.fields.some(
+            (f) => f.label === "Agent" && f.value === "browser",
+        ),
+        true,
+    );
     // Agent name equals schema name -> no redundant suffix.
     assert.equal(rows[1].label, "code");
-    assert.equal(rows[1].tooltip?.includes("Agent:"), false);
+    assert.equal(
+        rows[1].tooltip?.fields.some((f) => f.label === "Agent"),
+        false,
+    );
 });

--- a/ts/packages/typeagent-studio/src/test/collisionsSource.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/collisionsSource.spec.ts
@@ -103,7 +103,7 @@ test("StudioServiceCollisionsSource delegates scan/clear and routes events", asy
 test("StudioServiceCollisionsSource lists empty / throws on scan when disconnected", async () => {
     const connection = new StudioServiceConnection(undefined, {
         endpoint: "ws://127.0.0.1:1",
-        backoffMs: [10_000],
+        baseBackoffMs: 10_000,
     });
     const source = new StudioServiceCollisionsSource(connection);
     try {

--- a/ts/packages/typeagent-studio/src/test/corpusTreePresentation.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/corpusTreePresentation.spec.ts
@@ -84,10 +84,10 @@ test("buildCorpusEntryNodes surfaces a feedback badge when present", () => {
         entry({
             id: "a",
             source: "feedback",
-            feedback: { rating: "negative", recordedAt: 1 },
+            feedback: { rating: "down", recordedAt: 1 },
         }),
     ]);
-    assert.equal(nodes[0].description, "feedback: negative");
+    assert.equal(nodes[0].description, "feedback: down");
 });
 
 test("truncateUtterance collapses whitespace and caps length", () => {

--- a/ts/packages/typeagent-studio/src/test/corpusTreePresentation.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/corpusTreePresentation.spec.ts
@@ -79,7 +79,7 @@ test("buildCorpusEntryNodes filters to the requested source and labels by uttera
     assert.equal(nodes[0].description, undefined);
 });
 
-test("buildCorpusEntryNodes surfaces a feedback badge when present", () => {
+test("buildCorpusEntryNodes surfaces feedback via the row rating when present", () => {
     const nodes = buildCorpusEntryNodes("player", "feedback", [
         entry({
             id: "a",
@@ -87,7 +87,9 @@ test("buildCorpusEntryNodes surfaces a feedback badge when present", () => {
             feedback: { rating: "down", recordedAt: 1 },
         }),
     ]);
-    assert.equal(nodes[0].description, "feedback: down");
+    // Feedback is conveyed by the row icon, not a description badge.
+    assert.equal(nodes[0].description, undefined);
+    assert.equal(nodes[0].feedbackRating, "down");
 });
 
 test("truncateUtterance collapses whitespace and caps length", () => {

--- a/ts/packages/typeagent-studio/src/test/eventLogSource.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/eventLogSource.spec.ts
@@ -110,7 +110,7 @@ test("StudioServiceEventSource (over the shared connection) seeds + fans out liv
 test("StudioServiceEventSource returns empty when the connection is down", async () => {
     const connection = new StudioServiceConnection(undefined, {
         endpoint: "ws://127.0.0.1:1", // nothing listening
-        backoffMs: [10_000],
+        baseBackoffMs: 10_000,
     });
     const source = new StudioServiceEventSource(connection);
     try {

--- a/ts/packages/typeagent-studio/src/test/gitRefProvider.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/gitRefProvider.spec.ts
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    listVersionRefs,
+    listRemoteRefs,
+    resolveRef,
+    resolveVersionProvenance,
+    type GitExec,
+} from "../gitRefProvider.js";
+
+const FS = "\u001f";
+
+/** Build a stub GitExec that returns canned stdout keyed by the first arg. */
+function stubExec(
+    responses: Record<string, string>,
+    failing: Set<string> = new Set(),
+): GitExec {
+    return async (args) => {
+        const key = args.join(" ");
+        if (failing.has(args[0])) {
+            throw new Error(`git ${key} failed`);
+        }
+        // Match on a prefix so callers can key by the leading subcommand.
+        for (const [prefix, out] of Object.entries(responses)) {
+            if (key.startsWith(prefix)) {
+                return out;
+            }
+        }
+        throw new Error(`unexpected git ${key}`);
+    };
+}
+
+test("listVersionRefs enumerates working tree, HEAD, branches, tags, commits", async () => {
+    const exec = stubExec({
+        // First line's %D decoration names the current branch; both lines are
+        // the recent-commit list.
+        "log -n": [
+            `a1b2c3d${FS}fix the rule${FS}HEAD -> feature, origin/feature`,
+            `9988776${FS}base commit${FS}`,
+        ].join("\n"),
+        // Branches and tags in one for-each-ref pass; full refname classifies.
+        "for-each-ref --sort=-committerdate": [
+            `refs/heads/feature${FS}feature${FS}a1b2c3d${FS}fix the rule`,
+            `refs/heads/main${FS}main${FS}9988776${FS}base commit`,
+            `refs/tags/v1.0${FS}v1.0${FS}9988776${FS}release one`,
+        ].join("\n"),
+    });
+
+    const refs = await listVersionRefs(exec);
+    const labels = refs.map((r) => r.label);
+
+    // Working tree is always first.
+    assert.deepEqual(refs[0].spec, { kind: "workingTree" });
+    assert.equal(refs[0].label, "working tree");
+
+    // HEAD reflects the current branch name.
+    assert.ok(labels.includes("HEAD (feature)"));
+
+    // Current branch is marked and sorted to the front of the branch list.
+    assert.ok(labels.includes("feature (current)"));
+    assert.ok(labels.includes("main"));
+    const featureIdx = labels.indexOf("feature (current)");
+    const mainIdx = labels.indexOf("main");
+    assert.ok(featureIdx < mainIdx);
+
+    // Tag and commit entries appear with git-ref specs.
+    const tag = refs.find((r) => r.label === "v1.0");
+    assert.deepEqual(tag?.spec, { kind: "git", ref: "v1.0" });
+    const commit = refs.find((r) => r.label.startsWith("9988776 "));
+    assert.deepEqual(commit?.spec, { kind: "git", ref: "9988776" });
+});
+
+test("listVersionRefs degrades to working tree outside a git repo", async () => {
+    const exec = stubExec({}, new Set(["log", "for-each-ref"]));
+    const refs = await listVersionRefs(exec);
+    assert.equal(refs.length, 1);
+    assert.deepEqual(refs[0].spec, { kind: "workingTree" });
+});
+
+test("listVersionRefs handles detached HEAD", async () => {
+    const exec = stubExec({
+        // No `HEAD -> ` segment in the decoration → detached.
+        "log -n": `a1b2c3d${FS}detached work${FS}`,
+        "for-each-ref --sort=-committerdate": "",
+    });
+    const refs = await listVersionRefs(exec);
+    const head = refs.find(
+        (r) => r.spec.kind === "git" && r.spec.ref === "HEAD",
+    );
+    assert.equal(head?.label, "HEAD");
+    assert.ok(head?.tooltip.includes("detached"));
+});
+
+test("listRemoteRefs lists remote branches and skips the origin/HEAD pointer", async () => {
+    const exec = stubExec({
+        "for-each-ref --sort=-committerdate": [
+            `origin/HEAD${FS}0000000${FS}`,
+            `origin/main${FS}9988776${FS}base commit`,
+            `origin/feature${FS}a1b2c3d${FS}fix the rule`,
+        ].join("\n"),
+    });
+    const refs = await listRemoteRefs(exec);
+    const names = refs.map((r) => r.label);
+    assert.ok(!names.includes("origin/HEAD"));
+    assert.ok(names.includes("origin/main"));
+    assert.ok(names.includes("origin/feature"));
+    const main = refs.find((r) => r.label === "origin/main");
+    assert.deepEqual(main?.spec, { kind: "git", ref: "origin/main" });
+});
+
+test("listRemoteRefs returns empty when enumeration fails", async () => {
+    const exec = stubExec({}, new Set(["for-each-ref"]));
+    const refs = await listRemoteRefs(exec);
+    assert.deepEqual(refs, []);
+});
+
+test("resolveRef resolves a typed commit to a git-ref version", async () => {
+    const exec = stubExec({
+        "log -n 1": `a1b2c3d${FS}fix the rule`,
+    });
+    const resolved = await resolveRef(exec, "  a1b2c3d  ");
+    assert.deepEqual(resolved?.spec, { kind: "git", ref: "a1b2c3d" });
+    assert.ok(resolved?.label.includes("fix the rule"));
+    assert.ok(resolved?.tooltip.includes("a1b2c3d"));
+});
+
+test("resolveRef returns undefined for an unresolvable ref", async () => {
+    const exec = stubExec({}, new Set(["log"]));
+    const resolved = await resolveRef(exec, "deadbeef");
+    assert.equal(resolved, undefined);
+});
+
+test("resolveRef returns undefined for empty input", async () => {
+    const exec = stubExec({ "log -n 1": `a1b2c3d${FS}x` });
+    const resolved = await resolveRef(exec, "   ");
+    assert.equal(resolved, undefined);
+});
+
+test("resolveVersionProvenance pins a git ref to its short SHA", async () => {
+    const exec = stubExec({ "rev-parse --short HEAD": "a1b2c3d\n" });
+    const prov = await resolveVersionProvenance(
+        { kind: "git", ref: "HEAD" },
+        exec,
+    );
+    assert.deepEqual(prov, {
+        label: "HEAD",
+        workingTree: false,
+        sha: "a1b2c3d",
+    });
+});
+
+test("resolveVersionProvenance records the HEAD a working tree sits on", async () => {
+    const exec = stubExec({ "rev-parse --short HEAD": "a1b2c3d\n" });
+    const prov = await resolveVersionProvenance({ kind: "workingTree" }, exec);
+    assert.deepEqual(prov, {
+        label: "working tree",
+        workingTree: true,
+        sha: "a1b2c3d",
+    });
+});
+
+test("resolveVersionProvenance degrades when the ref can't be resolved", async () => {
+    const exec = stubExec({}, new Set(["rev-parse"]));
+    const prov = await resolveVersionProvenance(
+        { kind: "git", ref: "nope" },
+        exec,
+    );
+    assert.deepEqual(prov, { label: "nope", workingTree: false });
+});

--- a/ts/packages/typeagent-studio/src/test/gitRefProvider.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/gitRefProvider.spec.ts
@@ -140,7 +140,9 @@ test("resolveRef returns undefined for empty input", async () => {
 });
 
 test("resolveVersionProvenance pins a git ref to its short SHA", async () => {
-    const exec = stubExec({ "rev-parse --short HEAD": "a1b2c3d\n" });
+    const exec = stubExec({
+        "rev-parse --short --end-of-options": "a1b2c3d\n",
+    });
     const prov = await resolveVersionProvenance(
         { kind: "git", ref: "HEAD" },
         exec,
@@ -150,6 +152,20 @@ test("resolveVersionProvenance pins a git ref to its short SHA", async () => {
         workingTree: false,
         sha: "a1b2c3d",
     });
+});
+
+test("resolveVersionProvenance guards a ref with --end-of-options", async () => {
+    let captured: string[] = [];
+    const exec: GitExec = async (args) => {
+        captured = args;
+        return "a1b2c3d\n";
+    };
+    await resolveVersionProvenance({ kind: "git", ref: "--output=evil" }, exec);
+    // `--end-of-options` must precede the ref so a leading-dash ref can't be
+    // parsed as a git option.
+    const eo = captured.indexOf("--end-of-options");
+    assert.ok(eo >= 0, "expected --end-of-options in the rev-parse args");
+    assert.equal(captured[eo + 1], "--output=evil");
 });
 
 test("resolveVersionProvenance records the HEAD a working tree sits on", async () => {

--- a/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
@@ -9,6 +9,12 @@ import {
     toImpactMethodNote,
     toImpactErrorLine,
     parseVersionInput,
+    narrowVersionSpec,
+    coerceVersionSpec,
+    formatVersionProvenance,
+    formatProvenanceLine,
+    stableStringify,
+    toActionDiff,
     toSideMethodLabel,
     buildImpactFilterChips,
     filterImpactRows,
@@ -158,6 +164,157 @@ test("parseVersionInput treats blanks/keywords as working tree, else a git ref",
         kind: "git",
         ref: "my-branch",
     });
+});
+
+test("narrowVersionSpec validates an untrusted spec object", () => {
+    assert.deepEqual(narrowVersionSpec({ kind: "workingTree" }), {
+        kind: "workingTree",
+    });
+    assert.deepEqual(narrowVersionSpec({ kind: "git", ref: "HEAD" }), {
+        kind: "git",
+        ref: "HEAD",
+    });
+    // Whitespace-only / empty / wrong-typed refs are rejected.
+    assert.equal(narrowVersionSpec({ kind: "git", ref: "" }), undefined);
+    assert.equal(narrowVersionSpec({ kind: "git", ref: "   " }), undefined);
+    assert.equal(narrowVersionSpec({ kind: "git", ref: 5 }), undefined);
+    assert.equal(narrowVersionSpec({ kind: "bogus" }), undefined);
+    assert.equal(narrowVersionSpec(undefined), undefined);
+    assert.equal(narrowVersionSpec("HEAD"), undefined);
+    // A valid ref is trimmed.
+    assert.deepEqual(narrowVersionSpec({ kind: "git", ref: " v1 " }), {
+        kind: "git",
+        ref: "v1",
+    });
+});
+
+test("coerceVersionSpec accepts typed specs, strings, else working tree", () => {
+    // Typed spec from a picker selection.
+    assert.deepEqual(coerceVersionSpec({ kind: "git", ref: "HEAD" }), {
+        kind: "git",
+        ref: "HEAD",
+    });
+    // Raw string falls back to parseVersionInput.
+    assert.deepEqual(coerceVersionSpec("my-branch"), {
+        kind: "git",
+        ref: "my-branch",
+    });
+    assert.deepEqual(coerceVersionSpec("working tree"), {
+        kind: "workingTree",
+    });
+    // A malformed object defaults to the working tree rather than throwing.
+    assert.deepEqual(coerceVersionSpec({ kind: "git", ref: "" }), {
+        kind: "workingTree",
+    });
+    assert.deepEqual(coerceVersionSpec(null), { kind: "workingTree" });
+    assert.deepEqual(coerceVersionSpec(42), { kind: "workingTree" });
+});
+
+test("formatVersionProvenance / formatProvenanceLine summarise a run", () => {
+    assert.equal(
+        formatVersionProvenance({
+            label: "HEAD (main)",
+            workingTree: false,
+            sha: "a1b2c3d",
+        }),
+        "HEAD (main) @ a1b2c3d",
+    );
+    assert.equal(
+        formatVersionProvenance({ label: "HEAD", workingTree: false }),
+        "HEAD",
+    );
+    assert.equal(
+        formatVersionProvenance({
+            label: "working tree",
+            workingTree: true,
+            sha: "a1b2c3d",
+        }),
+        "working tree (on a1b2c3d)",
+    );
+    assert.equal(
+        formatProvenanceLine({
+            a: { label: "HEAD (main)", workingTree: false, sha: "a1b2c3d" },
+            b: { label: "working tree", workingTree: true, sha: "a1b2c3d" },
+            runAt: 0,
+        }),
+        "Ran HEAD (main) @ a1b2c3d \u2192 working tree (on a1b2c3d)",
+    );
+});
+
+test("stableStringify sorts object keys so reorders aren't diffed", () => {
+    assert.equal(
+        stableStringify({ b: 1, a: { d: 2, c: 3 } }),
+        stableStringify({ a: { c: 3, d: 2 }, b: 1 }),
+    );
+});
+
+test("toActionDiff marks identical actions regardless of key order", () => {
+    const diff = toActionDiff(
+        row({
+            equal: true,
+            actionA: { name: "play", value: 1 },
+            actionB: { value: 1, name: "play" },
+        }),
+    );
+    assert.equal(diff.identical, true);
+    assert.equal(diff.onlyA, false);
+    assert.equal(diff.onlyB, false);
+    assert.equal(diff.addedCount, 0);
+    assert.equal(diff.removedCount, 0);
+    assert.ok(diff.lines.every((l) => l.kind === "context"));
+});
+
+test("toActionDiff produces added/removed lines for a changed action", () => {
+    const diff = toActionDiff(
+        row({
+            equal: false,
+            actionA: { name: "play", track: "despacito" },
+            actionB: { name: "play", track: "bohemian" },
+        }),
+    );
+    assert.equal(diff.identical, false);
+    assert.ok(diff.addedCount >= 1);
+    assert.ok(diff.removedCount >= 1);
+    // The unchanged "name" line stays as context.
+    assert.ok(
+        diff.lines.some(
+            (l) => l.kind === "context" && l.text.includes('"name"'),
+        ),
+    );
+    assert.ok(
+        diff.lines.some(
+            (l) => l.kind === "removed" && l.text.includes("despacito"),
+        ),
+    );
+    assert.ok(
+        diff.lines.some(
+            (l) => l.kind === "added" && l.text.includes("bohemian"),
+        ),
+    );
+});
+
+test("toActionDiff flags a new match (no action on A)", () => {
+    const diff = toActionDiff(row({ equal: false, actionB: { name: "play" } }));
+    assert.equal(diff.onlyB, true);
+    assert.equal(diff.onlyA, false);
+    assert.equal(diff.identical, false);
+    // A side renders the "(no action)" placeholder as a removed line.
+    assert.ok(
+        diff.lines.some(
+            (l) => l.kind === "removed" && l.text.includes("(no action)"),
+        ),
+    );
+});
+
+test("toActionDiff flags a lost match (no action on B)", () => {
+    const diff = toActionDiff(row({ equal: false, actionA: { name: "play" } }));
+    assert.equal(diff.onlyA, true);
+    assert.equal(diff.onlyB, false);
+    assert.ok(
+        diff.lines.some(
+            (l) => l.kind === "added" && l.text.includes("(no action)"),
+        ),
+    );
 });
 
 // A spread of every status for the filter helpers: 2 equal, 1 each of the

--- a/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
@@ -14,6 +14,14 @@ import {
     toImpactComparisonLine,
     toImpactHeaderFields,
     toSideMethodLabel,
+    buildImpactFilterChips,
+    filterImpactRows,
+    defaultImpactFilters,
+    impactFilterNote,
+    impactEmptyState,
+    allRowsEqual,
+    IMPACT_FILTER_ORDER,
+    type ReplayRowStatus,
 } from "../webviewKit/replayViewModel.js";
 
 function row(overrides: Partial<ActionDelta>): ActionDelta {
@@ -237,4 +245,85 @@ test("toImpactHeaderFields labels a construction-cache run", () => {
     });
     assert.equal(headerValue(fields, "method"), "construction cache");
     assert.ok(/cache/i.test(headerValue(fields, "fidelity")!));
+});
+
+// A spread of every status for the filter helpers: 2 equal, 1 each of the
+// three difference kinds.
+function mixedRows() {
+    return toImpactRows([
+        row({ equal: true, utteranceId: "e1" }),
+        row({ equal: true, utteranceId: "e2" }),
+        row({ equal: false, actionA: {}, actionB: {}, utteranceId: "c1" }),
+        row({ equal: false, actionB: {}, utteranceId: "n1" }),
+        row({ equal: false, actionA: {}, utteranceId: "l1" }),
+    ]);
+}
+
+test("buildImpactFilterChips counts each status in fixed order", () => {
+    const chips = buildImpactFilterChips(mixedRows());
+    assert.deepEqual(
+        chips.map((c) => c.status),
+        IMPACT_FILTER_ORDER,
+    );
+    const byStatus = new Map(chips.map((c) => [c.status, c.count]));
+    assert.equal(byStatus.get("equal"), 2);
+    assert.equal(byStatus.get("changed"), 1);
+    assert.equal(byStatus.get("new-match"), 1);
+    assert.equal(byStatus.get("lost-match"), 1);
+    // Every chip carries a non-empty human label.
+    assert.ok(chips.every((c) => c.label.length > 0));
+});
+
+test("defaultImpactFilters hides equal rows so the report opens on differences", () => {
+    const active = defaultImpactFilters();
+    assert.ok(!active.has("equal"));
+    assert.ok(active.has("changed"));
+    assert.ok(active.has("new-match"));
+    assert.ok(active.has("lost-match"));
+    const shown = filterImpactRows(mixedRows(), active);
+    assert.equal(shown.length, 3);
+    assert.ok(shown.every((r) => r.status !== "equal"));
+});
+
+test("filterImpactRows keeps only rows whose status is active", () => {
+    const active = new Set<ReplayRowStatus>(["lost-match"]);
+    const shown = filterImpactRows(mixedRows(), active);
+    assert.equal(shown.length, 1);
+    assert.equal(shown[0].status, "lost-match");
+});
+
+test("impactFilterNote describes the non-empty hidden statuses", () => {
+    const chips = buildImpactFilterChips(mixedRows());
+    const note = impactFilterNote(chips, defaultImpactFilters());
+    // The 2 equal rows are hidden by default.
+    assert.ok(note);
+    assert.ok(/2 rows hidden/.test(note!));
+    assert.ok(/equal/.test(note!));
+});
+
+test("impactFilterNote is silent when nothing with rows is hidden", () => {
+    const chips = buildImpactFilterChips(mixedRows());
+    const all = new Set<ReplayRowStatus>(IMPACT_FILTER_ORDER);
+    assert.equal(impactFilterNote(chips, all), undefined);
+});
+
+test("allRowsEqual is true only when every row is equal", () => {
+    assert.ok(
+        allRowsEqual(
+            toImpactRows([
+                row({ equal: true, utteranceId: "e1" }),
+                row({ equal: true, utteranceId: "e2" }),
+            ]),
+        ),
+    );
+    assert.ok(!allRowsEqual(mixedRows()));
+    // An empty set is not "all equal" — there's simply nothing to compare.
+    assert.ok(!allRowsEqual([]));
+});
+
+test("impactEmptyState gives first-run guidance", () => {
+    const state = impactEmptyState();
+    assert.ok(state.title.length > 0);
+    assert.ok(/base/i.test(state.hint));
+    assert.ok(/compare/i.test(state.hint));
 });

--- a/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
@@ -3,20 +3,17 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { ActionDelta, ReplaySummary } from "@typeagent/core/replay";
+import type { ActionDelta } from "@typeagent/core/replay";
 import {
     toImpactRows,
-    toImpactSummaryLine,
     toImpactMethodNote,
     toImpactErrorLine,
     parseVersionInput,
-    describeVersion,
-    toImpactComparisonLine,
-    toImpactHeaderFields,
     toSideMethodLabel,
     buildImpactFilterChips,
     filterImpactRows,
     defaultImpactFilters,
+    allStatusesActive,
     impactFilterNote,
     impactEmptyState,
     allRowsEqual,
@@ -116,27 +113,6 @@ test("toSideMethodLabel gives a short per-side label", () => {
     assert.equal(toSideMethodLabel("identity"), "identity");
 });
 
-test("toImpactSummaryLine renders a headline", () => {
-    const summary = {
-        runId: "r1",
-        agent: "player",
-        versionA: { kind: "workingTree" },
-        versionB: { kind: "workingTree" },
-        corpusSize: 3,
-        rowCount: 3,
-        equalCount: 3,
-        changedCount: 0,
-        newMatchCount: 0,
-        lostMatchCount: 0,
-        collisionDelta: 0,
-        duration: 42,
-    } as ReplaySummary;
-    const line = toImpactSummaryLine(summary);
-    assert.ok(line.includes("player"));
-    assert.ok(line.includes("3 rows"));
-    assert.ok(line.includes("42ms"));
-});
-
 test("toImpactMethodNote labels static-grammar but stays silent for identity", () => {
     assert.equal(toImpactMethodNote("identity"), undefined);
     const note = toImpactMethodNote("static-grammar");
@@ -184,73 +160,6 @@ test("parseVersionInput treats blanks/keywords as working tree, else a git ref",
     });
 });
 
-test("describeVersion and toImpactComparisonLine read the resolved versions", () => {
-    assert.equal(describeVersion({ kind: "workingTree" }), "working tree");
-    assert.equal(describeVersion({ kind: "git", ref: "HEAD" }), "HEAD");
-    const line = toImpactComparisonLine({
-        versionA: { kind: "git", ref: "HEAD" },
-        versionB: { kind: "workingTree" },
-    } as ReplaySummary);
-    assert.ok(line.includes("HEAD"));
-    assert.ok(line.includes("working tree"));
-    assert.ok(line.includes("\u2192"));
-});
-
-function headerValue(
-    fields: ReturnType<typeof toImpactHeaderFields>,
-    label: string,
-): string | undefined {
-    return fields.find((f) => f.label === label)?.value;
-}
-
-test("toImpactHeaderFields fills placeholders before a run", () => {
-    const fields = toImpactHeaderFields({});
-    // Every field present with a tooltip.
-    assert.deepEqual(
-        fields.map((f) => f.label),
-        ["repo", "agent", "method", "fidelity", "sandbox", "policy"],
-    );
-    assert.ok(fields.every((f) => f.tooltip.length > 0));
-    assert.equal(headerValue(fields, "repo"), "\u2014");
-    assert.equal(headerValue(fields, "agent"), "\u2014");
-    assert.equal(headerValue(fields, "method"), "\u2014");
-    assert.equal(headerValue(fields, "policy"), "\u2014");
-    // Sandbox is honestly "not used" — the static-grammar path is not sandbox-bound.
-    assert.equal(headerValue(fields, "sandbox"), "not used");
-});
-
-test("toImpactHeaderFields reflects a static-grammar run as indicative", () => {
-    const fields = toImpactHeaderFields({
-        repo: "TypeAgent",
-        agent: "player",
-        method: "static-grammar",
-        missPolicy: "needs-explanation",
-    });
-    assert.equal(headerValue(fields, "repo"), "TypeAgent");
-    assert.equal(headerValue(fields, "agent"), "player");
-    assert.equal(headerValue(fields, "method"), "static grammar");
-    assert.equal(headerValue(fields, "fidelity"), "indicative");
-    assert.equal(headerValue(fields, "policy"), "needs-explanation");
-    assert.equal(headerValue(fields, "sandbox"), "not used");
-});
-
-test("toImpactHeaderFields labels the identity baseline distinctly", () => {
-    const fields = toImpactHeaderFields({ method: "identity" });
-    assert.equal(headerValue(fields, "method"), "identity");
-    assert.ok(/baseline/i.test(headerValue(fields, "fidelity")!));
-});
-
-test("toImpactHeaderFields labels a construction-cache run", () => {
-    const fields = toImpactHeaderFields({
-        repo: "TypeAgent",
-        agent: "player",
-        method: "construction-cache",
-        missPolicy: "needs-explanation",
-    });
-    assert.equal(headerValue(fields, "method"), "construction cache");
-    assert.ok(/cache/i.test(headerValue(fields, "fidelity")!));
-});
-
 // A spread of every status for the filter helpers: 2 equal, 1 each of the
 // three difference kinds.
 function mixedRows() {
@@ -278,15 +187,34 @@ test("buildImpactFilterChips counts each status in fixed order", () => {
     assert.ok(chips.every((c) => c.label.length > 0));
 });
 
-test("defaultImpactFilters hides equal rows so the report opens on differences", () => {
+test("defaultImpactFilters shows every status so the report opens on All", () => {
     const active = defaultImpactFilters();
-    assert.ok(!active.has("equal"));
-    assert.ok(active.has("changed"));
-    assert.ok(active.has("new-match"));
-    assert.ok(active.has("lost-match"));
+    for (const status of IMPACT_FILTER_ORDER) {
+        assert.ok(active.has(status));
+    }
     const shown = filterImpactRows(mixedRows(), active);
-    assert.equal(shown.length, 3);
-    assert.ok(shown.every((r) => r.status !== "equal"));
+    assert.equal(shown.length, mixedRows().length);
+});
+
+test("allStatusesActive is true only when nothing with rows is hidden", () => {
+    const chips = buildImpactFilterChips(mixedRows());
+    assert.ok(allStatusesActive(chips, defaultImpactFilters()));
+    const noEqual = new Set<ReplayRowStatus>(
+        IMPACT_FILTER_ORDER.filter((s) => s !== "equal"),
+    );
+    // equal has rows in the fixture, so hiding it drops out of the All view.
+    assert.ok(!allStatusesActive(chips, noEqual));
+});
+
+test("allStatusesActive ignores statuses with no rows", () => {
+    // Only equal rows: the empty difference buckets must not block the All view.
+    const chips = buildImpactFilterChips(
+        toImpactRows([
+            row({ equal: true, utteranceId: "e1" }),
+            row({ equal: true, utteranceId: "e2" }),
+        ]),
+    );
+    assert.ok(allStatusesActive(chips, new Set<ReplayRowStatus>(["equal"])));
 });
 
 test("filterImpactRows keeps only rows whose status is active", () => {
@@ -298,8 +226,14 @@ test("filterImpactRows keeps only rows whose status is active", () => {
 
 test("impactFilterNote describes the non-empty hidden statuses", () => {
     const chips = buildImpactFilterChips(mixedRows());
-    const note = impactFilterNote(chips, defaultImpactFilters());
-    // The 2 equal rows are hidden by default.
+    // Hide equal explicitly (the All default shows everything).
+    const differences = new Set<ReplayRowStatus>([
+        "changed",
+        "new-match",
+        "lost-match",
+    ]);
+    const note = impactFilterNote(chips, differences);
+    // The 2 equal rows are hidden.
     assert.ok(note);
     assert.ok(/2 rows hidden/.test(note!));
     assert.ok(/equal/.test(note!));

--- a/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/replayViewModel.spec.ts
@@ -55,7 +55,9 @@ test("toImpactRows classifies and shapes rows for the webview", () => {
     );
     // Browser-neutral: no Quick Pick `$(...)` icon syntax leaks through.
     assert.ok(rows.every((r) => !r.statusLabel.includes("$(")));
-    assert.equal(rows[0].detail, "A:hit B:hit \u00b7 10/12ms");
+    assert.equal(rows[0].resolutionA, "hit");
+    assert.equal(rows[0].resolutionB, "hit");
+    assert.equal(rows[0].latency, "10/12ms");
 });
 
 test("toImpactRows collapses long utterances", () => {
@@ -85,12 +87,12 @@ test("toImpactRows tags cache-served and grammar fall-through on the constructio
         "construction-cache",
     );
     // The cache side spells out the source; the grammar side stays raw.
-    assert.equal(rows[0].detail, "A:hit B:hit\u00b7cache \u00b7 10/12ms");
-    assert.equal(rows[1].detail, "A:hit B:miss\u00b7grammar \u00b7 10/12ms");
-    assert.equal(
-        rows[2].detail,
-        "A:needs-explanation B:hit\u00b7cache \u00b7 10/12ms",
-    );
+    assert.equal(rows[0].resolutionA, "hit");
+    assert.equal(rows[0].resolutionB, "hit\u00b7cache");
+    assert.equal(rows[1].resolutionB, "miss\u00b7grammar");
+    assert.equal(rows[2].resolutionA, "needs-explanation");
+    assert.equal(rows[2].resolutionB, "hit\u00b7cache");
+    assert.equal(rows[0].latency, "10/12ms");
 });
 
 test("toImpactRows leaves tokens raw when neither side ran the construction cache", () => {
@@ -99,7 +101,9 @@ test("toImpactRows leaves tokens raw when neither side ran the construction cach
         "schema-grammar",
         "schema-grammar",
     );
-    assert.equal(r.detail, "A:hit B:hit \u00b7 10/12ms");
+    assert.equal(r.resolutionA, "hit");
+    assert.equal(r.resolutionB, "hit");
+    assert.equal(r.latency, "10/12ms");
 });
 
 test("toSideMethodLabel gives a short per-side label", () => {

--- a/ts/packages/typeagent-studio/src/test/sandboxSource.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/sandboxSource.spec.ts
@@ -88,7 +88,7 @@ test("StudioServiceSandboxSource delegates lifecycle + routes sandbox events", a
 test("StudioServiceSandboxSource: reads empty / mutations reject when disconnected", async () => {
     const connection = new StudioServiceConnection(undefined, {
         endpoint: "ws://127.0.0.1:1",
-        backoffMs: [10_000],
+        baseBackoffMs: 10_000,
     });
     const source = new StudioServiceSandboxSource(connection);
     try {

--- a/ts/packages/typeagent-studio/src/test/sandboxTreePresentation.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/sandboxTreePresentation.spec.ts
@@ -119,9 +119,12 @@ test("buildSandboxAgentNodes maps agents sorted by name", () => {
     );
     assert.equal(nodes[0].kind, "agent");
     assert.equal(nodes[0].agentName, "calendar");
-    assert.equal(nodes[0].description, "healthy \u00b7 s1");
+    // Health is shown via the row icon now; the description carries just the
+    // schema fingerprint.
+    assert.equal(nodes[0].description, "s1");
+    assert.equal(nodes[0].health, "healthy");
     assert.equal(nodes[0].contextValue, "sandboxAgent");
-    assert.equal(nodes[1].description, "warning \u00b7 s2");
+    assert.equal(nodes[1].description, "s2");
 });
 
 test("formatSandboxState covers every state literal", () => {
@@ -165,5 +168,7 @@ test("agent node omits the fingerprint when the schema hash is a sentinel", () =
             ],
         }),
     );
-    assert.equal(nodes[0].description, "unknown");
+    // No real schema hash -> no fingerprint -> no description (icon carries
+    // the unknown-health state).
+    assert.equal(nodes[0].description, undefined);
 });

--- a/ts/packages/typeagent-studio/src/test/studioServiceConnection.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioServiceConnection.spec.ts
@@ -118,7 +118,7 @@ test("a dropped socket transitions back to disconnected", async () => {
     // Long backoff so the scheduled retry doesn't fire during the test.
     const connection = new StudioServiceConnection(undefined, {
         endpoint: stub.endpoint,
-        backoffMs: [60_000],
+        baseBackoffMs: 60_000,
     });
     try {
         assert.equal(await connection.connect(), true);
@@ -140,7 +140,7 @@ test("a dropped socket transitions back to disconnected", async () => {
 test("connect() resolves false when unreachable", async () => {
     const connection = new StudioServiceConnection(undefined, {
         endpoint: "ws://127.0.0.1:1",
-        backoffMs: [60_000],
+        baseBackoffMs: 60_000,
     });
     try {
         assert.equal(await connection.connect(), false);
@@ -154,7 +154,7 @@ test("reuses the same client across a reconnect (rebind, not recreate)", async (
     const stub = await startStubServer();
     const connection = new StudioServiceConnection(undefined, {
         endpoint: stub.endpoint,
-        backoffMs: [50],
+        baseBackoffMs: 50,
     });
     try {
         assert.equal(await connection.connect(), true);
@@ -183,7 +183,7 @@ test("delivers events over the rebound socket after a reconnect", async () => {
     const stub = await startStubServer();
     const connection = new StudioServiceConnection(undefined, {
         endpoint: stub.endpoint,
-        backoffMs: [50],
+        baseBackoffMs: 50,
     });
     const received: StudioEvent[] = [];
     connection.onEvent((e) => received.push(e));
@@ -207,7 +207,7 @@ test("keeps the same client across multiple sequential reconnects", async () => 
     const stub = await startStubServer();
     const connection = new StudioServiceConnection(undefined, {
         endpoint: stub.endpoint,
-        backoffMs: [50],
+        baseBackoffMs: 50,
     });
     try {
         assert.equal(await connection.connect(), true);
@@ -231,7 +231,7 @@ test("setTarget connects a fresh client to the new endpoint (no stale reuse)", a
     const stubB = await startStubServer();
     const connection = new StudioServiceConnection(undefined, {
         endpoint: stubA.endpoint,
-        backoffMs: [50],
+        baseBackoffMs: 50,
     });
     try {
         assert.equal(await connection.connect(), true);

--- a/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
@@ -12,17 +12,29 @@ test("parseWebviewMessage accepts well-formed messages", () => {
     assert.deepEqual(parseWebviewMessage({ type: "reconnect" }), {
         type: "reconnect",
     });
+    assert.deepEqual(parseWebviewMessage({ type: "pickAgent" }), {
+        type: "pickAgent",
+    });
+    assert.deepEqual(parseWebviewMessage({ type: "pickVersion", side: "a" }), {
+        type: "pickVersion",
+        side: "a",
+    });
+    assert.deepEqual(parseWebviewMessage({ type: "pickVersion", side: "b" }), {
+        type: "pickVersion",
+        side: "b",
+    });
+    // Missing/invalid version fields coerce to the working tree.
     assert.deepEqual(
         parseWebviewMessage({ type: "run", requestId: 3, agent: "player" }),
         {
             type: "run",
             requestId: 3,
             agent: "player",
-            versionA: "",
-            versionB: "",
+            versionA: { kind: "workingTree" },
+            versionB: { kind: "workingTree" },
         },
     );
-    // Version fields are carried through when supplied as strings.
+    // String version fields are coerced (legacy text-field / test seam).
     assert.deepEqual(
         parseWebviewMessage({
             type: "run",
@@ -35,25 +47,42 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             type: "run",
             requestId: 4,
             agent: "player",
-            versionA: "HEAD",
-            versionB: "working tree",
+            versionA: { kind: "git", ref: "HEAD" },
+            versionB: { kind: "workingTree" },
         },
     );
-    // Non-string version fields fall back to empty (→ working tree downstream).
+    // Typed specs from a picker selection are validated and taken as-is.
+    assert.deepEqual(
+        parseWebviewMessage({
+            type: "run",
+            requestId: 6,
+            agent: "player",
+            versionA: { kind: "git", ref: "v1.0" },
+            versionB: { kind: "workingTree" },
+        }),
+        {
+            type: "run",
+            requestId: 6,
+            agent: "player",
+            versionA: { kind: "git", ref: "v1.0" },
+            versionB: { kind: "workingTree" },
+        },
+    );
+    // Non-string / malformed version fields fall back to the working tree.
     assert.deepEqual(
         parseWebviewMessage({
             type: "run",
             requestId: 5,
             agent: "player",
             versionA: 42,
-            versionB: null,
+            versionB: { kind: "git", ref: "" },
         }),
         {
             type: "run",
             requestId: 5,
             agent: "player",
-            versionA: "",
-            versionB: "",
+            versionA: { kind: "workingTree" },
+            versionB: { kind: "workingTree" },
         },
     );
 });
@@ -63,6 +92,12 @@ test("parseWebviewMessage rejects malformed / hostile input", () => {
     assert.equal(parseWebviewMessage(null), undefined);
     assert.equal(parseWebviewMessage("ready"), undefined);
     assert.equal(parseWebviewMessage({ type: "bogus" }), undefined);
+    // pickVersion requires a valid side.
+    assert.equal(parseWebviewMessage({ type: "pickVersion" }), undefined);
+    assert.equal(
+        parseWebviewMessage({ type: "pickVersion", side: "c" }),
+        undefined,
+    );
     // run requires both a numeric requestId and a string agent.
     assert.equal(
         parseWebviewMessage({ type: "run", agent: "player" }),

--- a/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
@@ -9,9 +9,6 @@ test("parseWebviewMessage accepts well-formed messages", () => {
     assert.deepEqual(parseWebviewMessage({ type: "ready" }), {
         type: "ready",
     });
-    assert.deepEqual(parseWebviewMessage({ type: "reconnect" }), {
-        type: "reconnect",
-    });
     assert.deepEqual(parseWebviewMessage({ type: "pickVersion", side: "a" }), {
         type: "pickVersion",
         side: "a",
@@ -91,6 +88,8 @@ test("parseWebviewMessage rejects malformed / hostile input", () => {
     assert.equal(parseWebviewMessage({ type: "bogus" }), undefined);
     // The agent is now fixed per panel — there is no agent picker message.
     assert.equal(parseWebviewMessage({ type: "pickAgent" }), undefined);
+    // Reconnect is automatic — the webview no longer sends a reconnect message.
+    assert.equal(parseWebviewMessage({ type: "reconnect" }), undefined);
     // pickVersion requires a valid side.
     assert.equal(parseWebviewMessage({ type: "pickVersion" }), undefined);
     assert.equal(

--- a/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
@@ -12,9 +12,6 @@ test("parseWebviewMessage accepts well-formed messages", () => {
     assert.deepEqual(parseWebviewMessage({ type: "reconnect" }), {
         type: "reconnect",
     });
-    assert.deepEqual(parseWebviewMessage({ type: "pickAgent" }), {
-        type: "pickAgent",
-    });
     assert.deepEqual(parseWebviewMessage({ type: "pickVersion", side: "a" }), {
         type: "pickVersion",
         side: "a",
@@ -92,6 +89,8 @@ test("parseWebviewMessage rejects malformed / hostile input", () => {
     assert.equal(parseWebviewMessage(null), undefined);
     assert.equal(parseWebviewMessage("ready"), undefined);
     assert.equal(parseWebviewMessage({ type: "bogus" }), undefined);
+    // The agent is now fixed per panel — there is no agent picker message.
+    assert.equal(parseWebviewMessage({ type: "pickAgent" }), undefined);
     // pickVersion requires a valid side.
     assert.equal(parseWebviewMessage({ type: "pickVersion" }), undefined);
     assert.equal(

--- a/ts/packages/typeagent-studio/src/textFormatting.ts
+++ b/ts/packages/typeagent-studio/src/textFormatting.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const ELLIPSIS = "\u2026";
+
+/**
+ * Collapse internal whitespace runs to single spaces, trim the ends, and cap
+ * the result at `max` characters (replacing the final character with an
+ * ellipsis when it overflows). Shared by the tree/webview presenters that
+ * render free-form utterances and action text into fixed-width rows.
+ */
+export function collapseAndTruncate(text: string, max: number): string {
+    const collapsed = text.replace(/\s+/g, " ").trim();
+    return collapsed.length > max
+        ? `${collapsed.slice(0, max - 1)}${ELLIPSIS}`
+        : collapsed;
+}

--- a/ts/packages/typeagent-studio/src/tooltipModel.ts
+++ b/ts/packages/typeagent-studio/src/tooltipModel.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * A pure, vscode-free description of a tree-row hover card. The presentation
+ * modules build these so the labelling can be unit-tested without the editor
+ * host; {@link ../baseTreeProvider} renders one into a `vscode.MarkdownString`
+ * so every Studio view gets the same bordered, bold-label hover cards.
+ */
+
+export interface TooltipField {
+    /** The field name, shown bold (e.g. "Agent", "Schema"). */
+    label: string;
+    /** The field value, shown after the label. */
+    value: string;
+    /** Render the value in inline `code` style (hashes, paths, ids). */
+    mono?: boolean;
+}
+
+export interface TooltipModel {
+    /** Optional bold heading rendered above the fields. */
+    title?: string;
+    /** The body rows, one per line. */
+    fields: TooltipField[];
+    /** Optional trailing italic note, e.g. an affordance hint. */
+    hint?: string;
+}
+
+/** A tooltip that is just a descriptive note (no field rows). */
+export function noteTooltip(hint: string): TooltipModel {
+    return { fields: [], hint };
+}

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -104,8 +104,8 @@ let openDetailId: string | undefined;
 // from openDetailId so equal rows — which have no A/B diff to show — can still
 // read as "selected" while the detail pane stays closed.
 let selectedId: string | undefined;
-// Active status filter; defaults to differences-only so the report opens
-// focused on regressions rather than a wall of unchanged rows.
+// Active status filter; defaults to all statuses (the "All" pill is lit), so a
+// fresh report shows every row and the user narrows with the filter chips.
 const activeFilters = defaultImpactFilters();
 // The current selection driving a run. Versions are typed specs resolved by the
 // host's git picker (or the defaults); the agent is fixed for the panel (set
@@ -119,7 +119,8 @@ const root = document.getElementById("root")!;
 // --- Static shell ---------------------------------------------------------
 // A native-feeling action bar: the agent this report is scoped to (read-only —
 // the report is opened per agent from the Corpora view), the A ⇄ B version
-// dropdowns, then the primary Run action and a reconnect button. Both versions
+// dropdowns, then the primary Run action and a connection indicator (the views
+// auto-reconnect, so there is no manual reconnect button). Both versions
 // are chosen through native VS Code QuickPicks the host opens (the webview can't
 // shell out to git); each control shows the current selection and asks the host
 // to open the relevant picker.

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -23,6 +23,14 @@ import {
     toImpactComparisonLine,
     toImpactHeaderFields,
     toSideMethodLabel,
+    buildImpactFilterChips,
+    filterImpactRows,
+    defaultImpactFilters,
+    impactFilterNote,
+    impactEmptyState,
+    allRowsEqual,
+    type ImpactRow,
+    type ReplayRowStatus,
 } from "../replayViewModel.js";
 
 /** A completed result persisted so the report survives navigate-away/reload. */
@@ -63,6 +71,13 @@ let controlsAvailable = false;
 let repoName: string | undefined;
 // The last result rendered, so the header reflects its method/policy.
 let lastRenderedResult: StudioReplayResult | undefined;
+// Rows from the last rendered result and the run's true total, kept so the
+// status filter can re-render the table without re-fetching.
+let currentRows: ImpactRow[] = [];
+let currentTotal = 0;
+// Active status filter; defaults to differences-only so the report opens
+// focused on regressions rather than a wall of unchanged rows.
+const activeFilters = defaultImpactFilters();
 
 const root = document.getElementById("root")!;
 
@@ -105,9 +120,20 @@ toolbar.append(
 const summaryEl = el("div", "summary");
 const comparisonEl = el("div", "comparison");
 const bannerEl = el("div", "banner");
+const filtersEl = el("div", "filters");
+const emptyStateEl = el("div", "empty-state");
 const tableWrap = el("div", "table-wrap");
 
-root.append(headerEl, toolbar, bannerEl, summaryEl, comparisonEl, tableWrap);
+root.append(
+    headerEl,
+    toolbar,
+    bannerEl,
+    summaryEl,
+    comparisonEl,
+    filtersEl,
+    emptyStateEl,
+    tableWrap,
+);
 
 setControlsEnabled(false);
 restoreSelection();
@@ -126,6 +152,7 @@ window.addEventListener("message", (event: MessageEvent) => {
             controlsAvailable = msg.connected && msg.agents.length > 0;
             setControlsEnabled(controlsAvailable);
             renderHeader();
+            renderEmptyState();
             setStatus(
                 msg.connected
                     ? msg.agents.length > 0
@@ -180,6 +207,10 @@ function runReplay(): void {
     comparisonEl.textContent = "";
     bannerEl.textContent = "";
     bannerEl.className = "banner";
+    filtersEl.textContent = "";
+    filtersEl.hidden = true;
+    emptyStateEl.hidden = true;
+    currentRows = [];
     tableWrap.textContent = "";
     vscode.postMessage({ type: "run", requestId, agent, versionA, versionB });
 }
@@ -197,9 +228,13 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     bannerEl.textContent = "";
     summaryEl.textContent = "";
     comparisonEl.textContent = "";
+    filtersEl.textContent = "";
+    filtersEl.hidden = true;
+    emptyStateEl.hidden = true;
     tableWrap.textContent = "";
     versionAInput.sub.textContent = "";
     versionBInput.sub.textContent = "";
+    currentRows = [];
     // A run-level error (a version that failed to build) aborts with an empty
     // summary — surface the failure instead of a misleading zero-row success.
     if (result.error) {
@@ -228,9 +263,61 @@ function renderResult(result: StudioReplayResult, restored = false): void {
 
     summaryEl.textContent = toImpactSummaryLine(result.summary);
     comparisonEl.textContent = toImpactComparisonLine(result.summary);
-    const rows = toImpactRows(result.rows, result.methodA, result.methodB);
-    const shown = rows.length;
-    const total = result.summary.rowCount;
+
+    currentRows = toImpactRows(result.rows, result.methodA, result.methodB);
+    currentTotal = result.summary.rowCount;
+
+    renderFilters();
+    renderTable();
+
+    const shown = currentRows.length;
+    setStatus(
+        restored
+            ? `Restored from last run — Run for live results (${shown} row(s)).`
+            : `Done — ${shown} row(s).`,
+    );
+}
+
+/** Paint the status filter chips for the rows of the current result. */
+function renderFilters(): void {
+    filtersEl.textContent = "";
+    const chips = buildImpactFilterChips(currentRows);
+    // Nothing to filter (no rows, or an error/empty run) — keep the bar hidden.
+    if (currentRows.length === 0) {
+        filtersEl.hidden = true;
+        return;
+    }
+    filtersEl.hidden = false;
+    for (const chip of chips) {
+        const button = document.createElement("button");
+        button.type = "button";
+        const isActive = activeFilters.has(chip.status);
+        const classes = ["filter-chip"];
+        if (isActive) classes.push("is-active");
+        if (chip.count === 0) classes.push("is-empty");
+        button.className = classes.join(" ");
+        button.setAttribute("aria-pressed", String(isActive));
+        button.textContent = `${chip.label} ${chip.count}`;
+        button.addEventListener("click", () => toggleFilter(chip.status));
+        filtersEl.appendChild(button);
+    }
+}
+
+/** Toggle one status in the active filter and re-render the table in place. */
+function toggleFilter(status: ReplayRowStatus): void {
+    if (activeFilters.has(status)) {
+        activeFilters.delete(status);
+    } else {
+        activeFilters.add(status);
+    }
+    renderFilters();
+    renderTable();
+}
+
+/** Build the rows table from `currentRows`, honouring the active filter. */
+function renderTable(): void {
+    tableWrap.textContent = "";
+    const rows = filterImpactRows(currentRows, activeFilters);
 
     const table = document.createElement("table");
     const head = document.createElement("tr");
@@ -250,20 +337,51 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     }
     tableWrap.appendChild(table);
 
-    if (shown < total) {
-        const note = el("div", "truncation");
-        note.textContent = `Showing first ${shown} of ${total} rows.`;
-        tableWrap.appendChild(note);
-    } else if (shown === 0) {
+    const chips = buildImpactFilterChips(currentRows);
+    if (rows.length === 0) {
+        // Distinguish "filtered everything out" from a genuinely all-equal run
+        // (the happy path of the regression journey: nothing changed).
         const empty = el("div", "truncation");
-        empty.textContent = "No corpus rows replayed.";
+        empty.textContent = allRowsEqual(currentRows)
+            ? `No differences — all ${currentRows.length} row(s) are equal between A and B.`
+            : "No rows match the active filter.";
         tableWrap.appendChild(empty);
+    } else {
+        const hiddenNote = impactFilterNote(chips, activeFilters);
+        if (hiddenNote) {
+            const note = el("div", "truncation");
+            note.textContent = hiddenNote;
+            tableWrap.appendChild(note);
+        }
     }
-    setStatus(
-        restored
-            ? `Restored from last run — Run for live results (${shown} row(s)).`
-            : `Done — ${shown} row(s).`,
-    );
+
+    // The host may cap the rows it sends; chips count the received rows, so a
+    // separate note reports the run's true total when it was truncated.
+    if (currentRows.length < currentTotal) {
+        const note = el("div", "truncation");
+        note.textContent = `Showing first ${currentRows.length} of ${currentTotal} rows.`;
+        tableWrap.appendChild(note);
+    }
+}
+
+/**
+ * First-run guidance: shown only before any replay has run and once the
+ * controls are usable, so a newcomer knows what the report does and how to
+ * start. Hidden the moment a run starts or a result/error arrives.
+ */
+function renderEmptyState(): void {
+    if (lastRenderedResult || !controlsAvailable) {
+        emptyStateEl.hidden = true;
+        return;
+    }
+    emptyStateEl.textContent = "";
+    const state = impactEmptyState();
+    const title = el("div", "empty-state-title");
+    title.textContent = state.title;
+    const hint = el("div", "empty-state-hint");
+    hint.textContent = state.hint;
+    emptyStateEl.append(title, hint);
+    emptyStateEl.hidden = false;
 }
 
 /** Render the provenance band (`repo · agent · method · …`) from what we know. */

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -30,6 +30,7 @@ import {
     impactEmptyState,
     allRowsEqual,
     formatProvenanceLine,
+    formatVersionProvenance,
     toActionDiff,
     type ImpactRow,
     type ReplayRowStatus,
@@ -102,7 +103,8 @@ let openDetailId: string | undefined;
 // focused on regressions rather than a wall of unchanged rows.
 const activeFilters = defaultImpactFilters();
 // The current selection driving a run. Versions are typed specs resolved by the
-// host's git picker (or the defaults); the agent comes from the agent picker.
+// host's git picker (or the defaults); the agent is fixed for the panel (set
+// from the host `init`, shown read-only and in the tab title).
 let currentAgent: string | undefined;
 let versionA: ResolvedVersion = DEFAULT_VERSION_A;
 let versionB: ResolvedVersion = DEFAULT_VERSION_B;
@@ -110,53 +112,70 @@ let versionB: ResolvedVersion = DEFAULT_VERSION_B;
 const root = document.getElementById("root")!;
 
 // --- Static shell ---------------------------------------------------------
-const toolbar = el("div", "toolbar");
-const statusEl = el("span", "status");
-// The agent and both versions are chosen through native VS Code QuickPicks the
-// host opens (the webview can't shell out to git); each control is a button that
-// shows the current selection and asks the host to open the relevant picker.
-const agentButton = pickerButton(
-    "agent",
-    "The agent whose corpus is replayed and compared.",
-    () => vscode.postMessage({ type: "pickAgent" }),
-);
-const versionAButton = pickerButton(
-    "Base (A)",
+// A native-feeling action bar: the agent this report is scoped to (read-only —
+// the report is opened per agent from the Corpora view), the A ⇄ B version
+// dropdowns, then the primary Run action and a reconnect button. Both versions
+// are chosen through native VS Code QuickPicks the host opens (the webview can't
+// shell out to git); each control shows the current selection and asks the host
+// to open the relevant picker.
+const actionBar = el("div", "action-bar");
+
+// The agent is fixed for the panel's lifetime; show it (also in the tab title)
+// so a report placed side-by-side with another stays self-identifying.
+const agentNameEl = el("span", "agent-name");
+const versionAButton = picker(
     "Choose the base (A) version to compare from.",
     () => vscode.postMessage({ type: "pickVersion", side: "a" }),
+    "A",
 );
-const versionBButton = pickerButton(
-    "Compare (B)",
+const versionBButton = picker(
     "Choose the compare (B) version to compare to.",
     () => vscode.postMessage({ type: "pickVersion", side: "b" }),
+    "B",
 );
-const swapButton = iconButton("\u21c4", "Swap A and B", () => swapVersions());
+const swapButton = toolButton("arrow-swap", "Swap A and B", () =>
+    swapVersions(),
+);
 swapButton.title = "Swap the base (A) and compare (B) versions.";
-const runButton = iconButton("\u25b6", "Run replay", () => runReplay());
+const runButton = toolButton("play", "Run", () => runReplay(), {
+    primary: true,
+    text: "Run",
+});
 runButton.title =
     "Replay the corpus against both versions and compare actions.";
-const reconnectButton = iconButton("\u21bb", "Reconnect", () => {
+const reconnectButton = toolButton("refresh", "Reconnect", () => {
     vscode.postMessage({ type: "reconnect" });
 });
 reconnectButton.title = "Re-attempt the connection to the studio service.";
-toolbar.append(
-    agentButton.wrap,
-    versionAButton.wrap,
-    swapButton,
-    versionBButton.wrap,
+
+actionBar.append(
+    group(codicon("library"), agentNameEl),
+    separator(),
+    group(versionAButton.button, swapButton, versionBButton.button),
+    spacer(),
     runButton,
     reconnectButton,
-    statusEl,
 );
 
-const bannerEl = el("div", "banner");
+// A slim sub-bar under the toolbar carries the run provenance (the concrete
+// commits each side ran against) and the live status text.
+const subBar = el("div", "sub-bar");
+const provenanceEl = el("span", "provenance");
+const statusEl = el("span", "status");
+subBar.append(provenanceEl, statusEl);
+
+// The scrolling content region: an inline error notification, the status filter,
+// first-run guidance, the results list, and the drill-in detail pane.
+const contentEl = el("div", "content");
+const notificationEl = el("div", "notification");
 const filtersEl = el("div", "filters");
 const emptyStateEl = el("div", "empty-state");
 const tableWrap = el("div", "table-wrap");
 const detailEl = el("div", "detail-pane");
 detailEl.hidden = true;
+contentEl.append(notificationEl, filtersEl, emptyStateEl, tableWrap, detailEl);
 
-root.append(toolbar, bannerEl, filtersEl, emptyStateEl, tableWrap, detailEl);
+root.append(actionBar, subBar, contentEl);
 
 setControlsEnabled(false);
 restoreSelection();
@@ -167,15 +186,16 @@ window.addEventListener("message", (event: MessageEvent) => {
     const msg = event.data as HostToWebviewMessage;
     switch (msg.type) {
         case "init":
-            adoptAgents(msg.agents);
-            controlsAvailable = msg.connected && msg.agents.length > 0;
+            currentAgent = msg.agent;
+            renderAgentName();
+            controlsAvailable = msg.connected && msg.available;
             setControlsEnabled(controlsAvailable);
             renderEmptyState();
             setStatus(
                 msg.connected
-                    ? msg.agents.length > 0
+                    ? msg.available
                         ? "Connected."
-                        : "Connected — no corpus agents found."
+                        : `Connected — no corpus found for ${msg.agent}.`
                     : "Studio service not found — start an agent-server with the studio agent enabled.",
             );
             break;
@@ -184,12 +204,6 @@ window.addEventListener("message", (event: MessageEvent) => {
             break;
         case "versionPicked":
             applyVersionPick(msg.side, msg.resolved);
-            break;
-        case "agentPicked":
-            currentAgent = msg.agent;
-            renderAgentButton();
-            persistState({ selectedAgent: msg.agent });
-            renderEmptyState();
             break;
         case "result":
             // Accept the matching run, or — when no run has been issued since
@@ -228,8 +242,8 @@ function runReplay(): void {
     persistState({ selectedAgent: agent, versionA, versionB });
     setControlsEnabled(false);
     setStatus(`Replaying ${agent}…`);
-    bannerEl.textContent = "";
-    bannerEl.className = "banner";
+    clearNotification();
+    provenanceEl.textContent = "";
     filtersEl.textContent = "";
     filtersEl.hidden = true;
     emptyStateEl.hidden = true;
@@ -278,8 +292,8 @@ function renderResult(
     // the full result on `ready` (recovery). The table is built with
     // `appendChild`, so without this clear the recovery render would append a
     // second table instead of upgrading the snapshot in place.
-    bannerEl.className = "banner";
-    bannerEl.textContent = "";
+    clearNotification();
+    provenanceEl.textContent = "";
     filtersEl.textContent = "";
     filtersEl.hidden = true;
     emptyStateEl.hidden = true;
@@ -291,8 +305,7 @@ function renderResult(
     // A run-level error (a version that failed to build) aborts with an empty
     // summary — surface the failure instead of a misleading zero-row success.
     if (result.error) {
-        bannerEl.className = "banner banner-error";
-        bannerEl.textContent = toImpactErrorLine(result.error);
+        showNotification(toImpactErrorLine(result.error));
         setStatus(restored ? "Restored — replay aborted." : "Replay aborted.");
         return;
     }
@@ -311,8 +324,7 @@ function renderResult(
     // The provenance line pins the report to the concrete commits it ran
     // against, so a later branch move doesn't make a bare HEAD label lie.
     if (provenance) {
-        bannerEl.className = "banner banner-provenance";
-        bannerEl.textContent = formatProvenanceLine(provenance);
+        renderProvenance(provenance);
     }
 
     currentRows = toImpactRows(result.rows, result.methodA, result.methodB);
@@ -341,6 +353,10 @@ function renderFilters(): void {
     }
     filtersEl.hidden = false;
 
+    const label = el("span", "filters-label");
+    label.append(codicon("list-filter"), document.createTextNode("Filter"));
+    filtersEl.appendChild(label);
+
     // The "All" pill resets the view to every row; it reads as active whenever
     // nothing with rows is hidden.
     filtersEl.appendChild(
@@ -359,20 +375,27 @@ function renderFilters(): void {
         // A status with no rows is nothing to filter on — show it for context
         // (a count of 0 is informative) but make it inert.
         filtersEl.appendChild(
-            chipButton(chip.label, chip.count, isActive, isEmpty, () =>
-                toggleFilter(chip.status),
+            chipButton(
+                chip.label,
+                chip.count,
+                isActive,
+                isEmpty,
+                () => toggleFilter(chip.status),
+                chip.status,
             ),
         );
     }
 }
 
-/** Build one filter pill button. Empty (zero-count) chips render inert. */
+/** Build one filter pill button. Empty (zero-count) chips render inert. A
+ *  `status` adds a colour dot mirroring the row status colour. */
 function chipButton(
     label: string,
     count: number,
     isActive: boolean,
     isEmpty: boolean,
     onClick: () => void,
+    status?: ReplayRowStatus,
 ): HTMLButtonElement {
     const button = document.createElement("button");
     button.type = "button";
@@ -381,7 +404,15 @@ function chipButton(
     if (isEmpty) classes.push("is-empty");
     button.className = classes.join(" ");
     button.setAttribute("aria-pressed", String(isActive));
-    button.textContent = `${label} ${count}`;
+    if (status) {
+        const dot = el("span", `chip-dot status-${status}`);
+        button.appendChild(dot);
+    }
+    const text = document.createElement("span");
+    text.textContent = label;
+    const countEl = el("span", "chip-count");
+    countEl.textContent = String(count);
+    button.append(text, countEl);
     if (isEmpty) {
         button.disabled = true;
     } else {
@@ -416,27 +447,25 @@ function renderTable(): void {
     const rows = filterImpactRows(currentRows, activeFilters);
 
     const table = document.createElement("table");
+    const thead = document.createElement("thead");
     const head = document.createElement("tr");
-    for (const h of [
-        "Utterance",
-        "Status",
-        "Base (A)",
-        "Compare (B)",
-        "Latency",
-    ]) {
+    for (const h of ["Utterance", "Status", "Base (A)", "Compare (B)", ""]) {
         const th = document.createElement("th");
-        th.textContent = h;
+        th.textContent = h || "Latency";
+        if (!h) th.setAttribute("aria-label", "Latency");
         head.appendChild(th);
     }
-    table.appendChild(head);
+    thead.appendChild(head);
+    table.appendChild(thead);
+    const tbody = document.createElement("tbody");
 
     for (const row of rows) {
         const tr = document.createElement("tr");
         tr.appendChild(cell(row.utterance));
-        tr.appendChild(cell(row.statusLabel, `status-${row.status}`));
+        tr.appendChild(statusCell(row.status, row.statusLabel));
         tr.appendChild(cell(row.resolutionA, "resolution"));
         tr.appendChild(cell(row.resolutionB, "resolution"));
-        tr.appendChild(cell(row.latency, "latency"));
+        tr.appendChild(latencyCell(row));
         // Difference rows drill into an action A/B diff; equal rows have nothing
         // to compare, so they stay inert.
         if (row.status !== "equal" && currentRawById.has(row.utteranceId)) {
@@ -455,8 +484,9 @@ function renderTable(): void {
                 }
             });
         }
-        table.appendChild(tr);
+        tbody.appendChild(tr);
     }
+    table.appendChild(tbody);
     tableWrap.appendChild(table);
 
     const chips = buildImpactFilterChips(currentRows);
@@ -520,19 +550,32 @@ function renderDetail(delta: ActionDelta): void {
     title.textContent = collapseWhitespace(delta.utterance);
     title.title = delta.utterance;
     const meta = el("span", "detail-meta");
-    meta.textContent = diff.onlyB
-        ? "new match (no action on A)"
-        : diff.onlyA
-          ? "lost match (no action on B)"
-          : diff.identical
-            ? "actions identical"
-            : `+${diff.addedCount} \u2212${diff.removedCount}`;
-    const close = iconButton("\u2715", "Close detail", () => closeDetail());
+    if (diff.onlyB) {
+        meta.append(codicon("diff-added"), text("new match (no action on A)"));
+    } else if (diff.onlyA) {
+        meta.append(
+            codicon("diff-removed"),
+            text("lost match (no action on B)"),
+        );
+    } else if (diff.identical) {
+        meta.append(codicon("pass"), text("actions identical"));
+    } else {
+        const added = el("span", "added");
+        added.textContent = `+${diff.addedCount}`;
+        const removed = el("span", "removed");
+        removed.textContent = `\u2212${diff.removedCount}`;
+        meta.append(added, removed);
+    }
+    const close = toolButton("close", "Close detail", () => closeDetail());
     close.classList.add("detail-close");
     header.append(title, meta, close);
 
     const legend = el("div", "detail-legend");
-    legend.textContent = "Base (A) \u2192 Compare (B)";
+    legend.append(
+        text("Base (A)"),
+        codicon("arrow-right"),
+        text("Compare (B)"),
+    );
 
     const body = el("pre", "detail-diff");
     for (const line of diff.lines) {
@@ -565,38 +608,26 @@ function renderEmptyState(): void {
     }
     emptyStateEl.textContent = "";
     const state = impactEmptyState();
+    const icon = codicon("git-compare");
     const title = el("div", "empty-state-title");
     title.textContent = state.title;
     const hint = el("div", "empty-state-hint");
     hint.textContent = state.hint;
-    emptyStateEl.append(title, hint);
+    emptyStateEl.append(icon, title, hint);
     emptyStateEl.hidden = false;
-}
-
-function adoptAgents(agents: string[]): void {
-    // Keep the persisted/selected agent if still available; otherwise default to
-    // the first agent so a newcomer can run without opening the picker first.
-    if (currentAgent && agents.includes(currentAgent)) {
-        // keep it
-    } else if (agents.length > 0) {
-        currentAgent = agents[0];
-        persistState({ selectedAgent: currentAgent });
-    }
-    renderAgentButton();
 }
 
 function restoreSelection(): void {
     const state = vscode.getState();
-    if (state?.selectedAgent) {
-        currentAgent = state.selectedAgent;
-    }
     if (state?.versionA) {
         versionA = state.versionA;
     }
     if (state?.versionB) {
         versionB = state.versionB;
     }
-    renderAgentButton();
+    // The agent is authoritative from the host `init`; until it arrives, show a
+    // neutral placeholder rather than a stale persisted value.
+    renderAgentName();
     // Re-render the last result immediately so navigating away and back doesn't
     // blank the report. The host also re-pushes the full result on `ready`
     // (recovery), which upgrades this possibly-truncated snapshot.
@@ -646,7 +677,6 @@ function persistResult(
 function setControlsEnabled(enabled: boolean): void {
     runButton.disabled = !enabled;
     swapButton.disabled = !enabled;
-    agentButton.button.disabled = !enabled;
     versionAButton.button.disabled = !enabled;
     versionBButton.button.disabled = !enabled;
 }
@@ -662,56 +692,155 @@ function el(tag: string, className: string): HTMLElement {
     return node;
 }
 
-function cell(text: string, className?: string): HTMLTableCellElement {
+function text(value: string): Text {
+    return document.createTextNode(value);
+}
+
+/** A codicon glyph element (VS Code's icon font). `name` matches a
+ *  `.codicon-<name>` rule in the stylesheet. */
+function codicon(name: string): HTMLElement {
+    return el("span", `codicon codicon-${name}`);
+}
+
+function cell(value: string, className?: string): HTMLTableCellElement {
     const td = document.createElement("td");
-    td.textContent = text;
+    td.textContent = value;
     if (className) {
         td.className = className;
     }
     return td;
 }
 
-/** A compact icon button (e.g. ▶ run, ↻ reconnect). `glyph` is the visible
- *  symbol; `label` is the accessible name and hover title. */
-function iconButton(
-    glyph: string,
+/** Map a row status to its codicon glyph (diff add/modify/remove, or pass). */
+function statusIcon(status: ReplayRowStatus): string {
+    switch (status) {
+        case "changed":
+            return "diff-modified";
+        case "new-match":
+            return "diff-added";
+        case "lost-match":
+            return "diff-removed";
+        default:
+            return "pass";
+    }
+}
+
+/** The status cell: a coloured codicon + label, like VS Code's diff decorations. */
+function statusCell(
+    status: ReplayRowStatus,
+    label: string,
+): HTMLTableCellElement {
+    const td = document.createElement("td");
+    td.className = "col-status";
+    const wrap = el("span", `status-cell status-${status}`);
+    wrap.append(codicon(statusIcon(status)), text(label));
+    td.appendChild(wrap);
+    return td;
+}
+
+/** The latency cell, with a faint expand chevron revealed on hover for rows that
+ *  drill into a detail diff. */
+function latencyCell(row: ImpactRow): HTMLTableCellElement {
+    const td = document.createElement("td");
+    td.className = "latency";
+    const value = el("span", "latency-value");
+    value.textContent = row.latency;
+    td.appendChild(value);
+    return td;
+}
+
+interface ToolButtonOptions {
+    /** Render with the primary button fill (used for the one Run action). */
+    primary?: boolean;
+    /** Optional visible label next to the icon. */
+    text?: string;
+}
+
+/** A toolbar button carrying a codicon (and optional label). `icon` matches a
+ *  `.codicon-<icon>` rule; `label` is the accessible name and hover title. */
+function toolButton(
+    icon: string,
     label: string,
     onClick: () => void,
+    opts: ToolButtonOptions = {},
 ): HTMLButtonElement {
     const b = document.createElement("button");
-    b.className = "icon-button";
-    b.textContent = glyph;
+    b.type = "button";
+    b.className = opts.primary ? "tool-button is-primary" : "tool-button";
+    b.append(codicon(icon));
+    if (opts.text) {
+        b.append(text(opts.text));
+    }
     b.setAttribute("aria-label", label);
     b.title = label;
     b.addEventListener("click", onClick);
     return b;
 }
 
-/** A labelled picker button (e.g. "Base (A)") that shows the current selection
- *  and asks the host to open the relevant native QuickPick on click. */
-function pickerButton(
-    label: string,
+/** A dropdown-style picker button: an optional side tag (A/B), the current
+ *  selection, and a trailing chevron. Asks the host to open a native QuickPick
+ *  on click. */
+function picker(
     description: string,
     onClick: () => void,
-): { wrap: HTMLElement; button: HTMLButtonElement; value: HTMLElement } {
-    const wrap = el("label", "picker-field");
-    const text = document.createElement("span");
-    text.className = "picker-label";
-    text.textContent = label;
+    sideTag?: string,
+): { button: HTMLButtonElement; value: HTMLElement } {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = "picker-button";
+    button.className = "picker";
     button.title = description;
-    button.setAttribute("aria-label", `${label}: choose`);
-    const value = document.createElement("span");
-    value.className = "picker-value";
-    button.appendChild(value);
+    button.setAttribute("aria-label", description);
+    if (sideTag) {
+        const tag = el("span", "picker-side");
+        tag.textContent = sideTag;
+        button.appendChild(tag);
+    }
+    const value = el("span", "picker-value");
+    button.append(value, codicon("chevron-down"));
     button.addEventListener("click", onClick);
-    wrap.append(text, button);
-    return { wrap, button, value };
+    return { button, value };
 }
 
-/** Paint both version buttons with their current labels and tooltips. */
+/** A grouped cluster of action-bar controls. */
+function group(...children: Node[]): HTMLElement {
+    const g = el("div", "bar-group");
+    g.append(...children);
+    return g;
+}
+
+/** A thin vertical separator between action-bar groups. */
+function separator(): HTMLElement {
+    return el("div", "bar-sep");
+}
+
+/** A flexible spacer that pushes trailing controls to the right edge. */
+function spacer(): HTMLElement {
+    return el("div", "bar-spacer");
+}
+
+/** Show an inline error notification in the content area. */
+function showNotification(message: string): void {
+    notificationEl.textContent = "";
+    notificationEl.append(codicon("error"), text(message));
+}
+
+/** Clear the inline error notification. */
+function clearNotification(): void {
+    notificationEl.textContent = "";
+}
+
+/** Paint the provenance strip: the concrete identity each side ran against. */
+function renderProvenance(provenance: RunProvenance): void {
+    provenanceEl.textContent = "";
+    provenanceEl.title = formatProvenanceLine(provenance);
+    provenanceEl.append(
+        text(formatVersionProvenance(provenance.a)),
+        codicon("arrow-right"),
+        text(formatVersionProvenance(provenance.b)),
+    );
+}
+
+/** Paint both version pickers with their current labels and tooltips. */
 function renderVersionButtons(): void {
     versionAButton.value.textContent = versionA.label;
     versionAButton.button.title = versionA.tooltip;
@@ -719,7 +848,10 @@ function renderVersionButtons(): void {
     versionBButton.button.title = versionB.tooltip;
 }
 
-/** Paint the agent button with the current selection (or a prompt). */
-function renderAgentButton(): void {
-    agentButton.value.textContent = currentAgent ?? "Select agent";
+/** Paint the read-only agent label with the current (host-fixed) selection. */
+function renderAgentName(): void {
+    agentNameEl.textContent = currentAgent ?? "—";
+    agentNameEl.title = currentAgent
+        ? `This report compares the "${currentAgent}" agent's corpus across two versions.`
+        : "";
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -100,6 +100,10 @@ let currentRawById = new Map<string, ActionDelta>();
 // The utterance id whose drill-in detail is open, or undefined when closed; kept
 // so a filter re-render can re-assert (or drop) the open detail.
 let openDetailId: string | undefined;
+// The utterance id of the visually selected row (turns blue). Tracked separately
+// from openDetailId so equal rows — which have no A/B diff to show — can still
+// read as "selected" while the detail pane stays closed.
+let selectedId: string | undefined;
 // Active status filter; defaults to differences-only so the report opens
 // focused on regressions rather than a wall of unchanged rows.
 const activeFilters = defaultImpactFilters();
@@ -464,10 +468,30 @@ function renderTable(): void {
     const table = document.createElement("table");
     const thead = document.createElement("thead");
     const head = document.createElement("tr");
-    for (const h of ["Utterance", "Status", "Base (A)", "Compare (B)", ""]) {
+    const headers: { label: string; title: string; ariaLabel?: string }[] = [
+        {
+            label: "Utterance",
+            title: "The corpus utterance that was replayed.",
+        },
+        {
+            label: "Status",
+            title: "How Base (A) and Compare (B) compare for this utterance.",
+        },
+        {
+            label: "Base (A)",
+            title: "How Base (A) resolved the utterance (cache state).",
+        },
+        {
+            label: "Compare (B)",
+            title: "How Compare (B) resolved the utterance (cache state).",
+        },
+        { label: "", title: LATENCY_TOOLTIP, ariaLabel: "Latency" },
+    ];
+    for (const h of headers) {
         const th = document.createElement("th");
-        th.textContent = h || "Latency";
-        if (!h) th.setAttribute("aria-label", "Latency");
+        th.textContent = h.label || "Latency";
+        th.title = h.title;
+        if (h.ariaLabel) th.setAttribute("aria-label", h.ariaLabel);
         head.appendChild(th);
     }
     thead.appendChild(head);
@@ -478,24 +502,44 @@ function renderTable(): void {
         const tr = document.createElement("tr");
         tr.appendChild(cell(row.utterance));
         tr.appendChild(statusCell(row.status, row.statusLabel));
-        tr.appendChild(cell(row.resolutionA, "resolution"));
-        tr.appendChild(cell(row.resolutionB, "resolution"));
+        tr.appendChild(
+            cell(
+                row.resolutionA,
+                "resolution",
+                resolutionTooltip(row.resolutionA),
+            ),
+        );
+        tr.appendChild(
+            cell(
+                row.resolutionB,
+                "resolution",
+                resolutionTooltip(row.resolutionB),
+            ),
+        );
         tr.appendChild(latencyCell(row));
-        // Difference rows drill into an action A/B diff; equal rows have nothing
-        // to compare, so they stay inert.
-        if (row.status !== "equal" && currentRawById.has(row.utteranceId)) {
+        // Every row is clickable. Difference rows drill into an action A/B diff;
+        // equal rows have nothing to compare, so a click just clears any open
+        // detail pane.
+        if (currentRawById.has(row.utteranceId)) {
+            const isDiff = row.status !== "equal";
             tr.classList.add("row-clickable");
-            if (row.utteranceId === openDetailId) {
+            if (row.utteranceId === selectedId) {
                 tr.classList.add("row-open");
             }
             tr.tabIndex = 0;
             tr.setAttribute("role", "button");
-            tr.title = "Show the action A/B diff for this utterance.";
-            tr.addEventListener("click", () => openDetail(row.utteranceId));
+            tr.title = isDiff
+                ? "Show the action A/B diff for this utterance."
+                : "Equal row — click to close the detail diff.";
+            const activate = () =>
+                isDiff
+                    ? openDetail(row.utteranceId)
+                    : selectEqualRow(row.utteranceId);
+            tr.addEventListener("click", activate);
             tr.addEventListener("keydown", (e: KeyboardEvent) => {
                 if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    openDetail(row.utteranceId);
+                    activate();
                 }
             });
         }
@@ -541,15 +585,27 @@ function openDetail(utteranceId: string): void {
         return;
     }
     openDetailId = utteranceId;
+    selectedId = utteranceId;
     renderDetail(delta);
     // Re-render the table so the open row gets its highlight.
     renderTable();
     detailEl.scrollIntoView({ block: "nearest" });
 }
 
-/** Hide and clear the drill-in detail pane. */
+/** Select an equal row: it has no A/B diff, so just highlight it and close any
+ *  open detail pane. */
+function selectEqualRow(utteranceId: string): void {
+    selectedId = utteranceId;
+    openDetailId = undefined;
+    detailEl.hidden = true;
+    detailEl.textContent = "";
+    renderTable();
+}
+
+/** Hide the drill-in detail pane and clear the row selection. */
 function closeDetail(): void {
     openDetailId = undefined;
+    selectedId = undefined;
     detailEl.hidden = true;
     detailEl.textContent = "";
 }
@@ -581,7 +637,10 @@ function renderDetail(delta: ActionDelta): void {
         removed.textContent = `\u2212${diff.removedCount}`;
         meta.append(added, removed);
     }
-    const close = toolButton("close", "Close detail", () => closeDetail());
+    const close = toolButton("close", "Close detail", () => {
+        closeDetail();
+        renderTable();
+    });
     close.classList.add("detail-close");
     header.append(title, meta, close);
 
@@ -717,13 +776,55 @@ function codicon(name: string): HTMLElement {
     return el("span", `codicon codicon-${name}`);
 }
 
-function cell(value: string, className?: string): HTMLTableCellElement {
+function cell(
+    value: string,
+    className?: string,
+    title?: string,
+): HTMLTableCellElement {
     const td = document.createElement("td");
     td.textContent = value;
     if (className) {
         td.className = className;
     }
+    if (title) {
+        td.title = title;
+    }
     return td;
+}
+
+const STATUS_TOOLTIP: Record<ReplayRowStatus, string> = {
+    equal: "Equal — Base (A) and Compare (B) resolved to the same action; nothing changed.",
+    changed:
+        "Changed — both sides resolved an action, but the two actions differ.",
+    "new-match":
+        "New match — Compare (B) resolved an action where Base (A) did not.",
+    "lost-match":
+        "Lost match — Base (A) resolved an action but Compare (B) no longer does.",
+};
+
+const LATENCY_TOOLTIP =
+    "Resolution latency in milliseconds — Base (A) / Compare (B).";
+
+/** Human description of a per-side resolution token (see `sideToken` in the
+ *  replay view model for how a raw cache state becomes one of these). */
+function resolutionTooltip(token: string): string {
+    switch (token) {
+        case "hit":
+        case "hit\u00b7cache":
+            return "Hit — the action was served from the construction cache.";
+        case "miss":
+            return "Miss — no construction matched this utterance.";
+        case "miss\u00b7grammar":
+            return "Miss — no cached construction matched; this side fell through to the grammar.";
+        case "needs-explanation":
+            return "Needs explanation — no cached construction matched and the miss policy skipped the LLM, so the utterance needs an explanation (LLM) to resolve.";
+        case "llm-resolved":
+            return "LLM resolved — the action was produced by calling the live language model.";
+        case "skipped":
+            return "Skipped — this utterance was not evaluated on this side.";
+        default:
+            return token;
+    }
 }
 
 /** Map a row status to its codicon glyph (diff add/modify/remove, or pass). */
@@ -747,6 +848,7 @@ function statusCell(
 ): HTMLTableCellElement {
     const td = document.createElement("td");
     td.className = "col-status";
+    td.title = STATUS_TOOLTIP[status];
     const wrap = el("span", `status-cell status-${status}`);
     wrap.append(codicon(statusIcon(status)), text(label));
     td.appendChild(wrap);
@@ -758,6 +860,7 @@ function statusCell(
 function latencyCell(row: ImpactRow): HTMLTableCellElement {
     const td = document.createElement("td");
     td.className = "latency";
+    td.title = LATENCY_TOOLTIP;
     const value = el("span", "latency-value");
     value.textContent = row.latency;
     td.appendChild(value);

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -17,15 +17,13 @@ import type {
 } from "../protocol.js";
 import {
     toImpactRows,
-    toImpactSummaryLine,
     toImpactMethodNote,
     toImpactErrorLine,
-    toImpactComparisonLine,
-    toImpactHeaderFields,
     toSideMethodLabel,
     buildImpactFilterChips,
     filterImpactRows,
     defaultImpactFilters,
+    allStatusesActive,
     impactFilterNote,
     impactEmptyState,
     allRowsEqual,
@@ -43,7 +41,6 @@ interface PanelState {
     selectedAgent?: string;
     versionA?: string;
     versionB?: string;
-    repoName?: string;
     lastResult?: PersistedResult;
 }
 interface VsCodeApi {
@@ -67,9 +64,8 @@ let latestRequestId = 0;
 // Run controls are re-enabled after a run only when this holds, so a result /
 // error never re-enables Run while the service is unavailable.
 let controlsAvailable = false;
-// Repo name for the context header (from `init`, falls back to persisted state).
-let repoName: string | undefined;
-// The last result rendered, so the header reflects its method/policy.
+// The last result rendered, so the fidelity tooltip and per-side resolution
+// reflect the current run; also gates the first-run empty state.
 let lastRenderedResult: StudioReplayResult | undefined;
 // Rows from the last rendered result and the run's true total, kept so the
 // status filter can re-render the table without re-fetching.
@@ -82,7 +78,6 @@ const activeFilters = defaultImpactFilters();
 const root = document.getElementById("root")!;
 
 // --- Static shell ---------------------------------------------------------
-const headerEl = el("div", "context-header");
 const toolbar = el("div", "toolbar");
 const statusEl = el("span", "status");
 const agentSelect = document.createElement("select");
@@ -91,7 +86,6 @@ agentSelect.setAttribute("aria-label", "Agent to replay");
 agentSelect.title = "The agent whose corpus is replayed and compared.";
 agentSelect.addEventListener("change", () => {
     persistState({ selectedAgent: agentSelect.value });
-    renderHeader();
 });
 // Two version fields drive the A→B compare. Defaults express the "find a
 // regression" journey: baseline HEAD vs the live working tree (your edits).
@@ -101,10 +95,10 @@ const versionBInput = versionField(
     "working tree",
     "working tree",
 );
-const runButton = button("Run replay", () => runReplay());
+const runButton = iconButton("\u25b6", "Run replay", () => runReplay());
 runButton.title =
     "Replay the corpus against both versions and compare actions.";
-const reconnectButton = button("Reconnect", () => {
+const reconnectButton = iconButton("\u21bb", "Reconnect", () => {
     vscode.postMessage({ type: "reconnect" });
 });
 reconnectButton.title = "Re-attempt the connection to the studio service.";
@@ -117,41 +111,24 @@ toolbar.append(
     statusEl,
 );
 
-const summaryEl = el("div", "summary");
-const comparisonEl = el("div", "comparison");
 const bannerEl = el("div", "banner");
 const filtersEl = el("div", "filters");
 const emptyStateEl = el("div", "empty-state");
 const tableWrap = el("div", "table-wrap");
 
-root.append(
-    headerEl,
-    toolbar,
-    bannerEl,
-    summaryEl,
-    comparisonEl,
-    filtersEl,
-    emptyStateEl,
-    tableWrap,
-);
+root.append(toolbar, bannerEl, filtersEl, emptyStateEl, tableWrap);
 
 setControlsEnabled(false);
 restoreSelection();
-renderHeader();
 
 // --- Messaging ------------------------------------------------------------
 window.addEventListener("message", (event: MessageEvent) => {
     const msg = event.data as HostToWebviewMessage;
     switch (msg.type) {
         case "init":
-            if (msg.repoName !== undefined) {
-                repoName = msg.repoName;
-                persistState({ repoName });
-            }
             populateAgents(msg.agents);
             controlsAvailable = msg.connected && msg.agents.length > 0;
             setControlsEnabled(controlsAvailable);
-            renderHeader();
             renderEmptyState();
             setStatus(
                 msg.connected
@@ -203,8 +180,6 @@ function runReplay(): void {
     persistState({ selectedAgent: agent, versionA, versionB });
     setControlsEnabled(false);
     setStatus(`Replaying ${agent}…`);
-    summaryEl.textContent = "";
-    comparisonEl.textContent = "";
     bannerEl.textContent = "";
     bannerEl.className = "banner";
     filtersEl.textContent = "";
@@ -217,7 +192,6 @@ function runReplay(): void {
 
 function renderResult(result: StudioReplayResult, restored = false): void {
     lastRenderedResult = result;
-    renderHeader();
     // Reset every output region first so a render fully *replaces* the previous
     // one. `renderResult` runs more than once per result on navigate-away/back:
     // `restoreSelection` paints the persisted snapshot, then the host re-pushes
@@ -226,43 +200,31 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     // second table instead of upgrading the snapshot in place.
     bannerEl.className = "banner";
     bannerEl.textContent = "";
-    summaryEl.textContent = "";
-    comparisonEl.textContent = "";
     filtersEl.textContent = "";
     filtersEl.hidden = true;
     emptyStateEl.hidden = true;
     tableWrap.textContent = "";
-    versionAInput.sub.textContent = "";
-    versionBInput.sub.textContent = "";
+    statusEl.title = "";
     currentRows = [];
     // A run-level error (a version that failed to build) aborts with an empty
     // summary — surface the failure instead of a misleading zero-row success.
     if (result.error) {
         bannerEl.className = "banner banner-error";
         bannerEl.textContent = toImpactErrorLine(result.error);
-        summaryEl.textContent = "";
-        comparisonEl.textContent = toImpactComparisonLine(result.summary);
-        tableWrap.textContent = "";
         setStatus(restored ? "Restored — replay aborted." : "Replay aborted.");
         return;
     }
 
-    const note = toImpactMethodNote(result.method);
-    if (note) {
-        bannerEl.className = "banner banner-note";
-        bannerEl.textContent = note;
-    } else {
-        bannerEl.className = "banner";
-        bannerEl.textContent = "";
-    }
-
-    // Per-side method under each version field: a git ref can never consult the
-    // live construction cache, so this makes the A/B asymmetry explicit.
-    versionAInput.sub.textContent = toSideMethodLabel(result.methodA);
-    versionBInput.sub.textContent = toSideMethodLabel(result.methodB);
-
-    summaryEl.textContent = toImpactSummaryLine(result.summary);
-    comparisonEl.textContent = toImpactComparisonLine(result.summary);
+    // The fidelity caveat (e.g. "indicative, not authoritative") and how each
+    // side resolved are kept as hover detail rather than visible banners so the
+    // report stays compact without losing the warning.
+    statusEl.title = toImpactMethodNote(result.method) ?? "";
+    versionAInput.input.title = `Base (A) resolved via ${toSideMethodLabel(
+        result.methodA,
+    )}`;
+    versionBInput.input.title = `Compare (B) resolved via ${toSideMethodLabel(
+        result.methodB,
+    )}`;
 
     currentRows = toImpactRows(result.rows, result.methodA, result.methodB);
     currentTotal = result.summary.rowCount;
@@ -271,10 +233,11 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     renderTable();
 
     const shown = currentRows.length;
+    const ms = result.summary.duration;
     setStatus(
         restored
             ? `Restored from last run — Run for live results (${shown} row(s)).`
-            : `Done — ${shown} row(s).`,
+            : `Done — ${shown} row(s) \u00b7 ${ms}ms.`,
     );
 }
 
@@ -288,26 +251,63 @@ function renderFilters(): void {
         return;
     }
     filtersEl.hidden = false;
+
+    // The "All" pill resets the view to every row; it reads as active whenever
+    // nothing with rows is hidden.
+    filtersEl.appendChild(
+        chipButton(
+            "All",
+            currentRows.length,
+            allStatusesActive(chips, activeFilters),
+            false,
+            selectAllFilters,
+        ),
+    );
+
     for (const chip of chips) {
-        const button = document.createElement("button");
-        button.type = "button";
         const isActive = activeFilters.has(chip.status);
         const isEmpty = chip.count === 0;
-        const classes = ["filter-chip"];
-        if (isActive) classes.push("is-active");
-        if (isEmpty) classes.push("is-empty");
-        button.className = classes.join(" ");
-        button.setAttribute("aria-pressed", String(isActive));
-        button.textContent = `${chip.label} ${chip.count}`;
         // A status with no rows is nothing to filter on — show it for context
         // (a count of 0 is informative) but make it inert.
-        if (isEmpty) {
-            button.disabled = true;
-        } else {
-            button.addEventListener("click", () => toggleFilter(chip.status));
-        }
-        filtersEl.appendChild(button);
+        filtersEl.appendChild(
+            chipButton(chip.label, chip.count, isActive, isEmpty, () =>
+                toggleFilter(chip.status),
+            ),
+        );
     }
+}
+
+/** Build one filter pill button. Empty (zero-count) chips render inert. */
+function chipButton(
+    label: string,
+    count: number,
+    isActive: boolean,
+    isEmpty: boolean,
+    onClick: () => void,
+): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    const classes = ["filter-chip"];
+    if (isActive) classes.push("is-active");
+    if (isEmpty) classes.push("is-empty");
+    button.className = classes.join(" ");
+    button.setAttribute("aria-pressed", String(isActive));
+    button.textContent = `${label} ${count}`;
+    if (isEmpty) {
+        button.disabled = true;
+    } else {
+        button.addEventListener("click", onClick);
+    }
+    return button;
+}
+
+/** Reset the active filter to every status (the "All" view). */
+function selectAllFilters(): void {
+    for (const status of defaultImpactFilters()) {
+        activeFilters.add(status);
+    }
+    renderFilters();
+    renderTable();
 }
 
 /** Toggle one status in the active filter and re-render the table in place. */
@@ -399,37 +399,6 @@ function renderEmptyState(): void {
     emptyStateEl.hidden = false;
 }
 
-/** Render the provenance band (`repo · agent · method · …`) from what we know. */
-function renderHeader(): void {
-    const agent = agentSelect.value || vscode.getState()?.selectedAgent;
-    const fields = toImpactHeaderFields({
-        ...(repoName !== undefined ? { repo: repoName } : {}),
-        ...(agent ? { agent } : {}),
-        ...(lastRenderedResult
-            ? {
-                  method: lastRenderedResult.method,
-                  missPolicy: lastRenderedResult.summary.missPolicy,
-              }
-            : {}),
-    });
-    headerEl.textContent = "";
-    fields.forEach((f, i) => {
-        if (i > 0) {
-            const sep = el("span", "context-sep");
-            sep.textContent = "·";
-            headerEl.appendChild(sep);
-        }
-        const item = el("span", "context-item");
-        item.title = f.tooltip;
-        const label = el("span", "context-label");
-        label.textContent = `${f.label}:`;
-        const value = el("span", "context-value");
-        value.textContent = f.value;
-        item.append(label, value);
-        headerEl.appendChild(item);
-    });
-}
-
 function populateAgents(agents: string[]): void {
     const previous = vscode.getState()?.selectedAgent;
     agentSelect.textContent = "";
@@ -446,7 +415,6 @@ function populateAgents(agents: string[]): void {
 
 function restoreSelection(): void {
     const state = vscode.getState();
-    repoName = state?.repoName;
     const previous = state?.selectedAgent;
     if (previous) {
         const opt = document.createElement("option");
@@ -521,9 +489,18 @@ function cell(text: string, className?: string): HTMLTableCellElement {
     return td;
 }
 
-function button(label: string, onClick: () => void): HTMLButtonElement {
+/** A compact icon button (e.g. ▶ run, ↻ reconnect). `glyph` is the visible
+ *  symbol; `label` is the accessible name and hover title. */
+function iconButton(
+    glyph: string,
+    label: string,
+    onClick: () => void,
+): HTMLButtonElement {
     const b = document.createElement("button");
-    b.textContent = label;
+    b.className = "icon-button";
+    b.textContent = glyph;
+    b.setAttribute("aria-label", label);
+    b.title = label;
     b.addEventListener("click", onClick);
     return b;
 }
@@ -534,7 +511,7 @@ function versionField(
     label: string,
     value: string,
     placeholder: string,
-): { wrap: HTMLElement; input: HTMLInputElement; sub: HTMLElement } {
+): { wrap: HTMLElement; input: HTMLInputElement } {
     const wrap = el("label", "version-field");
     const text = document.createElement("span");
     text.className = "version-label";
@@ -553,12 +530,6 @@ function versionField(
             runReplay();
         }
     });
-    // Filled in after a run with how this side actually resolved (e.g.
-    // "construction cache" vs "schema-enriched grammar"), so the per-side
-    // method is visible right under the field rather than collapsed into the
-    // single run-level chip.
-    const sub = el("span", "version-method");
-    sub.textContent = "";
-    wrap.append(text, input, sub);
-    return { wrap, input, sub };
+    wrap.append(text, input);
+    return { wrap, input };
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -11,9 +11,11 @@
  */
 
 import type { StudioReplayResult } from "@typeagent/core/runtime";
+import type { ActionDelta } from "@typeagent/core/replay";
 import type {
     HostToWebviewMessage,
     WebviewToHostMessage,
+    ReplaySide,
 } from "../protocol.js";
 import {
     toImpactRows,
@@ -27,20 +29,39 @@ import {
     impactFilterNote,
     impactEmptyState,
     allRowsEqual,
+    formatProvenanceLine,
+    toActionDiff,
     type ImpactRow,
     type ReplayRowStatus,
+    type ResolvedVersion,
+    type RunProvenance,
 } from "../replayViewModel.js";
+
+/** Default base (A): the last commit — the baseline of the regression journey. */
+const DEFAULT_VERSION_A: ResolvedVersion = {
+    spec: { kind: "git", ref: "HEAD" },
+    label: "HEAD",
+    tooltip: "Last commit (HEAD).",
+};
+/** Default compare (B): the live working tree (your uncommitted edits). */
+const DEFAULT_VERSION_B: ResolvedVersion = {
+    spec: { kind: "workingTree" },
+    label: "working tree",
+    tooltip: "Your uncommitted edits in the working tree.",
+};
 
 /** A completed result persisted so the report survives navigate-away/reload. */
 interface PersistedResult {
     payload: StudioReplayResult;
+    /** Resolved identity of both sides, captured at run time. */
+    provenance?: RunProvenance;
     /** Epoch ms the run completed, for the "restored" hint. */
     runAt: number;
 }
 interface PanelState {
     selectedAgent?: string;
-    versionA?: string;
-    versionB?: string;
+    versionA?: ResolvedVersion;
+    versionB?: ResolvedVersion;
     lastResult?: PersistedResult;
 }
 interface VsCodeApi {
@@ -71,30 +92,46 @@ let lastRenderedResult: StudioReplayResult | undefined;
 // status filter can re-render the table without re-fetching.
 let currentRows: ImpactRow[] = [];
 let currentTotal = 0;
+// Raw deltas of the current result keyed by utterance id, so a row drill-in can
+// build the action A/B diff without the host re-sending the payload.
+let currentRawById = new Map<string, ActionDelta>();
+// The utterance id whose drill-in detail is open, or undefined when closed; kept
+// so a filter re-render can re-assert (or drop) the open detail.
+let openDetailId: string | undefined;
 // Active status filter; defaults to differences-only so the report opens
 // focused on regressions rather than a wall of unchanged rows.
 const activeFilters = defaultImpactFilters();
+// The current selection driving a run. Versions are typed specs resolved by the
+// host's git picker (or the defaults); the agent comes from the agent picker.
+let currentAgent: string | undefined;
+let versionA: ResolvedVersion = DEFAULT_VERSION_A;
+let versionB: ResolvedVersion = DEFAULT_VERSION_B;
 
 const root = document.getElementById("root")!;
 
 // --- Static shell ---------------------------------------------------------
 const toolbar = el("div", "toolbar");
 const statusEl = el("span", "status");
-const agentSelect = document.createElement("select");
-agentSelect.className = "agent-select";
-agentSelect.setAttribute("aria-label", "Agent to replay");
-agentSelect.title = "The agent whose corpus is replayed and compared.";
-agentSelect.addEventListener("change", () => {
-    persistState({ selectedAgent: agentSelect.value });
-});
-// Two version fields drive the A→B compare. Defaults express the "find a
-// regression" journey: baseline HEAD vs the live working tree (your edits).
-const versionAInput = versionField("Base (A)", "HEAD", "HEAD");
-const versionBInput = versionField(
-    "Compare (B)",
-    "working tree",
-    "working tree",
+// The agent and both versions are chosen through native VS Code QuickPicks the
+// host opens (the webview can't shell out to git); each control is a button that
+// shows the current selection and asks the host to open the relevant picker.
+const agentButton = pickerButton(
+    "agent",
+    "The agent whose corpus is replayed and compared.",
+    () => vscode.postMessage({ type: "pickAgent" }),
 );
+const versionAButton = pickerButton(
+    "Base (A)",
+    "Choose the base (A) version to compare from.",
+    () => vscode.postMessage({ type: "pickVersion", side: "a" }),
+);
+const versionBButton = pickerButton(
+    "Compare (B)",
+    "Choose the compare (B) version to compare to.",
+    () => vscode.postMessage({ type: "pickVersion", side: "b" }),
+);
+const swapButton = iconButton("\u21c4", "Swap A and B", () => swapVersions());
+swapButton.title = "Swap the base (A) and compare (B) versions.";
 const runButton = iconButton("\u25b6", "Run replay", () => runReplay());
 runButton.title =
     "Replay the corpus against both versions and compare actions.";
@@ -103,9 +140,10 @@ const reconnectButton = iconButton("\u21bb", "Reconnect", () => {
 });
 reconnectButton.title = "Re-attempt the connection to the studio service.";
 toolbar.append(
-    agentSelect,
-    versionAInput.wrap,
-    versionBInput.wrap,
+    agentButton.wrap,
+    versionAButton.wrap,
+    swapButton,
+    versionBButton.wrap,
     runButton,
     reconnectButton,
     statusEl,
@@ -115,18 +153,21 @@ const bannerEl = el("div", "banner");
 const filtersEl = el("div", "filters");
 const emptyStateEl = el("div", "empty-state");
 const tableWrap = el("div", "table-wrap");
+const detailEl = el("div", "detail-pane");
+detailEl.hidden = true;
 
-root.append(toolbar, bannerEl, filtersEl, emptyStateEl, tableWrap);
+root.append(toolbar, bannerEl, filtersEl, emptyStateEl, tableWrap, detailEl);
 
 setControlsEnabled(false);
 restoreSelection();
+renderVersionButtons();
 
 // --- Messaging ------------------------------------------------------------
 window.addEventListener("message", (event: MessageEvent) => {
     const msg = event.data as HostToWebviewMessage;
     switch (msg.type) {
         case "init":
-            populateAgents(msg.agents);
+            adoptAgents(msg.agents);
             controlsAvailable = msg.connected && msg.agents.length > 0;
             setControlsEnabled(controlsAvailable);
             renderEmptyState();
@@ -141,6 +182,15 @@ window.addEventListener("message", (event: MessageEvent) => {
         case "status":
             setStatus(msg.text);
             break;
+        case "versionPicked":
+            applyVersionPick(msg.side, msg.resolved);
+            break;
+        case "agentPicked":
+            currentAgent = msg.agent;
+            renderAgentButton();
+            persistState({ selectedAgent: msg.agent });
+            renderEmptyState();
+            break;
         case "result":
             // Accept the matching run, or — when no run has been issued since
             // this load (id still 0) — a host recovery re-push of the last
@@ -148,8 +198,8 @@ window.addEventListener("message", (event: MessageEvent) => {
             // so a genuinely stale earlier result can't then overwrite it.
             if (latestRequestId === 0 || msg.requestId === latestRequestId) {
                 latestRequestId = msg.requestId;
-                renderResult(msg.payload);
-                persistResult(msg.payload);
+                renderResult(msg.payload, false, msg.provenance);
+                persistResult(msg.payload, msg.provenance);
                 setControlsEnabled(controlsAvailable);
             }
             break;
@@ -169,14 +219,12 @@ vscode.postMessage({ type: "ready" });
 
 // --- Behavior -------------------------------------------------------------
 function runReplay(): void {
-    const agent = agentSelect.value;
+    const agent = currentAgent;
     if (!agent) {
         return;
     }
     requestId += 1;
     latestRequestId = requestId;
-    const versionA = versionAInput.input.value;
-    const versionB = versionBInput.input.value;
     persistState({ selectedAgent: agent, versionA, versionB });
     setControlsEnabled(false);
     setStatus(`Replaying ${agent}…`);
@@ -186,11 +234,43 @@ function runReplay(): void {
     filtersEl.hidden = true;
     emptyStateEl.hidden = true;
     currentRows = [];
+    currentRawById = new Map();
+    closeDetail();
     tableWrap.textContent = "";
-    vscode.postMessage({ type: "run", requestId, agent, versionA, versionB });
+    vscode.postMessage({
+        type: "run",
+        requestId,
+        agent,
+        versionA: versionA.spec,
+        versionB: versionB.spec,
+    });
 }
 
-function renderResult(result: StudioReplayResult, restored = false): void {
+/** Apply a version selection from the host picker to one side. */
+function applyVersionPick(side: ReplaySide, resolved: ResolvedVersion): void {
+    if (side === "a") {
+        versionA = resolved;
+    } else {
+        versionB = resolved;
+    }
+    renderVersionButtons();
+    persistState({ versionA, versionB });
+}
+
+/** Swap the base (A) and compare (B) versions. */
+function swapVersions(): void {
+    const tmp = versionA;
+    versionA = versionB;
+    versionB = tmp;
+    renderVersionButtons();
+    persistState({ versionA, versionB });
+}
+
+function renderResult(
+    result: StudioReplayResult,
+    restored = false,
+    provenance?: RunProvenance,
+): void {
     lastRenderedResult = result;
     // Reset every output region first so a render fully *replaces* the previous
     // one. `renderResult` runs more than once per result on navigate-away/back:
@@ -206,6 +286,8 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     tableWrap.textContent = "";
     statusEl.title = "";
     currentRows = [];
+    currentRawById = new Map(result.rows.map((r) => [r.utteranceId, r]));
+    closeDetail();
     // A run-level error (a version that failed to build) aborts with an empty
     // summary — surface the failure instead of a misleading zero-row success.
     if (result.error) {
@@ -219,12 +301,19 @@ function renderResult(result: StudioReplayResult, restored = false): void {
     // side resolved are kept as hover detail rather than visible banners so the
     // report stays compact without losing the warning.
     statusEl.title = toImpactMethodNote(result.method) ?? "";
-    versionAInput.input.title = `Base (A) resolved via ${toSideMethodLabel(
+    versionAButton.button.title = `${versionA.tooltip}\nResolved via ${toSideMethodLabel(
         result.methodA,
     )}`;
-    versionBInput.input.title = `Compare (B) resolved via ${toSideMethodLabel(
+    versionBButton.button.title = `${versionB.tooltip}\nResolved via ${toSideMethodLabel(
         result.methodB,
     )}`;
+
+    // The provenance line pins the report to the concrete commits it ran
+    // against, so a later branch move doesn't make a bare HEAD label lie.
+    if (provenance) {
+        bannerEl.className = "banner banner-provenance";
+        bannerEl.textContent = formatProvenanceLine(provenance);
+    }
 
     currentRows = toImpactRows(result.rows, result.methodA, result.methodB);
     currentTotal = result.summary.rowCount;
@@ -348,6 +437,24 @@ function renderTable(): void {
         tr.appendChild(cell(row.resolutionA, "resolution"));
         tr.appendChild(cell(row.resolutionB, "resolution"));
         tr.appendChild(cell(row.latency, "latency"));
+        // Difference rows drill into an action A/B diff; equal rows have nothing
+        // to compare, so they stay inert.
+        if (row.status !== "equal" && currentRawById.has(row.utteranceId)) {
+            tr.classList.add("row-clickable");
+            if (row.utteranceId === openDetailId) {
+                tr.classList.add("row-open");
+            }
+            tr.tabIndex = 0;
+            tr.setAttribute("role", "button");
+            tr.title = "Show the action A/B diff for this utterance.";
+            tr.addEventListener("click", () => openDetail(row.utteranceId));
+            tr.addEventListener("keydown", (e: KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    openDetail(row.utteranceId);
+                }
+            });
+        }
         table.appendChild(tr);
     }
     tableWrap.appendChild(table);
@@ -379,6 +486,73 @@ function renderTable(): void {
     }
 }
 
+/** Open the row drill-in for `utteranceId`, rendering the action A/B diff. The
+ *  raw delta is looked up from the current result; a missing id closes the pane
+ *  (e.g. the row was filtered out by a status change). */
+function openDetail(utteranceId: string): void {
+    const delta = currentRawById.get(utteranceId);
+    if (!delta) {
+        closeDetail();
+        return;
+    }
+    openDetailId = utteranceId;
+    renderDetail(delta);
+    // Re-render the table so the open row gets its highlight.
+    renderTable();
+    detailEl.scrollIntoView({ block: "nearest" });
+}
+
+/** Hide and clear the drill-in detail pane. */
+function closeDetail(): void {
+    openDetailId = undefined;
+    detailEl.hidden = true;
+    detailEl.textContent = "";
+}
+
+/** Paint the detail pane: a header (utterance + close) and the unified A/B diff
+ *  of the two resolved actions. */
+function renderDetail(delta: ActionDelta): void {
+    detailEl.textContent = "";
+    const diff = toActionDiff(delta);
+
+    const header = el("div", "detail-header");
+    const title = el("span", "detail-title");
+    title.textContent = collapseWhitespace(delta.utterance);
+    title.title = delta.utterance;
+    const meta = el("span", "detail-meta");
+    meta.textContent = diff.onlyB
+        ? "new match (no action on A)"
+        : diff.onlyA
+          ? "lost match (no action on B)"
+          : diff.identical
+            ? "actions identical"
+            : `+${diff.addedCount} \u2212${diff.removedCount}`;
+    const close = iconButton("\u2715", "Close detail", () => closeDetail());
+    close.classList.add("detail-close");
+    header.append(title, meta, close);
+
+    const legend = el("div", "detail-legend");
+    legend.textContent = "Base (A) \u2192 Compare (B)";
+
+    const body = el("pre", "detail-diff");
+    for (const line of diff.lines) {
+        const span = document.createElement("span");
+        span.className = `diff-line diff-${line.kind}`;
+        const sign =
+            line.kind === "added" ? "+" : line.kind === "removed" ? "-" : " ";
+        span.textContent = `${sign} ${line.text}\n`;
+        body.appendChild(span);
+    }
+
+    detailEl.append(header, legend, body);
+    detailEl.hidden = false;
+}
+
+/** Collapse runs of whitespace to single spaces for a compact one-line header. */
+function collapseWhitespace(text: string): string {
+    return text.replace(/\s+/g, " ").trim();
+}
+
 /**
  * First-run guidance: shown only before any replay has run and once the
  * controls are usable, so a newcomer knows what the report does and how to
@@ -399,41 +573,39 @@ function renderEmptyState(): void {
     emptyStateEl.hidden = false;
 }
 
-function populateAgents(agents: string[]): void {
-    const previous = vscode.getState()?.selectedAgent;
-    agentSelect.textContent = "";
-    for (const a of agents) {
-        const opt = document.createElement("option");
-        opt.value = a;
-        opt.textContent = a;
-        agentSelect.appendChild(opt);
+function adoptAgents(agents: string[]): void {
+    // Keep the persisted/selected agent if still available; otherwise default to
+    // the first agent so a newcomer can run without opening the picker first.
+    if (currentAgent && agents.includes(currentAgent)) {
+        // keep it
+    } else if (agents.length > 0) {
+        currentAgent = agents[0];
+        persistState({ selectedAgent: currentAgent });
     }
-    if (previous && agents.includes(previous)) {
-        agentSelect.value = previous;
-    }
+    renderAgentButton();
 }
 
 function restoreSelection(): void {
     const state = vscode.getState();
-    const previous = state?.selectedAgent;
-    if (previous) {
-        const opt = document.createElement("option");
-        opt.value = previous;
-        opt.textContent = previous;
-        agentSelect.appendChild(opt);
-        agentSelect.value = previous;
+    if (state?.selectedAgent) {
+        currentAgent = state.selectedAgent;
     }
-    if (state?.versionA !== undefined) {
-        versionAInput.input.value = state.versionA;
+    if (state?.versionA) {
+        versionA = state.versionA;
     }
-    if (state?.versionB !== undefined) {
-        versionBInput.input.value = state.versionB;
+    if (state?.versionB) {
+        versionB = state.versionB;
     }
+    renderAgentButton();
     // Re-render the last result immediately so navigating away and back doesn't
     // blank the report. The host also re-pushes the full result on `ready`
     // (recovery), which upgrades this possibly-truncated snapshot.
     if (state?.lastResult) {
-        renderResult(state.lastResult.payload, true);
+        renderResult(
+            state.lastResult.payload,
+            true,
+            state.lastResult.provenance,
+        );
     }
 }
 
@@ -454,19 +626,29 @@ function persistState(extra: Partial<PanelState>): void {
 }
 
 /** Persist a completed result (row-capped) so a reload re-renders it. */
-function persistResult(payload: StudioReplayResult): void {
+function persistResult(
+    payload: StudioReplayResult,
+    provenance?: RunProvenance,
+): void {
     const bounded =
         payload.rows.length > MAX_PERSISTED_ROWS
             ? { ...payload, rows: payload.rows.slice(0, MAX_PERSISTED_ROWS) }
             : payload;
-    persistState({ lastResult: { payload: bounded, runAt: Date.now() } });
+    persistState({
+        lastResult: {
+            payload: bounded,
+            runAt: Date.now(),
+            ...(provenance ? { provenance } : {}),
+        },
+    });
 }
 
 function setControlsEnabled(enabled: boolean): void {
     runButton.disabled = !enabled;
-    agentSelect.disabled = !enabled;
-    versionAInput.input.disabled = !enabled;
-    versionBInput.input.disabled = !enabled;
+    swapButton.disabled = !enabled;
+    agentButton.button.disabled = !enabled;
+    versionAButton.button.disabled = !enabled;
+    versionBButton.button.disabled = !enabled;
 }
 
 function setStatus(text: string): void {
@@ -505,31 +687,39 @@ function iconButton(
     return b;
 }
 
-/** A labelled version text field (e.g. "Base (A)"): label + input wrapped for
- *  the toolbar. `value` seeds the default; `placeholder` hints the keyword. */
-function versionField(
+/** A labelled picker button (e.g. "Base (A)") that shows the current selection
+ *  and asks the host to open the relevant native QuickPick on click. */
+function pickerButton(
     label: string,
-    value: string,
-    placeholder: string,
-): { wrap: HTMLElement; input: HTMLInputElement } {
-    const wrap = el("label", "version-field");
+    description: string,
+    onClick: () => void,
+): { wrap: HTMLElement; button: HTMLButtonElement; value: HTMLElement } {
+    const wrap = el("label", "picker-field");
     const text = document.createElement("span");
-    text.className = "version-label";
+    text.className = "picker-label";
     text.textContent = label;
-    const input = document.createElement("input");
-    input.type = "text";
-    input.className = "version-input";
-    input.value = value;
-    input.placeholder = placeholder;
-    input.setAttribute(
-        "aria-label",
-        `${label} version (git ref or working tree)`,
-    );
-    input.addEventListener("keydown", (e: KeyboardEvent) => {
-        if (e.key === "Enter" && !runButton.disabled) {
-            runReplay();
-        }
-    });
-    wrap.append(text, input);
-    return { wrap, input };
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "picker-button";
+    button.title = description;
+    button.setAttribute("aria-label", `${label}: choose`);
+    const value = document.createElement("span");
+    value.className = "picker-value";
+    button.appendChild(value);
+    button.addEventListener("click", onClick);
+    wrap.append(text, button);
+    return { wrap, button, value };
+}
+
+/** Paint both version buttons with their current labels and tooltips. */
+function renderVersionButtons(): void {
+    versionAButton.value.textContent = versionA.label;
+    versionAButton.button.title = versionA.tooltip;
+    versionBButton.value.textContent = versionB.label;
+    versionBButton.button.title = versionB.tooltip;
+}
+
+/** Paint the agent button with the current selection (or a prompt). */
+function renderAgentButton(): void {
+    agentButton.value.textContent = currentAgent ?? "Select agent";
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -16,6 +16,7 @@ import type {
     HostToWebviewMessage,
     WebviewToHostMessage,
     ReplaySide,
+    ConnectionState,
 } from "../protocol.js";
 import {
     toImpactRows,
@@ -143,10 +144,11 @@ const runButton = toolButton("play", "Run", () => runReplay(), {
 });
 runButton.title =
     "Replay the corpus against both versions and compare actions.";
-const reconnectButton = toolButton("refresh", "Reconnect", () => {
-    vscode.postMessage({ type: "reconnect" });
-});
-reconnectButton.title = "Re-attempt the connection to the studio service.";
+
+// A single connection indicator (no manual reconnect button): it mirrors the
+// shared service connection and reflects auto-reconnect. Painted by
+// `renderConnection` from the host's `connection` messages.
+const connectionPill = el("div", "conn-pill");
 
 actionBar.append(
     group(codicon("library"), agentNameEl),
@@ -154,7 +156,7 @@ actionBar.append(
     group(versionAButton.button, swapButton, versionBButton.button),
     spacer(),
     runButton,
-    reconnectButton,
+    connectionPill,
 );
 
 // A slim sub-bar under the toolbar carries the run provenance (the concrete
@@ -178,6 +180,7 @@ contentEl.append(notificationEl, filtersEl, emptyStateEl, tableWrap, detailEl);
 root.append(actionBar, subBar, contentEl);
 
 setControlsEnabled(false);
+renderConnection("connecting");
 restoreSelection();
 renderVersionButtons();
 
@@ -191,13 +194,25 @@ window.addEventListener("message", (event: MessageEvent) => {
             controlsAvailable = msg.connected && msg.available;
             setControlsEnabled(controlsAvailable);
             renderEmptyState();
+            // The connection pill conveys reachability; keep the status line for
+            // the agent-specific caveat (or clear it when all is well).
             setStatus(
                 msg.connected
                     ? msg.available
-                        ? "Connected."
-                        : `Connected — no corpus found for ${msg.agent}.`
-                    : "Studio service not found — start an agent-server with the studio agent enabled.",
+                        ? ""
+                        : `No corpus found for ${msg.agent}.`
+                    : "Couldn't reach the Studio service.",
             );
+            break;
+        case "connection":
+            renderConnection(msg.state);
+            // While not connected, keep the controls off and drop any stale
+            // status text; a reconnect re-pushes init, which re-enables them.
+            if (msg.state !== "connected") {
+                controlsAvailable = false;
+                setControlsEnabled(false);
+                setStatus("");
+            }
             break;
         case "status":
             setStatus(msg.text);
@@ -854,4 +869,22 @@ function renderAgentName(): void {
     agentNameEl.title = currentAgent
         ? `This report compares the "${currentAgent}" agent's corpus across two versions.`
         : "";
+}
+
+/** Paint the single connection indicator from the shared connection state.
+ *  Disconnected is shown as "reconnecting" because the host auto-retries. */
+function renderConnection(state: ConnectionState): void {
+    connectionPill.className = `conn-pill conn-${state}`;
+    connectionPill.textContent = "";
+    if (state === "connected") {
+        connectionPill.append(codicon("circle-filled"), text("Connected"));
+        connectionPill.title = "Connected to the Studio service.";
+    } else if (state === "connecting") {
+        connectionPill.append(codicon("sync"), text("Connecting…"));
+        connectionPill.title = "Connecting to the Studio service…";
+    } else {
+        connectionPill.append(codicon("sync"), text("Reconnecting…"));
+        connectionPill.title =
+            "Studio service unavailable — reconnecting automatically.";
+    }
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -292,13 +292,20 @@ function renderFilters(): void {
         const button = document.createElement("button");
         button.type = "button";
         const isActive = activeFilters.has(chip.status);
+        const isEmpty = chip.count === 0;
         const classes = ["filter-chip"];
         if (isActive) classes.push("is-active");
-        if (chip.count === 0) classes.push("is-empty");
+        if (isEmpty) classes.push("is-empty");
         button.className = classes.join(" ");
         button.setAttribute("aria-pressed", String(isActive));
         button.textContent = `${chip.label} ${chip.count}`;
-        button.addEventListener("click", () => toggleFilter(chip.status));
+        // A status with no rows is nothing to filter on — show it for context
+        // (a count of 0 is informative) but make it inert.
+        if (isEmpty) {
+            button.disabled = true;
+        } else {
+            button.addEventListener("click", () => toggleFilter(chip.status));
+        }
         filtersEl.appendChild(button);
     }
 }
@@ -321,7 +328,13 @@ function renderTable(): void {
 
     const table = document.createElement("table");
     const head = document.createElement("tr");
-    for (const h of ["", "Utterance", "Detail"]) {
+    for (const h of [
+        "Utterance",
+        "Status",
+        "Base (A)",
+        "Compare (B)",
+        "Latency",
+    ]) {
         const th = document.createElement("th");
         th.textContent = h;
         head.appendChild(th);
@@ -330,9 +343,11 @@ function renderTable(): void {
 
     for (const row of rows) {
         const tr = document.createElement("tr");
-        tr.appendChild(cell(row.statusLabel, `status-${row.status}`));
         tr.appendChild(cell(row.utterance));
-        tr.appendChild(cell(row.detail, "detail"));
+        tr.appendChild(cell(row.statusLabel, `status-${row.status}`));
+        tr.appendChild(cell(row.resolutionA, "resolution"));
+        tr.appendChild(cell(row.resolutionB, "resolution"));
+        tr.appendChild(cell(row.latency, "latency"));
         table.appendChild(tr);
     }
     tableWrap.appendChild(table);

--- a/ts/packages/typeagent-studio/src/webviewKit/host.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/host.ts
@@ -7,6 +7,13 @@ import { buildWebviewHtml, createWebviewNonce } from "./webviewHtml.js";
 export interface WebviewKitPanelOptions {
     /** Stable view type; one live panel per type (reveal-existing behavior). */
     viewType: string;
+    /**
+     * Optional sub-key that lets several panels of the same `viewType` coexist
+     * (e.g. one Impact Report per agent). Reveal-existing keys on
+     * `viewType` + `instanceKey`, so distinct keys open distinct tabs the user
+     * can place side-by-side; omit it for the singleton behavior.
+     */
+    instanceKey?: string;
     title: string;
     /** Path segments (from the extension root) to the client script bundle. */
     scriptPath: string[];
@@ -20,11 +27,12 @@ export interface WebviewKitPanelOptions {
 
 /**
  * Thin, reusable wrapper over a `vscode.WebviewPanel`: enforces one live panel
- * per `viewType` (reveal the existing one instead of opening a second), builds a
- * locked-down CSP'd HTML shell with a per-load nonce, restricts
- * `localResourceRoots` to the bundle + media dirs, and exposes typed
- * `post`/`dispose`. State restore is left to the webview via `setState` — the
- * panel intentionally does not `retainContextWhenHidden`.
+ * per `viewType` (or per `viewType`+`instanceKey` when set) — revealing the
+ * existing one instead of opening a second — builds a locked-down CSP'd HTML
+ * shell with a per-load nonce, restricts `localResourceRoots` to the bundle +
+ * media dirs, and exposes typed `post`/`dispose`. State restore is left to the
+ * webview via `setState` — the panel intentionally does not
+ * `retainContextWhenHidden`.
  */
 export class WebviewKitPanel {
     private static readonly live = new Map<string, WebviewKitPanel>();
@@ -53,7 +61,8 @@ export class WebviewKitPanel {
         context: vscode.ExtensionContext,
         options: WebviewKitPanelOptions,
     ): WebviewKitPanel {
-        const existing = WebviewKitPanel.live.get(options.viewType);
+        const key = WebviewKitPanel.registryKey(options);
+        const existing = WebviewKitPanel.live.get(key);
         if (existing) {
             existing.panel.reveal();
             return existing;
@@ -77,9 +86,17 @@ export class WebviewKitPanel {
             },
         );
         const wrapper = new WebviewKitPanel(panel, options);
-        WebviewKitPanel.live.set(options.viewType, wrapper);
+        WebviewKitPanel.live.set(key, wrapper);
         wrapper.render(context);
         return wrapper;
+    }
+
+    /** Registry key: distinct per (viewType, instanceKey) so per-instance panels
+     *  (e.g. one Impact Report per agent) don't collapse onto one another. */
+    private static registryKey(options: WebviewKitPanelOptions): string {
+        return options.instanceKey !== undefined
+            ? `${options.viewType}::${options.instanceKey}`
+            : options.viewType;
     }
 
     private render(context: vscode.ExtensionContext): void {
@@ -126,7 +143,7 @@ export class WebviewKitPanel {
             return;
         }
         this.disposed = true;
-        WebviewKitPanel.live.delete(this.options.viewType);
+        WebviewKitPanel.live.delete(WebviewKitPanel.registryKey(this.options));
         for (const d of this.disposables.splice(0)) {
             d.dispose();
         }

--- a/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
@@ -27,10 +27,13 @@ export type HostToWebviewMessage =
     /** Initial (or restored) state + connection on load. */
     | {
           type: "init";
-          /** Corpus agents available to replay (channel `listCorpusAgents`). */
-          agents: string[];
+          /** The agent this report is scoped to (fixed at panel open). */
+          agent: string;
           /** Whether the studio service channel is reachable. */
           connected: boolean;
+          /** Whether `agent` has a corpus available to replay (channel
+           *  `listCorpusAgents`). */
+          available: boolean;
       }
     /** A connection/loading status line for the webview to surface. */
     | { type: "status"; text: string }
@@ -45,9 +48,7 @@ export type HostToWebviewMessage =
     /** A failure for a prior `run` request (or general error). */
     | { type: "error"; requestId?: number; message: string }
     /** Result of a host version QuickPick (omitted message ⇒ user cancelled). */
-    | { type: "versionPicked"; side: ReplaySide; resolved: ResolvedVersion }
-    /** Result of a host agent QuickPick (omitted message ⇒ user cancelled). */
-    | { type: "agentPicked"; agent: string };
+    | { type: "versionPicked"; side: ReplaySide; resolved: ResolvedVersion };
 
 /** Messages the webview posts to the extension host. */
 export type WebviewToHostMessage =
@@ -65,8 +66,6 @@ export type WebviewToHostMessage =
       }
     /** Ask the host to open a native version QuickPick for one side. */
     | { type: "pickVersion"; side: ReplaySide }
-    /** Ask the host to open a native agent QuickPick. */
-    | { type: "pickAgent" }
     /** Re-attempt the service connection. */
     | { type: "reconnect" };
 
@@ -85,7 +84,6 @@ export function parseWebviewMessage(
     switch (msg.type) {
         case "ready":
         case "reconnect":
-        case "pickAgent":
             return { type: msg.type };
         case "pickVersion": {
             const side = narrowSide((value as { side?: unknown }).side);

--- a/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
@@ -12,6 +12,15 @@
  */
 
 import type { StudioReplayResult } from "@typeagent/core/runtime";
+import type { VersionSpec } from "@typeagent/core/replay";
+import {
+    coerceVersionSpec,
+    type ResolvedVersion,
+    type RunProvenance,
+} from "./replayViewModel.js";
+
+/** Which launch-control side a version applies to. */
+export type ReplaySide = "a" | "b";
 
 /** Messages the extension host posts to the webview. */
 export type HostToWebviewMessage =
@@ -26,9 +35,19 @@ export type HostToWebviewMessage =
     /** A connection/loading status line for the webview to surface. */
     | { type: "status"; text: string }
     /** A completed replay result for a prior `run` request. */
-    | { type: "result"; requestId: number; payload: StudioReplayResult }
+    | {
+          type: "result";
+          requestId: number;
+          payload: StudioReplayResult;
+          /** Resolved identity of both sides, captured at run time. */
+          provenance?: RunProvenance;
+      }
     /** A failure for a prior `run` request (or general error). */
-    | { type: "error"; requestId?: number; message: string };
+    | { type: "error"; requestId?: number; message: string }
+    /** Result of a host version QuickPick (omitted message ⇒ user cancelled). */
+    | { type: "versionPicked"; side: ReplaySide; resolved: ResolvedVersion }
+    /** Result of a host agent QuickPick (omitted message ⇒ user cancelled). */
+    | { type: "agentPicked"; agent: string };
 
 /** Messages the webview posts to the extension host. */
 export type WebviewToHostMessage =
@@ -39,13 +58,21 @@ export type WebviewToHostMessage =
           type: "run";
           requestId: number;
           agent: string;
-          /** Raw base (A) version field; empty/"working tree" → working tree. */
-          versionA: string;
-          /** Raw compare (B) version field; empty/"working tree" → working tree. */
-          versionB: string;
+          /** Validated base (A) version spec. */
+          versionA: VersionSpec;
+          /** Validated compare (B) version spec. */
+          versionB: VersionSpec;
       }
+    /** Ask the host to open a native version QuickPick for one side. */
+    | { type: "pickVersion"; side: ReplaySide }
+    /** Ask the host to open a native agent QuickPick. */
+    | { type: "pickAgent" }
     /** Re-attempt the service connection. */
     | { type: "reconnect" };
+
+function narrowSide(value: unknown): ReplaySide | undefined {
+    return value === "a" || value === "b" ? value : undefined;
+}
 
 /** Narrow an untrusted value into a {@link WebviewToHostMessage}. */
 export function parseWebviewMessage(
@@ -58,7 +85,12 @@ export function parseWebviewMessage(
     switch (msg.type) {
         case "ready":
         case "reconnect":
+        case "pickAgent":
             return { type: msg.type };
+        case "pickVersion": {
+            const side = narrowSide((value as { side?: unknown }).side);
+            return side ? { type: "pickVersion", side } : undefined;
+        }
         case "run": {
             const m = value as {
                 requestId?: unknown;
@@ -72,12 +104,15 @@ export function parseWebviewMessage(
                 m.requestId >= 0 &&
                 typeof m.agent === "string"
             ) {
+                // Accept either a typed spec (picker selection) or a raw string
+                // (legacy text field / test seam); always re-validate host-side
+                // rather than trusting the webview's object.
                 return {
                     type: "run",
                     requestId: m.requestId,
                     agent: m.agent,
-                    versionA: typeof m.versionA === "string" ? m.versionA : "",
-                    versionB: typeof m.versionB === "string" ? m.versionB : "",
+                    versionA: coerceVersionSpec(m.versionA),
+                    versionB: coerceVersionSpec(m.versionB),
                 };
             }
             return undefined;

--- a/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
@@ -22,6 +22,11 @@ import {
 /** Which launch-control side a version applies to. */
 export type ReplaySide = "a" | "b";
 
+/** Shared service connection state mirrored to the webview. Declared here (not
+ *  imported from the node-only connection module) so the browser bundle stays
+ *  free of node/ws; the values match `StudioConnectionState`. */
+export type ConnectionState = "disconnected" | "connecting" | "connected";
+
 /** Messages the extension host posts to the webview. */
 export type HostToWebviewMessage =
     /** Initial (or restored) state + connection on load. */
@@ -37,6 +42,9 @@ export type HostToWebviewMessage =
       }
     /** A connection/loading status line for the webview to surface. */
     | { type: "status"; text: string }
+    /** The shared service connection state, so the webview can show a single
+     *  connection indicator and reflect auto-reconnect (no manual button). */
+    | { type: "connection"; state: ConnectionState }
     /** A completed replay result for a prior `run` request. */
     | {
           type: "result";
@@ -65,9 +73,7 @@ export type WebviewToHostMessage =
           versionB: VersionSpec;
       }
     /** Ask the host to open a native version QuickPick for one side. */
-    | { type: "pickVersion"; side: ReplaySide }
-    /** Re-attempt the service connection. */
-    | { type: "reconnect" };
+    | { type: "pickVersion"; side: ReplaySide };
 
 function narrowSide(value: unknown): ReplaySide | undefined {
     return value === "a" || value === "b" ? value : undefined;
@@ -83,7 +89,6 @@ export function parseWebviewMessage(
     const msg = value as { type?: unknown };
     switch (msg.type) {
         case "ready":
-        case "reconnect":
             return { type: msg.type };
         case "pickVersion": {
             const side = narrowSide((value as { side?: unknown }).side);

--- a/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
@@ -22,8 +22,6 @@ export type HostToWebviewMessage =
           agents: string[];
           /** Whether the studio service channel is reachable. */
           connected: boolean;
-          /** Workspace repository name for the context header (basename). */
-          repoName?: string;
       }
     /** A connection/loading status line for the webview to surface. */
     | { type: "status"; text: string }

--- a/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
@@ -93,6 +93,104 @@ export function toImpactRows(
     return rows.map((row) => toImpactRow(row, methodA, methodB));
 }
 
+export type { ReplayRowStatus };
+
+/** Fixed chip order: differences first (the regression journey), equal last. */
+export const IMPACT_FILTER_ORDER: ReplayRowStatus[] = [
+    "changed",
+    "new-match",
+    "lost-match",
+    "equal",
+];
+
+/** The difference statuses — everything except `equal`. */
+const DIFFERENCE_STATUSES: ReplayRowStatus[] = [
+    "changed",
+    "new-match",
+    "lost-match",
+];
+
+export interface ImpactFilterChip {
+    status: ReplayRowStatus;
+    /** Human word for the status, e.g. "changed". */
+    label: string;
+    /** How many received rows have this status. */
+    count: number;
+}
+
+/**
+ * The default active filter: differences only (`equal` hidden) so the report
+ * opens focused on what changed between versions rather than burying a handful
+ * of regressions under a long list of unchanged rows.
+ */
+export function defaultImpactFilters(): Set<ReplayRowStatus> {
+    return new Set<ReplayRowStatus>(DIFFERENCE_STATUSES);
+}
+
+/** Per-status chip descriptors (counts taken from the received rows). */
+export function buildImpactFilterChips(
+    rows: readonly ImpactRow[],
+): ImpactFilterChip[] {
+    const counts = new Map<ReplayRowStatus, number>();
+    for (const row of rows) {
+        counts.set(row.status, (counts.get(row.status) ?? 0) + 1);
+    }
+    return IMPACT_FILTER_ORDER.map((status) => ({
+        status,
+        label: STATUS_LABEL[status],
+        count: counts.get(status) ?? 0,
+    }));
+}
+
+/** Keep only rows whose status is in the active set. */
+export function filterImpactRows(
+    rows: readonly ImpactRow[],
+    active: ReadonlySet<ReplayRowStatus>,
+): ImpactRow[] {
+    return rows.filter((row) => active.has(row.status));
+}
+
+/** True when every received row is `equal` (no differences between A and B). */
+export function allRowsEqual(rows: readonly ImpactRow[]): boolean {
+    return rows.length > 0 && rows.every((row) => row.status === "equal");
+}
+
+/**
+ * A note describing rows hidden by the active filter (e.g. the `equal` rows the
+ * default view omits), or `undefined` when nothing with a non-zero count is
+ * hidden.
+ */
+export function impactFilterNote(
+    chips: readonly ImpactFilterChip[],
+    active: ReadonlySet<ReplayRowStatus>,
+): string | undefined {
+    const hidden = chips.filter(
+        (chip) => !active.has(chip.status) && chip.count > 0,
+    );
+    if (hidden.length === 0) {
+        return undefined;
+    }
+    const total = hidden.reduce((sum, chip) => sum + chip.count, 0);
+    const parts = hidden.map((chip) => `${chip.count} ${chip.label}`);
+    return `${total} row${total === 1 ? "" : "s"} hidden (${parts.join(", ")}).`;
+}
+
+export interface ImpactEmptyState {
+    title: string;
+    hint: string;
+}
+
+/**
+ * First-run guidance shown in the report body before any replay has run, so a
+ * newcomer understands the A→B compare and how to start one.
+ */
+export function impactEmptyState(): ImpactEmptyState {
+    return {
+        title: "Compare two versions of an agent",
+        hint: "Choose an agent, set Base (A) and Compare (B), then Run replay to see how its actions differ between versions. Base defaults to HEAD and Compare to your working tree — ideal for catching regressions in uncommitted edits.",
+    };
+}
+
 /** One-line headline for a replay summary (reused from the command surface). */
 export function toImpactSummaryLine(summary: ReplaySummary): string {
     return formatReplaySummaryLine(summary);

--- a/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
@@ -244,6 +244,45 @@ export function parseVersionInput(raw: string | undefined): VersionSpec {
     return { kind: "git", ref: value };
 }
 
+/**
+ * Narrow an untrusted value (e.g. a version object posted by the webview after a
+ * QuickPick selection) into a typed {@link VersionSpec}, or `undefined` when it
+ * is not a well-formed spec. The host must NOT trust an arbitrary object the
+ * webview sends, so every `run` spec is re-validated here before it reaches the
+ * replay engine.
+ */
+export function narrowVersionSpec(value: unknown): VersionSpec | undefined {
+    if (typeof value !== "object" || value === null) {
+        return undefined;
+    }
+    const v = value as { kind?: unknown; ref?: unknown };
+    if (v.kind === "workingTree") {
+        return { kind: "workingTree" };
+    }
+    if (v.kind === "git" && typeof v.ref === "string" && v.ref.trim() !== "") {
+        return { kind: "git", ref: v.ref.trim() };
+    }
+    return undefined;
+}
+
+/**
+ * Coerce an untrusted version field from a `run` message into a
+ * {@link VersionSpec}. A well-formed typed spec (from a picker selection) is
+ * taken as-is after validation; a raw string falls back to
+ * {@link parseVersionInput} (the legacy text-field / test seam); anything else
+ * defaults to the working tree.
+ */
+export function coerceVersionSpec(value: unknown): VersionSpec {
+    const narrowed = narrowVersionSpec(value);
+    if (narrowed) {
+        return narrowed;
+    }
+    if (typeof value === "string") {
+        return parseVersionInput(value);
+    }
+    return { kind: "workingTree" };
+}
+
 const METHOD_LABEL: Record<StudioReplayMethod, string> = {
     identity: "identity",
     "static-grammar": "static grammar",
@@ -255,4 +294,186 @@ const METHOD_LABEL: Record<StudioReplayMethod, string> = {
  *  Used as hover detail rather than a visible column. */
 export function toSideMethodLabel(method: StudioReplayMethod): string {
     return METHOD_LABEL[method];
+}
+
+/**
+ * A version the user selected through a picker: the typed spec the host will run
+ * plus the resolved, human-readable label/tooltip to show in the launch control.
+ */
+export interface ResolvedVersion {
+    spec: VersionSpec;
+    /** Short display label, e.g. "HEAD (main)", "v1.2.0", "a1b2c3d fix rule". */
+    label: string;
+    /** Full meaning, shown as the control's hover title. */
+    tooltip: string;
+}
+
+/** The concrete identity a side actually ran against, captured at run time so a
+ *  bare `HEAD`/branch label (which goes stale when the branch moves) or drifting
+ *  working-tree content is pinned to the commit the report reflects. */
+export interface VersionProvenance {
+    /** The display label the run used (e.g. "HEAD (main)"). */
+    label: string;
+    /** The resolved commit SHA, when the side is a git ref. */
+    sha?: string;
+    /** True when the side is the live working tree (uncommitted edits). */
+    workingTree: boolean;
+}
+
+/** Provenance for a completed run: the resolved identity of both sides plus when
+ *  the run completed. Persisted with the report so it stays self-describing. */
+export interface RunProvenance {
+    a: VersionProvenance;
+    b: VersionProvenance;
+    /** Epoch ms the run was issued. */
+    runAt: number;
+}
+
+/** Short label for one side's captured identity, e.g. "working tree",
+ *  "HEAD (main) @ a1b2c3d", or just the label when no SHA was resolved. */
+export function formatVersionProvenance(p: VersionProvenance): string {
+    if (p.workingTree) {
+        return p.sha ? `working tree (on ${p.sha})` : "working tree";
+    }
+    return p.sha ? `${p.label} @ ${p.sha}` : p.label;
+}
+
+/** One-line provenance summary for the report header/tooltip, e.g.
+ *  "Ran HEAD (main) @ a1b2c3d \u2192 working tree". */
+export function formatProvenanceLine(p: RunProvenance): string {
+    return `Ran ${formatVersionProvenance(p.a)} \u2192 ${formatVersionProvenance(
+        p.b,
+    )}`;
+}
+
+/** The kind of a unified-diff line: present on both sides, only B (added), or
+ *  only A (removed). */
+export type DiffLineKind = "context" | "added" | "removed";
+
+export interface DiffLine {
+    kind: DiffLineKind;
+    text: string;
+}
+
+/** A row drill-in's action A → B comparison, as a unified line diff of the two
+ *  resolved actions serialised to canonical (key-sorted) pretty JSON. */
+export interface ActionDiff {
+    lines: DiffLine[];
+    /** Lines present only on side B. */
+    addedCount: number;
+    /** Lines present only on side A. */
+    removedCount: number;
+    /** Both sides resolved an action and they serialise identically. */
+    identical: boolean;
+    /** Side A resolved no action (a new match in B). */
+    onlyB: boolean;
+    /** Side B resolved no action (a lost match from A). */
+    onlyA: boolean;
+}
+
+/** Placeholder shown for a side that resolved no action. */
+const NO_ACTION_TEXT = "(no action)";
+/** LCS is O(n·m); above this product fall back to a naive replace-block diff so
+ *  a pathologically large action can't lock up the webview. */
+const DIFF_LCS_CELL_BUDGET = 250_000;
+
+/** Recursively sort object keys so two equivalent actions serialise identically
+ *  regardless of key insertion order (a property reorder isn't a real change). */
+function sortValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(sortValue);
+    }
+    if (value !== null && typeof value === "object") {
+        const out: Record<string, unknown> = {};
+        for (const key of Object.keys(
+            value as Record<string, unknown>,
+        ).sort()) {
+            out[key] = sortValue((value as Record<string, unknown>)[key]);
+        }
+        return out;
+    }
+    return value;
+}
+
+/** Canonical pretty JSON (sorted keys, 2-space indent) for diffing actions. */
+export function stableStringify(value: unknown): string {
+    return JSON.stringify(sortValue(value), null, 2);
+}
+
+/** Unified line diff of `a` → `b` via LCS, with a naive fallback for very large
+ *  inputs (all A removed, then all B added). */
+function diffLines(a: string[], b: string[]): DiffLine[] {
+    const n = a.length;
+    const m = b.length;
+    if (n * m > DIFF_LCS_CELL_BUDGET) {
+        return [
+            ...a.map((text): DiffLine => ({ kind: "removed", text })),
+            ...b.map((text): DiffLine => ({ kind: "added", text })),
+        ];
+    }
+    // dp[i][j] = LCS length of a[i:] and b[j:].
+    const dp: number[][] = Array.from({ length: n + 1 }, () =>
+        new Array<number>(m + 1).fill(0),
+    );
+    for (let i = n - 1; i >= 0; i--) {
+        for (let j = m - 1; j >= 0; j--) {
+            dp[i][j] =
+                a[i] === b[j]
+                    ? dp[i + 1][j + 1] + 1
+                    : Math.max(dp[i + 1][j], dp[i][j + 1]);
+        }
+    }
+    const out: DiffLine[] = [];
+    let i = 0;
+    let j = 0;
+    while (i < n && j < m) {
+        if (a[i] === b[j]) {
+            out.push({ kind: "context", text: a[i] });
+            i++;
+            j++;
+        } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+            out.push({ kind: "removed", text: a[i] });
+            i++;
+        } else {
+            out.push({ kind: "added", text: b[j] });
+            j++;
+        }
+    }
+    while (i < n) {
+        out.push({ kind: "removed", text: a[i] });
+        i++;
+    }
+    while (j < m) {
+        out.push({ kind: "added", text: b[j] });
+        j++;
+    }
+    return out;
+}
+
+/**
+ * Build the A→B action diff for a row drill-in from the {@link ActionDelta} we
+ * already have — no engine round-trip. A side that resolved no action (a new or
+ * lost match) is rendered against the `(no action)` placeholder so the diff still
+ * reads as a clean add/remove block.
+ */
+export function toActionDiff(row: ActionDelta): ActionDiff {
+    const aPresent = row.actionA !== undefined;
+    const bPresent = row.actionB !== undefined;
+    const aText = aPresent ? stableStringify(row.actionA) : NO_ACTION_TEXT;
+    const bText = bPresent ? stableStringify(row.actionB) : NO_ACTION_TEXT;
+    const lines = diffLines(aText.split("\n"), bText.split("\n"));
+    let addedCount = 0;
+    let removedCount = 0;
+    for (const line of lines) {
+        if (line.kind === "added") addedCount++;
+        else if (line.kind === "removed") removedCount++;
+    }
+    return {
+        lines,
+        addedCount,
+        removedCount,
+        identical: aPresent && bPresent && aText === bText,
+        onlyB: !aPresent && bPresent,
+        onlyA: aPresent && !bPresent,
+    };
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
@@ -13,16 +13,14 @@
 import type {
     ActionDelta,
     ReplayCacheState,
-    ReplayMissPolicy,
-    ReplaySummary,
     VersionSpec,
 } from "@typeagent/core/replay";
 import type { StudioReplayResult } from "@typeagent/core/runtime";
 import {
     classifyReplayRow,
-    formatReplaySummaryLine,
     type ReplayRowStatus,
 } from "../replayPresentation.js";
+import { collapseAndTruncate } from "../textFormatting.js";
 
 type StudioReplayMethod = StudioReplayResult["method"];
 type ReplayRunError = NonNullable<StudioReplayResult["error"]>;
@@ -50,8 +48,7 @@ const STATUS_LABEL: Record<ReplayRowStatus, string> = {
 };
 
 function collapse(text: string, max = 120): string {
-    const s = text.replace(/\s+/g, " ").trim();
-    return s.length > max ? `${s.slice(0, max - 1)}\u2026` : s;
+    return collapseAndTruncate(text, max);
 }
 
 /**
@@ -106,13 +103,6 @@ export const IMPACT_FILTER_ORDER: ReplayRowStatus[] = [
     "equal",
 ];
 
-/** The difference statuses — everything except `equal`. */
-const DIFFERENCE_STATUSES: ReplayRowStatus[] = [
-    "changed",
-    "new-match",
-    "lost-match",
-];
-
 export interface ImpactFilterChip {
     status: ReplayRowStatus;
     /** Human word for the status, e.g. "changed". */
@@ -122,12 +112,23 @@ export interface ImpactFilterChip {
 }
 
 /**
- * The default active filter: differences only (`equal` hidden) so the report
- * opens focused on what changed between versions rather than burying a handful
- * of regressions under a long list of unchanged rows.
+ * The default active filter: every status, so a fresh run opens on the "All"
+ * view and the user sees the complete result before narrowing down.
  */
 export function defaultImpactFilters(): Set<ReplayRowStatus> {
-    return new Set<ReplayRowStatus>(DIFFERENCE_STATUSES);
+    return new Set<ReplayRowStatus>(IMPACT_FILTER_ORDER);
+}
+
+/**
+ * True when the active set hides nothing that has rows — i.e. the "All" pill is
+ * lit. Statuses with a zero count are ignored so an empty `equal` bucket does
+ * not keep "All" from reading as active.
+ */
+export function allStatusesActive(
+    chips: readonly ImpactFilterChip[],
+    active: ReadonlySet<ReplayRowStatus>,
+): boolean {
+    return chips.every((chip) => chip.count === 0 || active.has(chip.status));
 }
 
 /** Per-status chip descriptors (counts taken from the received rows). */
@@ -194,11 +195,8 @@ export function impactEmptyState(): ImpactEmptyState {
     };
 }
 
-/** One-line headline for a replay summary (reused from the command surface). */
-export function toImpactSummaryLine(summary: ReplaySummary): string {
-    return formatReplaySummaryLine(summary);
-}
-
+/** Per-method caveat text explaining how faithfully each replay method reflects
+ *  real dispatch. */
 const METHOD_NOTE: Record<StudioReplayMethod, string | undefined> = {
     identity: undefined,
     "static-grammar":
@@ -246,28 +244,6 @@ export function parseVersionInput(raw: string | undefined): VersionSpec {
     return { kind: "git", ref: value };
 }
 
-/** Short label for a version: the git ref, or `working tree`. */
-export function describeVersion(spec: VersionSpec): string {
-    return spec.kind === "workingTree" ? "working tree" : spec.ref;
-}
-
-/** A `Comparing A → B` line built from the summary's resolved versions. */
-export function toImpactComparisonLine(summary: ReplaySummary): string {
-    return `Comparing ${describeVersion(summary.versionA)} \u2192 ${describeVersion(
-        summary.versionB,
-    )}`;
-}
-
-/** One labelled field in the Impact Report context header. */
-export interface ImpactHeaderField {
-    label: string;
-    value: string;
-    /** Hover text explaining what the field means. */
-    tooltip: string;
-}
-
-const PLACEHOLDER = "\u2014";
-
 const METHOD_LABEL: Record<StudioReplayMethod, string> = {
     identity: "identity",
     "static-grammar": "static grammar",
@@ -275,77 +251,8 @@ const METHOD_LABEL: Record<StudioReplayMethod, string> = {
     "construction-cache": "construction cache",
 };
 
-const FIDELITY_LABEL: Record<StudioReplayMethod, string> = {
-    identity: "baseline (no grammar diff)",
-    "static-grammar": "indicative",
-    "schema-grammar": "indicative (schema-enriched)",
-    "construction-cache": "faithful cache hits, indicative grammar",
-};
-
-/**
- * Short label for how a single A/B side resolved, rendered under that side's
- * version field. The construction cache is live-only, so a git ref reads
- * `schema-enriched grammar`/`static grammar` while only a working-tree side can
- * show `construction cache` — making the asymmetry explicit instead of letting
- * the single run-level method chip imply the cache served both sides.
- */
+/** Short label for how a side resolved actions, e.g. "schema-enriched grammar".
+ *  Used as hover detail rather than a visible column. */
 export function toSideMethodLabel(method: StudioReplayMethod): string {
     return METHOD_LABEL[method];
-}
-
-/**
- * The provenance band shown above the controls: what this report pertains to
- * (`repo · agent · method · fidelity · sandbox · policy`). Deliberately omits a
- * sandbox id — neither the identity nor the static-grammar method runs in a
- * sandbox (they read grammar source from git / the working tree), so labelling
- * one would falsely imply the result reflects a loaded runtime agent. A real
- * sandbox label only becomes meaningful with the full-fidelity replay path.
- */
-export function toImpactHeaderFields(input: {
-    repo?: string;
-    agent?: string;
-    method?: StudioReplayMethod;
-    missPolicy?: ReplayMissPolicy;
-}): ImpactHeaderField[] {
-    const method = input.method;
-    return [
-        {
-            label: "repo",
-            value:
-                input.repo && input.repo.length > 0 ? input.repo : PLACEHOLDER,
-            tooltip: "The workspace repository this report runs against.",
-        },
-        {
-            label: "agent",
-            value:
-                input.agent && input.agent.length > 0
-                    ? input.agent
-                    : PLACEHOLDER,
-            tooltip: "The agent whose corpus is being replayed.",
-        },
-        {
-            label: "method",
-            value: method ? METHOD_LABEL[method] : PLACEHOLDER,
-            tooltip:
-                "How utterances are resolved into actions for the compare.",
-        },
-        {
-            label: "fidelity",
-            value: method ? FIDELITY_LABEL[method] : PLACEHOLDER,
-            tooltip:
-                "How faithfully the result reflects real dispatch. Static-grammar replay is indicative, not authoritative.",
-        },
-        {
-            label: "sandbox",
-            value: "not used",
-            tooltip:
-                "Static-grammar replay reads grammar from git / the working tree and is not sandbox-bound. A sandbox is only used by the full-fidelity replay path.",
-        },
-        {
-            label: "policy",
-            value: input.missPolicy ?? PLACEHOLDER,
-            tooltip:
-                "Cache-miss policy for the run. needs-explanation stays deterministic (no LLM calls).",
-        },
-    ];
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/replayViewModel.ts
@@ -33,8 +33,12 @@ export interface ImpactRow {
     statusLabel: string;
     /** The corpus utterance (collapsed whitespace, bounded). */
     utterance: string;
-    /** Cache states + latencies, e.g. "A:hit B:miss · 12/8ms". */
-    detail: string;
+    /** How side A (Base) resolved, e.g. "hit" or "hit\u00b7cache". */
+    resolutionA: string;
+    /** How side B (Compare) resolved, e.g. "miss\u00b7grammar". */
+    resolutionB: string;
+    /** Latency pair "A/B", e.g. "10/12ms". */
+    latency: string;
     utteranceId: string;
 }
 
@@ -77,10 +81,9 @@ export function toImpactRow(
         status,
         statusLabel: STATUS_LABEL[status],
         utterance: collapse(row.utterance),
-        detail: `A:${sideToken(row.cacheStateA, methodA)} B:${sideToken(
-            row.cacheStateB,
-            methodB,
-        )} \u00b7 ${row.latencyA}/${row.latencyB}ms`,
+        resolutionA: sideToken(row.cacheStateA, methodA),
+        resolutionB: sideToken(row.cacheStateB, methodB),
+        latency: `${row.latencyA}/${row.latencyB}ms`,
         utteranceId: row.utteranceId,
     };
 }

--- a/ts/packages/typeagent-studio/src/webviewKit/webviewHtml.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/webviewHtml.ts
@@ -2,19 +2,17 @@
 // Licensed under the MIT License.
 
 /**
- * Pure builders for a VS Code webview's HTML shell and its capability nonce.
+ * Pure builders for a VS Code webview's HTML shell.
  *
  * Kept free of `vscode`/DOM so the strict Content-Security-Policy can be
  * unit-tested. The host (`host.ts`) supplies the resolved `asWebviewUri`
- * strings and `cspSource`.
+ * strings and `cspSource`. The per-load nonce comes from the shared
+ * {@link createWebviewNonce} so every webview surface uses one crypto source.
  */
 
-import { randomBytes } from "node:crypto";
+import { createWebviewNonce } from "@typeagent/core/webview";
 
-/** A per-load nonce (base64) for the CSP `script-src`/`style-src`. */
-export function createWebviewNonce(): string {
-    return randomBytes(16).toString("base64");
-}
+export { createWebviewNonce };
 
 export interface WebviewHtmlOptions {
     /** Per-load nonce from {@link createWebviewNonce}. */

--- a/ts/packages/utils/webSocketUtils/package.json
+++ b/ts/packages/utils/webSocketUtils/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./originAllowlist": "./dist/originAllowlist.js",
-    "./heartbeat": "./dist/heartbeat.js"
+    "./heartbeat": "./dist/heartbeat.js",
+    "./rpcChannel": "./dist/rpcChannel.js"
   },
   "files": [
     "dist",
@@ -28,6 +29,7 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
+    "@typeagent/agent-rpc": "workspace:*",
     "@typeagent/config": "workspace:*",
     "debug": "^4.4.0",
     "dotenv": "^16.3.1",

--- a/ts/packages/utils/webSocketUtils/package.json
+++ b/ts/packages/utils/webSocketUtils/package.json
@@ -15,7 +15,8 @@
     ".": "./dist/index.js",
     "./originAllowlist": "./dist/originAllowlist.js",
     "./heartbeat": "./dist/heartbeat.js",
-    "./rpcChannel": "./dist/rpcChannel.js"
+    "./rpcChannel": "./dist/rpcChannel.js",
+    "./backoff": "./dist/backoff.js"
   },
   "files": [
     "dist",

--- a/ts/packages/utils/webSocketUtils/src/backoff.ts
+++ b/ts/packages/utils/webSocketUtils/src/backoff.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface BackoffOptions {
+    /** Delay before the first retry and the growth base, in milliseconds. */
+    baseMs: number;
+    /** Upper bound applied to every delay, in milliseconds. */
+    maxMs: number;
+}
+
+export interface Backoff {
+    /** Delay (ms) to wait for the current attempt, then advance the counter. */
+    next(): number;
+    /** Reset to the first attempt — call once a connection succeeds. */
+    reset(): void;
+    /** Number of attempts taken since construction or the last {@link reset}. */
+    readonly attempt: number;
+}
+
+/**
+ * Exponential backoff with a ceiling. Successive delays double from `baseMs`
+ * (`baseMs`, `2·baseMs`, `4·baseMs`, …) and are clamped to `maxMs`, so a peer
+ * that stays down settles into steady retries at the cap instead of either
+ * hammering it or waiting ever-longer. Calling {@link Backoff.reset} after a
+ * successful connect makes the next outage start quickly from `baseMs` again.
+ */
+export function createBackoff({ baseMs, maxMs }: BackoffOptions): Backoff {
+    let attempt = 0;
+    return {
+        next(): number {
+            const delay = Math.min(maxMs, baseMs * 2 ** attempt);
+            attempt += 1;
+            return delay;
+        },
+        reset(): void {
+            attempt = 0;
+        },
+        get attempt(): number {
+            return attempt;
+        },
+    };
+}

--- a/ts/packages/utils/webSocketUtils/src/rpcChannel.ts
+++ b/ts/packages/utils/webSocketUtils/src/rpcChannel.ts
@@ -23,7 +23,7 @@ export function createWebSocketRpcChannel(socket: WebSocket): RpcChannel {
     socket.on("message", (data: WebSocket.RawData) => {
         let message: unknown;
         try {
-            message = JSON.parse(data.toString());
+            message = JSON.parse(rawDataToString(data));
         } catch {
             return; // ignore non-JSON frames
         }
@@ -32,4 +32,24 @@ export function createWebSocketRpcChannel(socket: WebSocket): RpcChannel {
     socket.on("close", () => adapter.notifyDisconnected());
 
     return adapter.channel;
+}
+
+/**
+ * Decode a `ws` frame to a UTF-8 string. `ws` can deliver a frame as a string,
+ * a `Buffer`, an `ArrayBuffer`, or an array of `Buffer`s (depending on the
+ * socket's `binaryType` and fragmentation), so decode each shape explicitly —
+ * a bare `data.toString()` on an `ArrayBuffer`/`Buffer[]` yields garbage and
+ * would silently drop valid RPC messages.
+ */
+function rawDataToString(data: WebSocket.RawData): string {
+    if (typeof data === "string") {
+        return data;
+    }
+    if (Array.isArray(data)) {
+        return Buffer.concat(data).toString("utf8");
+    }
+    if (data instanceof ArrayBuffer) {
+        return Buffer.from(data).toString("utf8");
+    }
+    return (data as Buffer).toString("utf8");
 }

--- a/ts/packages/utils/webSocketUtils/src/rpcChannel.ts
+++ b/ts/packages/utils/webSocketUtils/src/rpcChannel.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { WebSocket } from "ws";
+import {
+    createChannelAdapter,
+    type RpcChannel,
+} from "@typeagent/agent-rpc/channel";
+
+/**
+ * Adapt a `ws` WebSocket to the `agent-rpc` {@link RpcChannel} interface.
+ *
+ * The handler bookkeeping (`on`/`once`/`off` and dispatch) is delegated to
+ * `agent-rpc`'s {@link createChannelAdapter}; this only supplies the transport
+ * glue — JSON-encode on send, JSON-decode on each frame (silently dropping
+ * non-JSON frames), and map the socket's `close` to a disconnect.
+ */
+export function createWebSocketRpcChannel(socket: WebSocket): RpcChannel {
+    const adapter = createChannelAdapter((message, cb) => {
+        socket.send(JSON.stringify(message), (err) => cb?.(err ?? null));
+    });
+
+    socket.on("message", (data: WebSocket.RawData) => {
+        let message: unknown;
+        try {
+            message = JSON.parse(data.toString());
+        } catch {
+            return; // ignore non-JSON frames
+        }
+        adapter.notifyMessage(message);
+    });
+    socket.on("close", () => adapter.notifyDisconnected());
+
+    return adapter.channel;
+}

--- a/ts/packages/vscode-shell/package.json
+++ b/ts/packages/vscode-shell/package.json
@@ -198,6 +198,7 @@
     "@typeagent/core": "workspace:*",
     "@typeagent/dispatcher-rpc": "workspace:*",
     "@typeagent/dispatcher-types": "workspace:*",
+    "@typeagent/websocket-utils": "workspace:*",
     "agent-dispatcher": "workspace:*",
     "ansi_up": "^6.0.6",
     "chat-ui": "workspace:*",

--- a/ts/packages/vscode-shell/src/agentServerBridge.ts
+++ b/ts/packages/vscode-shell/src/agentServerBridge.ts
@@ -17,6 +17,10 @@ import {
 } from "@typeagent/agent-server-client/conversation";
 import { awaitCommand } from "@typeagent/dispatcher-types";
 import { AGENT_SERVER_DEFAULT_URL } from "@typeagent/agent-server-protocol";
+import {
+    createBackoff,
+    type Backoff,
+} from "@typeagent/websocket-utils/backoff";
 import type { ClientIO } from "@typeagent/dispatcher-rpc/types";
 
 import {
@@ -133,7 +137,13 @@ export class AgentServerBridge {
     // wait between reconnect attempts. Replaces the old behavior of
     // broadcasting a fresh error/disconnect message every retry cycle.
     private reconnectCountdown: NodeJS.Timeout | undefined;
-    private reconnectAttempt = 0;
+    // Exponential backoff (2s, 4s, 8s, … capped at 30s) shared with the Studio
+    // service connection. Quick first retries recover fast when the server
+    // restarts; the cap keeps the long-tail polite for genuinely-down servers.
+    private readonly reconnectBackoff: Backoff = createBackoff({
+        baseMs: 2000,
+        maxMs: 30000,
+    });
     private reconnectRemainingSec: number | undefined;
     private lastConnectError: string | undefined;
     // Suppress disconnect handler during intentional reconnects
@@ -2660,11 +2670,10 @@ export class AgentServerBridge {
         if (this.reconnectTimer) {
             return;
         }
-        this.reconnectAttempt++;
-        // Backoff: 4s, 6s, 8s, ... capped at 30s. Quick first retries
-        // recover fast when the server restarts; the cap keeps the
-        // long-tail polite for genuinely-down servers.
-        const backoff = Math.min(30, 2 + this.reconnectAttempt * 2);
+        // Seconds the shared exponential backoff says to wait before the next
+        // attempt. The countdown ribbon and reconnect timer below run in
+        // seconds, so round the millisecond delay to whole seconds.
+        const backoff = Math.round(this.reconnectBackoff.next() / 1000);
         this.reconnectRemainingSec = backoff;
         this.broadcastReconnect("waiting");
         if (this.reconnectCountdown) {
@@ -2695,7 +2704,7 @@ export class AgentServerBridge {
         this.broadcastToWebviews({
             type: "reconnectStatus",
             phase,
-            attempt: this.reconnectAttempt,
+            attempt: this.reconnectBackoff.attempt,
             secondsRemaining:
                 phase === "waiting" ? this.reconnectRemainingSec : undefined,
             error: this.lastConnectError,
@@ -2712,7 +2721,7 @@ export class AgentServerBridge {
             this.reconnectCountdown = undefined;
         }
         this.reconnectRemainingSec = undefined;
-        this.reconnectAttempt = 0;
+        this.reconnectBackoff.reset();
         this.lastConnectError = undefined;
         this.broadcastReconnect("cleared");
     }

--- a/ts/packages/vscode-shell/src/chatViewProvider.ts
+++ b/ts/packages/vscode-shell/src/chatViewProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as vscode from "vscode";
+import { createWebviewNonce } from "@typeagent/core/webview";
 import { AgentServerBridge } from "./agentServerBridge.js";
 
 /**
@@ -121,7 +122,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         const scriptUri = `${webview.asWebviewUri(scriptPath)}?v=${stamp(scriptPath)}`;
         const styleUri = `${webview.asWebviewUri(stylePath)}?v=${stamp(stylePath)}`;
         const codiconUri = `${webview.asWebviewUri(codiconPath)}?v=${stamp(codiconPath)}`;
-        const nonce = getNonce();
+        const nonce = createWebviewNonce();
 
         return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -147,14 +148,4 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 </body>
 </html>`;
     }
-}
-
-function getNonce(): string {
-    let text = "";
-    const chars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    for (let i = 0; i < 32; i++) {
-        text += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-    return text;
 }

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -6039,6 +6039,9 @@ importers:
 
   packages/utils/webSocketUtils:
     dependencies:
+      '@typeagent/agent-rpc':
+        specifier: workspace:*
+        version: link:../../agentRpc
       '@typeagent/config':
         specifier: workspace:*
         version: link:../../config
@@ -6149,6 +6152,9 @@ importers:
       '@typeagent/dispatcher-types':
         specifier: workspace:*
         version: link:../dispatcher/types
+      '@typeagent/websocket-utils':
+        specifier: workspace:*
+        version: link:../utils/webSocketUtils
       agent-dispatcher:
         specifier: workspace:*
         version: link:../dispatcher/dispatcher

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 8.18.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
+        version: 29.7.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -919,7 +919,7 @@ importers:
         version: 12.0.2(webpack@5.105.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -5870,6 +5870,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
+      '@vscode/codicons':
+        specifier: ^0.0.42
+        version: 0.0.42
       '@vscode/vsce':
         specifier: ^3.2.1
         version: 3.4.0


### PR DESCRIPTION
Advances the Studio "find a regression" journey: a native, per-agent \*\*Impact
Report\*\*, a single coherent **connection experience** across the sidebar, and a
batch of shared-helper dedupe.

## Critical changes

**Impact Report — native redesign.** Rebuilt into a VS Code-native, per-agent
webview that compares how an agent resolves a corpus across two versions:

- Git-hydrated **Base/Compare pickers** (tags, branches, commits, and the
  working tree) so you can diff a committed version against uncommitted edits.
- **Action-level diff** — drill into a changed row for a side-by-side Base vs
  Compare view with per-side cache state.
- **Status filter chips**, a first-run empty state, and hover tooltips that
  explain every value (status terms, resolution tokens, the `A/Bms`
  Base/Compare latency).

**One connection experience.** The four views (Sandboxes, Corpora, Event Log,
Collisions) drop their per-view Connect/Reconnect buttons for a single
status-bar indicator (e.g. *Connected* / *Reconnecting in 2s…*) that
auto-reconnects with backoff. Views show the native loading bar while connecting,
then content or a placeholder.

**Tree polish.** Trees now render Markdown hover cards and lean on icons for
status (sandbox health, corpus thumbs-up/down feedback) instead of duplicated
text.

## Supporting changes

- Deduped shared helpers: schema-file hash (cache/dispatcher/replay), WebSocket
  RPC channel, webview nonce, reconnect backoff, agent-name resolution, and a
  base class for the tree providers.
- Replay construction-cache layer for the live side (reports a cache `hit`
  distinct from a grammar match, gated on the dispatcher's schema-hash check).
- Hardened every user/webview-supplied git ref with `--end-of-options` so a
  leading-dash ref can't be parsed as a git option (defense-in-depth on the
  host↔git boundary; the webview itself never shells out to git).

## Testing

Studio suite green (\~180 tests); typecheck and Prettier clean.

19 commits · 60 files.