### PR TITLE
Handle wix constraints for multi-file components

### DIFF
--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -63,7 +63,8 @@
       <ComponentGroupRef Id="CopilotPluginComponents" />
       <!-- Static files and registry -->
       <ComponentRef Id="MarketplaceJsonComponent" />
-      <ComponentRef Id="RegisterScriptComponent" />
+      <ComponentRef Id="RegisterPluginPs1Component" />
+      <ComponentRef Id="RegisterPluginMjsComponent" />
       <ComponentRef Id="RegistryComponent" />
     </Feature>
 
@@ -83,12 +84,14 @@
 
     <!-- register-plugin.ps1 — helper for post-install Copilot CLI registration -->
     <DirectoryRef Id="TYPEAGENTROOT">
-      <Component Id="RegisterScriptComponent" Guid="*">
+      <Component Id="RegisterPluginPs1Component" Guid="*">
         <File Id="RegisterPluginPs1" Name="register-plugin.ps1"
               Source="$(var.InstallerSourceDir)\register-plugin.ps1" />
+        <RemoveFolder Id="RemoveTypeAgentFolder" Directory="TYPEAGENTROOT" On="uninstall" />
+      </Component>
+      <Component Id="RegisterPluginMjsComponent" Guid="*">
         <File Id="RegisterPluginMjs" Name="register-plugin.mjs"
               Source="$(var.InstallerSourceDir)\..\common\register-plugin.mjs" />
-        <RemoveFolder Id="RemoveTypeAgentFolder" Directory="TYPEAGENTROOT" On="uninstall" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
The RegisterScriptComponent contained 2 files (register-plugin.ps1 and register-plugin.mjs) with an auto-generated GUID (Guid="*"), which violates WiX constraints for multi-file components.

Fix Applied:
Split into two separate components:
- RegisterPluginPs1Component — contains register-plugin.ps1
- RegisterPluginMjsComponent — contains register-plugin.mjs Each component now has its own auto-generated GUID, which is valid for single-file components.