### PR TITLE
Update trigger functionality

### DIFF
--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -39,6 +39,12 @@ trigger:
   branches:
     include:
       - main
+      # GitHub's merge queue pushes candidate commits to temporary branches
+      # named gh-readonly-queue/<base>/pr-<n>-<sha> and expects the required
+      # status checks to run against them. Azure Pipelines has no merge_group
+      # event, so include the queue branches in the CI trigger to make this
+      # pipeline run (and report back) while a PR sits in the queue for main.
+      - gh-readonly-queue/main/*      
   paths:
     include:
       - ts/**


### PR DESCRIPTION
This pull request updates the Azure Pipelines CI trigger configuration to ensure that status checks run for GitHub's merge queue branches. This change allows the pipeline to execute and report results for pull requests that are in the merge queue for the `main` branch.

CI trigger improvements:

* Updated the `trigger` section in `pipelines/azure-smoke-tests.yml` to include `gh-readonly-queue/main/*` branches, ensuring Azure Pipelines runs for merge queue candidate branches and reports status checks as required by GitHub.