### PR TITLE
Fix docsAutogen diff detection and tests

### DIFF
--- a/ts/tools/docsAutogen/src/git.ts
+++ b/ts/tools/docsAutogen/src/git.ts
@@ -182,7 +182,14 @@ export class Git {
         validateGitRefArg(from, "ref");
         if (to !== null) validateGitRefArg(to, "ref");
         const refspec = to === null ? from : `${from}..${to}`;
-        const args = ["diff", "--name-only", refspec, "--"];
+        // `--relative` prints paths relative to the process cwd (the monorepo
+        // root, e.g. `ts/`) rather than the git repo root. The repo root can
+        // be an ancestor of the monorepo root (TypeAgent lives under `ts/`),
+        // so without this the paths carry a `ts/` prefix that never matches
+        // package relDirs — which changeDetection computes relative to the
+        // monorepo root — and change detection would attribute zero files to
+        // any package. See detectChangedPackages in changeDetection.ts.
+        const args = ["diff", "--name-only", "--relative", refspec, "--"];
         const out = await this.runOk(args);
         return parseLines(out);
     }

--- a/ts/tools/docsAutogen/test/git.spec.ts
+++ b/ts/tools/docsAutogen/test/git.spec.ts
@@ -92,4 +92,42 @@ describe("Git arg shape", () => {
             "origin/main",
         ]);
     });
+    // Regression: change detection maps changed files to packages by their
+    // relDir, which is relative to the monorepo root (the git cwd). git prints
+    // paths relative to the repo root by default, so when the monorepo root is
+    // a subdirectory (TypeAgent under `ts/`) the paths carry a `ts/` prefix and
+    // match nothing — the `--since` run silently selects zero packages. The
+    // `--relative` flag makes git speak the same coordinate system.
+    it("passes --relative in diffNameOnly (paths relative to cwd, not repo root)", async () => {
+        const { runner, calls } = recordingRunner(() => ({
+            stdout: "packages/cache/src/cache.ts\n",
+            stderr: "",
+            code: 0,
+        }));
+        const git = new Git("/repo/ts", runner);
+        await git.diffNameOnly("base-sha", "head-sha");
+        expect(calls[0]).toEqual([
+            "diff",
+            "--name-only",
+            "--relative",
+            "base-sha..head-sha",
+            "--",
+        ]);
+    });
+    it("builds a single-ref diffNameOnly refspec with --relative", async () => {
+        const { runner, calls } = recordingRunner(() => ({
+            stdout: "",
+            stderr: "",
+            code: 0,
+        }));
+        const git = new Git("/repo/ts", runner);
+        await git.diffNameOnly("HEAD");
+        expect(calls[0]).toEqual([
+            "diff",
+            "--name-only",
+            "--relative",
+            "HEAD",
+            "--",
+        ]);
+    });
 });


### PR DESCRIPTION
The daily doc pipeline's  --since  change detection always selected zero packages, so it reported "nothing to do" even when packages had changed — silently doing nothing every run.

Root cause: a path-namespace mismatch.

•  git diff  returned paths relative to the repo root →  ts/packages/cache/… 
• but packages are keyed relative to the monorepo root ( ts/ , where  pnpm-workspace.yaml  lives) →  packages/cache 
• the  ts/  prefix meant the "does this file belong to this package?" check never matched → 0 packages attributed.

It slipped through because unit tests fed already-stripped paths, and prior "working" runs were full sweeps, not the incremental  --since  path.