### PR TITLE
Make embeddings optional; add embedding config

### DIFF
--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -255,7 +255,6 @@ embedding:
   model: Xenova/all-MiniLM-L6-v2 # local provider only (384-d, ~23MB)
   # cacheDir: /var/lib/typeagent/models  # pre-stage weights (air-gapped)
 
-
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  Key Vault                                                       ║
 # ╚═══════════════════════════════════════════════════════════════════╝

--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -232,6 +232,31 @@ reasoning:
   copilotModel: claude-sonnet-4.5 # override default Copilot reasoning model
 
 # ╔═══════════════════════════════════════════════════════════════════╗
+# ║  Embedding provider                                              ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+#
+# Selects where text embeddings come from, independent of the chat
+# `modelProvider`. Useful for self-host: e.g. route chat through Copilot
+# while still producing embeddings from a bundled CPU-only local model.
+#
+#   provider:
+#     local  - CPU-only transformers.js model (no GPU, no API key). Weights
+#              download from the Hugging Face hub on first use and are cached.
+#     openai - use the `openAI.endpointEmbedding` / `modelEmbedding` above.
+#     azure  - use the `azureOpenAI` embedding deployment.
+#     none   - disable embeddings; embedding-dependent features degrade
+#              gracefully (see the self-host docs).
+#
+# When omitted, the provider is inferred from the configured embedding
+# endpoints (openAI/azureOpenAI), or disabled if none is present.
+
+embedding:
+  provider: local
+  model: Xenova/all-MiniLM-L6-v2 # local provider only (384-d, ~23MB)
+  # cacheDir: /var/lib/typeagent/models  # pre-stage weights (air-gapped)
+
+
+# ╔═══════════════════════════════════════════════════════════════════╗
 # ║  Key Vault                                                       ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 #

--- a/ts/packages/agents/agentUtils/graphUtils/src/calendarDataIndex.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/calendarDataIndex.ts
@@ -9,7 +9,10 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    tryCreateEmbeddingModel,
+} from "@typeagent/aiclient";
 
 export type EventInfo = {
     eventId: string;
@@ -28,9 +31,11 @@ export interface CalendarDataIndex {
 
 export function createCalendarDataIndex() {
     let eventEmbeddings: Record<string, NormalizedEmbedding> = {};
-    let embeddingModel: TextEmbeddingModel;
-
-    embeddingModel = openai.createEmbeddingModel();
+    // Undefined when no embedding provider is configured (e.g. Copilot /
+    // self-host "none" mode). Semantic event lookup is then disabled and
+    // search returns no matches instead of failing.
+    const embeddingModel: TextEmbeddingModel | undefined =
+        tryCreateEmbeddingModel();
     return {
         addOrUpdate,
         remove,
@@ -39,6 +44,9 @@ export function createCalendarDataIndex() {
     };
 
     async function addOrUpdate(eventInfo: EventInfo) {
+        if (embeddingModel === undefined) {
+            return;
+        }
         let embedding = await generateEmbedding(
             embeddingModel,
             String(eventInfo.eventData),
@@ -60,6 +68,9 @@ export function createCalendarDataIndex() {
         query: string | NormalizedEmbedding,
         maxMatches: number,
     ): Promise<ScoredItem<NameValue<string>>[]> {
+        if (embeddingModel === undefined) {
+            return [];
+        }
         const embeddings = Object.values(eventEmbeddings);
         const eventIds = Object.keys(eventEmbeddings);
 

--- a/ts/packages/agents/browser/src/agent/tabTitleIndex.mts
+++ b/ts/packages/agents/browser/src/agent/tabTitleIndex.mts
@@ -9,7 +9,11 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    openai,
+    isEmbeddingAvailable,
+} from "@typeagent/aiclient";
 
 export interface TabTitleIndex {
     addOrUpdate(title: string, tabId: number): Promise<void>;
@@ -25,11 +29,12 @@ export function createTabTitleIndex() {
     let tabEmbeddings: Record<number, NormalizedEmbedding> = {};
     // Undefined when no embedding provider is configured; tab-title fuzzy
     // search is then disabled and returns no matches instead of failing.
-    const embeddingModel: TextEmbeddingModel | undefined = isEmbeddingAvailable()
-        ? openai.createEmbeddingModel(
-              openai.apiSettingsFromEnv(openai.ModelType.Embedding),
-          )
-        : undefined;
+    const embeddingModel: TextEmbeddingModel | undefined =
+        isEmbeddingAvailable()
+            ? openai.createEmbeddingModel(
+                  openai.apiSettingsFromEnv(openai.ModelType.Embedding),
+              )
+            : undefined;
 
     return {
         addOrUpdate,

--- a/ts/packages/agents/browser/src/agent/tabTitleIndex.mts
+++ b/ts/packages/agents/browser/src/agent/tabTitleIndex.mts
@@ -9,7 +9,7 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai } from "@typeagent/aiclient";
+import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
 
 export interface TabTitleIndex {
     addOrUpdate(title: string, tabId: number): Promise<void>;
@@ -23,11 +23,13 @@ export interface TabTitleIndex {
 
 export function createTabTitleIndex() {
     let tabEmbeddings: Record<number, NormalizedEmbedding> = {};
-    let embeddingModel: TextEmbeddingModel;
-
-    const aiSettings = openai.apiSettingsFromEnv(openai.ModelType.Embedding);
-
-    embeddingModel = openai.createEmbeddingModel(aiSettings);
+    // Undefined when no embedding provider is configured; tab-title fuzzy
+    // search is then disabled and returns no matches instead of failing.
+    const embeddingModel: TextEmbeddingModel | undefined = isEmbeddingAvailable()
+        ? openai.createEmbeddingModel(
+              openai.apiSettingsFromEnv(openai.ModelType.Embedding),
+          )
+        : undefined;
 
     return {
         addOrUpdate,
@@ -37,7 +39,7 @@ export function createTabTitleIndex() {
     };
 
     async function addOrUpdate(title: string, tabId: number) {
-        if (!title) {
+        if (!title || embeddingModel === undefined) {
             return;
         }
 
@@ -59,6 +61,9 @@ export function createTabTitleIndex() {
         query: string | NormalizedEmbedding,
         maxMatches: number,
     ): Promise<ScoredItem<NameValue<number>>[]> {
+        if (embeddingModel === undefined) {
+            return [];
+        }
         const embeddings = Object.values(tabEmbeddings);
         const tabIds = Object.keys(tabEmbeddings);
 

--- a/ts/packages/agents/desktop/src/programNameIndex.ts
+++ b/ts/packages/agents/desktop/src/programNameIndex.ts
@@ -10,7 +10,11 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    openai,
+    isEmbeddingAvailable,
+} from "@typeagent/aiclient";
 import registerDebug from "debug";
 const debugError = registerDebug("typeagent:desktop:error");
 

--- a/ts/packages/agents/desktop/src/programNameIndex.ts
+++ b/ts/packages/agents/desktop/src/programNameIndex.ts
@@ -10,7 +10,7 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai } from "@typeagent/aiclient";
+import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
 import registerDebug from "debug";
 const debugError = registerDebug("typeagent:desktop:error");
 
@@ -54,15 +54,17 @@ export function createProgramNameIndex(
     let programEmbeddings: Record<string, NormalizedEmbedding> =
         initialEmbeddings ?? {};
 
-    const embeddingModel: TextEmbeddingModel =
+    const embeddingModel: TextEmbeddingModel | undefined =
         modelOverride ??
-        (() => {
-            const aiSettings = openai.apiSettingsFromEnv(
-                openai.ModelType.Embedding,
-                vals,
-            );
-            return openai.createEmbeddingModel(aiSettings);
-        })();
+        (isEmbeddingAvailable()
+            ? (() => {
+                  const aiSettings = openai.apiSettingsFromEnv(
+                      openai.ModelType.Embedding,
+                      vals,
+                  );
+                  return openai.createEmbeddingModel(aiSettings);
+              })()
+            : undefined);
 
     return {
         addOrUpdate,
@@ -83,6 +85,9 @@ export function createProgramNameIndex(
     }
 
     async function addOrUpdate(programName: string) {
+        if (embeddingModel === undefined) {
+            return;
+        }
         if (programEmbeddings[programName] !== undefined) {
             return;
         }
@@ -113,6 +118,9 @@ export function createProgramNameIndex(
         query: string | NormalizedEmbedding,
         maxMatches: number,
     ): Promise<ScoredItem<NameValue<string>>[]> {
+        if (embeddingModel === undefined) {
+            return [];
+        }
         const embeddings = Object.values(programEmbeddings);
         const programNames = Object.keys(programEmbeddings);
 

--- a/ts/packages/agents/montage/src/agent/montageActionHandler.ts
+++ b/ts/packages/agents/montage/src/agent/montageActionHandler.ts
@@ -36,7 +36,10 @@ import {
 } from "@typeagent/agent-sdk/helpers/display";
 import registerDebug from "debug";
 import { createSemanticMap } from "typeagent";
-import { openai, TextEmbeddingModel } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    tryCreateEmbeddingModel,
+} from "@typeagent/aiclient";
 
 const debug = registerDebug("typeagent:agent:montage");
 
@@ -370,9 +373,11 @@ async function updateMontageContext(
             }
         }
 
-        // create the embedding model for fuzzy matching
+        // create the embedding model for fuzzy matching (undefined when no
+        // embedding provider is configured; fuzzy match then degrades to
+        // exact-title matching).
         if (!agentContext.fuzzyMatchingModel) {
-            agentContext.fuzzyMatchingModel = openai.createEmbeddingModel();
+            agentContext.fuzzyMatchingModel = tryCreateEmbeddingModel();
         }
     } else {
         // shut down service

--- a/ts/packages/agents/screencapture/src/windowMatcher.ts
+++ b/ts/packages/agents/screencapture/src/windowMatcher.ts
@@ -10,7 +10,11 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    openai,
+    isEmbeddingAvailable,
+} from "@typeagent/aiclient";
 import registerDebug from "debug";
 import type { WindowInfo } from "./platform/windowEnumerator.js";
 

--- a/ts/packages/agents/screencapture/src/windowMatcher.ts
+++ b/ts/packages/agents/screencapture/src/windowMatcher.ts
@@ -10,7 +10,7 @@ import {
     ScoredItem,
     NameValue,
 } from "typeagent";
-import { TextEmbeddingModel, openai } from "@typeagent/aiclient";
+import { TextEmbeddingModel, openai, isEmbeddingAvailable } from "@typeagent/aiclient";
 import registerDebug from "debug";
 import type { WindowInfo } from "./platform/windowEnumerator.js";
 
@@ -31,15 +31,17 @@ export function createProgramNameIndex(
 ): ProgramNameIndex {
     let programEmbeddings: Record<string, NormalizedEmbedding> = {};
 
-    const embeddingModel: TextEmbeddingModel =
+    const embeddingModel: TextEmbeddingModel | undefined =
         modelOverride ??
-        (() => {
-            const aiSettings = openai.apiSettingsFromEnv(
-                openai.ModelType.Embedding,
-                vals,
-            );
-            return openai.createEmbeddingModel(aiSettings);
-        })();
+        (isEmbeddingAvailable()
+            ? (() => {
+                  const aiSettings = openai.apiSettingsFromEnv(
+                      openai.ModelType.Embedding,
+                      vals,
+                  );
+                  return openai.createEmbeddingModel(aiSettings);
+              })()
+            : undefined);
 
     return {
         addOrUpdate,
@@ -48,6 +50,9 @@ export function createProgramNameIndex(
     };
 
     async function addOrUpdate(programName: string) {
+        if (embeddingModel === undefined) {
+            return;
+        }
         if (programEmbeddings[programName] !== undefined) {
             return;
         }
@@ -75,7 +80,7 @@ export function createProgramNameIndex(
         const embeddings = Object.values(programEmbeddings);
         const programNames = Object.keys(programEmbeddings);
 
-        if (embeddings.length === 0) {
+        if (embeddingModel === undefined || embeddings.length === 0) {
             return [];
         }
 

--- a/ts/packages/config/src/runtime/build.ts
+++ b/ts/packages/config/src/runtime/build.ts
@@ -35,6 +35,8 @@ import {
     DeploymentEndpoint,
     DeploymentMode,
     type AzureOpenAIConfig,
+    type EmbeddingConfig,
+    type EmbeddingProviderMode,
 } from "./types.js";
 
 /**
@@ -158,6 +160,7 @@ export function buildConfig(flat: FlatEnv): Config {
     const reasoning = buildReasoning(remaining);
     const copilot = buildCopilot(remaining);
     const modelProvider = buildModelProvider(remaining);
+    const embedding = buildEmbedding(remaining);
 
     return {
         azureOpenAI,
@@ -174,6 +177,7 @@ export function buildConfig(flat: FlatEnv): Config {
         ...(reasoning ? { reasoning } : {}),
         ...(copilot ? { copilot } : {}),
         ...(modelProvider !== undefined ? { modelProvider } : {}),
+        ...(embedding ? { embedding } : {}),
         extra: new Map(remaining),
     };
 }
@@ -872,6 +876,35 @@ function buildReasoning(flat: Map<string, string>) {
     return {
         ...(Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
         ...(copilotModel !== undefined ? { copilotModel } : {}),
+    };
+}
+
+function buildEmbedding(
+    flat: Map<string, string>,
+): EmbeddingConfig | undefined {
+    const providerRaw = popString(flat, "TYPEAGENT_EMBEDDING_PROVIDER");
+    const model = popString(flat, "TYPEAGENT_EMBEDDING_MODEL");
+    const cacheDir = popString(flat, "TYPEAGENT_EMBEDDING_CACHE_DIR");
+
+    let provider: EmbeddingProviderMode | undefined;
+    if (providerRaw !== undefined) {
+        const v = providerRaw.toLowerCase();
+        if (v === "local" || v === "openai" || v === "azure" || v === "none") {
+            provider = v;
+        } else {
+            // Unknown value — leave it in extra rather than emitting a
+            // malformed typed field.
+            flat.set("TYPEAGENT_EMBEDDING_PROVIDER", providerRaw);
+        }
+    }
+
+    if (provider === undefined && model === undefined && cacheDir === undefined)
+        return undefined;
+
+    return {
+        ...(provider !== undefined ? { provider } : {}),
+        ...(model !== undefined ? { model } : {}),
+        ...(cacheDir !== undefined ? { cacheDir } : {}),
     };
 }
 

--- a/ts/packages/config/src/runtime/shim.ts
+++ b/ts/packages/config/src/runtime/shim.ts
@@ -251,6 +251,16 @@ export function configToEnv(config: Config): EnvOutput {
                 f.httpEndpointLogicAppConnectionId;
     }
 
+    // Embedding provider selection.
+    if (config.embedding) {
+        if (config.embedding.provider !== undefined)
+            out.TYPEAGENT_EMBEDDING_PROVIDER = config.embedding.provider;
+        if (config.embedding.model !== undefined)
+            out.TYPEAGENT_EMBEDDING_MODEL = config.embedding.model;
+        if (config.embedding.cacheDir !== undefined)
+            out.TYPEAGENT_EMBEDDING_CACHE_DIR = config.embedding.cacheDir;
+    }
+
     // Extra: untyped passthrough. Last so it can override typed values
     // for keys we haven't migrated yet (the user wrote them explicitly).
     for (const [k, v] of config.extra) {

--- a/ts/packages/config/src/runtime/tree.ts
+++ b/ts/packages/config/src/runtime/tree.ts
@@ -463,6 +463,17 @@ export function configToTree(config: Config): ConfigTree {
         if (Object.keys(c).length > 0) tree.copilot = c;
     }
 
+    if (config.embedding) {
+        const e: ConfigTree = {};
+        if (config.embedding.provider !== undefined)
+            e.provider = config.embedding.provider;
+        if (config.embedding.model !== undefined)
+            e.model = config.embedding.model;
+        if (config.embedding.cacheDir !== undefined)
+            e.cacheDir = config.embedding.cacheDir;
+        if (Object.keys(e).length > 0) tree.embedding = e;
+    }
+
     return tree;
 }
 
@@ -485,6 +496,7 @@ const TYPED_SECTION_KEYS = new Set([
     "reasoning",
     "copilot",
     "modelProvider",
+    "embedding",
 ]);
 
 export function isTypedSectionKey(key: string): boolean {
@@ -985,6 +997,22 @@ function emitModelProvider(node: unknown, out: FlatEnv): void {
     out.TYPEAGENT_MODEL_PROVIDER = node;
 }
 
+function emitEmbedding(node: unknown, out: FlatEnv): void {
+    const e = asObject(node, "embedding");
+    if (e.provider !== undefined)
+        out.TYPEAGENT_EMBEDDING_PROVIDER = asString(
+            e.provider,
+            "embedding.provider",
+        );
+    if (e.model !== undefined)
+        out.TYPEAGENT_EMBEDDING_MODEL = asString(e.model, "embedding.model");
+    if (e.cacheDir !== undefined)
+        out.TYPEAGENT_EMBEDDING_CACHE_DIR = asString(
+            e.cacheDir,
+            "embedding.cacheDir",
+        );
+}
+
 function emitCopilot(node: unknown, out: FlatEnv): void {
     const c = asObject(node, "copilot");
     if (c.defaultModel !== undefined)
@@ -1082,6 +1110,9 @@ export function typedSectionToFlat(key: string, node: unknown): FlatEnv {
             break;
         case "modelProvider":
             emitModelProvider(node, out);
+            break;
+        case "embedding":
+            emitEmbedding(node, out);
             break;
         default:
             throw new Error(`Not a typed section: '${key}'.`);

--- a/ts/packages/config/src/runtime/types.ts
+++ b/ts/packages/config/src/runtime/types.ts
@@ -216,6 +216,31 @@ export interface AzureFoundryConfig {
  */
 export type ModelProviderMode = "azure" | "openai" | "ollama" | "copilot";
 
+/**
+ * Source of text embeddings, independent of the chat `modelProvider`.
+ * - "local": CPU-only transformers.js model bundled with the app.
+ * - "openai" / "azure": hosted embedding endpoints.
+ * - "none": embeddings disabled; consumers must degrade gracefully.
+ */
+export type EmbeddingProviderMode = "local" | "openai" | "azure" | "none";
+
+/**
+ * Embedding provider configuration. Kept separate from chat provider
+ * selection so a deployment can, for example, route chat through Copilot
+ * while still producing embeddings from a bundled local model. Endpoint /
+ * key for hosted providers reuse the existing `openAI` / `azureOpenAI`
+ * embedding entries; this section only selects the provider and (for the
+ * local provider) the model and weight cache directory.
+ */
+export interface EmbeddingConfig {
+    /** Which embedding provider to use. */
+    readonly provider?: EmbeddingProviderMode | undefined;
+    /** Local-provider model id (e.g. `Xenova/all-MiniLM-L6-v2`). */
+    readonly model?: string | undefined;
+    /** Directory used to cache / pre-stage local model weights. */
+    readonly cacheDir?: string | undefined;
+}
+
 export interface ReasoningConfig {
     /** Reasoning-loop timeout in milliseconds (0 = disabled). */
     readonly timeoutMs?: number | undefined;
@@ -262,6 +287,12 @@ export interface Config {
     readonly azureFoundry?: AzureFoundryConfig | undefined;
     readonly reasoning?: ReasoningConfig | undefined;
     readonly copilot?: CopilotConfig | undefined;
+    /**
+     * Embedding provider selection, independent of `modelProvider`. When
+     * omitted the embedding source is inferred from the configured hosted
+     * embedding endpoints (or disabled when none is present).
+     */
+    readonly embedding?: EmbeddingConfig | undefined;
     /**
      * Active provider mode for model resolution. When set, unprefixed
      * `createChatModel` calls route through this provider's mapping.

--- a/ts/packages/config/test/flatten.spec.ts
+++ b/ts/packages/config/test/flatten.spec.ts
@@ -36,6 +36,21 @@ describe("flatten", () => {
         });
     });
 
+    test("flattens the typed embedding section to TYPEAGENT_EMBEDDING_* vars", () => {
+        const out = flatten({
+            embedding: {
+                provider: "local",
+                model: "Xenova/all-MiniLM-L6-v2",
+                cacheDir: "/models",
+            },
+        });
+        expect(out).toEqual({
+            TYPEAGENT_EMBEDDING_PROVIDER: "local",
+            TYPEAGENT_EMBEDDING_MODEL: "Xenova/all-MiniLM-L6-v2",
+            TYPEAGENT_EMBEDDING_CACHE_DIR: "/models",
+        });
+    });
+
     test("env: top-level passthrough leaves keys verbatim", () => {
         const out = flatten({
             env: {

--- a/ts/packages/config/test/runtime.shim.spec.ts
+++ b/ts/packages/config/test/runtime.shim.spec.ts
@@ -36,6 +36,31 @@ describe("configToEnv: shim projection", () => {
         expect(out.AZURE_OPENAI_MAX_RETRYATTEMPTS).toBe("3");
     });
 
+    test("round-trips the embedding provider section", () => {
+        const flat: FlatEnv = {
+            TYPEAGENT_EMBEDDING_PROVIDER: "local",
+            TYPEAGENT_EMBEDDING_MODEL: "Xenova/all-MiniLM-L6-v2",
+            TYPEAGENT_EMBEDDING_CACHE_DIR: "/var/lib/typeagent/models",
+        };
+        const config = buildConfig(flat);
+        expect(config.embedding).toEqual({
+            provider: "local",
+            model: "Xenova/all-MiniLM-L6-v2",
+            cacheDir: "/var/lib/typeagent/models",
+        });
+        const out = configToEnv(config);
+        for (const [k, v] of Object.entries(flat)) {
+            expect(out[k]).toBe(v);
+        }
+    });
+
+    test("leaves an unknown embedding provider value in extras", () => {
+        const out = configToEnv(
+            buildConfig({ TYPEAGENT_EMBEDDING_PROVIDER: "bogus" }),
+        );
+        expect(out.TYPEAGENT_EMBEDDING_PROVIDER).toBe("bogus");
+    });
+
     test("preserves extras verbatim", () => {
         const flat: FlatEnv = {
             AZURE_FOUNDRY_AGENT_ID_FOO: "asst_xyz",

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaSemanticMap.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaSemanticMap.ts
@@ -14,10 +14,11 @@ import {
     SimilarityType,
     TopNCollection,
 } from "typeagent";
-import { TextEmbeddingModel, openai } from "@typeagent/aiclient";
+import { TextEmbeddingModel, tryCreateEmbeddingModel } from "@typeagent/aiclient";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:dispatcher:semantic");
+const debugError = registerDebug("typeagent:dispatcher:semantic:error");
 
 type Entry = {
     embedding: NormalizedEmbedding;
@@ -29,15 +30,38 @@ export type EmbeddingCache = Map<string, NormalizedEmbedding>;
 
 export class ActionSchemaSemanticMap {
     private readonly actionSemanticMaps = new Map<string, Map<string, Entry>>();
-    private readonly model: TextEmbeddingModel;
+    private readonly model: TextEmbeddingModel | undefined;
+    // Set when no embedding provider is configured, or when embedding
+    // generation fails at load time. In that state semantic schema
+    // selection is unavailable and callers fall back to inline/search
+    // routing instead of the daemon failing to start.
+    private disabled: boolean;
     public constructor(model?: TextEmbeddingModel) {
-        this.model = model ?? openai.createEmbeddingModel();
+        this.model = model ?? tryCreateEmbeddingModel();
+        this.disabled = this.model === undefined;
+        if (this.disabled) {
+            debug(
+                "No embedding provider configured; action semantic map disabled (schema routing falls back to inline/search).",
+            );
+        }
     }
+
+    /**
+     * True when semantic schema selection is available. False when no
+     * embedding provider is configured or embeddings failed to load.
+     */
+    public get enabled(): boolean {
+        return !this.disabled && this.model !== undefined;
+    }
+
     public async addActionSchemaFile(
         config: ActionConfig,
         actionSchemaFile: ActionSchemaFile,
         cache?: EmbeddingCache,
     ) {
+        if (!this.enabled) {
+            return;
+        }
         const keys: string[] = [];
         const definitions: ActionSchemaTypeDefinition[] = [];
 
@@ -77,7 +101,7 @@ export class ActionSchemaSemanticMap {
             const start = Date.now();
             try {
                 const embeddings = await generateTextEmbeddingsWithRetry(
-                    this.model,
+                    this.model!,
                     keys,
                 );
                 debug(
@@ -91,11 +115,28 @@ export class ActionSchemaSemanticMap {
                     });
                 }
             } catch (e: any) {
-                debug(
+                // Do not fail agent initialization (which would exit the
+                // daemon) when embeddings are unavailable at load time.
+                // Disable semantic schema selection and fall back to
+                // inline/search routing instead.
+                this.disable(
                     `Failed to get embeddings for ${config.schemaName} after ${Date.now() - start}ms: ${e?.message ?? e}`,
                 );
-                throw e;
             }
+        }
+    }
+
+    private disable(reason: string): void {
+        if (this.disabled) {
+            return;
+        }
+        this.disabled = true;
+        this.actionSemanticMaps.clear();
+        debugError(reason);
+        if (process.env.NODE_ENV !== "test") {
+            console.warn(
+                `Action semantic map disabled — schema routing falls back to inline/search. ${reason}`,
+            );
         }
     }
 
@@ -109,7 +150,18 @@ export class ActionSchemaSemanticMap {
         filter: (schemaName: string) => boolean,
         minScore: number = 0,
     ): Promise<ScoredItem<Entry>[]> {
-        const embedding = await generateEmbeddingWithRetry(this.model, request);
+        if (!this.enabled) {
+            return [];
+        }
+        let embedding: NormalizedEmbedding;
+        try {
+            embedding = await generateEmbeddingWithRetry(this.model!, request);
+        } catch (e: any) {
+            this.disable(
+                `Failed to embed request for semantic schema selection: ${e?.message ?? e}`,
+            );
+            return [];
+        }
         const matches = new TopNCollection<Entry>(maxMatches, {} as Entry);
         for (const [name, actionSemanticMap] of this.actionSemanticMaps) {
             if (!filter(name)) {

--- a/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaSemanticMap.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/actionSchemaSemanticMap.ts
@@ -14,7 +14,10 @@ import {
     SimilarityType,
     TopNCollection,
 } from "typeagent";
-import { TextEmbeddingModel, tryCreateEmbeddingModel } from "@typeagent/aiclient";
+import {
+    TextEmbeddingModel,
+    tryCreateEmbeddingModel,
+} from "@typeagent/aiclient";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:dispatcher:semantic");

--- a/ts/packages/knowPro/src/conversation.ts
+++ b/ts/packages/knowPro/src/conversation.ts
@@ -3,7 +3,10 @@
 
 import { PromptSection } from "typechat";
 import { IConversation, DateRange } from "./interfaces.js";
-import { tryCreateEmbeddingModel, TextEmbeddingModel } from "@typeagent/aiclient";
+import {
+    tryCreateEmbeddingModel,
+    TextEmbeddingModel,
+} from "@typeagent/aiclient";
 import {
     TextEmbeddingIndexSettings,
     createTextEmbeddingIndexSettings,

--- a/ts/packages/knowPro/src/conversation.ts
+++ b/ts/packages/knowPro/src/conversation.ts
@@ -3,7 +3,7 @@
 
 import { PromptSection } from "typechat";
 import { IConversation, DateRange } from "./interfaces.js";
-import { openai, TextEmbeddingModel } from "@typeagent/aiclient";
+import { tryCreateEmbeddingModel, TextEmbeddingModel } from "@typeagent/aiclient";
 import {
     TextEmbeddingIndexSettings,
     createTextEmbeddingIndexSettings,
@@ -19,12 +19,23 @@ export interface ConversationSettings {
     semanticRefIndexSettings: SemanticRefIndexSettings;
 }
 
+let embeddingUnavailableAnnounced = false;
+
 export function createConversationSettings(
     embeddingModel?: TextEmbeddingModel | undefined,
     embeddingSize?: number,
 ): ConversationSettings {
-    embeddingModel ??= openai.createEmbeddingModel();
+    // May be undefined when no embedding provider is configured (e.g. Copilot
+    // self-host without a local embedder). Embedding-backed indexes then no-op
+    // and search degrades to exact/alias/edit-distance matching.
+    embeddingModel ??= tryCreateEmbeddingModel();
     embeddingSize ??= 1536;
+    if (embeddingModel === undefined && !embeddingUnavailableAnnounced) {
+        embeddingUnavailableAnnounced = true;
+        console.warn(
+            "knowPro: no embedding provider configured. Semantic (embedding) search over messages and semantic related-term expansion are disabled; exact, alias, and edit-distance matching remain available.",
+        );
+    }
     const minCosineSimilarity = 0.85;
     return {
         relatedTermIndexSettings: {

--- a/ts/packages/knowPro/src/fuzzyIndex.ts
+++ b/ts/packages/knowPro/src/fuzzyIndex.ts
@@ -320,6 +320,15 @@ export class TextEmbeddingIndex {
     }
 
     /**
+     * True when an embedding model is available. When false, this index
+     * silently no-ops indexing and returns no matches on lookup, allowing
+     * self-host deployments without an embedding provider to keep working.
+     */
+    public get isEmbeddingEnabled(): boolean {
+        return this.settings.embeddingModel !== undefined;
+    }
+
+    /**
      * Convert text into embeddings and add them to the internal index.
      * This can throw
      * @param textToIndex
@@ -327,6 +336,9 @@ export class TextEmbeddingIndex {
     public async addText(
         textToIndex: string | string[],
     ): Promise<ListIndexingResult> {
+        if (this.settings.embeddingModel === undefined) {
+            return { numberCompleted: 0 };
+        }
         return addTextToEmbeddingIndex(
             this.embeddingIndex,
             this.settings.embeddingModel,
@@ -346,6 +358,9 @@ export class TextEmbeddingIndex {
         eventHandler?: IndexingEventHandlers,
         batchSize?: number,
     ): Promise<ListIndexingResult> {
+        if (this.settings.embeddingModel === undefined) {
+            return { numberCompleted: 0 };
+        }
         return addTextBatchToEmbeddingIndex(
             this.embeddingIndex,
             this.settings.embeddingModel,
@@ -364,6 +379,9 @@ export class TextEmbeddingIndex {
         maxMatches?: number,
         minScore?: number,
     ): Promise<Scored[]> {
+        if (this.settings.embeddingModel === undefined) {
+            return [];
+        }
         maxMatches ??= this.settings.maxMatches;
         minScore ??= this.settings.minScore;
         return indexOfNearestTextInIndex(
@@ -380,6 +398,9 @@ export class TextEmbeddingIndex {
         maxMatches?: number,
         minScore?: number,
     ): Promise<Scored[][]> {
+        if (this.settings.embeddingModel === undefined) {
+            return [];
+        }
         maxMatches ??= this.settings.maxMatches;
         minScore ??= this.settings.minScore;
         return indexesOfNearestTextBatchInIndex(
@@ -417,7 +438,7 @@ export function deserializeEmbedding(array: number[]): NormalizedEmbedding {
 }
 
 export type TextEmbeddingIndexSettings = {
-    embeddingModel: TextEmbeddingModel;
+    embeddingModel: TextEmbeddingModel | undefined;
     embeddingSize: number;
     minScore: number;
     maxMatches?: number | undefined;
@@ -427,7 +448,7 @@ export type TextEmbeddingIndexSettings = {
 };
 
 export function createTextEmbeddingIndexSettings(
-    embeddingModel: TextEmbeddingModel,
+    embeddingModel: TextEmbeddingModel | undefined,
     embeddingSize: number,
     minScore?: number,
     maxMatches?: number,

--- a/ts/packages/knowPro/src/messageIndex.ts
+++ b/ts/packages/knowPro/src/messageIndex.ts
@@ -66,7 +66,9 @@ export class MessageTextIndex implements IMessageTextEmbeddingIndex {
      * ranking (see isMessageTextEmbeddingIndex and search.ts).
      */
     public get isEmbeddingEnabled(): boolean {
-        return this.settings.embeddingIndexSettings.embeddingModel !== undefined;
+        return (
+            this.settings.embeddingIndexSettings.embeddingModel !== undefined
+        );
     }
 
     public addMessages(
@@ -127,7 +129,8 @@ export class MessageTextIndex implements IMessageTextEmbeddingIndex {
 
     public generateEmbedding(text: string): Promise<NormalizedEmbedding> {
         // Note: if you rename generateEmbedding, be sure to also fix isMessageTextEmbeddingIndex
-        const embeddingModel = this.settings.embeddingIndexSettings.embeddingModel;
+        const embeddingModel =
+            this.settings.embeddingIndexSettings.embeddingModel;
         if (embeddingModel === undefined) {
             throw new Error(
                 "Message text embedding index is disabled (no embedding model configured)",

--- a/ts/packages/knowPro/src/messageIndex.ts
+++ b/ts/packages/knowPro/src/messageIndex.ts
@@ -31,6 +31,7 @@ export interface IMessageTextIndexData {
 
 export interface IMessageTextEmbeddingIndex extends IMessageTextIndex {
     readonly size: number;
+    readonly isEmbeddingEnabled?: boolean;
     generateEmbedding(text: string): Promise<NormalizedEmbedding>;
     lookupByEmbedding(
         textEmbedding: NormalizedEmbedding,
@@ -57,6 +58,15 @@ export class MessageTextIndex implements IMessageTextEmbeddingIndex {
 
     public get size(): number {
         return this.textLocationIndex.size;
+    }
+
+    /**
+     * True only when an embedding model is available. When false, message
+     * semantic search is disabled and callers fall back to non-embedding
+     * ranking (see isMessageTextEmbeddingIndex and search.ts).
+     */
+    public get isEmbeddingEnabled(): boolean {
+        return this.settings.embeddingIndexSettings.embeddingModel !== undefined;
     }
 
     public addMessages(
@@ -117,10 +127,13 @@ export class MessageTextIndex implements IMessageTextEmbeddingIndex {
 
     public generateEmbedding(text: string): Promise<NormalizedEmbedding> {
         // Note: if you rename generateEmbedding, be sure to also fix isMessageTextEmbeddingIndex
-        return generateEmbeddingWithRetry(
-            this.settings.embeddingIndexSettings.embeddingModel,
-            text,
-        );
+        const embeddingModel = this.settings.embeddingIndexSettings.embeddingModel;
+        if (embeddingModel === undefined) {
+            throw new Error(
+                "Message text embedding index is disabled (no embedding model configured)",
+            );
+        }
+        return generateEmbeddingWithRetry(embeddingModel, text);
     }
 
     public lookupByEmbedding(
@@ -236,6 +249,7 @@ export function isMessageTextEmbeddingIndex(
     return (
         textIndex.generateEmbedding !== undefined &&
         textIndex.lookupByEmbedding !== undefined &&
-        textIndex.lookupInSubsetByEmbedding !== undefined
+        textIndex.lookupInSubsetByEmbedding !== undefined &&
+        (textIndex.isEmbeddingEnabled ?? true)
     );
 }

--- a/ts/packages/knowPro/src/relatedTermsIndex.ts
+++ b/ts/packages/knowPro/src/relatedTermsIndex.ts
@@ -89,13 +89,22 @@ export type RelatedTermIndexSettings = {
 export class RelatedTermsIndex implements ITermToRelatedTermsIndex {
     private aliasMap: TermToRelatedTermsMap;
     private embeddingIndex: TermEmbeddingIndex | undefined;
+    private fuzzyTermIndex: TermEmbeddingIndex | TermEditDistanceIndex | undefined;
 
     constructor(public settings: RelatedTermIndexSettings) {
         this.aliasMap = new TermToRelatedTermsMap();
         if (settings.embeddingIndexSettings) {
-            this.embeddingIndex = new TermEmbeddingIndex(
-                settings.embeddingIndexSettings,
-            );
+            if (settings.embeddingIndexSettings.embeddingModel !== undefined) {
+                this.embeddingIndex = new TermEmbeddingIndex(
+                    settings.embeddingIndexSettings,
+                );
+                this.fuzzyTermIndex = this.embeddingIndex;
+            } else {
+                // No embedding provider: fall back to Levenshtein edit-distance
+                // fuzzy matching so related-term expansion still works (with
+                // reduced recall) instead of being disabled entirely.
+                this.fuzzyTermIndex = new TermEditDistanceIndex();
+            }
         }
     }
 
@@ -103,8 +112,11 @@ export class RelatedTermsIndex implements ITermToRelatedTermsIndex {
         return this.aliasMap;
     }
 
-    public get fuzzyIndex() {
-        return this.embeddingIndex;
+    public get fuzzyIndex():
+        | TermEmbeddingIndex
+        | TermEditDistanceIndex
+        | undefined {
+        return this.fuzzyTermIndex;
     }
 
     public serialize(): ITermsToRelatedTermsIndexData {
@@ -122,12 +134,15 @@ export class RelatedTermsIndex implements ITermToRelatedTermsIndex {
             }
             if (
                 data.textEmbeddingData &&
-                this.settings.embeddingIndexSettings
+                this.settings.embeddingIndexSettings &&
+                this.settings.embeddingIndexSettings.embeddingModel !==
+                    undefined
             ) {
                 this.embeddingIndex = new TermEmbeddingIndex(
                     this.settings.embeddingIndexSettings,
                 );
                 this.embeddingIndex.deserialize(data.textEmbeddingData);
+                this.fuzzyTermIndex = this.embeddingIndex;
             }
         }
     }
@@ -413,10 +428,18 @@ export class TermEmbeddingIndex
 
 export class TermEditDistanceIndex
     extends TextEditDistanceIndex
-    implements ITermToRelatedTermsFuzzy
+    implements ITermToRelatedTermsFuzzy, TextEmbeddingCache
 {
     constructor(textArray: string[] = []) {
         super(textArray);
+    }
+
+    /**
+     * Edit-distance matching keeps no embeddings, so there is nothing to cache.
+     * Implemented to satisfy TextEmbeddingCache consumers of fuzzyIndex.
+     */
+    public getEmbedding(_text: string): number[] | undefined {
+        return undefined;
     }
 
     public async addTerms(terms: string[]): Promise<ListIndexingResult> {

--- a/ts/packages/knowPro/src/relatedTermsIndex.ts
+++ b/ts/packages/knowPro/src/relatedTermsIndex.ts
@@ -89,7 +89,10 @@ export type RelatedTermIndexSettings = {
 export class RelatedTermsIndex implements ITermToRelatedTermsIndex {
     private aliasMap: TermToRelatedTermsMap;
     private embeddingIndex: TermEmbeddingIndex | undefined;
-    private fuzzyTermIndex: TermEmbeddingIndex | TermEditDistanceIndex | undefined;
+    private fuzzyTermIndex:
+        | TermEmbeddingIndex
+        | TermEditDistanceIndex
+        | undefined;
 
     constructor(public settings: RelatedTermIndexSettings) {
         this.aliasMap = new TermToRelatedTermsMap();

--- a/ts/packages/knowPro/src/serialization.ts
+++ b/ts/packages/knowPro/src/serialization.ts
@@ -72,7 +72,10 @@ export async function readConversationDataFromFile(
         fileData,
         embeddingSize,
     );
-    if (!embeddingsCompatible && getStoredEmbeddingSize(fileData) !== undefined) {
+    if (
+        !embeddingsCompatible &&
+        getStoredEmbeddingSize(fileData) !== undefined
+    ) {
         console.warn(
             `knowPro: persisted embeddings (size ${getStoredEmbeddingSize(fileData)}) are incompatible with the current embedding model (size ${embeddingSize ?? "none"}). Dropping stored vectors; affected indexes will rebuild.`,
         );
@@ -109,7 +112,10 @@ export async function readConversationDataFromBuffer(
         fileData,
         embeddingSize,
     );
-    if (!embeddingsCompatible && getStoredEmbeddingSize(fileData) !== undefined) {
+    if (
+        !embeddingsCompatible &&
+        getStoredEmbeddingSize(fileData) !== undefined
+    ) {
         console.warn(
             `knowPro: persisted embeddings (size ${getStoredEmbeddingSize(fileData)}) are incompatible with the current embedding model (size ${embeddingSize ?? "none"}). Dropping stored vectors; affected indexes will rebuild.`,
         );

--- a/ts/packages/knowPro/src/serialization.ts
+++ b/ts/packages/knowPro/src/serialization.ts
@@ -68,7 +68,17 @@ export async function readConversationDataFromFile(
     };
     validateFileData(fileData, embeddingSize);
     let embeddings: Float32Array[] | undefined;
-    if (embeddingSize && embeddingSize > 0) {
+    const embeddingsCompatible = arePersistedEmbeddingsCompatible(
+        fileData,
+        embeddingSize,
+    );
+    if (!embeddingsCompatible && getStoredEmbeddingSize(fileData) !== undefined) {
+        console.warn(
+            `knowPro: persisted embeddings (size ${getStoredEmbeddingSize(fileData)}) are incompatible with the current embedding model (size ${embeddingSize ?? "none"}). Dropping stored vectors; affected indexes will rebuild.`,
+        );
+        dropPersistedEmbeddings(fileData.jsonData);
+    }
+    if (embeddingsCompatible && embeddingSize && embeddingSize > 0) {
         const embeddingsBuffer = await readFile(
             path.join(dirPath, baseFileName + EmbeddingFileSuffix),
         );
@@ -90,16 +100,27 @@ export async function readConversationDataFromBuffer(
         return undefined;
     }
     let embeddings: Float32Array[] | undefined;
-    if (embeddingSize && embeddingSize > 0) {
-        if (embeddingsBuffer) {
-            embeddings = deserializeEmbeddings(embeddingsBuffer, embeddingSize);
-        }
-    }
     let fileData: ConversationFileData = {
         jsonData: JSON.parse(jsonData),
-        binaryData: { embeddings },
+        binaryData: {},
     };
     validateFileData(fileData);
+    const embeddingsCompatible = arePersistedEmbeddingsCompatible(
+        fileData,
+        embeddingSize,
+    );
+    if (!embeddingsCompatible && getStoredEmbeddingSize(fileData) !== undefined) {
+        console.warn(
+            `knowPro: persisted embeddings (size ${getStoredEmbeddingSize(fileData)}) are incompatible with the current embedding model (size ${embeddingSize ?? "none"}). Dropping stored vectors; affected indexes will rebuild.`,
+        );
+        dropPersistedEmbeddings(fileData.jsonData);
+    }
+    if (embeddingsCompatible && embeddingSize && embeddingSize > 0) {
+        if (embeddingsBuffer) {
+            embeddings = deserializeEmbeddings(embeddingsBuffer, embeddingSize);
+            fileData.binaryData.embeddings = embeddings;
+        }
+    }
     fileData.jsonData.fileHeader ??= createFileHeader();
     return fromConversationFileData(fileData);
 }
@@ -154,15 +175,63 @@ function validateFileData(
     if (fileData.jsonData === undefined) {
         throw new Error(`${Error_FileCorrupt}: Missing json data`);
     }
-    if (expectedEmbeddingSize && fileData.jsonData.embeddingFileHeader) {
-        const actualEmbeddingSize =
+}
+
+/**
+ * The persisted embedding size, if the file records it.
+ */
+function getStoredEmbeddingSize(
+    fileData: ConversationFileData,
+): number | undefined {
+    if (fileData.jsonData?.embeddingFileHeader) {
+        return (
             fileData.jsonData.embeddingFileHeader.modelMetadata
-                ?.embeddingSize ?? modelMetadata_ada002().embeddingSize;
-        if (expectedEmbeddingSize !== actualEmbeddingSize) {
-            throw new Error(
-                `File has embeddings of size ${actualEmbeddingSize}, expected size ${expectedEmbeddingSize}`,
-            );
-        }
+                ?.embeddingSize ?? modelMetadata_ada002().embeddingSize
+        );
+    }
+    return undefined;
+}
+
+/**
+ * Returns true when the persisted embeddings can be loaded under the current
+ * embedding model. Incompatible (different-dimension) or absent expectations
+ * mean we must NOT load the persisted vectors.
+ *
+ * Persisted embedding indexes are fixed-dimension. When a self-host user
+ * switches embedding providers (e.g. Azure 1536-d -> local 384-d), the stored
+ * vectors are unusable. Rather than throw at load, we drop the stale vectors
+ * and let the affected indexes rebuild / degrade.
+ */
+function arePersistedEmbeddingsCompatible(
+    fileData: ConversationFileData,
+    expectedEmbeddingSize?: number | undefined,
+): boolean {
+    if (!expectedEmbeddingSize || expectedEmbeddingSize <= 0) {
+        // No embedding model available now: cannot use persisted vectors.
+        return false;
+    }
+    const storedSize = getStoredEmbeddingSize(fileData);
+    if (storedSize === undefined) {
+        return true;
+    }
+    return storedSize === expectedEmbeddingSize;
+}
+
+/**
+ * Clear persisted embedding vectors and their associated text so downstream
+ * deserialization sees consistent (empty) embedding indexes. The indexes will
+ * be repopulated the next time the conversation is indexed.
+ */
+function dropPersistedEmbeddings(jsonData: ConversationJsonData): void {
+    if (jsonData.relatedTermsIndexData?.textEmbeddingData) {
+        jsonData.relatedTermsIndexData.textEmbeddingData = undefined;
+    }
+    if (jsonData.messageIndexData?.indexData) {
+        jsonData.messageIndexData.indexData = undefined;
+    }
+    if (jsonData.embeddingFileHeader) {
+        jsonData.embeddingFileHeader.relatedCount = undefined;
+        jsonData.embeddingFileHeader.messageCount = undefined;
     }
 }
 

--- a/ts/packages/knowPro/src/textLocationIndex.ts
+++ b/ts/packages/knowPro/src/textLocationIndex.ts
@@ -64,6 +64,9 @@ export class TextToTextLocationIndex implements ITextToTextLocationIndex {
         text: string,
         textLocation: TextLocation,
     ): Promise<ListIndexingResult> {
+        if (this.settings.embeddingModel === undefined) {
+            return { numberCompleted: 0 };
+        }
         const result = await addTextToEmbeddingIndex(
             this.embeddingIndex,
             this.settings.embeddingModel,
@@ -80,6 +83,9 @@ export class TextToTextLocationIndex implements ITextToTextLocationIndex {
         eventHandler?: IndexingEventHandlers,
         batchSize?: number,
     ): Promise<ListIndexingResult> {
+        if (this.settings.embeddingModel === undefined) {
+            return { numberCompleted: 0 };
+        }
         const indexingEvents = createMessageIndexingEventHandler(
             textAndLocations,
             eventHandler,
@@ -106,6 +112,9 @@ export class TextToTextLocationIndex implements ITextToTextLocationIndex {
         maxMatches?: number,
         thresholdScore?: number,
     ): Promise<ScoredTextLocation[]> {
+        if (this.settings.embeddingModel === undefined) {
+            return [];
+        }
         const matches = await indexOfNearestTextInIndex(
             this.embeddingIndex,
             this.settings.embeddingModel,
@@ -136,6 +145,9 @@ export class TextToTextLocationIndex implements ITextToTextLocationIndex {
         maxMatches?: number,
         thresholdScore?: number,
     ): Promise<ScoredTextLocation[]> {
+        if (this.settings.embeddingModel === undefined) {
+            return [];
+        }
         const matches = await indexOfNearestTextInIndexSubset(
             this.embeddingIndex,
             this.settings.embeddingModel,

--- a/ts/packages/knowledgeProcessor/src/conversation/conversationManager.ts
+++ b/ts/packages/knowledgeProcessor/src/conversation/conversationManager.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 import path from "path";
-import { ChatModel, openai, tryCreateEmbeddingModel } from "@typeagent/aiclient";
+import {
+    ChatModel,
+    openai,
+    tryCreateEmbeddingModel,
+} from "@typeagent/aiclient";
 import {
     ObjectFolderSettings,
     SearchOptions,

--- a/ts/packages/knowledgeProcessor/src/conversation/conversationManager.ts
+++ b/ts/packages/knowledgeProcessor/src/conversation/conversationManager.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import path from "path";
-import { ChatModel, openai } from "@typeagent/aiclient";
+import { ChatModel, openai, tryCreateEmbeddingModel } from "@typeagent/aiclient";
 import {
     ObjectFolderSettings,
     SearchOptions,
@@ -406,16 +406,17 @@ export async function createConversationManager(
         if (existingConversation) {
             return existingConversation.settings;
         }
-        const embeddingModel = createEmbeddingCache(
-            openai.createEmbeddingModel(),
-            64,
-        );
+        const innerModel = tryCreateEmbeddingModel();
+        const embeddingModel =
+            innerModel === undefined
+                ? undefined
+                : createEmbeddingCache(innerModel, 64);
         return {
             indexSettings: {
                 caseSensitive: false,
                 concurrency: 2,
                 embeddingModel,
-                semanticIndex: true,
+                semanticIndex: embeddingModel !== undefined,
             },
         };
     }

--- a/ts/packages/memory/conversation/src/common.ts
+++ b/ts/packages/memory/conversation/src/common.ts
@@ -4,16 +4,23 @@
 import * as kpLib from "knowledge-processor";
 import * as kp from "knowpro";
 import * as ms from "memory-storage";
-import { openai } from "@typeagent/aiclient";
+import { tryCreateEmbeddingModel } from "@typeagent/aiclient";
 import { IndexFileSettings, IndexingState } from "./memory.js";
 
 export function createEmbeddingModelWithCache(
     cacheSize: number,
     getCache?: () => kpLib.TextEmbeddingCache | undefined,
     embeddingSize = 1536,
-): [kpLib.TextEmbeddingModelWithCache, number] {
+): [kpLib.TextEmbeddingModelWithCache | undefined, number] {
+    // May be undefined when no embedding provider is configured (e.g. Copilot
+    // self-host without a local embedder). Memory then indexes/searches with
+    // exact + alias + edit-distance matching and skips embedding-only features.
+    const innerModel = tryCreateEmbeddingModel();
+    if (innerModel === undefined) {
+        return [undefined, embeddingSize];
+    }
     const embeddingModel = kpLib.createEmbeddingCache(
-        openai.createEmbeddingModel(),
+        innerModel,
         cacheSize,
         getCache,
     );

--- a/ts/packages/memory/conversation/src/docMemory.ts
+++ b/ts/packages/memory/conversation/src/docMemory.ts
@@ -107,7 +107,10 @@ export class DocMemory
         tags?: string[],
     ) {
         settings ??= createDocMemorySettings();
-        if (!settings.embeddingModel.getPersistentCache) {
+        if (
+            settings.embeddingModel !== undefined &&
+            !settings.embeddingModel.getPersistentCache
+        ) {
             settings.embeddingModel.getPersistentCache = () =>
                 this.secondaryIndexes.termToRelatedTermsIndex.fuzzyIndex;
         }

--- a/ts/packages/memory/conversation/src/memory.ts
+++ b/ts/packages/memory/conversation/src/memory.ts
@@ -14,7 +14,7 @@ import { createEmbeddingModelWithCache } from "./common.js";
 
 export interface MemorySettings {
     languageModel: ChatModel;
-    embeddingModel: TextEmbeddingModelWithCache;
+    embeddingModel: TextEmbeddingModelWithCache | undefined;
     embeddingSize: number;
     conversationSettings: kp.ConversationSettings;
     queryTranslator?: kp.SearchQueryTranslator | undefined;
@@ -248,8 +248,10 @@ export abstract class Memory<
         this.settings.queryTranslator ??= kp.createSearchQueryTranslator(
             this.settings.languageModel,
         );
-        this.settings.embeddingModel.getPersistentCache = () =>
-            this.getPersistentEmbeddingCache();
+        if (this.settings.embeddingModel !== undefined) {
+            this.settings.embeddingModel.getPersistentCache = () =>
+                this.getPersistentEmbeddingCache();
+        }
 
         this.addStandardNoiseTerms();
     }
@@ -583,12 +585,16 @@ export abstract class Memory<
         // Turn off caching during indexing because:
         // - LRU caches will not be useful
         // - Any persistent caches will be rebuilt anyway
-        this.settings.embeddingModel.cacheEnabled = false;
+        if (this.settings.embeddingModel !== undefined) {
+            this.settings.embeddingModel.cacheEnabled = false;
+        }
     }
 
     protected endIndexing(): void {
         // See note in beginIndexing for why this was turned off during indexing
-        this.settings.embeddingModel.cacheEnabled = true;
+        if (this.settings.embeddingModel !== undefined) {
+            this.settings.embeddingModel.cacheEnabled = true;
+        }
     }
 
     public getModelInstructions(): PromptSection[] | undefined {

--- a/ts/packages/memory/image/src/imageCollection.ts
+++ b/ts/packages/memory/image/src/imageCollection.ts
@@ -23,7 +23,7 @@ import {
     SemanticRefCollection,
 } from "knowpro";
 import { createEmbeddingCache } from "knowledge-processor";
-import { openai, TextEmbeddingModel } from "@typeagent/aiclient";
+import { tryCreateEmbeddingModel, TextEmbeddingModel } from "@typeagent/aiclient";
 //import registerDebug from "debug";
 import sqlite from "better-sqlite3";
 import * as ms from "memory-storage";
@@ -265,13 +265,20 @@ export class ImageCollection
      * Create an embedding model that can just leverage those embeddings
      * @returns embedding model, size of embedding
      */
-    private createEmbeddingModel(): [TextEmbeddingModel, number] {
+    private createEmbeddingModel(): [TextEmbeddingModel | undefined, number] {
+        // Undefined when no embedding provider is configured; image semantic
+        // search is then disabled while exact/alias term search still works.
+        const innerModel = tryCreateEmbeddingModel();
         return [
-            createEmbeddingCache(
-                openai.createEmbeddingModel(),
-                64,
-                () => this.secondaryIndexes.termToRelatedTermsIndex.fuzzyIndex,
-            ),
+            innerModel === undefined
+                ? undefined
+                : createEmbeddingCache(
+                      innerModel,
+                      64,
+                      () =>
+                          this.secondaryIndexes.termToRelatedTermsIndex
+                              .fuzzyIndex,
+                  ),
             1536,
         ];
     }

--- a/ts/packages/memory/image/src/imageCollection.ts
+++ b/ts/packages/memory/image/src/imageCollection.ts
@@ -23,7 +23,10 @@ import {
     SemanticRefCollection,
 } from "knowpro";
 import { createEmbeddingCache } from "knowledge-processor";
-import { tryCreateEmbeddingModel, TextEmbeddingModel } from "@typeagent/aiclient";
+import {
+    tryCreateEmbeddingModel,
+    TextEmbeddingModel,
+} from "@typeagent/aiclient";
 //import registerDebug from "debug";
 import sqlite from "better-sqlite3";
 import * as ms from "memory-storage";


### PR DESCRIPTION
Add a typed embedding section to config and runtime (types, build, shim, tree) allowing selection of local/openai/azure/none and model/cacheDir. Update many agents and libraries to use tryCreateEmbeddingModel / isEmbeddingAvailable so embedding model can be undefined; components now degrade gracefully (no-ops, return empty results, fall back to edit-distance matching, and emit warnings) instead of failing when embeddings are unavailable. Add tests for embedding env flattening and shim round-trip. Improve handling of persisted embeddings compatibility and clearing stale vectors.