### PR TITLE
pipelines: prime REGISTRY cache after publishing to ADO_REGISTRY

### DIFF
--- a/pipelines/azure-build-package-shell.yml
+++ b/pipelines/azure-build-package-shell.yml
@@ -61,7 +61,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
 
       - template: include-update-package-version.yml
         parameters:

--- a/pipelines/azure-build-publish-agent-server.yml
+++ b/pipelines/azure-build-publish-agent-server.yml
@@ -80,7 +80,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
           # Manual/scheduled; skip store caching (the Windows post-job cache save
           # can exceed its timeout and fail the job after a successful publish).
           enableCache: false

--- a/pipelines/azure-build-publish-copilot-plugin.yml
+++ b/pipelines/azure-build-publish-copilot-plugin.yml
@@ -52,7 +52,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
           enableCache: false
 
       - template: include-update-package-version.yml

--- a/pipelines/azure-build-publish-mcp.yml
+++ b/pipelines/azure-build-publish-mcp.yml
@@ -60,7 +60,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
           # Manual/scheduled; skip store caching (the Windows post-job cache save
           # can exceed its timeout and fail the job after a successful publish).
           enableCache: false

--- a/pipelines/azure-build-ts.yml
+++ b/pipelines/azure-build-ts.yml
@@ -35,7 +35,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
 
       - template: include-update-package-version.yml
         parameters:
@@ -89,8 +89,8 @@ jobs:
         workingDirectory: $(buildDirectory)
 
       - script: |
-          echo $(ADO_REGISTRY)
-          echo "registry=$(ADO_REGISTRY)" > .npmrc
+          echo $(PUBLISH_REGISTRY)
+          echo "registry=$(PUBLISH_REGISTRY)" > .npmrc
           cat .npmrc
         displayName: "Create .npmrc file."
         workingDirectory: $(NpmRcDirectory)
@@ -103,17 +103,17 @@ jobs:
       - script: |
           for file in $(publishedPackageDirectory)/*.tgz; do
             echo "Publishing file: $file"
-            npm publish --registry=$(ADO_REGISTRY) --tag=latest "$file"
+            npm publish --registry=$(PUBLISH_REGISTRY) --tag=latest "$file"
           done
         displayName: "Publish packages"
         workingDirectory: $(NpmRcDirectory)
 
-      # ADO_REGISTRY is an upstream source of REGISTRY. Upstreams are
-      # pull-through: a package published to ADO_REGISTRY only shows up in
-      # REGISTRY after something requests it through REGISTRY. Do that request
-      # here so freshly published versions are cached in REGISTRY immediately.
-      # npm pack downloads just the tarball (no dep resolution), which is
-      # enough to trigger the upstream fetch.
+      # PUBLISH_REGISTRY is an upstream source of INSTALL_REGISTRY. Upstreams
+      # are pull-through: a package published to PUBLISH_REGISTRY only shows up
+      # in INSTALL_REGISTRY after something requests it through INSTALL_REGISTRY.
+      # Do that request here so freshly published versions are cached in
+      # INSTALL_REGISTRY immediately. npm pack downloads just the tarball (no
+      # dep resolution), which is enough to trigger the upstream fetch.
       - script: |
           set -e
           primeDir=$(mktemp -d)
@@ -122,7 +122,7 @@ jobs:
           for file in $(publishedPackageDirectory)/*.tgz; do
             name=$(tar -xzOf "$file" package/package.json | jq -r .name)
             version=$(tar -xzOf "$file" package/package.json | jq -r .version)
-            echo "Priming REGISTRY cache: $name@$version"
-            npm pack --registry=$(REGISTRY) "$name@$version" > /dev/null
+            echo "Priming INSTALL_REGISTRY cache: $name@$version"
+            npm pack --registry=$(INSTALL_REGISTRY) "$name@$version" > /dev/null
           done
-        displayName: "Prime REGISTRY cache from upstream"
+        displayName: "Prime INSTALL_REGISTRY cache from upstream"

--- a/pipelines/azure-build-ts.yml
+++ b/pipelines/azure-build-ts.yml
@@ -112,17 +112,17 @@ jobs:
       # pull-through: a package published to ADO_REGISTRY only shows up in
       # REGISTRY after something requests it through REGISTRY. Do that request
       # here so freshly published versions are cached in REGISTRY immediately.
+      # npm pack downloads just the tarball (no dep resolution), which is
+      # enough to trigger the upstream fetch.
       - script: |
           set -e
           primeDir=$(mktemp -d)
           cp $(buildDirectory)/.npmrc "$primeDir/.npmrc"
           cd "$primeDir"
-          npm init -y > /dev/null
           for file in $(publishedPackageDirectory)/*.tgz; do
             name=$(tar -xzOf "$file" package/package.json | jq -r .name)
             version=$(tar -xzOf "$file" package/package.json | jq -r .version)
             echo "Priming REGISTRY cache: $name@$version"
-            npm install --no-save --registry=$(REGISTRY) "$name@$version"
+            npm pack --registry=$(REGISTRY) "$name@$version" > /dev/null
           done
         displayName: "Prime REGISTRY cache from upstream"
-        workingDirectory: $(NpmRcDirectory)

--- a/pipelines/azure-build-ts.yml
+++ b/pipelines/azure-build-ts.yml
@@ -107,3 +107,22 @@ jobs:
           done
         displayName: "Publish packages"
         workingDirectory: $(NpmRcDirectory)
+
+      # ADO_REGISTRY is an upstream source of REGISTRY. Upstreams are
+      # pull-through: a package published to ADO_REGISTRY only shows up in
+      # REGISTRY after something requests it through REGISTRY. Do that request
+      # here so freshly published versions are cached in REGISTRY immediately.
+      - script: |
+          set -e
+          primeDir=$(mktemp -d)
+          cp $(buildDirectory)/.npmrc "$primeDir/.npmrc"
+          cd "$primeDir"
+          npm init -y > /dev/null
+          for file in $(publishedPackageDirectory)/*.tgz; do
+            name=$(tar -xzOf "$file" package/package.json | jq -r .name)
+            version=$(tar -xzOf "$file" package/package.json | jq -r .version)
+            echo "Priming REGISTRY cache: $name@$version"
+            npm install --no-save --registry=$(REGISTRY) "$name@$version"
+          done
+        displayName: "Prime REGISTRY cache from upstream"
+        workingDirectory: $(NpmRcDirectory)

--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -48,7 +48,7 @@
 #     'build-pipeline-kv' vault (the vault uses RBAC authorization, not access
 #     policies). Authorize the pipeline to use the connection on first run.
 #   * Pipeline variables (define in the pipeline UI or a linked variable group):
-#       - REGISTRY         npm registry URL used by include-prepare-repo.yml to
+#       - INSTALL_REGISTRY npm registry URL used by include-prepare-repo.yml to
 #                          restore dependencies (internal Azure Artifacts feed).
 #   * Pull request validation settings (Edit > ... > Triggers, UI-only) - to run
 #     fork PRs behind a write-access gate, set: "Build pull requests from forks"
@@ -120,7 +120,7 @@ jobs:
         parameters:
           buildDirectory: $(buildDirectory)
           nodeVersion: $(nodeVersion)
-          registry: $(REGISTRY)
+          registry: $(INSTALL_REGISTRY)
 
       # keytar links against libsecret at runtime on Linux; install before any
       # TypeAgent process (CLI / shell) loads the native module.


### PR DESCRIPTION
Two related pipeline changes.

## 1. Prime `INSTALL_REGISTRY` cache after publishing

Adds a step to the TS build/publish pipeline that, right after `npm publish` uploads packages to `PUBLISH_REGISTRY`, pulls each freshly published `name@version` through `INSTALL_REGISTRY` so the upstream/pull-through feed caches them immediately.

**Why:** `PUBLISH_REGISTRY` is configured as an upstream source of `INSTALL_REGISTRY`. Upstreams in Azure Artifacts are pull-through: a package only appears in the downstream feed after something requests it there. Without this step, the first consumer of a freshly published version pays the pull-through latency (and sometimes sees transient not-found errors during that window). Priming here shifts that cost into the publish pipeline.

**How:**
- Copies the already-authenticated `.npmrc` (registry = `INSTALL_REGISTRY`, token added by `npmAuthenticate@0`) into a temp dir.
- For each `.tgz` under `publishedPackageDirectory`, extracts `name` and `version` from the tarball's `package.json` and runs `npm pack --registry=$(INSTALL_REGISTRY) name@version`.

`npm pack` (not `npm install`) is enough - it downloads just the tarball and skips dep resolution, which is all we need to trigger the pull-through fetch.

## 2. Rename `REGISTRY` / `ADO_REGISTRY` -> `INSTALL_REGISTRY` / `PUBLISH_REGISTRY`

The old names collided: both feeds are npm registries hosted in Azure DevOps, so which one was which required knowing the setup. Name them by role instead:

- `INSTALL_REGISTRY` - what consumers install from (the aggregating feed with upstream sources).
- `PUBLISH_REGISTRY` - where `@typeagent/*` packages are published to.
