### PR TITLE
Smoke tests: install dependencies from public npm instead of the internal feed

### DIFF
--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -31,9 +31,15 @@
 #     principal must hold the 'Key Vault Secrets User' RBAC role on the
 #     'build-pipeline-kv' vault (the vault uses RBAC authorization, not access
 #     policies). Authorize the pipeline to use the connection on first run.
-#   * Pipeline variables (define in the pipeline UI or a linked variable group):
-#       - REGISTRY         npm registry URL used by include-prepare-repo.yml to
-#                          restore dependencies (internal Azure Artifacts feed).
+#
+# Dependency restore uses the PUBLIC npm registry (registry.npmjs.org), the same
+# as the GitHub Actions build lanes (build_ts / build_package_shell) and local
+# dev. This keeps the package source consistent across all CI and avoids failures
+# where a freshly-published transitive version (e.g. from a Dependabot lockfile
+# bump) is not yet present in an internal Azure Artifacts feed. The smoke tests
+# only need the WIF service connection for Azure OpenAI secrets, which is
+# independent of the npm registry — so no internal feed (or REGISTRY variable) is
+# required here.
 
 trigger:
   branches:
@@ -86,13 +92,13 @@ jobs:
     pool:
       vmImage: $(image)
     steps:
-      # Checkout + internal npm registry auth + Node + pnpm install
-      # (--frozen-lockfile --strict-peer-dependencies).
+      # Checkout + Node + pnpm install (--frozen-lockfile --strict-peer-dependencies).
+      # No 'registry' is passed, so install uses the default public npm registry —
+      # matching the GitHub Actions lanes and local dev.
       - template: include-prepare-repo.yml
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
 
       # keytar links against libsecret at runtime on Linux; install before any
       # TypeAgent process (CLI / shell) loads the native module.

--- a/pipelines/include-prepare-repo.yml
+++ b/pipelines/include-prepare-repo.yml
@@ -6,8 +6,13 @@ parameters:
     type: string
   - name: nodeVersion
     type: string
+  # Optional npm registry. When set (e.g. an internal Azure Artifacts feed URL),
+  # an .npmrc is written and authenticated so pnpm restores from that feed. When
+  # omitted (empty), the build uses the default public npm registry
+  # (registry.npmjs.org) with no auth — matching the GitHub Actions lanes.
   - name: registry
     type: string
+    default: ""
   # Set false to skip pnpm-store caching. Useful for manual/scheduled pipelines
   # where the Windows post-job cache save can exceed its timeout and fail the job.
   - name: enableCache
@@ -19,16 +24,20 @@ steps:
     displayName: "Checkout TypeAgent Repository"
     path: typeagent
 
-  - bash: |
-      echo "registry=${{ parameters.registry }}" > .npmrc
-      cat .npmrc
-    displayName: Set npm registry
-    workingDirectory: ${{ parameters.buildDirectory }}
+  # Only configure and authenticate a custom registry when one is supplied.
+  # When 'registry' is empty, these steps are skipped and pnpm uses the default
+  # public npm registry (no .npmrc, no auth) — same as the GitHub Actions lanes.
+  - ${{ if ne(parameters.registry, '') }}:
+      - bash: |
+          echo "registry=${{ parameters.registry }}" > .npmrc
+          cat .npmrc
+        displayName: Set npm registry
+        workingDirectory: ${{ parameters.buildDirectory }}
 
-  - task: npmAuthenticate@0
-    displayName: Authenticate to npm registry
-    inputs:
-      workingFile: ${{ parameters.buildDirectory }}/.npmrc
+      - task: npmAuthenticate@0
+        displayName: Authenticate to npm registry
+        inputs:
+          workingFile: ${{ parameters.buildDirectory }}/.npmrc
 
   - task: UseNode@1
     displayName: Setup Node.js v${{ parameters.nodeVersion }}


### PR DESCRIPTION
## Why

The ADO smoke-test pipeline added in the recent WIF migration (#2549, #2551)
restores dependencies from the org's internal Azure Artifacts feed, while the
GitHub Actions build lanes (`build_ts`, `build_package_shell`) and local dev use
the **public npm registry**. That difference opens a gap between the two build
environments: a PR can be green on the GitHub builds but red on smoke whenever a
freshly-published transitive version isn't yet present in the internal feed —
e.g. a Dependabot lockfile bump fails with `ERR_PNPM_FETCH_404` (`qs@6.15.3` in
#2556), even though every GitHub check passes.

This PR closes that gap on the smoke side by resolving packages from public npm —
the same source the rest of CI and local dev already use.

We intentionally fix this here rather than wiring internal-feed authentication
into GitHub Actions. The original intent of the last two WIF PRs was secretless
**Azure** auth (Key Vault / Azure OpenAI), not npm package sourcing — the
internal feed only came along incidentally via the shared
`include-prepare-repo.yml` template. Aligning smoke on public npm keeps package
resolution consistent across all CI without adding any new npm-registry auth work
on the GitHub side.

## Changes

- **`pipelines/include-prepare-repo.yml`** — make `registry` optional. The
  `.npmrc` + `npmAuthenticate` steps now run only when a registry is supplied.
  This is backward-compatible: the build/publish pipelines still pass
  `$(REGISTRY)` and are unaffected.
- **`pipelines/azure-smoke-tests.yml`** — omit `registry`, so the smoke job
  installs from public npm, matching the GitHub Actions lanes.

## Not changed

- The ADO build/publish pipelines continue to use the internal feed.
- The smoke pipeline's WIF / Azure auth is untouched — still used for the Azure
  OpenAI secrets, which is independent of the npm registry.
