### PR TITLE
TypeAgent Studio (part 5): two-mode Impact Report replay

### DIFF
--- a/ts/packages/typeagent-core/src/runtime/studioRuntimeCore.ts
+++ b/ts/packages/typeagent-core/src/runtime/studioRuntimeCore.ts
@@ -233,6 +233,21 @@ export interface PackagingHealthGateResult {
     checkedAgent?: string;
 }
 
+/**
+ * Which deterministic dispatch path replay models:
+ * - `nfa-grammar` (default) — grammar-only matching through the real NFA grammar
+ *   store, symmetric for both versions. The construction cache is NOT consulted
+ *   (faithful to the dispatcher's `grammarSystem: "nfa"` mode, where cache
+ *   validation is intentionally skipped). The cleanest signal for "what did my
+ *   `.agr` edit change", since A and B are equivalent environments.
+ * - `completionBased-cache` — the live working-tree side additionally consults
+ *   the agent's real per-session construction cache before the grammar match
+ *   (faithful to the dispatcher's default `completionBased` mode). Asymmetric:
+ *   only the working-tree side reads the cache, so a cache hit can mask or fake a
+ *   grammar regression. Opt-in for "what would my default dispatcher likely do".
+ */
+export type StudioReplayMode = "nfa-grammar" | "completionBased-cache";
+
 /** Request shape for {@link StudioRuntime.replayCorpus}. Versions and miss
  *  policy default to a deterministic working-tree self-compare. */
 export interface StudioReplayRequest {
@@ -241,6 +256,8 @@ export interface StudioReplayRequest {
     versionA?: VersionSpec;
     versionB?: VersionSpec;
     missPolicy?: ReplayMissPolicy;
+    /** Deterministic dispatch path to model. Defaults to `nfa-grammar`. */
+    mode?: StudioReplayMode;
 }
 
 /**
@@ -546,6 +563,15 @@ export interface CreateStudioRuntimeOptions {
      * deterministic identity replay over each entry's captured `expectedAction`.
      */
     replayResolver?: ReplayActionResolver;
+    /**
+     * Resolves the live construction-cache layer for the working-tree side of a
+     * replay. Injected so tests can exercise the mode gating (the default
+     * discovers the dispatcher's live cache from the instance dir, which a test
+     * can't fabricate). Only consulted in `completionBased-cache` mode.
+     */
+    resolveConstructionCache?: (
+        target: GrammarReplayTarget,
+    ) => Promise<ConstructionCacheLayer | undefined>;
     collisions?: CollisionService;
     /**
      * Scans agents' compiled grammars for collisions. Injected so tests can
@@ -995,6 +1021,7 @@ export function createStudioRuntimeCore(
             return feedback.list(filter);
         },
         async replayCorpus(request) {
+            const mode: StudioReplayMode = request.mode ?? "nfa-grammar";
             const replayOptions = {
                 agent: request.agent,
                 corpus: request.corpus ?? {},
@@ -1024,12 +1051,21 @@ export function createStudioRuntimeCore(
                 );
                 if (target !== undefined) {
                     // Best-effort consult of the agent's live per-session
-                    // construction cache for the working-tree side. Hash-gated to
-                    // the current schema exactly as the dispatcher gates it, so a
-                    // schema edit invalidates the cached constructions (→ stale →
-                    // grammar fallback) rather than reporting a phantom cache hit.
+                    // construction cache for the working-tree side — but ONLY in
+                    // `completionBased-cache` mode. In the default `nfa-grammar`
+                    // mode the dispatcher does not consult the cache (grammar
+                    // rules alone decide the match), so replay stays grammar-only
+                    // and A/B-symmetric. Hash-gated to the current schema exactly
+                    // as the dispatcher gates it, so a schema edit invalidates the
+                    // cached constructions (→ stale → grammar fallback) rather
+                    // than reporting a phantom cache hit.
                     const constructionCache =
-                        await resolveConstructionCacheLayer(target);
+                        mode === "completionBased-cache"
+                            ? await (
+                                  options.resolveConstructionCache ??
+                                  resolveConstructionCacheLayer
+                              )(target)
+                            : undefined;
 
                     const grammarResolver = createGrammarReplayResolver({
                         target,

--- a/ts/packages/typeagent-studio/src/impactReportView.ts
+++ b/ts/packages/typeagent-studio/src/impactReportView.ts
@@ -360,6 +360,10 @@ export function openImpactReport(
                 // free of LLM calls.
                 versionA: msg.versionA,
                 versionB: msg.versionB,
+                // The webview's mode toggle selects which deterministic dispatch
+                // path to model (grammar-only vs construction-cache-first); the
+                // runtime defaults unknown/missing to the cache-free baseline.
+                mode: msg.mode,
                 missPolicy: "needs-explanation",
             });
             post({

--- a/ts/packages/typeagent-studio/src/test/studioRuntimeCore.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioRuntimeCore.spec.ts
@@ -1182,3 +1182,168 @@ test("scanGrammarCollisions defaults to agents loaded across sandboxes", async (
 
     assert.deepEqual(received, []);
 });
+
+// --- Replay mode gating (Level B) -----------------------------------------
+// `replayCorpus` consults the live construction cache only in
+// `completionBased-cache` mode; the default `nfa-grammar` mode matches against
+// the grammar alone. These tests scaffold a real single-schema agent so the
+// auto-engaged grammar path runs, and inject a spy cache resolver so the gating
+// is observable without a real on-disk construction cache.
+
+const GATING_GRAMMAR = [
+    "<Start> = <Pause> | <Resume>;",
+    '<Pause> = pause -> { actionName: "pause" };',
+    '<Resume> = resume -> { actionName: "resume" };',
+].join("\n");
+
+const GATING_SCHEMA_TS = [
+    "export type DemoActions = PauseAction | ResumeAction;",
+    "",
+    "// Pause playback.",
+    'export type PauseAction = { actionName: "pause" };',
+    "",
+    "// Resume playback.",
+    'export type ResumeAction = { actionName: "resume" };',
+    "",
+].join("\n");
+
+const GATING_MANIFEST = JSON.stringify({
+    schema: {
+        originalSchemaFile: "./demoSchema.ts",
+        schemaType: { action: "DemoActions" },
+    },
+});
+
+/**
+ * Scaffold a temp repo whose `packages/agents/demo` is a discoverable
+ * single-schema agent (grammar + schema + manifest), so `resolveRepoRoot` and
+ * `resolveGrammarReplayTarget` engage the real grammar replay path.
+ */
+async function scaffoldGatingRepo(): Promise<string> {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "studio-gating-"));
+    const agentDir = path.join(
+        repoRoot,
+        "packages",
+        "agents",
+        "demo",
+        "src",
+        "agent",
+    );
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+        path.join(agentDir, "demoSchema.agr"),
+        GATING_GRAMMAR,
+        "utf8",
+    );
+    await fs.writeFile(
+        path.join(agentDir, "demoSchema.ts"),
+        GATING_SCHEMA_TS,
+        "utf8",
+    );
+    await fs.writeFile(
+        path.join(agentDir, "demoManifest.json"),
+        GATING_MANIFEST,
+        "utf8",
+    );
+    return repoRoot;
+}
+
+function gatingEntry(id: string, utterance: string): CorpusEntry {
+    return {
+        id,
+        utterance,
+        agent: "demo",
+        source: "in-repo",
+        provenance: { sourceUri: `mem://${id}` },
+    };
+}
+
+/** A spy `resolveConstructionCache` that records consults and returns a valid
+ *  layer resolving "pause" from the cache. */
+function spyCacheResolver(record: { consulted: boolean }) {
+    return async () => {
+        record.consulted = true;
+        return {
+            status: "valid" as const,
+            cacheFilePath: "/stub/constructions.json",
+            schemaName: "demo",
+            currentHash: "hash=",
+            cachedHash: "hash=",
+            match(utterance: string) {
+                return utterance === "pause"
+                    ? { schemaName: "demo", actionName: "pause" }
+                    : undefined;
+            },
+        };
+    };
+}
+
+test("replayCorpus skips the construction cache in the default nfa-grammar mode", async () => {
+    const repoRoot = await scaffoldGatingRepo();
+    try {
+        const corpus = new StubCorpusService([gatingEntry("p", "pause")]);
+        const record = { consulted: false };
+        const runtime = createStudioRuntimeCore(
+            createContext([repoRoot]).context,
+            { corpus, resolveConstructionCache: spyCacheResolver(record) },
+        );
+
+        const result = await runtime.replayCorpus({
+            agent: "demo",
+            missPolicy: "needs-explanation",
+            mode: "nfa-grammar",
+        });
+
+        assert.equal(record.consulted, false);
+        assert.notEqual(result.method, "construction-cache");
+    } finally {
+        await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+});
+
+test("replayCorpus omitting the mode defaults to grammar-only (no cache consult)", async () => {
+    const repoRoot = await scaffoldGatingRepo();
+    try {
+        const corpus = new StubCorpusService([gatingEntry("p", "pause")]);
+        const record = { consulted: false };
+        const runtime = createStudioRuntimeCore(
+            createContext([repoRoot]).context,
+            { corpus, resolveConstructionCache: spyCacheResolver(record) },
+        );
+
+        const result = await runtime.replayCorpus({
+            agent: "demo",
+            missPolicy: "needs-explanation",
+        });
+
+        assert.equal(record.consulted, false);
+        assert.notEqual(result.method, "construction-cache");
+    } finally {
+        await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+});
+
+test("replayCorpus consults the construction cache in completionBased-cache mode", async () => {
+    const repoRoot = await scaffoldGatingRepo();
+    try {
+        const corpus = new StubCorpusService([gatingEntry("p", "pause")]);
+        const record = { consulted: false };
+        const runtime = createStudioRuntimeCore(
+            createContext([repoRoot]).context,
+            { corpus, resolveConstructionCache: spyCacheResolver(record) },
+        );
+
+        const result = await runtime.replayCorpus({
+            agent: "demo",
+            missPolicy: "needs-explanation",
+            mode: "completionBased-cache",
+        });
+
+        assert.equal(record.consulted, true);
+        // A valid cache layer for the working-tree side surfaces as the
+        // construction-cache method.
+        assert.equal(result.method, "construction-cache");
+    } finally {
+        await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+});

--- a/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/webviewProtocol.spec.ts
@@ -17,7 +17,8 @@ test("parseWebviewMessage accepts well-formed messages", () => {
         type: "pickVersion",
         side: "b",
     });
-    // Missing/invalid version fields coerce to the working tree.
+    // Missing/invalid version fields coerce to the working tree; an absent mode
+    // defaults to the grammar-only baseline.
     assert.deepEqual(
         parseWebviewMessage({ type: "run", requestId: 3, agent: "player" }),
         {
@@ -26,6 +27,7 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: { kind: "workingTree" },
             versionB: { kind: "workingTree" },
+            mode: "nfa-grammar",
         },
     );
     // String version fields are coerced (legacy text-field / test seam).
@@ -36,6 +38,7 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: "HEAD",
             versionB: "working tree",
+            mode: "completionBased-cache",
         }),
         {
             type: "run",
@@ -43,9 +46,11 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: { kind: "git", ref: "HEAD" },
             versionB: { kind: "workingTree" },
+            mode: "completionBased-cache",
         },
     );
-    // Typed specs from a picker selection are validated and taken as-is.
+    // Typed specs from a picker selection are validated and taken as-is; an
+    // unknown mode value falls back to the grammar-only baseline.
     assert.deepEqual(
         parseWebviewMessage({
             type: "run",
@@ -53,6 +58,7 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: { kind: "git", ref: "v1.0" },
             versionB: { kind: "workingTree" },
+            mode: "bogus-mode",
         }),
         {
             type: "run",
@@ -60,6 +66,7 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: { kind: "git", ref: "v1.0" },
             versionB: { kind: "workingTree" },
+            mode: "nfa-grammar",
         },
     );
     // Non-string / malformed version fields fall back to the working tree.
@@ -77,6 +84,7 @@ test("parseWebviewMessage accepts well-formed messages", () => {
             agent: "player",
             versionA: { kind: "workingTree" },
             versionB: { kind: "workingTree" },
+            mode: "nfa-grammar",
         },
     );
 });

--- a/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/client/impactReport.ts
@@ -10,7 +10,10 @@
  * `vscode`, or node built-ins (so it bundles for the browser).
  */
 
-import type { StudioReplayResult } from "@typeagent/core/runtime";
+import type {
+    StudioReplayResult,
+    StudioReplayMode,
+} from "@typeagent/core/runtime";
 import type { ActionDelta } from "@typeagent/core/replay";
 import type {
     HostToWebviewMessage,
@@ -64,6 +67,7 @@ interface PanelState {
     selectedAgent?: string;
     versionA?: ResolvedVersion;
     versionB?: ResolvedVersion;
+    mode?: StudioReplayMode;
     lastResult?: PersistedResult;
 }
 interface VsCodeApi {
@@ -113,6 +117,31 @@ const activeFilters = defaultImpactFilters();
 let currentAgent: string | undefined;
 let versionA: ResolvedVersion = DEFAULT_VERSION_A;
 let versionB: ResolvedVersion = DEFAULT_VERSION_B;
+// Which deterministic dispatch path the next run models. `nfa-grammar` (default)
+// matches both sides against the compiled grammar only — symmetric, no cache.
+// `completionBased-cache` lets the working-tree side consult the live
+// construction cache first (the default-dispatcher path). Persisted with the
+// version selection so a reload keeps the chosen mode.
+let mode: StudioReplayMode = "nfa-grammar";
+
+/** Short toolbar label for each replay mode. */
+const MODE_LABEL: Record<StudioReplayMode, string> = {
+    "nfa-grammar": "Grammar",
+    "completionBased-cache": "Cache",
+};
+/** Hover copy explaining each mode and that the button toggles between them. */
+const MODE_TOOLTIP: Record<StudioReplayMode, string> = {
+    "nfa-grammar":
+        "Grammar mode: both versions match against the compiled grammar only — " +
+        "the construction cache is never consulted, so A and B stay symmetric. " +
+        "Cleanest signal for what a grammar or schema edit changed. " +
+        "Click to switch to Cache mode.",
+    "completionBased-cache":
+        "Cache mode: the working-tree side consults the live construction cache " +
+        "before the grammar (the default dispatcher path), so a cache hit reflects " +
+        "what the dispatcher would serve. Asymmetric — a B-side cache hit can mask " +
+        "a grammar regression. Click to switch to Grammar mode.",
+};
 
 const root = document.getElementById("root")!;
 
@@ -143,6 +172,16 @@ const swapButton = toolButton("arrow-swap", "Swap A and B", () =>
     swapVersions(),
 );
 swapButton.title = "Swap the base (A) and compare (B) versions.";
+
+// A two-state toggle for the replay mode. Only two modes exist, so a click
+// flips between them (no dropdown). Built by hand (not `toolButton`) so we keep
+// a handle on the label node and update it in place from `renderModeButton`.
+const modeButton = document.createElement("button");
+modeButton.type = "button";
+modeButton.className = "tool-button";
+const modeButtonText = text("");
+modeButton.append(codicon("settings"), modeButtonText);
+modeButton.addEventListener("click", () => cycleMode());
 const runButton = toolButton("play", "Run", () => runReplay(), {
     primary: true,
     text: "Run",
@@ -159,6 +198,8 @@ actionBar.append(
     group(codicon("library"), agentNameEl),
     separator(),
     group(versionAButton.button, swapButton, versionBButton.button),
+    separator(),
+    group(modeButton),
     spacer(),
     runButton,
     connectionPill,
@@ -188,6 +229,7 @@ setControlsEnabled(false);
 renderConnection("connecting");
 restoreSelection();
 renderVersionButtons();
+renderModeButton();
 
 // --- Messaging ------------------------------------------------------------
 window.addEventListener("message", (event: MessageEvent) => {
@@ -259,7 +301,7 @@ function runReplay(): void {
     }
     requestId += 1;
     latestRequestId = requestId;
-    persistState({ selectedAgent: agent, versionA, versionB });
+    persistState({ selectedAgent: agent, versionA, versionB, mode });
     setControlsEnabled(false);
     setStatus(`Replaying ${agent}…`);
     clearNotification();
@@ -277,7 +319,25 @@ function runReplay(): void {
         agent,
         versionA: versionA.spec,
         versionB: versionB.spec,
+        mode,
     });
+}
+
+/** Flip the replay mode between its two states and persist the choice. */
+function cycleMode(): void {
+    mode = mode === "nfa-grammar" ? "completionBased-cache" : "nfa-grammar";
+    renderModeButton();
+    persistState({ mode });
+}
+
+/** Paint the mode toggle's label and tooltip from the current `mode`. */
+function renderModeButton(): void {
+    modeButtonText.textContent = MODE_LABEL[mode];
+    modeButton.title = MODE_TOOLTIP[mode];
+    modeButton.setAttribute(
+        "aria-label",
+        `Replay mode: ${MODE_LABEL[mode]}. ${MODE_TOOLTIP[mode]}`,
+    );
 }
 
 /** Apply a version selection from the host picker to one side. */
@@ -700,6 +760,9 @@ function restoreSelection(): void {
     if (state?.versionB) {
         versionB = state.versionB;
     }
+    if (state?.mode) {
+        mode = state.mode;
+    }
     // The agent is authoritative from the host `init`; until it arrives, show a
     // neutral placeholder rather than a stale persisted value.
     renderAgentName();
@@ -754,6 +817,7 @@ function setControlsEnabled(enabled: boolean): void {
     swapButton.disabled = !enabled;
     versionAButton.button.disabled = !enabled;
     versionBButton.button.disabled = !enabled;
+    modeButton.disabled = !enabled;
 }
 
 function setStatus(text: string): void {

--- a/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
+++ b/ts/packages/typeagent-studio/src/webviewKit/protocol.ts
@@ -11,7 +11,10 @@
  * touches a socket (the security boundary).
  */
 
-import type { StudioReplayResult } from "@typeagent/core/runtime";
+import type {
+    StudioReplayResult,
+    StudioReplayMode,
+} from "@typeagent/core/runtime";
 import type { VersionSpec } from "@typeagent/core/replay";
 import {
     coerceVersionSpec,
@@ -71,12 +74,23 @@ export type WebviewToHostMessage =
           versionA: VersionSpec;
           /** Validated compare (B) version spec. */
           versionB: VersionSpec;
+          /** Which deterministic dispatch path to model. */
+          mode: StudioReplayMode;
       }
     /** Ask the host to open a native version QuickPick for one side. */
     | { type: "pickVersion"; side: ReplaySide };
 
 function narrowSide(value: unknown): ReplaySide | undefined {
     return value === "a" || value === "b" ? value : undefined;
+}
+
+/**
+ * Narrow an untrusted mode into a {@link StudioReplayMode}, defaulting unknown
+ * or missing values to the grammar-only `nfa-grammar` baseline (the safer,
+ * cache-free default the runtime also falls back to).
+ */
+function narrowMode(value: unknown): StudioReplayMode {
+    return value === "completionBased-cache" ? value : "nfa-grammar";
 }
 
 /** Narrow an untrusted value into a {@link WebviewToHostMessage}. */
@@ -100,6 +114,7 @@ export function parseWebviewMessage(
                 agent?: unknown;
                 versionA?: unknown;
                 versionB?: unknown;
+                mode?: unknown;
             };
             if (
                 typeof m.requestId === "number" &&
@@ -116,6 +131,7 @@ export function parseWebviewMessage(
                     agent: m.agent,
                     versionA: coerceVersionSpec(m.versionA),
                     versionB: coerceVersionSpec(m.versionB),
+                    mode: narrowMode(m.mode),
                 };
             }
             return undefined;


### PR DESCRIPTION
## Summary

Stacked on #2553 (part 4). Makes the Impact Report replay's deterministic dispatch model **explicit** instead of implicitly mixing two paths that never coexist in a real dispatcher config.

Two modes, surfaced as a toggle in the report's action bar:

- **`nfa-grammar`** (default) — both versions match against the compiled grammar only; the construction cache is never consulted, so A and B stay symmetric. The cleanest signal for what a grammar/schema edit changed. Faithful to the dispatcher's `nfa` grammar system.
- **`completionBased-cache`** (opt-in) — the working-tree side consults the live construction cache before the grammar (the default-dispatcher path). A B-side cache hit reflects what the dispatcher would serve, but the run is asymmetric.

## Changes

**Level A — core gating**
- Add `StudioReplayMode = "nfa-grammar" | "completionBased-cache"` and `mode?` on `StudioReplayRequest` (default `nfa-grammar`).
- Gate the live construction-cache consult behind `completionBased-cache`. Default runs are now grammar-only and A/B-symmetric; the `construction-cache` method label no longer auto-appears.

**Level B — plumbing + UI + test**
- Thread `mode` through the webview `run` message; `parseWebviewMessage` validates it (unknown/missing → `nfa-grammar`). The host forwards it into `replayCorpus`; the channel/RPC layers ride on `StudioReplayRequest` unchanged.
- Add a two-state **Grammar ⇄ Cache** toggle to the action bar with explanatory tooltips, persisted/restored alongside the version selection and disabled with the other controls during a run.
- Add an injectable `resolveConstructionCache` seam to `CreateStudioRuntimeOptions` (mirrors `replayResolver`/`collisionScanner`) so the gating is testable without a live cache.

## Testing
- `pnpm run build typeagent-core` — green
- Studio suite — **184/184**
- Core replay specs (`replay|grammarReplay|constructionCache`) — **40/40**
- 3 new runtime gating tests: cache skipped in `nfa-grammar` (and when mode omitted), consulted in `completionBased-cache`
- esbuild webview bundle clean; prettier clean

## Notes
- `grammarResolver.ts` / `constructionCacheResolver.ts` unchanged — the gate lives at the runtime call site.
- Next fidelity rung (separate slice): **L4a** — stand up one live working-tree agent and run real `validateWildcardMatch`/`validateEntityWildcardMatch`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>