### PR TITLE
Fix remaining CodeQL alerts (#327, #333, #334)

### DIFF
--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -582,29 +582,36 @@ function spawnAgentServer(
                 );
             } else {
                 const psExe = resolvePowerShellExe();
-                // Pass serverPath to the child through the environment rather
-                // than the command line so it never reaches cmd.exe or the
-                // PowerShell parser as text. Only the numeric port and
-                // idleTimeout are interpolated into the command; the path is
-                // read from $env:TYPEAGENT_SERVER_PATH at runtime. The command
-                // is handed to PowerShell as a base64 -EncodedCommand blob,
-                // whose alphabet is inert to both cmd.exe and PowerShell.
+                // Pass the server path, port and idle timeout to the child
+                // through the environment rather than the command line so none
+                // of them ever reach cmd.exe or the PowerShell parser as text.
+                // The command handed to PowerShell is therefore a fixed
+                // constant that only reads $env values at runtime, delivered as
+                // a base64 -EncodedCommand blob whose alphabet is inert to both
+                // cmd.exe and PowerShell.
                 const psCommand =
-                    `& node $env:TYPEAGENT_SERVER_PATH --port ${port}` +
-                    (idleTimeout > 0 ? ` --idle-timeout ${idleTimeout}` : "");
+                    `$host.UI.RawUI.WindowTitle = ` +
+                    `"TypeAgent Server (port $env:TYPEAGENT_SERVER_PORT)"; ` +
+                    `& node $env:TYPEAGENT_SERVER_PATH --port $env:TYPEAGENT_SERVER_PORT` +
+                    (idleTimeout > 0
+                        ? ` --idle-timeout $env:TYPEAGENT_SERVER_IDLE_TIMEOUT`
+                        : "");
                 const encodedCommand = Buffer.from(
                     psCommand,
                     "utf16le",
                 ).toString("base64");
                 const psArgs = ["-NoExit", "-EncodedCommand", encodedCommand];
                 // The first quoted argument to `start` is the new window's
-                // title. It MUST be non-empty: an empty title leaves the
-                // console window title blank, which trips a libuv bug on
+                // initial title. It MUST be non-empty: an empty title leaves
+                // the console window title blank, which trips a libuv bug on
                 // Windows — GetConsoleTitleW returns 0 with GetLastError()==0,
                 // libuv reads that as success but leaves process_title NULL,
                 // and the next process.title read aborts with
                 // "Assertion failed: process_title, file src\\win\\util.c".
-                const windowTitle = `TypeAgent Server (port ${port})`;
+                // A fixed literal keeps caller-supplied values out of the
+                // cmd.exe argument list; the port is appended to the title from
+                // the environment once PowerShell starts (see psCommand above).
+                const windowTitle = "TypeAgent Server";
                 const child = spawn(
                     "cmd.exe",
                     ["/c", "start", windowTitle, psExe, ...psArgs],
@@ -614,6 +621,8 @@ function spawnAgentServer(
                         env: {
                             ...process.env,
                             TYPEAGENT_SERVER_PATH: serverPath,
+                            TYPEAGENT_SERVER_PORT: String(port),
+                            TYPEAGENT_SERVER_IDLE_TIMEOUT: String(idleTimeout),
                         },
                     },
                 );

--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -585,10 +585,12 @@ function spawnAgentServer(
                 // Pass the server path, port and idle timeout to the child
                 // through the environment rather than the command line so none
                 // of them ever reach cmd.exe or the PowerShell parser as text.
-                // The command handed to PowerShell is therefore a fixed
-                // constant that only reads $env values at runtime, delivered as
-                // a base64 -EncodedCommand blob whose alphabet is inert to both
-                // cmd.exe and PowerShell.
+                // The command handed to PowerShell is assembled only from
+                // string literals (the --idle-timeout flag is appended based on
+                // whether idleTimeout is set, but its text is still literal) and
+                // reads the actual values from $env at runtime. It is delivered
+                // as a base64 -EncodedCommand blob whose alphabet is inert to
+                // both cmd.exe and PowerShell.
                 const psCommand =
                     `$host.UI.RawUI.WindowTitle = ` +
                     `"TypeAgent Server (port $env:TYPEAGENT_SERVER_PORT)"; ` +

--- a/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
@@ -300,7 +300,7 @@ async function isAgentPackage(
     token: string,
     fetchFn: typeof fetch,
 ): Promise<boolean> {
-    const url = `${registry.replace(/\/$/, "")}/${packageName.replace("/", "%2F")}`;
+    const url = `${registry.replace(/\/$/, "")}/${packageName.replace(/\//g, "%2F")}`;
     const res = await fetchFn(url, {
         headers: { Authorization: `Bearer ${token}` },
     });
@@ -321,7 +321,7 @@ async function fetchPackument(
     token: string,
     fetchFn: typeof fetch,
 ): Promise<unknown | undefined> {
-    const url = `${registry.replace(/\/$/, "")}/${packageName.replace("/", "%2F")}`;
+    const url = `${registry.replace(/\/$/, "")}/${packageName.replace(/\//g, "%2F")}`;
     try {
         const res = await fetchFn(url, {
             headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
Follow-up to #2610. Clears the three CodeQL code-scanning alerts still open after that merge.

## #327 - js/shell-command-constructed-from-input (agentServerClient.ts)
The previous fix routed the server **path** via the environment, but the numeric `port`/`idleTimeout` were still concatenated into both the `-EncodedCommand` blob and the `cmd.exe start` window-title argument, so CodeQL still saw caller-supplied data reach the shell.

Now the port and idle timeout are passed to the child through the environment as well (`TYPEAGENT_SERVER_PORT`, `TYPEAGENT_SERVER_IDLE_TIMEOUT`). The encoded PowerShell command and the `start` window-title argument are fixed string literals - no function-parameter data is concatenated into the command line. The port is re-appended to the visible window title *inside* PowerShell from the environment, so the window title is unchanged for users.

## #333 / #334 - js/incomplete-sanitization (feedSource.ts)
`packageName.replace("/", "%2F")` only replaced the first `/`. Switched to a global replace (`/\//g`) so every slash in a scoped package name is encoded for the registry URL. Behaviorally identical for today's single-slash npm names, but robust and satisfies the query.

## Verification
- `agentServer/client` package builds/typechecks clean.
- `feedSource.ts` change is a type-identical regex-literal swap; validated by CI's full build (local workspace install is blocked here by the internal-feed auth 401).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
