### PR TITLE
Add self-host provider and config generator during install

### DIFF
--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -106,11 +106,50 @@ openAI:
   maxRetryAttempts: 3
 
   # Ollama / local OpenAI-compatible endpoint.
-  # Also emits OLLAMA_ENDPOINT for backward compatibility.
+  # NOTE: use the BASE url here (no /v1/chat/completions). It is emitted verbatim
+  # as OLLAMA_ENDPOINT and the client appends the /v1/chat/completions (chat) and
+  # /v1/embeddings (embedding) paths itself. A full path here would be doubled.
   local:
     apiKey: None # Ollama doesn't require a key
-    endpoint: http://localhost:11434/v1/chat/completions
+    endpoint: http://localhost:11434
     model: phi3
+
+# ╔═══════════════════════════════════════════════════════════════════╗
+# ║  Self-host provider presets                                      ║
+# ╚═══════════════════════════════════════════════════════════════════╝
+#
+# For machines WITHOUT AI Systems Key Vault access, TypeAgent can run entirely
+# against a local (Ollama) or Copilot-SDK chat backend. The install scripts and
+# MSI generate one of these config.local.yaml shapes automatically via
+# `typeagent-serve.mjs provision --provider ollama|copilot`
+# (tools/scripts/generate-selfhost-config.mjs). The blocks below are the
+# equivalent hand-written config; omit the `vault:` section in these modes.
+#
+# --- Ollama (local chat + local embeddings) --------------------------------
+# modelProvider: ollama
+# openAI:
+#   apiKey: ollama            # dummy, non-empty
+#   local:
+#     apiKey: None
+#     endpoint: http://localhost:11434   # BASE url (see note above)
+#     model: llama3.2
+# embedding:
+#   provider: local           # bundled CPU-only model; no GPU / key / network
+#   model: Xenova/all-MiniLM-L6-v2
+#
+# --- Copilot (Copilot SDK chat + local embeddings) -------------------------
+# modelProvider: copilot
+# copilot:
+#   defaultModel: claude-sonnet-4.5   # requires an authenticated `copilot` CLI
+# embedding:
+#   provider: local
+#   model: Xenova/all-MiniLM-L6-v2
+#
+# To use Ollama for embeddings instead of the bundled local model, set
+# `embedding.provider: openai` and add
+# `openAI.endpointEmbedding: http://localhost:11434/v1/embeddings` (FULL path)
+# plus `openAI.modelEmbedding: nomic-embed-text`. Set `embedding.provider: none`
+# to disable embeddings entirely (semantic/fuzzy features degrade gracefully).
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  Azure Speech SDK                                                ║

--- a/ts/package.json
+++ b/ts/package.json
@@ -107,6 +107,7 @@
       "exifreader",
       "keytar",
       "koffi",
+      "onnxruntime-node",
       "protobufjs",
       "puppeteer",
       "sharp"

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -207,11 +207,11 @@ During an **interactive** install the MSI shows a provider-selection dialog
 / None), and an Ollama host field. The same choices can be driven **silently**
 through public properties:
 
-| Property     | Values                            | Default                   | Notes |
-|--------------|-----------------------------------|---------------------------|-------|
-| `PROVIDER`   | `AISYSTEMS`, `OLLAMA`, `COPILOT`  | `AISYSTEMS`               | `OLLAMA`/`COPILOT` generate `config.local.yaml` during install (no Key Vault). |
-| `EMBEDDING`  | `LOCAL`, `OLLAMA`, `OPENAI`, `NONE` | `LOCAL`                 | Embedding source for the self-host providers. `LOCAL` = bundled CPU-only model. |
-| `OLLAMAHOST` | any URL                           | `http://localhost:11434`  | Ollama base URL (used for `OLLAMA` chat and/or embeddings). |
+| Property     | Values                              | Default                  | Notes                                                                           |
+| ------------ | ----------------------------------- | ------------------------ | ------------------------------------------------------------------------------- |
+| `PROVIDER`   | `AISYSTEMS`, `OLLAMA`, `COPILOT`    | `AISYSTEMS`              | `OLLAMA`/`COPILOT` generate `config.local.yaml` during install (no Key Vault).  |
+| `EMBEDDING`  | `LOCAL`, `OLLAMA`, `OPENAI`, `NONE` | `LOCAL`                  | Embedding source for the self-host providers. `LOCAL` = bundled CPU-only model. |
+| `OLLAMAHOST` | any URL                             | `http://localhost:11434` | Ollama base URL (used for `OLLAMA` chat and/or embeddings).                     |
 
 ```powershell
 # AI Systems (default) — provisions via az login + getKeys after install

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -194,6 +194,50 @@ msiexec /i "$env:TEMP\typeagent-msi-stage\out\TypeAgent-0.0.1-local-win32-x64.ms
 Get-Item "$env:LOCALAPPDATA\TypeAgent\agent-server" -ErrorAction SilentlyContinue
 ```
 
+## Endpoint provider selection (self-host)
+
+TypeAgent needs an LLM endpoint configuration (`config.local.yaml`) at runtime.
+By default it is downloaded from the AI Systems Key Vault, but machines without
+Key Vault access can instead run against a local **Ollama** server or the
+**Copilot** SDK.
+
+During an **interactive** install the MSI shows a provider-selection dialog
+(after the license page) with radio-button groups for the chat provider
+(AI Systems / Ollama / Copilot), the embedding provider (Local / Ollama / OpenAI
+/ None), and an Ollama host field. The same choices can be driven **silently**
+through public properties:
+
+| Property     | Values                            | Default                   | Notes |
+|--------------|-----------------------------------|---------------------------|-------|
+| `PROVIDER`   | `AISYSTEMS`, `OLLAMA`, `COPILOT`  | `AISYSTEMS`               | `OLLAMA`/`COPILOT` generate `config.local.yaml` during install (no Key Vault). |
+| `EMBEDDING`  | `LOCAL`, `OLLAMA`, `OPENAI`, `NONE` | `LOCAL`                 | Embedding source for the self-host providers. `LOCAL` = bundled CPU-only model. |
+| `OLLAMAHOST` | any URL                           | `http://localhost:11434`  | Ollama base URL (used for `OLLAMA` chat and/or embeddings). |
+
+```powershell
+# AI Systems (default) — provisions via az login + getKeys after install
+msiexec /i TypeAgent-<version>-win32-x64.msi
+
+# Local Ollama chat with the bundled local embedding model
+msiexec /i TypeAgent-<version>-win32-x64.msi PROVIDER=OLLAMA
+
+# Copilot SDK chat (requires an authenticated `copilot` CLI) + local embeddings
+msiexec /i TypeAgent-<version>-win32-x64.msi PROVIDER=COPILOT
+
+# Fully silent
+msiexec /i TypeAgent-<version>-win32-x64.msi /quiet PROVIDER=OLLAMA EMBEDDING=LOCAL
+```
+
+The UI is a custom scheme (`WixUI_TypeAgent`): WelcomeDlg → LicenseAgreementDlg →
+**ProviderDlg** → VerifyReadyDlg. For `OLLAMA`/`COPILOT`, a deferred, impersonated
+custom action runs `node "[INSTALLFOLDER]typeagent-serve.mjs" provision --provider
+[PROVIDER] --embedding [EMBEDDING] --ollama-host [OLLAMAHOST] --force` as the
+installing user, writing `config.local.yaml` to `~/.typeagent`. For `AISYSTEMS`
+(the default), config provisioning remains an interactive post-install step
+(`az login` + `getKeys`), since it requires browser/device authentication that a
+silent installer cannot perform. Fine-grained overrides (chat model, embedding
+endpoint, API keys) are available on the `provision`/`generate-selfhost-config`
+CLI; re-run provisioning post-install to adjust them.
+
 ## Pipeline Usage
 
 ### Automatic (on `main` branch)

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -40,6 +40,18 @@
     <MajorUpgrade DowngradeErrorMessage="A newer version of TypeAgent is already installed." />
 
     <!-- ═══════════════════════════════════════════════
+         Endpoint provider selection (self-host)
+         Public properties (pass uppercase on the msiexec command line, e.g.
+           msiexec /i TypeAgent.msi PROVIDER=OLLAMA
+         AISYSTEMS (default) leaves config provisioning to the interactive
+         post-install step (az login + getKeys). OLLAMA/COPILOT synthesize a
+         config.local.yaml during install via generate-selfhost-config.
+         ═══════════════════════════════════════════════ -->
+    <Property Id="PROVIDER" Value="AISYSTEMS" Secure="yes" />
+    <Property Id="EMBEDDING" Value="LOCAL" Secure="yes" />
+    <Property Id="OLLAMAHOST" Value="http://localhost:11434" Secure="yes" />
+
+    <!-- ═══════════════════════════════════════════════
          Directory layout
          ═══════════════════════════════════════════════ -->
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -139,13 +151,151 @@
                   Return="ignore"
                   Impersonate="yes" />
 
+    <!-- ═══════════════════════════════════════════════
+         Custom action — self-host config provisioning
+         For PROVIDER=OLLAMA/COPILOT, synthesize config.local.yaml via
+         generate-selfhost-config (bundled under agent-server\tools). Runs as the
+         installing user so it writes to the user's ~/.typeagent config dir and so
+         'node' resolves from the user PATH. AISYSTEMS mode is skipped here (its
+         provisioning is the interactive az login + getKeys post-install step).
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="ProvisionSelfHostConfig"
+           Before="ProvisionSelfHostConfig"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;&amp; node '[INSTALLFOLDER]typeagent-serve.mjs' provision --provider '[PROVIDER]' --embedding '[EMBEDDING]' --ollama-host '[OLLAMAHOST]' --force&quot;" />
+
+    <CustomAction Id="ProvisionSelfHostConfig"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
     <InstallExecuteSequence>
       <Custom Action="RegisterCopilotPlugin"   After="InstallFiles">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="ProvisionSelfHostConfig" After="RegisterCopilotPlugin">(NOT REMOVE~="ALL") AND (PROVIDER&lt;&gt;"AISYSTEMS")</Custom>
       <Custom Action="UnregisterCopilotPlugin" Before="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
 
-    <!-- UI: minimal built-in sequence for install progress/finish -->
-    <UIRef Id="WixUI_Minimal" />
+    <!-- UI: custom sequence adding a provider/embedding selection dialog -->
+    <UIRef Id="WixUI_TypeAgent" />
 
   </Product>
+
+  <!-- ═══════════════════════════════════════════════
+       Custom UI scheme: WixUI_TypeAgent
+       WelcomeDlg → LicenseAgreementDlg → ProviderDlg → VerifyReadyDlg
+       Adds a provider/embedding selection dialog bound to the public
+       PROVIDER / EMBEDDING / OLLAMAHOST properties. Modeled on
+       WixUI_InstallDir (minus the install-directory dialog, since this
+       product installs to a fixed per-user location).
+       ═══════════════════════════════════════════════ -->
+  <Fragment>
+    <UI Id="WixUI_TypeAgent">
+      <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+      <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+      <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+
+      <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+      <Property Id="WixUI_Mode" Value="InstallDir" />
+
+      <DialogRef Id="ErrorDlg" />
+      <DialogRef Id="FatalError" />
+      <DialogRef Id="FilesInUse" />
+      <DialogRef Id="MsiRMFilesInUse" />
+      <DialogRef Id="PrepareDlg" />
+      <DialogRef Id="ProgressDlg" />
+      <DialogRef Id="ResumeDlg" />
+      <DialogRef Id="UserExit" />
+
+      <!-- ═══ Provider / embedding selection dialog ═══ -->
+      <Dialog Id="ProviderDlg" Width="370" Height="270" Title="[ProductName] Setup">
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
+                 TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
+        <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+        <Control Id="Title" Type="Text" X="15" Y="6" Width="300" Height="15"
+                 Transparent="yes" NoPrefix="yes"
+                 Text="{\WixUI_Font_Title}Endpoint providers" />
+        <Control Id="Description" Type="Text" X="25" Y="23" Width="330" Height="15"
+                 Transparent="yes" NoPrefix="yes"
+                 Text="Choose how TypeAgent connects to language models." />
+
+        <Control Id="ProviderLabel" Type="Text" X="20" Y="55" Width="330" Height="12"
+                 Transparent="yes" NoPrefix="yes"
+                 Text="{\WixUI_Font_Title}Completion (chat) provider" />
+        <Control Id="ProviderRadio" Type="RadioButtonGroup" X="24" Y="70"
+                 Width="326" Height="52" Property="PROVIDER">
+          <RadioButtonGroup Property="PROVIDER">
+            <RadioButton Value="AISYSTEMS" X="0" Y="0" Width="322" Height="16"
+                         Text="AI Systems — download config from Azure Key Vault (needs az login access)" />
+            <RadioButton Value="OLLAMA" X="0" Y="17" Width="322" Height="16"
+                         Text="Ollama — local OpenAI-compatible server (no Key Vault)" />
+            <RadioButton Value="COPILOT" X="0" Y="34" Width="322" Height="16"
+                         Text="GitHub Copilot — Copilot SDK chat via an authenticated copilot CLI" />
+          </RadioButtonGroup>
+        </Control>
+
+        <Control Id="EmbeddingLabel" Type="Text" X="20" Y="128" Width="330" Height="12"
+                 Transparent="yes" NoPrefix="yes"
+                 Text="{\WixUI_Font_Title}Embedding provider (Ollama / Copilot only)" />
+        <Control Id="EmbeddingRadio" Type="RadioButtonGroup" X="24" Y="143"
+                 Width="326" Height="52" Property="EMBEDDING">
+          <RadioButtonGroup Property="EMBEDDING">
+            <RadioButton Value="LOCAL" X="0" Y="0" Width="322" Height="14"
+                         Text="Local — bundled CPU-only model (no GPU, API key or network)" />
+            <RadioButton Value="OLLAMA" X="0" Y="14" Width="322" Height="14"
+                         Text="Ollama — embeddings from the local Ollama server" />
+            <RadioButton Value="OPENAI" X="0" Y="28" Width="322" Height="14"
+                         Text="OpenAI — embeddings from an OpenAI endpoint (configure post-install)" />
+            <RadioButton Value="NONE" X="0" Y="42" Width="322" Height="14"
+                         Text="None — disable embeddings (semantic features degrade gracefully)" />
+          </RadioButtonGroup>
+        </Control>
+
+        <Control Id="OllamaHostLabel" Type="Text" X="20" Y="205" Width="70" Height="14"
+                 Transparent="yes" NoPrefix="yes" Text="Ollama host:" />
+        <Control Id="OllamaHostEdit" Type="Edit" X="92" Y="203" Width="258" Height="16"
+                 Property="OLLAMAHOST" Text="{80}" />
+
+        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+                 Text="!(loc.WixUIBack)" />
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17"
+                 Default="yes" Text="!(loc.WixUINext)" />
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17"
+                 Cancel="yes" Text="!(loc.WixUICancel)">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+      </Dialog>
+
+      <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+
+      <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="ProviderDlg">LicenseAccepted = "1"</Publish>
+
+      <Publish Dialog="ProviderDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+      <Publish Dialog="ProviderDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ProviderDlg" Order="1">NOT Installed</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="3">Installed AND PATCH</Publish>
+
+      <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+
+      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+
+      <InstallUISequence>
+        <Show Dialog="WelcomeDlg" Before="ProgressDlg">NOT Installed</Show>
+      </InstallUISequence>
+
+      <Property Id="ARPNOMODIFY" Value="1" />
+    </UI>
+
+    <UIRef Id="WixUI_Common" />
+  </Fragment>
 </Wix>

--- a/ts/tools/scripts/deployAgentServer.mjs
+++ b/ts/tools/scripts/deployAgentServer.mjs
@@ -173,6 +173,12 @@ function main() {
         path.join(toolsOut, "getKeys.config.json"),
     );
     copyInto(path.join(scriptsDir, "lib"), path.join(toolsOut, "lib"));
+    // Self-host config generator (used by `provision --provider ollama|copilot`
+    // on machines without AI Systems Key Vault access).
+    copyInto(
+        path.join(scriptsDir, "generate-selfhost-config.mjs"),
+        path.join(toolsOut, "generate-selfhost-config.mjs"),
+    );
     const sample = path.join(tsRoot, "config.sample.yaml");
     if (fs.existsSync(sample)) {
         copyInto(sample, path.join(toolsOut, "config.sample.yaml"));

--- a/ts/tools/scripts/generate-selfhost-config.mjs
+++ b/ts/tools/scripts/generate-selfhost-config.mjs
@@ -78,10 +78,7 @@ function resolveOutPath() {
         return path.resolve(process.env.TYPEAGENT_CONFIG_LOCAL);
     }
     if (process.env.TYPEAGENT_CONFIG_DIR) {
-        return path.join(
-            process.env.TYPEAGENT_CONFIG_DIR,
-            "config.local.yaml",
-        );
+        return path.join(process.env.TYPEAGENT_CONFIG_DIR, "config.local.yaml");
     }
     return path.resolve(__dirname, "../../config.local.yaml");
 }
@@ -194,8 +191,7 @@ function buildConfigTree(options) {
             openAI.apiKey ??= "sk-REPLACE_ME";
             openAI.endpointEmbedding =
                 embeddingEndpoint || "https://api.openai.com/v1/embeddings";
-            openAI.modelEmbedding =
-                embeddingModel || "text-embedding-3-small";
+            openAI.modelEmbedding = embeddingModel || "text-embedding-3-small";
             embeddingSection.provider = "openai";
             break;
         case "none":
@@ -285,9 +281,7 @@ function main() {
             `  Prereq: 'ollama serve' running with the '${options.chatModel || DEFAULT_OLLAMA_CHAT_MODEL}' model pulled.`,
         );
     } else {
-        console.log(
-            "  Prereq: an authenticated 'copilot' CLI (github login).",
-        );
+        console.log("  Prereq: an authenticated 'copilot' CLI (github login).");
     }
     if (embedding === "local") {
         console.log(

--- a/ts/tools/scripts/generate-selfhost-config.mjs
+++ b/ts/tools/scripts/generate-selfhost-config.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * generate-selfhost-config — emit a config.local.yaml for self-host machines
+ * that do NOT have access to the AI Systems Key Vault.
+ *
+ * This is the single source of truth for the "provider choice" self-host flow:
+ * the install scripts and the MSI both call it (via
+ * `typeagent-serve.mjs provision --provider <mode>`) instead of the Key Vault
+ * (`getKeys`) path.
+ *
+ * Two chat providers are supported:
+ *   - ollama:  local OpenAI-compatible chat (`ollama serve`).
+ *   - copilot: GitHub Copilot SDK chat (requires an authenticated `copilot` CLI).
+ *
+ * Embeddings are independent of the chat provider (the Copilot SDK has none).
+ * By default we configure the bundled CPU-only local embedder (transformers.js,
+ * no GPU / API key / network at runtime after first download). Callers can
+ * instead point at an Ollama or OpenAI embedding endpoint, or disable embeddings
+ * entirely (embedding-dependent features then degrade gracefully).
+ *
+ * Config path precedence mirrors getKeys / the @typeagent/config loader:
+ *   --out
+ *   > TYPEAGENT_CONFIG_LOCAL
+ *   > <TYPEAGENT_CONFIG_DIR>/config.local.yaml
+ *   > <repo ts/>/config.local.yaml   (in-repo default; unchanged for devs)
+ *
+ * Usage:
+ *   node generate-selfhost-config.mjs --provider ollama|copilot [options]
+ *
+ * Options:
+ *   --out <path>                Output file (overrides env-based resolution).
+ *   --force                     Overwrite an existing config.local.yaml.
+ *   --ollama-host <url>         Ollama base URL (default http://localhost:11434).
+ *   --chat-model <name>         Ollama chat model (default llama3.2).
+ *   --copilot-model <name>      Copilot chat model (default claude-sonnet-4.5).
+ *   --embedding <mode>          local (default) | ollama | openai | none.
+ *   --embedding-endpoint <url>  Embedding endpoint (openai mode; full path).
+ *   --embedding-model <name>    Embedding model name.
+ *   --local-embedding-model <n> transformers.js model (default Xenova/all-MiniLM-L6-v2).
+ *   --openai-key <key>          API key for openai embedding mode.
+ *   --dry-run                   Print the YAML to stdout without writing.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
+const DEFAULT_OLLAMA_CHAT_MODEL = "llama3.2";
+const DEFAULT_COPILOT_MODEL = "claude-sonnet-4.5";
+const DEFAULT_LOCAL_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
+const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
+
+function arg(name, fallback) {
+    const i = process.argv.indexOf(name);
+    return i !== -1 && i + 1 < process.argv.length
+        ? process.argv[i + 1]
+        : fallback;
+}
+
+function hasFlag(name) {
+    return process.argv.includes(name);
+}
+
+// Match getKeys.mjs / the loader's output-path precedence.
+function resolveOutPath() {
+    const explicit = arg("--out");
+    if (explicit) {
+        return path.resolve(explicit);
+    }
+    if (process.env.TYPEAGENT_CONFIG_LOCAL) {
+        return path.resolve(process.env.TYPEAGENT_CONFIG_LOCAL);
+    }
+    if (process.env.TYPEAGENT_CONFIG_DIR) {
+        return path.join(
+            process.env.TYPEAGENT_CONFIG_DIR,
+            "config.local.yaml",
+        );
+    }
+    return path.resolve(__dirname, "../../config.local.yaml");
+}
+
+// Strip a trailing chat path from an Ollama URL so we keep only the base
+// (aiclient appends /v1/chat/completions itself for OLLAMA_ENDPOINT).
+function ollamaBaseUrl(url) {
+    let base = (url ?? DEFAULT_OLLAMA_HOST).trim().replace(/\/+$/, "");
+    base = base.replace(/\/v1\/chat\/completions$/i, "");
+    base = base.replace(/\/v1$/i, "");
+    return base;
+}
+
+// Minimal YAML emitter for the flat/nested shape we produce. Values are only
+// strings/numbers here, so quote strings that could otherwise be misparsed.
+function yamlScalar(value) {
+    if (typeof value === "number") {
+        return String(value);
+    }
+    const s = String(value);
+    // Quote when it contains characters YAML would treat specially, or looks
+    // like a non-string scalar. URLs (with ':') as *values* are fine unquoted
+    // in block style, but quoting is safest for keys like api paths.
+    if (
+        s === "" ||
+        /^[\s]|[\s]$/.test(s) ||
+        /[:#{}\[\],&*!|>'"%@`]/.test(s) ||
+        /^(true|false|null|yes|no|on|off|~)$/i.test(s) ||
+        /^[-+]?\d/.test(s)
+    ) {
+        return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    }
+    return s;
+}
+
+// Render a nested plain-object tree into block-style YAML.
+function renderYaml(node, indent = 0) {
+    const pad = "  ".repeat(indent);
+    let out = "";
+    for (const [key, value] of Object.entries(node)) {
+        if (value === undefined || value === null) {
+            continue;
+        }
+        if (typeof value === "object" && !Array.isArray(value)) {
+            const nested = renderYaml(value, indent + 1);
+            if (nested.trim().length === 0) {
+                continue;
+            }
+            out += `${pad}${key}:\n${nested}`;
+        } else {
+            out += `${pad}${key}: ${yamlScalar(value)}\n`;
+        }
+    }
+    return out;
+}
+
+function buildConfigTree(options) {
+    const {
+        provider,
+        ollamaHost,
+        chatModel,
+        copilotModel,
+        embedding,
+        embeddingEndpoint,
+        embeddingModel,
+        localEmbeddingModel,
+        openaiKey,
+    } = options;
+
+    const tree = {};
+    tree.modelProvider = provider;
+
+    const openAI = {};
+    if (provider === "ollama") {
+        // Ollama exposes an OpenAI-compatible surface. The `local` sub-section
+        // emits OLLAMA_ENDPOINT (base URL; aiclient appends the chat path).
+        openAI.apiKey = "ollama"; // dummy, non-empty
+        openAI.local = {
+            apiKey: "None",
+            endpoint: ollamaBaseUrl(ollamaHost),
+            model: chatModel || DEFAULT_OLLAMA_CHAT_MODEL,
+        };
+    }
+
+    if (provider === "copilot") {
+        tree.copilot = {
+            defaultModel: copilotModel || DEFAULT_COPILOT_MODEL,
+        };
+    }
+
+    // Embedding wiring (independent of chat provider).
+    const embeddingSection = {};
+    switch (embedding) {
+        case "local":
+            embeddingSection.provider = "local";
+            embeddingSection.model =
+                localEmbeddingModel || DEFAULT_LOCAL_EMBEDDING_MODEL;
+            break;
+        case "ollama":
+            openAI.apiKey ??= "ollama";
+            openAI.endpointEmbedding = `${ollamaBaseUrl(ollamaHost)}/v1/embeddings`;
+            openAI.modelEmbedding =
+                embeddingModel || DEFAULT_OLLAMA_EMBEDDING_MODEL;
+            embeddingSection.provider = "openai";
+            break;
+        case "openai":
+            if (openaiKey) {
+                openAI.apiKey = openaiKey;
+            }
+            openAI.apiKey ??= "sk-REPLACE_ME";
+            openAI.endpointEmbedding =
+                embeddingEndpoint || "https://api.openai.com/v1/embeddings";
+            openAI.modelEmbedding =
+                embeddingModel || "text-embedding-3-small";
+            embeddingSection.provider = "openai";
+            break;
+        case "none":
+            embeddingSection.provider = "none";
+            break;
+        default:
+            throw new Error(`Unknown embedding mode: ${embedding}`);
+    }
+
+    if (Object.keys(openAI).length > 0) {
+        tree.openAI = openAI;
+    }
+    tree.embedding = embeddingSection;
+    return tree;
+}
+
+function header(provider, embedding) {
+    return [
+        "# Copyright (c) Microsoft Corporation.",
+        "# Licensed under the MIT License.",
+        "#",
+        "# TypeAgent self-host configuration (generated).",
+        `# Chat provider: ${provider}. Embedding source: ${embedding}.`,
+        "# This file replaces the Key Vault download for machines without AI",
+        "# Systems access. Regenerate with generate-selfhost-config.mjs.",
+        "#",
+        "# NOTE: no `vault:` section — this deployment does not use Key Vault.",
+        "",
+        "",
+    ].join("\n");
+}
+
+function main() {
+    const provider = (arg("--provider") ?? "").toLowerCase();
+    if (provider !== "ollama" && provider !== "copilot") {
+        console.error(
+            "generate-selfhost-config: --provider must be 'ollama' or 'copilot'.\n" +
+                "(AI Systems provisioning uses getKeys, not this generator.)",
+        );
+        return 1;
+    }
+
+    let embedding = (arg("--embedding") ?? "local").toLowerCase();
+    const validEmbedding = ["local", "ollama", "openai", "none"];
+    if (!validEmbedding.includes(embedding)) {
+        console.error(
+            `generate-selfhost-config: --embedding must be one of ${validEmbedding.join(", ")}.`,
+        );
+        return 1;
+    }
+
+    const options = {
+        provider,
+        ollamaHost: arg("--ollama-host", DEFAULT_OLLAMA_HOST),
+        chatModel: arg("--chat-model"),
+        copilotModel: arg("--copilot-model"),
+        embedding,
+        embeddingEndpoint: arg("--embedding-endpoint"),
+        embeddingModel: arg("--embedding-model"),
+        localEmbeddingModel: arg("--local-embedding-model"),
+        openaiKey: arg("--openai-key"),
+    };
+
+    const tree = buildConfigTree(options);
+    const yaml = header(provider, embedding) + renderYaml(tree);
+
+    if (hasFlag("--dry-run")) {
+        process.stdout.write(yaml);
+        return 0;
+    }
+
+    const outPath = resolveOutPath();
+    if (fs.existsSync(outPath) && !hasFlag("--force")) {
+        console.error(
+            `Refusing to overwrite existing ${outPath} (pass --force to replace it).`,
+        );
+        return 1;
+    }
+
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, yaml, "utf8");
+    console.log(
+        `Wrote self-host config (${provider} chat, ${embedding} embeddings) to ${outPath}`,
+    );
+    if (provider === "ollama") {
+        console.log(
+            `  Prereq: 'ollama serve' running with the '${options.chatModel || DEFAULT_OLLAMA_CHAT_MODEL}' model pulled.`,
+        );
+    } else {
+        console.log(
+            "  Prereq: an authenticated 'copilot' CLI (github login).",
+        );
+    }
+    if (embedding === "local") {
+        console.log(
+            "  Embeddings: bundled CPU-only local model (downloads weights on first use).",
+        );
+    } else if (embedding === "none") {
+        console.log(
+            "  Embeddings: disabled — semantic search / fuzzy features degrade gracefully.",
+        );
+    }
+    return 0;
+}
+
+process.exit(main());

--- a/ts/tools/scripts/install-typeagent.ps1
+++ b/ts/tools/scripts/install-typeagent.ps1
@@ -17,18 +17,22 @@
        variant bundles those runtimes, so this step is skipped.
     3. Downloads the agent-server Universal package for this RID from the feed.
     4. Installs and registers the Copilot CLI plugin (from feed by default, or -PluginSource).
-    5. Runs config provisioning (getKeys, browser login) and starts the daemon
-       via the artifact's typeagent-serve.mjs.
+    5. Runs config provisioning and starts the daemon via the artifact's
+       typeagent-serve.mjs. Config provisioning depends on -Provider:
+         aisystems (default) - getKeys + browser login (AI Systems Key Vault).
+         ollama / copilot     - synthesize config.local.yaml locally (no Key Vault).
     6. (Optional, -DevTunnel) sets up a Microsoft Dev Tunnel and hosts it so a
        client on another device can reach the service.
 
   Azure CLI (with az login) is used to download from the feed. This is the
-  install-time exception; runtime config provisioning still uses getKeys'
-  browser credential (no az login needed for that).
+  install-time exception; runtime config provisioning uses getKeys' browser
+  credential (aisystems) or a locally generated config (ollama/copilot).
 
 .EXAMPLE
   pwsh ./install-typeagent.ps1
   pwsh ./install-typeagent.ps1 -Variant full -Version 0.0.1-12345
+  pwsh ./install-typeagent.ps1 -Provider ollama    # local chat, no Key Vault
+  pwsh ./install-typeagent.ps1 -Provider copilot   # Copilot SDK chat, no Key Vault
   pwsh ./install-typeagent.ps1 -DevTunnel   # also expose the service via a Dev Tunnel
   pwsh ./install-typeagent.ps1 -BootstrapPrereqs
   pwsh ./install-typeagent.ps1 -Upgrade     # force fresh download, replacing existing assets
@@ -65,7 +69,23 @@ param(
     [switch]$DevTunnel,
     # With -DevTunnel: allow anonymous client access (WARNING: removes the only
     # access control on the otherwise-unauthenticated service). Default private.
-    [switch]$DevTunnelAnonymous
+    [switch]$DevTunnelAnonymous,
+    # Endpoint provider for LLM calls:
+    #   aisystems - download config from the AI Systems Key Vault (default, needs az login access).
+    #   ollama    - local OpenAI-compatible chat via 'ollama serve' (no Key Vault).
+    #   copilot   - GitHub Copilot SDK chat via an authenticated 'copilot' CLI (no Key Vault).
+    [ValidateSet("aisystems", "ollama", "copilot")]
+    [string]$Provider = "aisystems",
+    # Embedding source for ollama/copilot providers (independent of chat):
+    #   local (default, bundled CPU-only), ollama, openai, or none.
+    [ValidateSet("local", "ollama", "openai", "none")]
+    [string]$Embedding = "local",
+    [string]$OllamaHost = "http://localhost:11434",
+    [string]$ChatModel = "",
+    [string]$CopilotModel = "",
+    [string]$EmbeddingEndpoint = "",
+    [string]$EmbeddingModel = "",
+    [string]$OpenAIKey = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -542,37 +562,78 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "  Copilot plugin '$pluginName' registered successfully"
 
 # --- 5. Provision config + start the daemon ----------------------------------
-Write-Step "Provisioning config (getKeys, browser login)"
-$provisionOutput = & node $serve provision 2>&1
-$provisionExitCode = $LASTEXITCODE
-if ($provisionOutput) { $provisionOutput | ForEach-Object { Write-Host $_ } }
+if ($Provider -eq "aisystems") {
+    Write-Step "Provisioning config (getKeys, browser login)"
+    $provisionOutput = & node $serve provision 2>&1
+    $provisionExitCode = $LASTEXITCODE
+    if ($provisionOutput) { $provisionOutput | ForEach-Object { Write-Host $_ } }
 
-if ($provisionExitCode -ne 0) {
-    $provisionText = ($provisionOutput | Out-String)
-    $isKeyVaultAuthError = (
-        $provisionText -match "Caller is not authorized" -or
-        $provisionText -match "Microsoft\.KeyVault/vaults/secrets/getSecret/action" -or
-        $provisionText -match "Failed to read 'typeagent-config' from vault"
-    )
+    if ($provisionExitCode -ne 0) {
+        $provisionText = ($provisionOutput | Out-String)
+        $isKeyVaultAuthError = (
+            $provisionText -match "Caller is not authorized" -or
+            $provisionText -match "Microsoft\.KeyVault/vaults/secrets/getSecret/action" -or
+            $provisionText -match "Failed to read 'typeagent-config' from vault"
+        )
 
-    if ($isKeyVaultAuthError) {
-        Write-Host "" 
-        Write-Host "Key Vault access failed for the current Azure identity." -ForegroundColor Yellow
-        Write-Host "Launching 'az login' so you can select an identity with access..." -ForegroundColor Yellow
-        & az login --only-show-errors | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Fail "Config provisioning failed and az login did not complete successfully."
+        if ($isKeyVaultAuthError) {
+            Write-Host "" 
+            Write-Host "Key Vault access failed for the current Azure identity." -ForegroundColor Yellow
+            Write-Host "Launching 'az login' so you can select an identity with access..." -ForegroundColor Yellow
+            & az login --only-show-errors | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Fail "Config provisioning failed and az login did not complete successfully."
+            }
+
+            Write-Step "Retrying config provisioning after az login"
+            $retryOutput = & node $serve provision 2>&1
+            $retryExitCode = $LASTEXITCODE
+            if ($retryOutput) { $retryOutput | ForEach-Object { Write-Host $_ } }
+            if ($retryExitCode -ne 0) {
+                Fail "Config provisioning failed after re-authentication. Confirm the selected identity has Key Vault access."
+            }
+        } else {
+            Fail "Config provisioning failed."
         }
+    }
+} else {
+    # Self-host provider: synthesize config.local.yaml locally (no Key Vault / az login).
+    Write-Step "Provisioning config for '$Provider' provider (self-host, no Key Vault)"
+    $provisionArgs = @($serve, "provision", "--provider", $Provider, "--force", "--embedding", $Embedding)
+    if ($Provider -eq "ollama") {
+        $provisionArgs += @("--ollama-host", $OllamaHost)
+        if ($ChatModel) { $provisionArgs += @("--chat-model", $ChatModel) }
+    }
+    if ($Provider -eq "copilot" -and $CopilotModel) {
+        $provisionArgs += @("--copilot-model", $CopilotModel)
+    }
+    if ($Embedding -eq "ollama") {
+        $provisionArgs += @("--ollama-host", $OllamaHost)
+    }
+    if ($EmbeddingEndpoint) { $provisionArgs += @("--embedding-endpoint", $EmbeddingEndpoint) }
+    if ($EmbeddingModel) { $provisionArgs += @("--embedding-model", $EmbeddingModel) }
+    if ($OpenAIKey) { $provisionArgs += @("--openai-key", $OpenAIKey) }
 
-        Write-Step "Retrying config provisioning after az login"
-        $retryOutput = & node $serve provision 2>&1
-        $retryExitCode = $LASTEXITCODE
-        if ($retryOutput) { $retryOutput | ForEach-Object { Write-Host $_ } }
-        if ($retryExitCode -ne 0) {
-            Fail "Config provisioning failed after re-authentication. Confirm the selected identity has Key Vault access."
+    & node @provisionArgs
+    if ($LASTEXITCODE -ne 0) {
+        Fail "Self-host config generation failed for provider '$Provider'."
+    }
+
+    if ($Provider -eq "ollama") {
+        Write-Host "  Reminder: ensure 'ollama serve' is running and the '$(if ($ChatModel) { $ChatModel } else { 'llama3.2' })' model is pulled." -ForegroundColor Yellow
+        # Best-effort reachability probe (non-fatal).
+        try {
+            $probe = [System.Net.HttpWebRequest]::Create("$OllamaHost/api/tags")
+            $probe.Timeout = 2000
+            $probe.Method = "GET"
+            $probe.GetResponse().Close()
+            Write-Host "  Ollama reachable at $OllamaHost." -ForegroundColor Green
+        } catch {
+            Write-Host "  WARNING: could not reach Ollama at $OllamaHost. Start it before using the agent." -ForegroundColor Yellow
         }
-    } else {
-        Fail "Config provisioning failed."
+    }
+    if ($Provider -eq "copilot") {
+        Write-Host "  Reminder: the 'copilot' CLI must be installed and authenticated (github login)." -ForegroundColor Yellow
     }
 }
 
@@ -585,23 +646,27 @@ $typeAgentConfigDir = if ($env:TYPEAGENT_CONFIG_DIR) {
     Join-Path $env:USERPROFILE ".typeagent"
 }
 $configLocalPath = Join-Path $typeAgentConfigDir "config.local.yaml"
-$hasEmbeddingEnv = -not [string]::IsNullOrWhiteSpace($env:AZURE_OPENAI_ENDPOINT_EMBEDDING)
+# Embeddings may come from an Azure/OpenAI endpoint OR the bundled local model
+# (embedding.provider: local). "none" intentionally disables embeddings and the
+# dependent features degrade gracefully, so no endpoint is required.
+$hasEmbeddingEnv = (-not [string]::IsNullOrWhiteSpace($env:AZURE_OPENAI_ENDPOINT_EMBEDDING)) -or
+    (-not [string]::IsNullOrWhiteSpace($env:OPENAI_ENDPOINT_EMBEDDING)) -or
+    (-not [string]::IsNullOrWhiteSpace($env:TYPEAGENT_EMBEDDING_PROVIDER))
 $hasEmbeddingInFile = $false
 if (Test-Path $configLocalPath) {
-    $hasEmbeddingInFile = [bool](Select-String -Path $configLocalPath -Pattern "AZURE_OPENAI_ENDPOINT_EMBEDDING|azureOpenAiEndpointEmbedding|endpoint_embedding" -Quiet)
+    $hasEmbeddingInFile = [bool](Select-String -Path $configLocalPath -Pattern "AZURE_OPENAI_ENDPOINT_EMBEDDING|OPENAI_ENDPOINT_EMBEDDING|azureOpenAiEndpointEmbedding|endpointEmbedding|endpoint_embedding|^embedding:|provider:\s*(local|openai|azure|none)" -Quiet)
 }
 
 if (-not $hasEmbeddingEnv -and -not $hasEmbeddingInFile) {
     $msg = @(
-        "Provisioning completed, but required embedding config was not found.",
-        "Missing: AZURE_OPENAI_ENDPOINT_EMBEDDING",
-        "Checked: env var and '$configLocalPath'",
-        "The agent server will start and then exit immediately without this setting.",
-        "Re-run provisioning with an identity that can read the expected config source (e.g. Key Vault),",
-        "or set AZURE_OPENAI_ENDPOINT_EMBEDDING in the environment/config before start.",
+        "Provisioning completed, but no embedding configuration was found.",
+        "Expected one of: an embedding endpoint (AZURE_OPENAI_ENDPOINT_EMBEDDING / OPENAI_ENDPOINT_EMBEDDING / endpointEmbedding),",
+        "or an 'embedding:' section (provider: local | openai | azure | none) in the config.",
+        "Checked: env vars and '$configLocalPath'",
+        "Without embeddings, semantic search and related features are disabled (the server still starts).",
         "For detailed startup diagnostics: set TYPEAGENT_DEBUG=1 and run 'node typeagent-serve.mjs start --debug', then 'node typeagent-serve.mjs logs'."
     ) -join [Environment]::NewLine
-    Fail $msg
+    Write-Warning $msg
 }
 
 # --- 6. Optional: set up + host a Dev Tunnel for cross-device access ----------
@@ -654,8 +719,8 @@ if (-not $NoStart) {
                 "Remediation:",
                 "  1) az login   (choose an account with access to the OpenAI resource/deployment)",
                 "  2) Verify config.local.yaml points to a deployment your selected principal can use",
-                "  3) Re-run: node \"$serve\" start --debug",
-                "  4) Check logs: node \"$serve\" logs"
+                "  3) Re-run: node `"$serve`" start --debug",
+                "  4) Check logs: node `"$serve`" logs"
             ) -join [Environment]::NewLine
             Fail $msg
         }
@@ -663,7 +728,7 @@ if (-not $NoStart) {
         if (Test-Path $daemonLogPath) {
             Write-Host "  Agent-server daemon log: $daemonLogPath" -ForegroundColor Yellow
         }
-        Fail "Agent server failed to start. Re-run with TYPEAGENT_DEBUG=1 and inspect 'node \"$serve\" logs'."
+        Fail "Agent server failed to start. Re-run with TYPEAGENT_DEBUG=1 and inspect 'node `"$serve`" logs'."
     }
 }
 

--- a/ts/tools/scripts/install-typeagent.sh
+++ b/ts/tools/scripts/install-typeagent.sh
@@ -13,6 +13,14 @@ FEED="typeagent"
 PLUGIN_SOURCE=""
 UPGRADE=0
 NO_START=0
+PROVIDER="aisystems"
+EMBEDDING="local"
+OLLAMA_HOST="http://localhost:11434"
+CHAT_MODEL=""
+COPILOT_MODEL=""
+EMBEDDING_ENDPOINT=""
+EMBEDDING_MODEL=""
+OPENAI_KEY=""
 
 usage() {
   cat <<'EOF'
@@ -32,6 +40,16 @@ Options:
   --feed <name>                      Azure Artifacts feed
   --upgrade                          Force fresh artifact download
   --no-start                         Do not start agent server after install
+  --provider <name>                  Endpoint provider: aisystems (default), ollama, or copilot.
+                                     aisystems downloads config from Key Vault (needs az access);
+                                     ollama/copilot synthesize config.local.yaml locally.
+  --embedding <mode>                 Embedding source for ollama/copilot: local (default), ollama, openai, none
+  --ollama-host <url>                Ollama base URL (default: http://localhost:11434)
+  --chat-model <name>                Ollama chat model (default: llama3.2)
+  --copilot-model <name>             Copilot chat model (default: claude-sonnet-4.5)
+  --embedding-endpoint <url>         Embedding endpoint (openai embedding mode; full path)
+  --embedding-model <name>           Embedding model name
+  --openai-key <key>                 API key for openai embedding mode
   --help                             Show this help
 EOF
 }
@@ -122,12 +140,29 @@ while [[ $# -gt 0 ]]; do
     --feed) FEED="$2"; shift 2 ;;
     --upgrade) UPGRADE=1; shift ;;
     --no-start) NO_START=1; shift ;;
+    --provider) PROVIDER="$2"; shift 2 ;;
+    --embedding) EMBEDDING="$2"; shift 2 ;;
+    --ollama-host) OLLAMA_HOST="$2"; shift 2 ;;
+    --chat-model) CHAT_MODEL="$2"; shift 2 ;;
+    --copilot-model) COPILOT_MODEL="$2"; shift 2 ;;
+    --embedding-endpoint) EMBEDDING_ENDPOINT="$2"; shift 2 ;;
+    --embedding-model) EMBEDDING_MODEL="$2"; shift 2 ;;
+    --openai-key) OPENAI_KEY="$2"; shift 2 ;;
     --help) usage; exit 0 ;;
     *) fail "Unknown option: $1" ;;
   esac
 done
 
 detect_platform_arch
+
+case "$PROVIDER" in
+  aisystems|ollama|copilot) ;;
+  *) fail "Unknown --provider '$PROVIDER' (expected aisystems, ollama, or copilot)" ;;
+esac
+case "$EMBEDDING" in
+  local|ollama|openai|none) ;;
+  *) fail "Unknown --embedding '$EMBEDDING' (expected local, ollama, openai, or none)" ;;
+esac
 
 if [[ -z "${INSTALL_DIR:-}" ]]; then
   if [[ "$PLATFORM" == "darwin" ]]; then
@@ -239,8 +274,37 @@ node "$REGISTER_SCRIPT" \
   --plugin-name typeagent \
   --log-path "$PLUGIN_REGISTER_LOG"
 
-log_step "Provisioning TypeAgent config"
-node "$SERVE" provision
+if [[ "$PROVIDER" == "aisystems" ]]; then
+  log_step "Provisioning TypeAgent config (Key Vault)"
+  node "$SERVE" provision
+else
+  log_step "Provisioning TypeAgent config for '$PROVIDER' provider (self-host, no Key Vault)"
+  PROVISION_ARGS=(provision --provider "$PROVIDER" --force --embedding "$EMBEDDING")
+  if [[ "$PROVIDER" == "ollama" ]]; then
+    PROVISION_ARGS+=(--ollama-host "$OLLAMA_HOST")
+    [[ -n "$CHAT_MODEL" ]] && PROVISION_ARGS+=(--chat-model "$CHAT_MODEL")
+  fi
+  if [[ "$PROVIDER" == "copilot" && -n "$COPILOT_MODEL" ]]; then
+    PROVISION_ARGS+=(--copilot-model "$COPILOT_MODEL")
+  fi
+  [[ "$EMBEDDING" == "ollama" ]] && PROVISION_ARGS+=(--ollama-host "$OLLAMA_HOST")
+  [[ -n "$EMBEDDING_ENDPOINT" ]] && PROVISION_ARGS+=(--embedding-endpoint "$EMBEDDING_ENDPOINT")
+  [[ -n "$EMBEDDING_MODEL" ]] && PROVISION_ARGS+=(--embedding-model "$EMBEDDING_MODEL")
+  [[ -n "$OPENAI_KEY" ]] && PROVISION_ARGS+=(--openai-key "$OPENAI_KEY")
+  node "$SERVE" "${PROVISION_ARGS[@]}"
+
+  if [[ "$PROVIDER" == "ollama" ]]; then
+    echo "  Reminder: ensure 'ollama serve' is running and the '${CHAT_MODEL:-llama3.2}' model is pulled."
+    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 2 "$OLLAMA_HOST/api/tags" >/dev/null 2>&1; then
+      echo "  Ollama reachable at $OLLAMA_HOST."
+    else
+      echo "  WARNING: could not reach Ollama at $OLLAMA_HOST. Start it before using the agent."
+    fi
+  fi
+  if [[ "$PROVIDER" == "copilot" ]]; then
+    echo "  Reminder: the 'copilot' CLI must be installed and authenticated (github login)."
+  fi
+fi
 
 if [[ "$NO_START" -eq 0 ]]; then
   log_step "Starting agent server"

--- a/ts/tools/scripts/typeagent-serve.mjs
+++ b/ts/tools/scripts/typeagent-serve.mjs
@@ -266,9 +266,7 @@ async function cmdProvision() {
         );
         // Forward provider + all generator options; drop launcher-only flags.
         const drop = new Set(["--port"]);
-        const passthrough = process.argv
-            .slice(3)
-            .filter((a) => !drop.has(a));
+        const passthrough = process.argv.slice(3).filter((a) => !drop.has(a));
         return runInline(generateConfigEntry, passthrough);
     }
 

--- a/ts/tools/scripts/typeagent-serve.mjs
+++ b/ts/tools/scripts/typeagent-serve.mjs
@@ -39,6 +39,11 @@ import { fileURLToPath } from "node:url";
 const artifactDir = path.dirname(fileURLToPath(import.meta.url));
 const serverEntry = path.join(artifactDir, "dist", "server.js");
 const getKeysEntry = path.join(artifactDir, "tools", "getKeys.mjs");
+const generateConfigEntry = path.join(
+    artifactDir,
+    "tools",
+    "generate-selfhost-config.mjs",
+);
 
 // Profile recorded by deployAgentServer when the artifact was profile-pruned.
 function readProfileMarker() {
@@ -243,6 +248,37 @@ async function cmdStart() {
 }
 
 async function cmdProvision() {
+    // Chat endpoint provider. Default 'aisystems' preserves today's behavior
+    // (Key Vault download via getKeys). 'ollama'/'copilot' synthesize a
+    // config.local.yaml locally with generate-selfhost-config (no Key Vault).
+    const provider = (arg("--provider") ?? "aisystems").toLowerCase();
+
+    if (provider === "ollama" || provider === "copilot") {
+        if (!fs.existsSync(generateConfigEntry)) {
+            console.error(
+                `Self-host config generator not found at ${generateConfigEntry}.`,
+            );
+            return 1;
+        }
+        const dir = process.env.TYPEAGENT_CONFIG_DIR;
+        console.log(
+            `Generating config.local.yaml for '${provider}' provider into ${dir}...`,
+        );
+        // Forward provider + all generator options; drop launcher-only flags.
+        const drop = new Set(["--port"]);
+        const passthrough = process.argv
+            .slice(3)
+            .filter((a) => !drop.has(a));
+        return runInline(generateConfigEntry, passthrough);
+    }
+
+    if (provider !== "aisystems") {
+        console.error(
+            `Unknown --provider '${provider}'. Use aisystems, ollama, or copilot.`,
+        );
+        return 1;
+    }
+
     if (!fs.existsSync(getKeysEntry)) {
         console.error(`getKeys not found at ${getKeysEntry}.`);
         return 1;
@@ -252,7 +288,17 @@ async function cmdProvision() {
         `Provisioning config.local.yaml into ${dir} (browser login)...`,
     );
     // Pass through any extra args after the subcommand (e.g. --vault, --verbose).
-    const passthrough = process.argv.slice(3).filter((a) => a !== "--port");
+    // Strip --provider/--port which getKeys does not understand.
+    const passthrough = [];
+    const rest = process.argv.slice(3);
+    for (let i = 0; i < rest.length; i++) {
+        if (rest[i] === "--provider") {
+            i++; // skip its value
+            continue;
+        }
+        if (rest[i] === "--port") continue;
+        passthrough.push(rest[i]);
+    }
     return runInline(getKeysEntry, passthrough);
 }
 


### PR DESCRIPTION
Adds support for Ollama/Copilot self-host provider flow:

- Introduces generate-selfhost-config.mjs to synthesize config.local.yaml for machines without AI Systems Key Vault access (ollama/copilot providers), with CLI options for embedding/chat models and output path.
- Wire the generator into typeagent-serve.mjs (provision subcommand) and deploy packaging.
- Extend install scripts (PowerShell / Bash) to allow --provider/--embedding options and to run local provisioning when provider != aisystems.
- Update MSI Wix UI and installer behavior to expose PROVIDER/EMBEDDING/OLLAMAHOST properties and run provisioning during install for OLLAMA/COPILOT.
- Update config.sample.yaml and README to document self-host presets and Ollama endpoint semantics.

This enables installs on systems without Key Vault access to run against local Ollama or Copilot SDK endpoints and select embedding sources (local/ollama/openai/none).