### PR TITLE
Add optional shell install and MSI blob publish

### DIFF
--- a/pipelines/azure-build-package-agent-server-msi.yml
+++ b/pipelines/azure-build-package-agent-server-msi.yml
@@ -40,6 +40,11 @@ variables:
     value: ""
   - name: resolvedPluginVersion
     value: ""
+  - name: channel
+    ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+      value: ${{ parameters.channel }}
+    ${{ if ne(variables['Build.Reason'], 'Manual') }}:
+      value: ci
 
 parameters:
   - name: publishArtifacts
@@ -52,6 +57,13 @@ parameters:
     values:
       - win32-x64
     displayName: "RID (Runtime ID)"
+  - name: channel
+    type: string
+    default: test
+    values:
+      - test
+      - lkg
+    displayName: "Blob channel (manual runs only; automatic runs use 'ci')"
 
 jobs:
   - job: build_sign_msi
@@ -271,17 +283,6 @@ jobs:
         displayName: Upload MSI artifact
         artifact: msi-${{ parameters.rid }}
 
-      # Step 5: Publish to Azure Storage (optional, requires approval)
-      - task: AzureFileCopy@6
-        displayName: Upload to Azure Storage (if publishArtifacts=true)
-        condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', 'true'))
-        inputs:
-          SourcePath: $(MSI_BUILD_DIR)\**
-          Destination: AzureBlob
-          azureSubscription: $(azureSubscription)
-          storage: $(azureStorageAccountName)
-          ContainerName: $(azureStorageContainerName)
-
   - job: publish_msi_feed
     displayName: Publish MSI Universal Package
     dependsOn: build_sign_msi
@@ -321,6 +322,64 @@ jobs:
               --description "TypeAgent MSI installer for $rid"
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
+  # Publish the signed MSI to Azure Blob Storage (alongside the shell installer).
+  # Gated by an environment approval and the publishArtifacts parameter. Reuses
+  # the shell's per-channel environment (typeagent-shell-<channel>) so the MSI
+  # inherits the same approvers/checks. Stages ONLY the signed .msi plus a
+  # latest.json discovery pointer into a clean folder (the raw MSI_BUILD_DIR also
+  # contains extracted agent-server/plugin artifacts and WiX intermediates that
+  # must not be uploaded).
+  - deployment: publish_msi_blob
+    displayName: Publish MSI to Azure Storage
+    dependsOn: build_sign_msi
+    condition: and(succeeded(), eq('${{ parameters.publishArtifacts }}', 'true'))
+    environment: typeagent-shell-$(channel)
+    pool:
+      # AzureFileCopy requires Windows
+      vmImage: windows-latest
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - download: current
+              artifact: msi-${{ parameters.rid }}
+              displayName: Download signed MSI artifact
+
+            - pwsh: |
+                $src  = "$(Pipeline.Workspace)/msi-${{ parameters.rid }}"
+                $dest = "$(Build.ArtifactStagingDirectory)/msi-publish"
+                New-Item -ItemType Directory -Force $dest | Out-Null
+
+                $msi = Get-ChildItem $src -Filter "*.msi" | Select-Object -First 1
+                if ($null -eq $msi) {
+                  Write-Error "No MSI found in $src"
+                  exit 1
+                }
+                Copy-Item $msi.FullName $dest
+
+                # Discovery pointer (mirrors electron-updater yml for the shell).
+                $hash = (Get-FileHash $msi.FullName -Algorithm SHA256).Hash.ToLower()
+                $meta = [ordered]@{
+                  version = "$(packageVersion)"
+                  file    = $msi.Name
+                  sha256  = $hash
+                }
+                $meta | ConvertTo-Json | Set-Content -Path (Join-Path $dest "latest.json") -Encoding utf8
+
+                Write-Host "Staged for blob publish:"
+                Get-ChildItem $dest | ForEach-Object { Write-Host "  $($_.Name)" }
+              displayName: Stage signed MSI + latest.json only
+
+            - task: AzureFileCopy@6
+              displayName: Upload MSI to Azure Storage (msi/$(channel))
+              inputs:
+                SourcePath: $(Build.ArtifactStagingDirectory)/msi-publish/*
+                Destination: AzureBlob
+                azureSubscription: $(azureSubscription)
+                storage: $(azureStorageAccountName)
+                ContainerName: $(azureStorageContainerName)
+                BlobPrefix: msi/$(channel)
 
   # Optional: sign the shell .exe while we're at it (Phase 2)
   - job: sign_shell_exe

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -238,6 +238,41 @@ silent installer cannot perform. Fine-grained overrides (chat model, embedding
 endpoint, API keys) are available on the `provision`/`generate-selfhost-config`
 CLI; re-run provisioning post-install to adjust them.
 
+## Optional: install the TypeAgent Shell (desktop app)
+
+The MSI can optionally download and silently install the **TypeAgent Shell**
+(the Electron desktop app) from the same Azure Blob Storage container used by the
+shell's auto-update feed. This is off by default. During an interactive install
+a checkbox on **ProviderDlg** ("Also install the TypeAgent Shell desktop app")
+enables it; silently, set the public properties:
+
+| Property         | Values / example                                      | Default | Notes                                                                        |
+| ---------------- | ----------------------------------------------------- | ------- | ---------------------------------------------------------------------------- |
+| `SHELL`          | `0`, `1`                                              | `0`     | `1` enables the optional shell download + silent install.                    |
+| `SHELLCHANNEL`   | `lkg`, `test`, `ci`                                   | `lkg`   | electron-updater channel to read (`<channel>-<arch>.yml`).                   |
+| `SHELLSTORAGE`   | Azure Storage account name                            | —       | Used with the Azure CLI (`az login`) to read the shell blobs.                |
+| `SHELLCONTAINER` | Azure Storage container name                          | —       | Defaults to `SHELLSTORAGE` if omitted.                                       |
+| `SHELLBASEURL`   | `https://<account>.blob.core.windows.net/<container>` | —       | Anonymous HTTPS base for a **public** container; when set, `az` is not used. |
+
+```powershell
+# Authenticated (az login) blob read from a private container
+msiexec /i TypeAgent-<version>-win32-x64.msi SHELL=1 SHELLSTORAGE=myaccount SHELLCONTAINER=mycontainer SHELLCHANNEL=lkg
+
+# Public container (no az): anonymous HTTPS download
+msiexec /i TypeAgent-<version>-win32-x64.msi SHELL=1 SHELLBASEURL=https://myaccount.blob.core.windows.net/mycontainer
+```
+
+When `SHELL=1`, a deferred, impersonated custom action runs the bundled
+`install-shell.ps1` (`[TYPEAGENTROOT]install-shell.ps1`), which reads the
+channel metadata, downloads `typeagentshell-<version>-win32-x64-setup.exe`, and
+runs it silently (NSIS `/S`). It runs as the installing user so blob auth and
+the per-user shell install target resolve correctly. The action is **non-fatal**
+(`Return="ignore"`): a shell download/install failure is logged to
+`%LOCALAPPDATA%\TypeAgent\logs\msi-install-shell.log` but does not roll back the
+agent-server install. Because the shell shares `~/.typeagent/config.local.yaml`,
+no extra config step is needed. `install-shell.ps1` is the Windows sibling of
+`install-shell.sh` and can also be run standalone.
+
 ## Pipeline Usage
 
 ### Automatic (on `main` branch)

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -52,6 +52,20 @@
     <Property Id="OLLAMAHOST" Value="http://localhost:11434" Secure="yes" />
 
     <!-- ═══════════════════════════════════════════════
+         Optional TypeAgent Shell install (Electron app)
+         SHELL=1 downloads and silently installs the shell's NSIS installer
+         from Azure Blob Storage (same container as the shell auto-update feed)
+         via a deferred custom action. SHELLBASEURL enables anonymous HTTPS
+         download for a public container; otherwise SHELLSTORAGE/SHELLCONTAINER
+         are used with the Azure CLI (az login).
+         ═══════════════════════════════════════════════ -->
+    <Property Id="SHELL" Value="0" Secure="yes" />
+    <Property Id="SHELLSTORAGE" Secure="yes" />
+    <Property Id="SHELLCONTAINER" Secure="yes" />
+    <Property Id="SHELLCHANNEL" Value="lkg" Secure="yes" />
+    <Property Id="SHELLBASEURL" Secure="yes" />
+
+    <!-- ═══════════════════════════════════════════════
          Directory layout
          ═══════════════════════════════════════════════ -->
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -77,6 +91,7 @@
       <ComponentRef Id="MarketplaceJsonComponent" />
       <ComponentRef Id="RegisterPluginPs1Component" />
       <ComponentRef Id="RegisterPluginMjsComponent" />
+      <ComponentRef Id="InstallShellPs1Component" />
       <ComponentRef Id="RegistryComponent" />
     </Feature>
 
@@ -104,6 +119,10 @@
       <Component Id="RegisterPluginMjsComponent" Guid="*">
         <File Id="RegisterPluginMjs" Name="register-plugin.mjs"
               Source="$(var.InstallerSourceDir)\..\common\register-plugin.mjs" />
+      </Component>
+      <Component Id="InstallShellPs1Component" Guid="*">
+        <File Id="InstallShellPs1" Name="install-shell.ps1"
+              Source="$(var.InstallerSourceDir)\..\..\scripts\install-shell.ps1" />
       </Component>
     </DirectoryRef>
 
@@ -171,9 +190,30 @@
                   Return="ignore"
                   Impersonate="yes" />
 
+    <!-- ═══════════════════════════════════════════════
+         Custom action — optional TypeAgent Shell install
+         For SHELL=1, download + silently install the shell's NSIS installer
+         from Azure Blob Storage via the bundled install-shell.ps1. Runs as the
+         installing user (impersonated) so blob auth (az login) and the per-user
+         shell install target resolve correctly. Non-fatal (Return="ignore") so
+         a shell hiccup does not roll back the agent-server install.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="InstallTypeAgentShell"
+           Before="InstallTypeAgentShell"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-shell.ps1&quot; -Storage &quot;[SHELLSTORAGE]&quot; -Container &quot;[SHELLCONTAINER]&quot; -Channel &quot;[SHELLCHANNEL]&quot; -BlobBaseUrl &quot;[SHELLBASEURL]&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-install-shell.log&quot;" />
+
+    <CustomAction Id="InstallTypeAgentShell"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
     <InstallExecuteSequence>
       <Custom Action="RegisterCopilotPlugin"   After="InstallFiles">NOT REMOVE~="ALL"</Custom>
       <Custom Action="ProvisionSelfHostConfig" After="RegisterCopilotPlugin">(NOT REMOVE~="ALL") AND (PROVIDER&lt;&gt;"AISYSTEMS")</Custom>
+      <Custom Action="InstallTypeAgentShell"   After="ProvisionSelfHostConfig">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
       <Custom Action="UnregisterCopilotPlugin" Before="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
 
@@ -256,6 +296,10 @@
                  Transparent="yes" NoPrefix="yes" Text="Ollama host:" />
         <Control Id="OllamaHostEdit" Type="Edit" X="92" Y="203" Width="258" Height="16"
                  Property="OLLAMAHOST" Text="{80}" />
+
+        <Control Id="ShellCheckBox" Type="CheckBox" X="20" Y="221" Width="340" Height="12"
+                 Property="SHELL" CheckBoxValue="1"
+                 Text="Also install the TypeAgent Shell desktop app (needs SHELLSTORAGE or SHELLBASEURL)" />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
         <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"

--- a/ts/tools/scripts/install-shell.ps1
+++ b/ts/tools/scripts/install-shell.ps1
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Download and install the TypeAgent Shell (Windows) from Azure Blob Storage.
+
+.DESCRIPTION
+    Windows sibling of install-shell.sh. Reads the electron-updater channel
+    metadata (<channel>-<arch>.yml) from the shell's Azure Blob Storage
+    container, resolves the NSIS setup package path, downloads it, and runs it
+    silently (NSIS /S).
+
+    Blob reads use either:
+      * an anonymous HTTPS base URL (-BlobBaseUrl), or
+      * the Azure CLI (az storage blob download --auth-mode login), matching
+        install-shell.sh. This requires 'az login' with access to the account.
+
+.EXAMPLE
+    pwsh ./install-shell.ps1 -Storage mystorage -Container mycontainer -Channel lkg
+
+.EXAMPLE
+    # Anonymous/public container (no az login required)
+    pwsh ./install-shell.ps1 -BlobBaseUrl https://mystorage.blob.core.windows.net/mycontainer -Channel lkg
+#>
+[CmdletBinding()]
+param(
+    [string]$Storage = "",
+    [string]$Container = "",
+    [string]$Channel = "lkg",
+    # Optional anonymous HTTPS base for public containers, e.g.
+    # https://<account>.blob.core.windows.net/<container>. When set, the Azure
+    # CLI is not used.
+    [string]$BlobBaseUrl = "",
+    [string]$LogPath = "$env:LOCALAPPDATA\TypeAgent\logs\install-shell.log",
+    # Do not launch the shell after install.
+    [switch]$NoStart
+)
+
+$ErrorActionPreference = "Stop"
+
+function Initialize-Log {
+    param([string]$Path)
+    if ($Path) {
+        $dir = Split-Path -Parent $Path
+        if ($dir -and -not (Test-Path $dir)) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        }
+        Set-Content -Path $Path -Value "" -Encoding utf8
+    }
+}
+
+function Write-Log {
+    param([string]$Message)
+    $line = "[$([DateTime]::UtcNow.ToString('o'))] $Message"
+    Write-Host $line
+    if ($LogPath) {
+        Add-Content -Path $LogPath -Value $line -Encoding utf8
+    }
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Log "ERROR: $Message"
+    exit 1
+}
+
+function Get-Arch {
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        "AMD64" { return "x64" }
+        "ARM64" { return "arm64" }
+        "x86"   { return "x64" }
+        default {
+            Fail "Unsupported processor architecture: $($env:PROCESSOR_ARCHITECTURE)"
+        }
+    }
+}
+
+function Test-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-BlobFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    if ($BlobBaseUrl) {
+        $url = "$($BlobBaseUrl.TrimEnd('/'))/$Name"
+        Write-Log "Downloading $url"
+        Invoke-WebRequest -Uri $url -OutFile $Destination -UseBasicParsing
+        return
+    }
+
+    if (-not (Test-Command az)) {
+        Fail "Azure CLI ('az') not found and no -BlobBaseUrl provided. Install Azure CLI or pass -BlobBaseUrl for a public container."
+    }
+    if (-not $Storage) {
+        Fail "-Storage is required when -BlobBaseUrl is not provided."
+    }
+
+    $containerName = if ($Container) { $Container } else { $Storage }
+    Write-Log "Downloading blob '$Name' from $Storage/$containerName"
+    & az storage blob download `
+        --account-name $Storage `
+        --container-name $containerName `
+        --name $Name `
+        --file $Destination `
+        --auth-mode login `
+        --overwrite 2>&1 | ForEach-Object { Write-Log "az> $_" }
+    if ($LASTEXITCODE -ne 0) {
+        Fail "Failed to download '$Name' from $Storage/$containerName. Ensure 'az login' has access to the account."
+    }
+}
+
+function Get-PackagePathFromYml {
+    param([Parameter(Mandatory = $true)][string]$YmlPath)
+
+    # electron-updater metadata: the top-level 'path:' entry names the setup exe.
+    $match = Select-String -Path $YmlPath -Pattern '^\s*path:\s*(.+)$' | Select-Object -First 1
+    if (-not $match) {
+        Fail "Could not find 'path:' in metadata file $YmlPath."
+    }
+    $value = $match.Matches[0].Groups[1].Value.Trim().Trim("'`"")
+    if (-not $value) {
+        Fail "Empty 'path:' value in metadata file $YmlPath."
+    }
+    return $value
+}
+
+Initialize-Log -Path $LogPath
+
+if (-not $BlobBaseUrl -and -not $Storage) {
+    Fail "Provide either -Storage (with optional -Container) or -BlobBaseUrl."
+}
+
+$arch = Get-Arch
+$channelArch = "$Channel-$arch"
+$ymlName = "$channelArch.yml"
+
+Write-Log "Installing TypeAgent Shell (channel '$Channel', arch '$arch')"
+
+$dest = Join-Path $env:TEMP "typeagent-install-shell"
+if (Test-Path $dest) {
+    Remove-Item -Recurse -Force $dest
+}
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+try {
+    $ymlPath = Join-Path $dest $ymlName
+    Get-BlobFile -Name $ymlName -Destination $ymlPath
+
+    $packageName = Get-PackagePathFromYml -YmlPath $ymlPath
+    Write-Log "Resolved shell package: $packageName"
+
+    $packagePath = Join-Path $dest $packageName
+    Get-BlobFile -Name $packageName -Destination $packagePath
+
+    if (-not (Test-Path $packagePath)) {
+        Fail "Shell package not found after download: $packagePath"
+    }
+
+    Write-Log "Running silent install: $packagePath /S"
+    $proc = Start-Process -FilePath $packagePath -ArgumentList "/S" -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        Fail "Shell installer exited with code $($proc.ExitCode)."
+    }
+
+    Write-Log "TypeAgent Shell installed successfully."
+
+    if (-not $NoStart) {
+        $exe = Join-Path $env:LOCALAPPDATA "Programs\typeagentshell\typeagentshell.exe"
+        if (Test-Path $exe) {
+            Write-Log "Launching TypeAgent Shell."
+            Start-Process -FilePath $exe | Out-Null
+        } else {
+            Write-Log "Shell executable not found at $exe; skipping launch."
+        }
+    }
+} finally {
+    if (Test-Path $dest) {
+        Remove-Item -Recurse -Force $dest -ErrorAction SilentlyContinue
+    }
+}
+
+exit 0

--- a/ts/tools/scripts/install-shell.sh
+++ b/ts/tools/scripts/install-shell.sh
@@ -2,27 +2,46 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-function download_yml() {
-    info "Downloading $1"
-    az storage blob download --account-name $STORAGE --container-name $CONTAINER --name $1 --file $DEST/$1 --overwrite --auth-mode login > $DEST/install-shell.log 2>&1
+# Download a blob by name into $DEST. Uses an anonymous HTTPS base URL
+# (SHELL_BASE_URL) when set, otherwise the Azure CLI with 'az login'.
+function download_blob() {
+    local name="$1"
+    if [[ -n "$BASE_URL" ]]; then
+        local url="${BASE_URL%/}/$name"
+        info "Downloading $url"
+        if command -v curl >/dev/null 2>&1; then
+            curl -fsSL "$url" -o "$DEST/$name" > $DEST/install-shell.log 2>&1
+        elif command -v wget >/dev/null 2>&1; then
+            wget -q "$url" -O "$DEST/$name" > $DEST/install-shell.log 2>&1
+        else
+            error "Neither curl nor wget is available to download $url"
+            return 1
+        fi
+        if [[ $? != 0 ]]; then
+            error "Failed to download $url"
+            cat $DEST/install-shell.log
+            return 1
+        fi
+        return 0
+    fi
+
+    info "Downloading $name"
+    az storage blob download --account-name $STORAGE --container-name $CONTAINER --name "$name" --file "$DEST/$name" --overwrite --auth-mode login > $DEST/install-shell.log 2>&1
     if [[ $? != 0 ]]; then
-        error "Failed to download $1 from $STORAGE/$CONTAINER"
+        error "Failed to download $name from $STORAGE/$CONTAINER."
         error "Ensure you that you are logged into azure cli with 'az login' and have access to the storage account."
-        cat $DEST/install-shell.log    
+        cat $DEST/install-shell.log
         return 1
     fi
     return 0
 }
 
+function download_yml() {
+    download_blob "$1"
+}
+
 function download_package() {
-    info "Downloading $1"
-    az storage blob download --account-name $STORAGE --container-name $CONTAINER --name "$1" --file "$DEST/$1" --overwrite --auth-mode login > $DEST/install-shell.log 2>&1
-    if [[ $? != 0 ]]; then
-        error "Failed to download $1 from $STORAGE/$CONTAINER."
-        cat $DEST/install-shell.log
-        return 1
-    fi
-    return 0
+    download_blob "$1"
 }
 
 function install_package_linux() {
@@ -58,6 +77,12 @@ function usage() {
     echo \ \ \<storage\>\ \ \ - The name of the storage account to use.
     echo \ \ \<container\> - The name of the container to use. \<storage\> will be used if not specified.
     echo \ \ \<channel\>\ \ \ - The channel to use. Default to 'lkg' if not specified.
+    echo
+    echo Environment variables:
+    echo \ \ SHELL_BASE_URL - Anonymous HTTPS base for a public container, e.g.
+    echo \ \ \ \ https://\<account\>.blob.core.windows.net/\<container\>. When set,
+    echo \ \ \ \ the Azure CLI is not used and \<storage\> is optional.
+    echo \ \ SHELL_CHANNEL\ \ - Fallback channel when not passed positionally.
 }
 
 function info() {
@@ -78,7 +103,9 @@ function cleanup() {
  
 }
 
-if [[ "$1" == "" ]]; then
+BASE_URL="${SHELL_BASE_URL:-}"
+
+if [[ "$1" == "" && -z "$BASE_URL" ]]; then
     error No storage account specified.
     usage
     exit 1
@@ -92,7 +119,7 @@ else
 fi
 
 if [[ "$3" == "" ]]; then
-    CHANNEL=lkg
+    CHANNEL="${SHELL_CHANNEL:-lkg}"
 else
     CHANNEL=$3
 fi
@@ -130,7 +157,13 @@ else
     YML=$CHANNEL-linux.yml
 fi
 
-info "Getting TypeAgent Shell from [30m[96m$CHANNEL[0m channel in [30m[93m$STORAGE/$CONTAINER[0m."
+if [[ -n "$BASE_URL" ]]; then
+    SOURCE_DESC=$BASE_URL
+else
+    SOURCE_DESC=$STORAGE/$CONTAINER
+fi
+
+info "Getting TypeAgent Shell from [30m[96m$CHANNEL[0m channel in [30m[93m$SOURCE_DESC[0m."
 download_yml $YML
 if [[ $? != 0 ]]; then 
     cleanup

--- a/ts/tools/scripts/install-typeagent.ps1
+++ b/ts/tools/scripts/install-typeagent.ps1
@@ -37,6 +37,7 @@
   pwsh ./install-typeagent.ps1 -BootstrapPrereqs
   pwsh ./install-typeagent.ps1 -Upgrade     # force fresh download, replacing existing assets
     pwsh ./install-typeagent.ps1 -PluginSource C:\temp\typeagent-plugin   # install plugin from local folder
+  pwsh ./install-typeagent.ps1 -Shell -ShellStorage myacct -ShellContainer mycontainer   # also install the desktop shell
 #>
 
 [CmdletBinding()]
@@ -85,7 +86,21 @@ param(
     [string]$CopilotModel = "",
     [string]$EmbeddingEndpoint = "",
     [string]$EmbeddingModel = "",
-    [string]$OpenAIKey = ""
+    [string]$OpenAIKey = "",
+    # Opt-in: also download and install the TypeAgent Shell (Electron desktop
+    # app) from Azure Blob Storage after the agent-server install, via the
+    # bundled install-shell.ps1.
+    [switch]$Shell,
+    # Azure Storage account holding the shell electron-builder output (used with
+    # az login). Ignored when -ShellBaseUrl is provided.
+    [string]$ShellStorage = "",
+    # Storage container; defaults to -ShellStorage when omitted.
+    [string]$ShellContainer = "",
+    # electron-updater channel to read (<channel>-<arch>.yml).
+    [string]$ShellChannel = "lkg",
+    # Anonymous HTTPS base for a public container, e.g.
+    # https://<account>.blob.core.windows.net/<container>. When set, az is not used.
+    [string]$ShellBaseUrl = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -740,4 +755,33 @@ Write-Host "  Logs:     node `"$serve`" logs"
 Write-Host "  Stop:     node `"$serve`" stop"
 if ($DevTunnel) {
     Write-Host "  Tunnel:   node `"$serve`" tunnel status   (list-tunnels.mjs shows the client URL + token)"
+}
+
+# --- 7. Optional: install the TypeAgent Shell desktop app --------------------
+if ($Shell) {
+    Write-Step "Installing TypeAgent Shell (desktop app)"
+    $installShellScript = Join-Path $PSScriptRoot "install-shell.ps1"
+    if (-not (Test-Path $installShellScript)) {
+        Fail "Shell installer script not found: $installShellScript"
+    }
+    if (-not $ShellBaseUrl -and -not $ShellStorage) {
+        Fail "Installing the shell requires -ShellStorage (with optional -ShellContainer) or -ShellBaseUrl."
+    }
+
+    # Run install-shell.ps1 in a child PowerShell process so its 'exit' calls do
+    # not terminate this installer.
+    $psExe = (Get-Process -Id $PID).Path
+    if (-not $psExe) { $psExe = "powershell.exe" }
+
+    $shellArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $installShellScript, "-Channel", $ShellChannel)
+    if ($ShellStorage) { $shellArgs += @("-Storage", $ShellStorage) }
+    if ($ShellContainer) { $shellArgs += @("-Container", $ShellContainer) }
+    if ($ShellBaseUrl) { $shellArgs += @("-BlobBaseUrl", $ShellBaseUrl) }
+    if ($NoStart) { $shellArgs += "-NoStart" }
+
+    & $psExe @shellArgs
+    if ($LASTEXITCODE -ne 0) {
+        Fail "TypeAgent Shell installation failed."
+    }
+    Write-Host "  TypeAgent Shell installed." -ForegroundColor Green
 }

--- a/ts/tools/scripts/install-typeagent.sh
+++ b/ts/tools/scripts/install-typeagent.sh
@@ -21,6 +21,11 @@ COPILOT_MODEL=""
 EMBEDDING_ENDPOINT=""
 EMBEDDING_MODEL=""
 OPENAI_KEY=""
+SHELL_INSTALL=0
+SHELL_STORAGE=""
+SHELL_CONTAINER=""
+SHELL_CHANNEL="lkg"
+SHELL_BASE_URL=""
 
 usage() {
   cat <<'EOF'
@@ -50,6 +55,13 @@ Options:
   --embedding-endpoint <url>         Embedding endpoint (openai embedding mode; full path)
   --embedding-model <name>           Embedding model name
   --openai-key <key>                 API key for openai embedding mode
+  --shell                            Also install the TypeAgent Shell (desktop app) after the agent-server
+  --shell-storage <account>          Azure Storage account with the shell build (used with az login)
+  --shell-container <name>           Storage container (default: same as --shell-storage)
+  --shell-channel <name>             Shell electron-updater channel (default: lkg)
+  --shell-base-url <url>             Anonymous HTTPS base URL for a public shell container
+                                     (e.g. https://<account>.blob.core.windows.net/<container>);
+                                     when set, Azure CLI is not used and --shell-storage is optional
   --help                             Show this help
 EOF
 }
@@ -148,6 +160,11 @@ while [[ $# -gt 0 ]]; do
     --embedding-endpoint) EMBEDDING_ENDPOINT="$2"; shift 2 ;;
     --embedding-model) EMBEDDING_MODEL="$2"; shift 2 ;;
     --openai-key) OPENAI_KEY="$2"; shift 2 ;;
+    --shell) SHELL_INSTALL=1; shift ;;
+    --shell-storage) SHELL_STORAGE="$2"; shift 2 ;;
+    --shell-container) SHELL_CONTAINER="$2"; shift 2 ;;
+    --shell-channel) SHELL_CHANNEL="$2"; shift 2 ;;
+    --shell-base-url) SHELL_BASE_URL="$2"; shift 2 ;;
     --help) usage; exit 0 ;;
     *) fail "Unknown option: $1" ;;
   esac
@@ -317,3 +334,20 @@ echo "  Start:  node \"$SERVE\" start"
 echo "  Status: node \"$SERVE\" status"
 echo "  Logs:   node \"$SERVE\" logs"
 echo "  Stop:   node \"$SERVE\" stop"
+
+if [[ "$SHELL_INSTALL" -eq 1 ]]; then
+  log_step "Installing TypeAgent Shell (desktop app)"
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  INSTALL_SHELL="$SCRIPT_DIR/install-shell.sh"
+  [[ -f "$INSTALL_SHELL" ]] || fail "Shell installer not found: $INSTALL_SHELL"
+  if [[ -n "$SHELL_BASE_URL" ]]; then
+    SHELL_BASE_URL="$SHELL_BASE_URL" bash "$INSTALL_SHELL" "" "" "$SHELL_CHANNEL" \
+      || fail "TypeAgent Shell installation failed."
+  else
+    [[ -n "$SHELL_STORAGE" ]] || fail "Installing the shell requires --shell-storage or --shell-base-url."
+    shell_container="${SHELL_CONTAINER:-$SHELL_STORAGE}"
+    bash "$INSTALL_SHELL" "$SHELL_STORAGE" "$shell_container" "$SHELL_CHANNEL" \
+      || fail "TypeAgent Shell installation failed."
+  fi
+  echo "  TypeAgent Shell installed."
+fi


### PR DESCRIPTION
Adds end-to-end support for delivering and installing the TypeAgent Shell alongside the agent server. The MSI pipeline now supports channel selection (`ci` for automatic runs), publishes signed MSI artifacts to blob storage via an approval-gated deployment job, and stages a `latest.json` metadata pointer.

WiX packaging now includes a bundled `install-shell.ps1`, new `SHELL*` installer properties, UI opt-in checkbox, and a non-fatal deferred custom action to install the shell during MSI setup. Installer scripts were extended on both Windows and Linux to support optional shell installation, channel/base-url configuration, and public-container downloads without Azure CLI login.