### PR TITLE
Fix open CodeQL code-scanning alerts

### DIFF
--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -556,10 +556,11 @@ function spawnAgentServer(
                 const psExe = fs.existsSync(pwsh7) ? pwsh7 : "powershell.exe";
                 // Pass serverPath to the child through the environment rather
                 // than the command line so it never reaches cmd.exe or the
-                // PowerShell parser as text. The command itself is a constant
-                // that reads $env:TYPEAGENT_SERVER_PATH, and it is handed to
-                // PowerShell as a base64 -EncodedCommand blob, whose alphabet
-                // is inert to both cmd.exe and PowerShell.
+                // PowerShell parser as text. Only the numeric port and
+                // idleTimeout are interpolated into the command; the path is
+                // read from $env:TYPEAGENT_SERVER_PATH at runtime. The command
+                // is handed to PowerShell as a base64 -EncodedCommand blob,
+                // whose alphabet is inert to both cmd.exe and PowerShell.
                 const psCommand =
                     `& node $env:TYPEAGENT_SERVER_PATH --port ${port}` +
                     (idleTimeout > 0 ? ` --idle-timeout ${idleTimeout}` : "");

--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -503,6 +503,36 @@ export interface AgentServerSpawnOptions {
     stdio?: StdioOptions;
 }
 
+// Locate a PowerShell executable on Windows. Prefer PowerShell 7+ (pwsh.exe)
+// from its standard install locations or PATH, so installs outside the default
+// "C:\Program Files\PowerShell\7" directory (winget, x86, a relocated Program
+// Files) are still found. Fall back to Windows PowerShell (powershell.exe),
+// which is always present. An absolute path is returned when one is found so
+// the result does not depend on the launcher's PATH.
+function resolvePowerShellExe(): string {
+    const candidates: string[] = [];
+    for (const base of [
+        process.env["ProgramFiles"],
+        process.env["ProgramW6432"],
+        process.env["ProgramFiles(x86)"],
+    ]) {
+        if (base) {
+            candidates.push(path.join(base, "PowerShell", "7", "pwsh.exe"));
+        }
+    }
+    for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+        if (dir) {
+            candidates.push(path.join(dir, "pwsh.exe"));
+        }
+    }
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+    return "powershell.exe";
+}
+
 function spawnAgentServer(
     serverPath: string,
     port: number,
@@ -552,8 +582,7 @@ function spawnAgentServer(
                     `Agent server process spawned hidden (pid: ${child.pid})`,
                 );
             } else {
-                const pwsh7 = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
-                const psExe = fs.existsSync(pwsh7) ? pwsh7 : "powershell.exe";
+                const psExe = resolvePowerShellExe();
                 // Pass serverPath to the child through the environment rather
                 // than the command line so it never reaches cmd.exe or the
                 // PowerShell parser as text. Only the numeric port and

--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -554,14 +554,20 @@ function spawnAgentServer(
             } else {
                 const pwsh7 = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
                 const psExe = fs.existsSync(pwsh7) ? pwsh7 : "powershell.exe";
-                // Single-quote and double any internal single quotes so a
-                // path containing quotes or PowerShell metacharacters can't
-                // break out of the -Command string. port/idleTimeout are
-                // numeric so they need no escaping.
-                const psQuote = (s: string) =>
-                    "'" + s.replace(/'/g, "''") + "'";
-                const psCommand = `& node ${psQuote(serverPath)} --port ${port}${idleTimeout > 0 ? ` --idle-timeout ${idleTimeout}` : ""}`;
-                const psArgs = ["-NoExit", "-Command", psCommand];
+                // Pass serverPath to the child through the environment rather
+                // than the command line so it never reaches cmd.exe or the
+                // PowerShell parser as text. The command itself is a constant
+                // that reads $env:TYPEAGENT_SERVER_PATH, and it is handed to
+                // PowerShell as a base64 -EncodedCommand blob, whose alphabet
+                // is inert to both cmd.exe and PowerShell.
+                const psCommand =
+                    `& node $env:TYPEAGENT_SERVER_PATH --port ${port}` +
+                    (idleTimeout > 0 ? ` --idle-timeout ${idleTimeout}` : "");
+                const encodedCommand = Buffer.from(
+                    psCommand,
+                    "utf16le",
+                ).toString("base64");
+                const psArgs = ["-NoExit", "-EncodedCommand", encodedCommand];
                 // The first quoted argument to `start` is the new window's
                 // title. It MUST be non-empty: an empty title leaves the
                 // console window title blank, which trips a libuv bug on
@@ -576,6 +582,10 @@ function spawnAgentServer(
                     {
                         detached: true,
                         stdio: "ignore",
+                        env: {
+                            ...process.env,
+                            TYPEAGENT_SERVER_PATH: serverPath,
+                        },
                     },
                 );
                 child.unref();

--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -503,12 +503,14 @@ export interface AgentServerSpawnOptions {
     stdio?: StdioOptions;
 }
 
-// Locate a PowerShell executable on Windows. Prefer PowerShell 7+ (pwsh.exe)
-// from its standard install locations or PATH, so installs outside the default
-// "C:\Program Files\PowerShell\7" directory (winget, x86, a relocated Program
-// Files) are still found. Fall back to Windows PowerShell (powershell.exe),
-// which is always present. An absolute path is returned when one is found so
-// the result does not depend on the launcher's PATH.
+// Choose a PowerShell executable for Windows. Detects whether PowerShell 7+
+// (pwsh) is installed by probing its standard install locations and PATH, so
+// installs outside the default "C:\Program Files\PowerShell\7" directory
+// (winget, x86, a relocated Program Files) are still recognized. Returns a bare
+// executable name — never an environment-derived path — so no path built from
+// the environment is ever routed through cmd.exe; `start` resolves the name via
+// PATH/App Paths, which every standard PowerShell 7 install registers. Falls
+// back to Windows PowerShell (powershell.exe), which is always present.
 function resolvePowerShellExe(): string {
     const candidates: string[] = [];
     for (const base of [
@@ -525,12 +527,9 @@ function resolvePowerShellExe(): string {
             candidates.push(path.join(dir, "pwsh.exe"));
         }
     }
-    for (const candidate of candidates) {
-        if (fs.existsSync(candidate)) {
-            return candidate;
-        }
-    }
-    return "powershell.exe";
+    return candidates.some((candidate) => fs.existsSync(candidate))
+        ? "pwsh.exe"
+        : "powershell.exe";
 }
 
 function spawnAgentServer(

--- a/ts/packages/vscode-chat/src/displayRender.ts
+++ b/ts/packages/vscode-chat/src/displayRender.ts
@@ -116,7 +116,10 @@ function tableToMarkdown(table: string[][]): string {
 }
 
 function escapeTableCell(cell: string): string {
-    return cell.replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
+    return cell
+        .replace(/\\/g, "\\\\")
+        .replace(/\|/g, "\\|")
+        .replace(/\r?\n/g, "<br>");
 }
 
 function tableToHtml(table: string[][]): string {
@@ -150,17 +153,27 @@ function stripMarkdownHtml(text: string): string {
 }
 
 function htmlToText(html: string): string {
-    return stripAnsi(
-        decodeHtmlEntities(
-            html
-                .replace(/<\s*br\s*\/?\s*>/gi, "\n")
-                .replace(/<\s*\/\s*(p|div|tr|li|h[1-6])\s*>/gi, "\n")
-                .replace(/<\s*\/\s*(td|th)\s*>/gi, " | ")
-                .replace(/<[^>]*>/g, "")
-                .replace(/[ \t]+\n/g, "\n")
-                .replace(/\n{3,}/g, "\n\n"),
-        ),
-    ).trim();
+    const withStructure = html
+        .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+        .replace(/<\s*\/\s*(p|div|tr|li|h[1-6])\s*>/gi, "\n")
+        .replace(/<\s*\/\s*(td|th)\s*>/gi, " | ");
+    const withoutTags = stripHtmlTags(withStructure)
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{3,}/g, "\n\n");
+    return stripAnsi(decodeHtmlEntities(withoutTags)).trim();
+}
+
+// Remove HTML tags, repeating until the string stops changing so that
+// overlapping or nested tags (e.g. "<scr<script>ipt>") can't reconstruct a
+// tag after a single removal pass.
+function stripHtmlTags(text: string): string {
+    let previous: string;
+    let current = text;
+    do {
+        previous = current;
+        current = current.replace(/<[^>]*>/g, "");
+    } while (current !== previous);
+    return current;
 }
 
 function stripAnsi(text: string): string {

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -74,16 +74,6 @@ const pluginHeatFile = path.join(outputPath, "CopilotPluginFiles.wxs");
 if (!fs.existsSync(outputPath)) fs.mkdirSync(outputPath, { recursive: true });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-function quoteCmdArg(arg) {
-    if (arg === "") {
-        return '""';
-    }
-    if (/[^A-Za-z0-9_\-.:\\/]/.test(arg)) {
-        return `"${arg.replace(/"/g, '\\"')}"`;
-    }
-    return arg;
-}
-
 function runCommand(cmd, cmdArgs, options = {}) {
     console.log(`\n▶ ${cmd} ${cmdArgs.join(" ")}`);
 


### PR DESCRIPTION
Resolves the 6 open CodeQL code-scanning alerts.

## Code fixes

- **`displayRender.ts` — `js/incomplete-multi-character-sanitization` (#321):** `htmlToText` stripped tags with a single `replace(/<[^>]*>/g, "")` pass, which nested/overlapping tags (e.g. `<scr<script>ipt>`) can survive by reconstructing a tag. Now strips iteratively until the string is stable.
- **`displayRender.ts` — `js/incomplete-sanitization` (#322):** `escapeTableCell` escaped `|` and newlines but not backslashes, so a trailing `\` could escape the escaping. Now escapes `\` first.
- **`build-msi.mjs` — `js/incomplete-sanitization` (#323):** removed the unused `quoteCmdArg` helper (dead code) that escaped quotes but not backslashes.
- **`agentServerClient.ts` — `js/shell-command-constructed-from-input` (#327):** the visible-window launch concatenated `serverPath` into a PowerShell `-Command` string routed through `cmd.exe /c start`. Now `serverPath` is passed via the child's environment and the command is handed to PowerShell as a base64 `-EncodedCommand`, so no path text reaches either shell parser. Behavior (new window, `-NoExit`) is unchanged.

## Dismissed as false positive

- **#324 `sign-msi.mjs` (clear-text-logging):** logs the *name* of the KeyVault secret to help operators grant `az` access, not the password value.
- **#325 `typeagent-serve.mjs` (shell-injection-from-environment):** the flagged input is `process.execPath` (the Node binary), not attacker-controlled; Node also quotes array args to `cmd.exe`.
