### PR TITLE
Moved to advanced codeql setup

### DIFF
--- a/.github/workflows/codeql-fork-upload.yml
+++ b/.github/workflows/codeql-fork-upload.yml
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Privileged companion to codeql.yml.
+#
+# CodeQL analysis of a fork pull request runs in codeql.yml under the unprivileged
+# `pull_request` event (read-only token, no secrets) and stores its SARIF as an
+# artifact. This workflow runs after that completes, in the trusted context of the
+# base repository (write token), and uploads the SARIF to code scanning so the
+# "Require code scanning results" ruleset rule is satisfied for fork PRs.
+#
+# SECURITY: This job must NEVER check out or execute the pull request's code. It
+# only downloads the SARIF artifact and uploads it. The destination ref/sha are
+# derived from the TRUSTED workflow_run payload (head_sha) plus a server-side PR
+# lookup — never from artifact contents — so a malicious fork cannot redirect
+# results to another ref. This is the safe alternative to pull_request_target.
+
+name: CodeQL fork upload
+
+on:
+  workflow_run:
+    workflows: ["CodeQL Advanced"]
+    types: [completed]
+
+concurrency:
+  group: codeql-fork-upload-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    name: Upload CodeQL results for fork PRs
+    runs-on: ubuntu-latest
+    # Only fork PR analysis runs that finished successfully. Push and
+    # internal-branch runs already uploaded their own results in codeql.yml.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.fork == true
+    permissions:
+      actions: read # download artifacts from the triggering run
+      contents: read
+      security-events: write # upload SARIF to code scanning
+    steps:
+      - name: Download CodeQL SARIF artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: codeql-sarif-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/codeql-sarif
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve pull request from trusted head SHA
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: prs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+            // Trust only a PR whose head commit matches the SHA GitHub reported
+            // for the analysis run and which targets this repository.
+            const expectedBase = `${context.repo.owner}/${context.repo.repo}`;
+            const pr = prs.find(
+              (p) => p.head.sha === headSha && p.base.repo.full_name === expectedBase,
+            );
+            if (!pr) {
+              core.setFailed(`No matching pull request for commit ${headSha}.`);
+              return;
+            }
+            core.setOutput("number", String(pr.number));
+            core.setOutput("sha", headSha);
+
+      - name: Upload CodeQL results to the pull request
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ runner.temp }}/codeql-sarif
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          sha: ${{ steps.pr.outputs.sha }}
+          wait-for-processing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# CodeQL advanced setup.
+#
+# Why this is not the stock single-file setup:
+#   Merging is gated by rulesets ("Require code scanning results" + "Require code
+#   quality results"). GitHub's CodeQL *default setup* — and any plain
+#   `on: pull_request` CodeQL workflow — cannot produce results for pull requests
+#   from FORKS, because fork-triggered runs get a read-only GITHUB_TOKEN and no
+#   secrets, so `analyze` cannot upload. Those PRs would then be blocked forever.
+#
+#   To fix that safely, this workflow ANALYZES the code (including untrusted fork
+#   code) in the unprivileged `pull_request` context and, for fork PRs, saves the
+#   SARIF as an artifact instead of uploading it. A separate, privileged workflow
+#   (codeql-fork-upload.yml) triggered by `workflow_run` then uploads that SARIF.
+#   The companion job never checks out or runs fork code, which avoids the
+#   "pwn request" vulnerability class you would get from `pull_request_target`.
+#
+# NOTE: This workflow REPLACES CodeQL "default setup". Disable default setup under
+#   Settings > Advanced Security > Code scanning first, otherwise the analyze step
+#   fails with a "default setup is enabled" conflict.
+
+name: "CodeQL Advanced"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload results for push / internal-branch PRs
+      packages: read # fetch internal CodeQL query packs
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: none
+          - language: java-kotlin
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    env:
+      # True only for PRs opened from a fork (head repo != this repo). Those runs
+      # get a read-only token and must defer the upload to codeql-fork-upload.yml.
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # For fork PRs, analyze the PR head commit so results map to the PR.
+          # Otherwise use the default ref (merge ref for internal PRs, branch tip
+          # for pushes).
+          ref: ${{ env.IS_FORK_PR == 'true' && github.event.pull_request.head.sha || github.ref }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Enable both the security ("code-scanning") and "code-quality" analyses
+          # so both ruleset rules can be satisfied. code-quality is currently a
+          # preview capability; if the analyze step rejects this input, remove the
+          # line and drop the "Require code quality results" rule from the ruleset.
+          analysis-kinds: code-scanning,code-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+          # Push and internal-branch PRs have a write token and upload directly.
+          # Fork PRs cannot upload here, so write SARIF to disk and hand it to the
+          # privileged companion workflow via an artifact.
+          upload: ${{ env.IS_FORK_PR == 'true' && 'never' || 'always' }}
+          output: sarif-results
+
+      - name: Stage SARIF for fork PR upload
+        if: ${{ env.IS_FORK_PR == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results
+          retention-days: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
           - language: csharp
             build-mode: none
           - language: java-kotlin
-            build-mode: autobuild
+            build-mode: none
           - language: javascript-typescript
             build-mode: none
           - language: python


### PR DESCRIPTION
This pull request introduces a new advanced CodeQL analysis workflow for GitHub Actions, replacing the default setup to support secure code scanning for pull requests from forks. The main changes include adding `.github/workflows/codeql.yml` for advanced CodeQL analysis and `.github/workflows/codeql-fork-upload.yml` to safely upload SARIF results from forked PRs. This setup ensures that fork PRs are analyzed without exposing secrets or write tokens, and results are uploaded securely in a privileged context.

**New advanced CodeQL workflow and fork PR support:**

* Added `.github/workflows/codeql.yml` to perform CodeQL analysis for multiple languages, supporting both direct uploads for internal PRs and artifact-based handoff for fork PRs. This workflow disables the default CodeQL setup and handles concurrency and permissions appropriately.
* Added `.github/workflows/codeql-fork-upload.yml`, a privileged companion workflow that uploads SARIF results for fork PRs after analysis completes. This workflow never checks out or executes untrusted code, ensuring security while satisfying code scanning requirements for fork PRs.