### PR TITLE
Fix bug with workflow cli build

### DIFF
--- a/ts/examples/workflow/cli/src/cli.ts
+++ b/ts/examples/workflow/cli/src/cli.ts
@@ -16,6 +16,7 @@ import {
     isGenericTask,
     isTypeParamRef,
     SchemaTemplateDefinition,
+    TaskTypeParameter,
 } from "workflow-model";
 import {
     TaskRegistry,
@@ -224,7 +225,9 @@ function cmdListTasks(): void {
     for (const task of allBuiltinTasks) {
         console.log(`${task.name}`);
         if (isGenericTask(task)) {
-            const params = task.typeParameters.map((p) => p.name).join(", ");
+            const params = task.typeParameters
+                .map((p: TaskTypeParameter) => p.name)
+                .join(", ");
             console.log(`  <${params}> (generic)`);
             const inputTmpl = task.inputSchemaTemplate;
             if (


### PR DESCRIPTION
 Fix error, in the  workflow-cli  example package ( ts/examples/workflow/cli/src/cli.ts:227 ) —  TS7006: Parameter 'p' implicitly has an 'any' type . Unrelated to  contextSelector  ( agent-dispatcher  compiled fine at step 189).
 
In that file  task.typeParameters  was inferring as  any , so the untyped  .map((p) => …)  callback tripped  noImplicitAny  — even though  workflow-model 's built  .d.ts  types it correctly as  TaskTypeParameter[] .