### PR TITLE
docs: reorganize wiki around build-an-agent + broaden contributing

### DIFF
--- a/ts/docs/agents/index.md
+++ b/ts/docs/agents/index.md
@@ -30,21 +30,6 @@ state, and what output it produces:
 | `view-ui`                | Rich interactive web-view UI             | `turtle`, `montage`, `markdown` |
 | `command-handler`        | Simple settings-style direct dispatch    | `settings`, `test`              |
 
-## Anatomy of an agent
-
-Each agent typically follows this layout:
-
-```
-packages/agents/<name>/src/
-  <name>Manifest.json    # metadata, schema pointers, emoji
-  <name>Schema.ts        # typed action/activity definitions
-  <name>Schema.agr       # grammar rules (NL → structured actions)
-  <name>ActionHandler.ts # implements instantiate(): AppAgent
-```
-
-The dispatcher calls `executeAction(action, context)` with already-validated,
-typed actions — agents never parse natural language directly.
-
 ## Adding an agent
 
 Building a new application agent? Start with

--- a/ts/docs/agents/index.md
+++ b/ts/docs/agents/index.md
@@ -47,12 +47,23 @@ typed actions — agents never parse natural language directly.
 
 ## Adding an agent
 
-After scaffolding a new agent (often via the
-[`onboarding`](../architecture/agents/agent-patterns.md) agent), regenerate the
-navigation:
+Building a new application agent? Start with
+[Build an agent](../guides/build-an-agent/index.md) - the canonical guide for
+picking a pattern, scaffolding (often via the `onboarding` agent), defining
+actions and grammar, and distributing your agent. The
+[Echo tutorial](../guides/build-an-agent/tutorial-echo.md) is a concrete
+standalone-package walkthrough if you'd rather start with working code.
+
+An agent does not need to live in this repo. Standalone agents in their own
+packages can be surfaced via `@package install` from a local path, catalog,
+or feed - see [Agent install sources](../architecture/lifecycle/agent-sources.md).
+
+If the agent **does** live in this repo under `ts/packages/agents/**`, its
+README shows up in the navigation above once you regenerate the wiki:
 
 ```bash
 node ts/docs/scripts/build-wiki.mjs
 ```
 
-See [Add an agent](../contributing/add-an-agent.md) for the full checklist.
+See [Add an agent](../contributing/add-an-agent.md) for the full
+wiki-registration checklist.

--- a/ts/docs/contributing/add-an-agent.md
+++ b/ts/docs/contributing/add-an-agent.md
@@ -1,43 +1,32 @@
-# Add an agent
+# Add an agent to the wiki
 
-When a new application agent is added under `ts/packages/agents/**`, follow
-these steps so it shows up in the [Agents](../agents/index.md) section. The flow
-mirrors [Add a package](./add-a-package.md), with a couple of agent-specific
-notes.
+Checklist for making a new application agent under `ts/packages/agents/**`
+appear in the [Agents](../agents/index.md) section of the wiki. This page
+covers the docs-registration flow only. For the actual agent-building
+walkthrough (patterns, scaffolding, iteration, distribution), see
+[Build an agent](../guides/build-an-agent/index.md).
 
-## 1. Scaffold the agent
+The flow mirrors [Add a package](./add-a-package.md), with a couple of
+agent-specific notes.
 
-Most agents are created with the **onboarding** agent, which walks an
-integration through discovery → schema → grammar → scaffolding → testing →
-packaging and picks an appropriate [agent pattern](../architecture/agents/agent-patterns.md).
-However it is created, an agent ends up with the standard layout:
+## 1. Write the agent README
 
-```
-packages/agents/<name>/src/
-  <name>Manifest.json    # metadata, schema pointers, emoji
-  <name>Schema.ts        # typed action/activity definitions
-  <name>Schema.agr       # grammar rules (NL → structured actions)
-  <name>ActionHandler.ts # implements instantiate(): AppAgent
-```
+Add a hand-written `README.md` at the agent's root, starting from the
+[agent page template](../templates/agent-page.md). Cover what the agent
+does, which pattern it follows, the actions it exposes, and any external
+setup (API keys, host-app plugins, OS requirements).
 
-## 2. Write the agent README
-
-Add a hand-written `README.md` at the agent's root. Start from the
-[agent page template](../templates/agent-page.md). Cover what the agent does,
-which pattern it follows, the actions it exposes, and any external setup
-(API keys, host-app plugins, OS requirements).
-
-## 3. (Optional) Generate the AI companion
+## 2. (Optional) Generate the AI companion
 
 ```bash
 node ts/tools/docsAutogen/bin/docs-autogen.cjs --package <name> --render --write
 ```
 
 For agent packages, the generated `README.AUTOGEN.md` includes a per-action
-reference table derived from the agent's schema, which is especially useful in
-the wiki.
+reference table derived from the agent's schema, which is especially useful
+in the wiki.
 
-## 4. Refresh the wiki navigation
+## 3. Refresh the wiki navigation
 
 ```bash
 node ts/docs/scripts/build-wiki.mjs
@@ -47,95 +36,15 @@ The agent is discovered under `ts/packages/agents/**` and added to
 `agents/toc.yml`. Nested agent packages (e.g. `agentUtils/graphUtils`) are
 handled automatically.
 
-## 5. Consider the patterns doc
+## 4. Consider the patterns doc
 
-If your agent introduces or exemplifies a pattern not already covered, update
-[Agent patterns](../architecture/agents/agent-patterns.md) (canonical home
-`ts/docs/architecture/agent-patterns.md`) so the agents index stays accurate.
+If your agent introduces or exemplifies a pattern not already covered,
+update [Agent patterns](../architecture/agents/agent-patterns.md)
+(canonical home `ts/docs/architecture/agents/agent-patterns.md`) so the
+agents index stays accurate.
 
-## 6. Preview and open a PR
+## 5. Preview and open a PR
 
-[Build locally](./build-locally.md), confirm the agent renders, then open a PR
-including the new `README.md`, the regenerated `agents/toc.yml`, and any
+[Build locally](./build-locally.md), confirm the agent renders, then open a
+PR including the new `README.md`, the regenerated `agents/toc.yml`, and any
 companion or pattern-doc updates.
-
-## Making an agent installable
-
-Bundled agents ship with the app. To let users **install** your agent on demand
-through `@package install`, it must be reachable from an
-[install source](../architecture/lifecycle/agent-sources.md). There are three
-ways, matching the three source kinds.
-
-### Local `path` (development)
-
-No packaging needed — a built agent directory installs directly from disk:
-
-```
-@package install echo <path to the built echo package>
-```
-
-This is the flow the [Creating an Agent](https://github.com/microsoft/TypeAgent/blob/main/docs/content/tutorial/agent.md)
-tutorial uses. It is the fastest inner loop and lets a local build **shadow** a
-published version when its `path` source is ordered ahead of the feed.
-
-### A `catalog` entry
-
-A catalog is a JSON file mapping agent short names to packages, so users install
-by name (`@package install echo`). Add an entry pointing at either a local path
-or a published package name:
-
-```jsonc
-{
-  "agents": {
-    "echo": { "name": "@company/echo-agent", "execMode": "separate" },
-  },
-}
-```
-
-### Publishing to a feed
-
-A `feed` source installs from an Azure Artifacts npm registry by package
-specifier (`@package install echo echo-agent@^1.2`). Two author-side requirements
-make a published package discoverable **as an agent**:
-
-1. **Declare the sentinel keyword.** Add `typeagent-agent` to your package's
-   `keywords` in `package.json`. Feed enumeration keeps only packages carrying
-   this keyword — scope membership alone is not enough, because support libraries
-   live in the same scope.
-
-   ```jsonc
-   // package.json
-   {
-     "keywords": ["typeagent-agent"],
-   }
-   ```
-
-2. **Pass the policy check.** `npm run check:policy` fails the build if a package
-   that exposes `"./agent/manifest"` in its `exports` is missing the keyword, so
-   the marker cannot be forgotten.
-
-3. **(Recommended) Declare a default agent name.** Add
-   `typeagent.defaultAgentName` to `package.json` so users can install by a
-   friendly name in one argument (`@package install echo`) instead of the full
-   package specifier. It must be a legal dispatcher agent identifier (letters,
-   digits, `-`/`_`, starting with a letter); an illegal or missing value simply
-   disables one-argument name install, and the package can still be installed
-   with the two-argument form (`@package install <package> <name>`). The same
-   field applies to `path` and catalog `path` entries, read from the resolved
-   directory's `package.json`.
-
-   ```jsonc
-   // package.json
-   {
-     "typeagent": { "defaultAgentName": "echo" },
-   }
-   ```
-
-Feed **installs** (by whoever runs `@package install`) additionally require
-`az login` on the installing machine and, unless the source is configured with an
-explicit `registry`/`scopes`, the `TYPEAGENT_FEED_REGISTRY` /
-`TYPEAGENT_FEED_SCOPES` environment values. See
-[Agent sources › the feed source](../architecture/lifecycle/agent-sources.md#the-feed-source)
-for how auth and enumeration work, and the
-[TypeAgent command reference](../overview/command-reference.md#package-source-list--order--add--remove---manage-install-sources)
-for the `@package source` commands that configure and order sources.

--- a/ts/docs/contributing/development-setup.md
+++ b/ts/docs/contributing/development-setup.md
@@ -1,0 +1,144 @@
+# Development setup
+
+Repo-contributor's entry point. The core setup (prereqs, build, run, test,
+lint) is covered in the [Overview](../overview/index.md) section. This
+page adds the pieces that only matter when you are changing the repo.
+
+## Get a working checkout
+
+Start with the overview pages, which cover everything a first-time
+contributor needs before their first PR:
+
+- [Getting started](../overview/getting-started.md) - prereqs, `pnpm i`,
+  `pnpm run build`, `pnpm run shell` / `pnpm run cli`, and the
+  "Test, lint, format" summary. Links out to the per-platform
+  [Windows](../overview/setup-windows.md) / [WSL2](../overview/setup-wsl2.md)
+  / [Linux](../overview/setup-linux.md) / [macOS](../overview/setup-macos.md)
+  setup guides.
+- [Service keys and configuration](../overview/service-keys.md):
+  `ts/config.local.yaml`, keyless (identity-based) access, and Azure Key
+  Vault management via `npm run getKeys`.
+
+The rest of this page assumes a working local build.
+
+## Running a single test
+
+`pnpm run test:local` and `pnpm run test:live` (documented in
+[Test, lint, format](../overview/getting-started.md#test-lint-format))
+run everything. To iterate on one test file or test name, `cd` into the
+package directory and use `jest-esm`, a wrapper around
+`node --experimental-vm-modules jest`:
+
+```bash
+pnpm run jest-esm --testPathPattern="merge.spec.js"
+pnpm run jest-esm --testNamePattern="your test name"
+```
+
+## Code style
+
+Prettier uses defaults (no `.prettierrc`). TypeScript and JavaScript use
+4-space indentation, JSON uses 2-space, line endings are LF, and every
+source file starts with the Microsoft copyright header.
+
+## Schema-change regeneration
+
+If you touched a translator or explainer schema, the built-in construction
+cache and test data need to be regenerated and evaluated for correctness.
+
+Test data lives under
+[`ts/packages/defaultAgentProvider/test/data`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/defaultAgentProvider/test/data),
+one file per translator/explainer. Use `agent-cli data add` to add new
+test cases.
+
+To regenerate, from the repo root or the
+[`ts/packages/cli`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli)
+directory:
+
+```bash
+pnpm run regen:builtin       # regenerate the builtin construction store
+pnpm run regen               # regenerate test data
+```
+
+To evaluate correctness:
+
+- `agent-cli data diff <file>`: open a test-data diff in VS Code.
+- Run `pnpm run test` to verify round-trip (also runs in CI).
+- Compare stats: `pnpm run regen -- -- --none` prints per-file and total
+  stats. Explanation failure counts and attempt/correction ratios should
+  stay roughly the same or improve.
+
+## Debugging and troubleshooting
+
+- [Developer tips](../overview/developer-tips.md): common pitfalls
+  (`pnpm i` after sync, `git clean -dfX` reset, `TYPEAGENT_EXECMODE=0` for
+  in-proc agents, VS Code `@debug` attach, Jest Explorer fixes).
+- `@debug` in the shell or CLI opens an inspector to attach VS Code to.
+- Traces use the [`debug`](https://www.npmjs.com/package/debug) package.
+  Set `DEBUG=typeagent:prompt` (or any `typeagent:*` namespace) in the
+  environment, or issue `@trace <pattern>` inside the interactive shell.
+
+## Submitting changes
+
+- Sign the CLA on your first PR; the bot will prompt you. Details in
+  [`CONTRIBUTIONS.md`](https://github.com/microsoft/TypeAgent/blob/main/CONTRIBUTIONS.md).
+- Run `pnpm run prettier` and `pnpm run test:local` before pushing.
+- Follow the
+  [Code of Conduct](https://github.com/microsoft/TypeAgent/blob/main/CODE_OF_CONDUCT.md).
+- Security issues go through
+  [`SECURITY.md`](https://github.com/microsoft/TypeAgent/blob/main/SECURITY.md),
+  not GitHub Issues.
+
+If your change touches documentation, see the wiki pages linked from
+[Contributing](./index.md); they cover adding pages, packages, agents,
+and running the doc-autogen pipeline.
+
+If you touched a translator or explainer schema, the built-in construction
+cache and test data need to be regenerated and evaluated for correctness.
+
+Test data lives under
+[`ts/packages/defaultAgentProvider/test/data`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/defaultAgentProvider/test/data),
+one file per translator/explainer. Use `agent-cli data add` to add new
+test cases.
+
+To regenerate, from the repo root or the
+[`ts/packages/cli`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli)
+directory:
+
+```bash
+pnpm run regen:builtin       # regenerate the builtin construction store
+pnpm run regen               # regenerate test data
+```
+
+To evaluate correctness:
+
+- `agent-cli data diff <file>`: open a test-data diff in VS Code.
+- Run `pnpm run test` to verify round-trip (also runs in CI).
+- Compare stats: `pnpm run regen -- -- --none` prints per-file and total
+  stats. Explanation failure counts and attempt/correction ratios should
+  stay roughly the same or improve.
+
+## Debugging and troubleshooting
+
+- [Developer tips](../overview/developer-tips.md): common pitfalls
+  (`pnpm i` after sync, `git clean -dfX` reset, `TYPEAGENT_EXECMODE=0` for
+  in-proc agents, VS Code `@debug` attach, Jest Explorer fixes).
+- The CLI and Shell define VS Code launch tasks; use `@debug` to expose an
+  inspector and then attach.
+- Traces use the [`debug`](https://www.npmjs.com/package/debug) package.
+  Set `DEBUG=typeagent:prompt` (or any `typeagent:*` namespace) in the
+  environment, or issue `@trace <pattern>` inside the interactive shell.
+
+## Submitting changes
+
+- Sign the CLA on your first PR; the bot will prompt you. Details in
+  [`CONTRIBUTIONS.md`](https://github.com/microsoft/TypeAgent/blob/main/CONTRIBUTIONS.md).
+- Run `pnpm run prettier` and `pnpm run test:local` before pushing.
+- Follow the
+  [Code of Conduct](https://github.com/microsoft/TypeAgent/blob/main/CODE_OF_CONDUCT.md).
+- Security issues go through
+  [`SECURITY.md`](https://github.com/microsoft/TypeAgent/blob/main/SECURITY.md),
+  not GitHub Issues.
+
+If your change touches documentation, see the wiki pages linked from
+[Contributing](./index.md); they cover adding pages, packages, agents,
+and running the doc-autogen pipeline.

--- a/ts/docs/contributing/index.md
+++ b/ts/docs/contributing/index.md
@@ -1,31 +1,50 @@
-# Contributing to the wiki
+# Contributing to TypeAgent
+
+This section covers **changing the TypeAgent repo**, both code and docs.
+If you are building an agent that consumes TypeAgent, start with
+[Build an agent](../guides/build-an-agent/index.md) instead.
+
+## Contributing code
+
+- **[Development setup](./development-setup.md)**: prereqs, build, run,
+  test, lint, and debug. The authoritative build instructions live in
+  [`ts/README.md`](https://github.com/microsoft/TypeAgent/blob/main/ts/README.md);
+  this wiki page is the index into it.
+- **[CLA and contribution basics](https://github.com/microsoft/TypeAgent/blob/main/CONTRIBUTIONS.md)**:
+  the CLA bot will decorate your first PR.
+- **[Code of Conduct](https://github.com/microsoft/TypeAgent/blob/main/CODE_OF_CONDUCT.md)**
+  and **[Security disclosure policy](https://github.com/microsoft/TypeAgent/blob/main/SECURITY.md)**
+  (do **not** file security issues on GitHub).
+
+## Contributing to the wiki
 
 This wiki is **source-controlled Markdown** that lives in the TypeAgent
 repository and is published with [DocFX](https://dotnet.github.io/docfx/).
-You contribute to it the same way you contribute code: edit Markdown, open a
-pull request, get it reviewed, and merge. There is no separate wiki editor and
-no out-of-band content store.
+You contribute to it the same way you contribute code: edit Markdown, open
+a pull request, get it reviewed, and merge. There is no separate wiki
+editor and no out-of-band content store.
 
-## The one rule: edit content where it lives
+### The one rule: edit content where it lives
 
-Every piece of knowledge has exactly one canonical home. Edit it there and it
-appears in the wiki automatically — never copy content into a second place.
+Every piece of knowledge has exactly one canonical home. Edit it there
+and it appears in the wiki automatically; never copy content into a second
+place.
 
-| You want to change…                        | Edit the file under…                                                                      |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| A conceptual / overview / contributor page | `ts/docs/**` (this directory)                                                             |
-| An architecture deep dive                  | `ts/docs/architecture/<group>/**`                                                         |
-| A workflow-system design / decision record | `ts/docs/architecture/workflows/**`                                                       |
-| A package's narrative docs                 | that package's `README.md`                                                                |
-| A package's generated reference            | regenerate its `README.AUTOGEN.md` via [doc-autogen](./doc-autogen.md) — do not hand-edit |
+| You want to change…                        | Edit the file under…                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| A conceptual / overview / contributor page | `ts/docs/**` (this directory)                                                            |
+| An architecture deep dive                  | `ts/docs/architecture/<group>/**`                                                        |
+| A workflow-system design / decision record | `ts/docs/architecture/workflows/**`                                                      |
+| A package's narrative docs                 | that package's `README.md`                                                               |
+| A package's generated reference            | regenerate its `README.AUTOGEN.md` via [doc-autogen](./doc-autogen.md); do not hand-edit |
 
-[How the wiki is structured](./wiki-structure.md) explains why, and how DocFX
-assembles these sources into one site.
+[How the wiki is structured](./wiki-structure.md) explains why, and how
+DocFX assembles these sources into one site.
 
-## Build & preview locally
+### Build and preview locally
 
-Before opening a PR, build the site to check your changes. Two steps — stage the
-package docs and regenerate navigation, then run DocFX:
+Before opening a PR, build the site to check your changes. Two steps:
+stage the package docs and regenerate navigation, then run DocFX.
 
 ```bash
 # one-time: install DocFX (needs the .NET SDK)
@@ -39,23 +58,26 @@ docfx build ts/docs/docfx.json
 docfx ts/docs/docfx.json --serve
 ```
 
-> Always run `node ts/docs/scripts/build-wiki.mjs` **before** `docfx build` — a
-> fresh checkout has no staged package docs or generated `toc.yml` files until it
-> runs. See [Build the wiki locally](./build-locally.md) for details.
+> Always run `node ts/docs/scripts/build-wiki.mjs` **before**
+> `docfx build`. A fresh checkout has no staged package docs or generated
+> `toc.yml` files until it runs. See
+> [Build the wiki locally](./build-locally.md) for details.
 
-## Common tasks
+### Common tasks
 
-- **[Add or edit a page](./add-a-page.md)** — the general workflow, including how
-  to register a new page in the navigation.
-- **[Add a package](./add-a-package.md)** — what to do so a new package's docs
-  show up.
-- **[Add an agent](./add-an-agent.md)** — same, for application agents.
-- **[The doc-autogen pipeline](./doc-autogen.md)** — how `README.AUTOGEN.md`
+- **[Add or edit a page](./add-a-page.md)**: the general workflow,
+  including how to register a new page in the navigation.
+- **[Add a package](./add-a-package.md)**: what to do so a new package's
+  docs show up.
+- **[Add an agent](./add-an-agent.md)**: the wiki-registration checklist
+  for a new agent. For the agent-building walkthrough, see
+  [Build an agent](../guides/build-an-agent/index.md).
+- **[The doc-autogen pipeline](./doc-autogen.md)**: how `README.AUTOGEN.md`
   companions are generated and how they feed the wiki.
-- **[Style guide](./style-guide.md)** — conventions for headings, links, and
-  Markdown that renders cleanly in DocFX.
-- **[Build the wiki locally](./build-locally.md)** — preview your changes before
-  opening a PR.
+- **[Style guide](./style-guide.md)**: conventions for headings, links,
+  and Markdown that renders cleanly in DocFX.
+- **[Build the wiki locally](./build-locally.md)**: preview your changes
+  before opening a PR.
 
 ## Templates
 

--- a/ts/docs/contributing/index.md
+++ b/ts/docs/contributing/index.md
@@ -58,8 +58,7 @@ docfx build ts/docs/docfx.json
 docfx ts/docs/docfx.json --serve
 ```
 
-> Always run `node ts/docs/scripts/build-wiki.mjs` **before**
-> `docfx build`. A fresh checkout has no staged package docs or generated
+> Always run `node ts/docs/scripts/build-wiki.mjs` **before** > `docfx build`. A fresh checkout has no staged package docs or generated
 > `toc.yml` files until it runs. See
 > [Build the wiki locally](./build-locally.md) for details.
 

--- a/ts/docs/contributing/toc.yml
+++ b/ts/docs/contributing/toc.yml
@@ -3,20 +3,24 @@
 
 - name: Contributing
   href: index.md
-- name: How the wiki is structured
-  href: wiki-structure.md
-- name: Add or edit a page
-  href: add-a-page.md
-- name: Add a package
-  href: add-a-package.md
-- name: Add an agent
-  href: add-an-agent.md
-- name: The doc-autogen pipeline
-  href: doc-autogen.md
-- name: Style guide
-  href: style-guide.md
-- name: Build the wiki locally
-  href: build-locally.md
+- name: Development setup
+  href: development-setup.md
+- name: Contributing to the wiki
+  items:
+    - name: How the wiki is structured
+      href: wiki-structure.md
+    - name: Add or edit a page
+      href: add-a-page.md
+    - name: Add a package
+      href: add-a-package.md
+    - name: Add an agent
+      href: add-an-agent.md
+    - name: The doc-autogen pipeline
+      href: doc-autogen.md
+    - name: Style guide
+      href: style-guide.md
+    - name: Build the wiki locally
+      href: build-locally.md
 - name: Templates
   items:
     - name: Package page

--- a/ts/docs/guides/build-an-agent/index.md
+++ b/ts/docs/guides/build-an-agent/index.md
@@ -1,0 +1,217 @@
+# Build an agent
+
+An **application agent** is a plugin that the
+[dispatcher](../../architecture/core/dispatcher.md) routes typed actions to.
+This section walks through building one, whether it lives inside the
+TypeAgent repo or in a package of your own.
+
+Two starting points, depending on where the agent will live:
+
+- **Bundled with TypeAgent** (`ts/packages/agents/<name>`): ships in the repo,
+  discoverable to any local build. Most agents in the tree are bundled.
+- **Standalone npm package**: your own repo, consumed by TypeAgent via
+  `@package install`.
+  [Tutorial: build an Echo agent (standalone package)](./tutorial-echo.md)
+  is the full external-package walkthrough.
+
+This page is the overview: the shape of an agent, the end-to-end flow, and
+distribution options. Deeper topics have their own sub-guides; see
+[Topics](#topics) below.
+
+## Topics
+
+Building an agent breaks into several areas of interest. This section will
+grow to cover each; today the following are available:
+
+- [User interaction (`ActionIO` and display)](./user-interaction.md): how an
+  action handler shows text, status, HTML, tables, and message kinds
+  (`info`/`status`/`warning`/`error`/`success`) to the user; append modes;
+  the display helpers from `@typeagent/agent-sdk/helpers/display`.
+
+Planned (not yet written; see the
+[agent SDK README](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/README.md)
+in the meantime):
+
+- **Actions and grammar** - authoring `<name>Schema.ts` and
+  `<name>Schema.agr`, the `executeAction` contract, validated typed actions.
+- **Agent lifecycle** - `initializeAgentContext`, `updateAgentContext`,
+  `closeAgentContext`, and when to hold long-lived resources.
+- **Readiness and setup flows** - `checkReadiness`, `setup`, and the
+  yes/no choice card pattern via `handleChoice`.
+- **Commands** (`@`-commands) - `getCommands` / `executeCommand` and
+  `CommandDescriptors`.
+- **Storage** - `instanceStorage` and `sessionStorage` on `ActionContext`.
+- **Streaming** - `streamPartialAction` and `streamingActionContext` for
+  incremental output.
+- **Dynamic display** - `getDynamicDisplay` for results that update over
+  time.
+
+## 1. Pick a pattern
+
+Every TypeAgent agent falls into one of nine architectural patterns based on
+how it talks to external systems, whether it keeps state, and what output it
+produces. Read [Agent patterns](../../architecture/agents/agent-patterns.md)
+first and pick one; use the corresponding examples as a reference.
+
+The most common choice is `schema-grammar`: a bounded set of typed actions
+defined in a `.ts` schema with a matching `.agr` grammar file.
+
+## 2. Scaffold the agent
+
+There are two ways to create the initial files:
+
+- **Automated (recommended):** the `onboarding` agent walks an integration
+  through discovery, schema, grammar, scaffolding, testing, and packaging,
+  and picks a pattern for you. From a running shell or CLI:
+  ```
+  start onboarding for <integration-name>
+  ```
+  See [`packages/agents/onboarding/README.md`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agents/onboarding/README.md).
+- **Manual:** copy an existing agent whose pattern matches yours (for
+  `schema-grammar`,
+  [`list`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/agents/list)
+  is a good starting point) and rename its files.
+
+Either way, an agent ends up with the standard layout:
+
+```
+packages/agents/<name>/src/
+  <name>Manifest.json    # metadata, schema pointers, emoji
+  <name>Schema.ts        # typed action/activity definitions
+  <name>Schema.agr       # grammar rules (NL to structured actions)
+  <name>ActionHandler.ts # implements instantiate(): AppAgent
+```
+
+## 3. Define actions and grammar
+
+Author the four files above. The important contracts:
+
+- `<name>Schema.ts` exports a union of typed actions. This is the API
+  surface the LLM (and grammar matcher) targets.
+- `<name>Schema.agr` maps natural-language patterns to those actions.
+- `<name>ActionHandler.ts` exports `instantiate(): AppAgent` and implements
+  `executeAction(action, context)`. The dispatcher hands you an
+  already-typed, already-validated action; agents never parse language
+  directly.
+
+See [Agent patterns](../../architecture/agents/agent-patterns.md) for
+pattern-specific details (long-lived resources, `closeAgentContext`,
+streaming, sub-agent orchestration, etc.).
+
+## 4. Build and try it
+
+From `ts/`:
+
+```bash
+pnpm run build
+pnpm run shell     # or: pnpm run cli
+```
+
+In a running shell or CLI, install a locally-built agent from disk:
+
+```
+@package install <name> <path to the built package>
+@config agent
+```
+
+`@package install` accepts a local path, a catalog entry, or a feed
+specifier; see [Agent install sources](../../architecture/lifecycle/agent-sources.md).
+While iterating, ordering a local `path` source ahead of the feed lets your
+local build **shadow** a published version.
+
+## 5. Distribute the agent
+
+Once the agent works, decide how users will install it. There are three
+sources, in order of decreasing friction.
+
+### Local `path` (development)
+
+No packaging needed. A built agent directory installs directly from disk:
+
+```
+@package install <name> <path to the built package>
+```
+
+This is the fastest inner loop and the flow used by the Echo tutorial.
+
+### A `catalog` entry
+
+A catalog is a JSON file mapping short names to packages, so users install
+by name (`@package install <name>`). Add an entry pointing at a local path
+or a published package name:
+
+```jsonc
+{
+  "agents": {
+    "<name>": { "name": "@company/<name>-agent", "execMode": "separate" },
+  },
+}
+```
+
+### Publishing to a feed
+
+A `feed` source installs from an Azure Artifacts npm registry by package
+specifier (`@package install <name> <name>-agent@^1.2`). Two author-side
+requirements make a published package discoverable **as an agent**:
+
+1. **Declare the sentinel keyword.** Add `typeagent-agent` to your
+   package's `keywords` in `package.json`. Feed enumeration keeps only
+   packages carrying this keyword; scope membership alone is not enough,
+   because support libraries live in the same scope.
+
+   ```jsonc
+   // package.json
+   {
+     "keywords": ["typeagent-agent"],
+   }
+   ```
+
+2. **Pass the policy check.** `npm run check:policy` fails the build if a
+   package that exposes `"./agent/manifest"` in its `exports` is missing
+   the keyword, so the marker cannot be forgotten.
+
+3. **(Recommended) Declare a default agent name.** Add
+   `typeagent.defaultAgentName` to `package.json` so users can install by
+   a friendly name in one argument (`@package install <name>`) instead of
+   the full package specifier. It must be a legal dispatcher agent
+   identifier (letters, digits, `-`/`_`, starting with a letter); an
+   illegal or missing value simply disables one-argument name install, and
+   the package can still be installed with the two-argument form
+   (`@package install <package> <name>`). The same field applies to
+   `path` and catalog `path` entries, read from the resolved directory's
+   `package.json`.
+
+   ```jsonc
+   // package.json
+   {
+     "typeagent": { "defaultAgentName": "<name>" },
+   }
+   ```
+
+Feed **installs** additionally require `az login` on the installing
+machine and, unless the source is configured with an explicit
+`registry`/`scopes`, the `TYPEAGENT_FEED_REGISTRY` /
+`TYPEAGENT_FEED_SCOPES` environment values. See
+[Agent sources › the feed source](../../architecture/lifecycle/agent-sources.md#the-feed-source)
+for how auth and enumeration work, and the
+[TypeAgent command reference](../../overview/command-reference.md#package-source-list--order--add--remove---manage-install-sources)
+for the `@package source` commands that configure and order sources.
+
+## Landing the docs
+
+If the agent lives in the repo, its README shows up on the wiki
+automatically once you follow the wiki-registration checklist in
+[Add an agent](../../contributing/add-an-agent.md).
+
+## Related
+
+- [Agent patterns](../../architecture/agents/agent-patterns.md): pick the right
+  shape for your agent.
+- [Dispatcher](../../architecture/core/dispatcher.md): how the host routes
+  actions to your agent.
+- [Agent SDK](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/agentSdk):
+  the `AppAgent` interface and helpers.
+- [Agent install sources](../../architecture/lifecycle/agent-sources.md): the
+  full path/catalog/feed model.
+- [Tutorial: build an Echo agent (standalone package)](./tutorial-echo.md):
+  step-by-step walkthrough of a standalone external agent.

--- a/ts/docs/guides/build-an-agent/tutorial-echo.md
+++ b/ts/docs/guides/build-an-agent/tutorial-echo.md
@@ -1,8 +1,8 @@
-# Building Agents for TypeAgent Dispatcher
+# Tutorial: build an Echo agent (standalone package)
 
 TypeAgent [Shell](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/shell) and [CLI](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli) are built using [TypeAgent Dispatcher](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/dispatcher). It has a configurable and extensible architecture that allow custom agents to plug into the system. The TypeAgent repo includes several example [agents](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/agents). **Application agents** can be built **_outside_** the TypeAgent repo by using the [TypeAgent SDK](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/README.md). These agents can be packaged as npm packages and then surfaced in the [Shell](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/shell) or [CLI](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli).
 
-This document describes how to build a custom application agent as an independent local NPM package **_outside of the repo_** that works with a locally built TypeAgent [Shell](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/shell) or [CLI](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli). The are two example agents in this repo you can reference: [Echo Agent](https://github.com/microsoft/TypeAgent/tree/main/ts/examples/agentExamples/echo) and [Measure Agent](https://github.com/microsoft/TypeAgent/tree/main/ts/examples/agentExamples/measure).
+This tutorial is a hands-on walkthrough of the **standalone external-package** case: authoring an agent in its own npm package outside the TypeAgent repo. For the broader picture (agent patterns, in-repo authoring, distribution via path / catalog / feed), start with [Build an agent](./index.md). This tutorial complements that guide with a concrete Echo example.
 
 ## Prerequisites
 
@@ -238,3 +238,17 @@ The `Echo` agent will be reloaded again after installation. It can be uninstalle
 ## Next step
 
 Start modifying the `Echo` agent and add new action schema and action handlers.
+
+## Where to go next
+
+- **Broader picture:** [Build an agent](./index.md) covers picking a pattern,
+  authoring in-repo vs. standalone, and the three distribution options
+  (path / catalog / feed).
+- **Display output to the user:** [User interaction (`ActionIO`)](./user-interaction.md)
+  walks through `setDisplay` / `appendDisplay`, message kinds, and the display
+  helpers exported from `@typeagent/agent-sdk/helpers/display`.
+- **Choose an architectural pattern:** [Agent patterns](../../architecture/agents/agent-patterns.md)
+  covers the nine patterns and when each is a good fit.
+- **Install sources for distribution:** [Agent install sources](../../architecture/lifecycle/agent-sources.md)
+  explains how path / catalog / feed sources resolve and how ordering works
+  (useful for shadowing a published version with a local build during iteration).

--- a/ts/docs/guides/build-an-agent/tutorial-echo.md
+++ b/ts/docs/guides/build-an-agent/tutorial-echo.md
@@ -44,7 +44,7 @@ The `package.json` contains references to **handler** and **manifest** files in 
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "tsc": "tsc -b"
   },
-  "keywords": [],
+  "keywords": ["typeagent-agent"],
   "dependencies": {
     "@typeagent/agent-sdk": "0.0.1"
   },
@@ -203,7 +203,7 @@ Start TypeAgent [Shell](https://github.com/microsoft/TypeAgent/tree/main/ts/pack
 # you can run these commands from the `ts` folder
 # in the TypeAgent root.
 
-pnpm run cli interactive
+pnpm run cli connect
 
 or
 
@@ -213,7 +213,7 @@ pnpm run shell
 In the [Shell](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/shell) or [CLI](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/cli), install the echo agent and check the status by issuing the command:
 
 ```
-@install echo <path to echo package>
+@package install echo <path to echo package>
 @config agent
 ```
 
@@ -232,7 +232,7 @@ When to run the shell this is how interaction with the `Echo` agent will look li
 The `Echo` agent will be reloaded again after installation. It can be uninstalled using the command:
 
 ```
-@uninstall echo
+@package uninstall echo
 ```
 
 ## Next step

--- a/ts/docs/guides/build-an-agent/user-interaction.md
+++ b/ts/docs/guides/build-an-agent/user-interaction.md
@@ -1,0 +1,234 @@
+# User interaction (`ActionIO` and display)
+
+An agent's `executeAction` (and `executeCommand`) handler receives an
+`ActionContext<T>`. The context exposes an `actionIO` object that is the
+agent's channel for sending output back to the user - text, Markdown,
+HTML, tables, status updates, progress. This page covers the display model,
+the append modes, the message kinds, and the helper functions.
+
+For the low-level type definitions, see
+[`packages/agentSdk/src/display.ts`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/src/display.ts)
+and the SDK
+[README](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/README.md#display-actioncontextactionio).
+
+## The `ActionIO` surface
+
+The methods on `context.actionIO` you should use:
+
+```ts
+interface ActionIO {
+  setDisplay(content: DisplayContent): void;
+  appendDisplay(content: DisplayContent, mode?: DisplayAppendMode): void;
+  appendDiagnosticData(data: any): void;
+}
+```
+
+- `setDisplay` replaces the current display block for this action with
+  `content`.
+- `appendDisplay` appends `content` to the display, using an append mode
+  (default `"inline"`).
+- `appendDiagnosticData` attaches diagnostic data (not surfaced to the
+  user); useful for host-side logging.
+
+### `actionIO` vs. `ActionResult`
+
+`actionIO` is the **progressive** channel. Anything written through it
+appears while the action is running.
+
+The **value** you return from `executeAction` is the authoritative
+`ActionResult` - dispatched, cached, and shown as the action's final
+outcome. Prefer returning an `ActionResult` for the "answer" and using
+`actionIO` for status updates, incremental progress, and rich UI that
+the result type can't express (HTML fragments, iframes, tables).
+
+See the helpers in
+[`@typeagent/agent-sdk/helpers/action`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/src/helpers/actionHelpers.ts)
+(`createActionResultFromTextDisplay`, `createActionResultFromError`, etc.).
+
+## `DisplayContent`
+
+Every write is a `DisplayContent`. In the simple case it is just a string
+(or `string[]` for multi-line, `string[][]` for a table):
+
+```ts
+context.actionIO.appendDisplay("Hello.");
+context.actionIO.appendDisplay(["Line 1", "Line 2"]);
+context.actionIO.appendDisplay([
+  ["Header A", "Header B"],
+  ["row 1a", "row 1b"],
+]);
+```
+
+For rich output, pass a `TypedDisplayContent` object:
+
+```ts
+context.actionIO.appendDisplay({
+  type: "markdown",
+  content: "Signed in as **Alice**",
+  kind: "success",
+});
+```
+
+Fields on `TypedDisplayContent`:
+
+| Field        | Purpose                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------- |
+| `type`       | `"text"`, `"markdown"`, `"html"`, or `"iframe"`. Host support varies; see below.        |
+| `content`    | The message body (string, string array, or 2-D array for tables).                       |
+| `kind`       | Optional [message kind](#message-kinds) - the host renders these with distinct styling. |
+| `speak`      | If `true`, the host may read the content out via TTS.                                   |
+| `alternates` | Fallback representations in other `type`s. The host picks whichever it supports best.   |
+
+### `type` support
+
+- `"text"` and `"markdown"` are universal. Text may include ANSI escape codes
+  for color; hosts that do not support ANSI strip it.
+- `"html"` is supported by the Shell (Electron) and other rich hosts;
+  content is sanitised before rendering. The CLI falls back to alternates
+  or the raw string.
+- `"iframe"` is Shell-only.
+
+Use `alternates` when you want the Shell to render HTML but the CLI to fall
+back to text:
+
+```ts
+context.actionIO.appendDisplay({
+  type: "html",
+  content: "<strong>OK</strong>",
+  alternates: [{ type: "text", content: "OK" }],
+});
+```
+
+## Append modes
+
+`appendDisplay` takes an optional `DisplayAppendMode`:
+
+| Mode          | Meaning                                                                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `"inline"`    | Default. Continues the previous inline chunk on the same visual line.                                |
+| `"block"`     | New block, separated from surrounding messages by line breaks.                                       |
+| `"temporary"` | Same as `"block"`, but the host replaces this chunk with whatever comes next. Good for status ticks. |
+| `"step"`      | Starts a new distinct message container/bubble - used by reasoning to show each phase inline.        |
+
+## Message kinds
+
+`DisplayMessageKind` gives the host a semantic hint so it can style the
+message consistently:
+
+- `"info"` - neutral notice.
+- `"status"` - transient status update (often paired with `"temporary"`).
+- `"warning"` - user attention, non-fatal.
+- `"error"` - the action failed or hit a recoverable problem.
+- `"success"` - completion of a step.
+
+Passing `kind` on a plain string requires the `TypedDisplayContent` object
+form; the helpers below wrap this for you.
+
+## Display helpers
+
+`@typeagent/agent-sdk/helpers/display` wraps the common patterns so you
+rarely write out `appendDisplay(..., { kind, ... })` by hand:
+
+```ts
+import {
+  displayInfo,
+  displayStatus,
+  displayWarn,
+  displayError,
+  displaySuccess,
+  displayResult,
+} from "@typeagent/agent-sdk/helpers/display";
+
+displayStatus("Logging in to calendar service...", context);
+displaySuccess(`Signed in as ${user.displayName}`, context);
+displayWarn("Already logged in.", context);
+displayError("Login failed.", context);
+```
+
+- `displayStatus` uses append mode `"temporary"` so the message is replaced
+  by the next write - use it for spinner-style progress.
+- The others use `"block"` and apply the matching `kind`.
+- `displayResult` writes with no kind or adornment.
+
+Each helper also accepts a callback form for building multi-line messages
+without concatenation:
+
+```ts
+displayInfo((log) => {
+  log("Configuration:");
+  log(`  endpoint: ${endpoint}`);
+  log(`  model:    ${model}`);
+}, context);
+```
+
+See [`displayHelpers.ts`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/src/helpers/displayHelpers.ts).
+
+## Worked example
+
+Adapted from the calendar agent's login flow (`calendarActionHandlerV3.ts`):
+
+```ts
+import {
+  displayStatus,
+  displaySuccess,
+  displayWarn,
+} from "@typeagent/agent-sdk/helpers/display";
+
+async function handleLogin(context: ActionContext<CalendarContext>) {
+  const provider = context.sessionContext.agentContext.provider;
+
+  if (await provider.isLoggedIn()) {
+    const user = await provider.getUser();
+    displayWarn(`Already logged in as ${user.displayName}`, context);
+    return;
+  }
+
+  displayStatus("Logging in to calendar service...", context);
+
+  const ok = await provider.login((prompt) => {
+    if (prompt.kind === "error") {
+      displayWarn(prompt.message, context);
+    } else {
+      // Device-code / browser messages surface as status ticks.
+      displayStatus(prompt.message, context);
+    }
+  });
+
+  if (ok) {
+    const user = await provider.getUser();
+    displaySuccess(`Signed in as ${user.displayName}`, context);
+  } else {
+    displayWarn("Login failed.", context);
+  }
+}
+```
+
+Notice the shape: a `displayStatus` opens the operation, further
+`displayStatus` messages replace it as work progresses, and a final
+`displaySuccess` or `displayWarn` closes with a persistent result.
+
+## Streaming a large result
+
+For actions that produce output progressively (LLM completions, long
+downloads), pair `actionIO` with `streamPartialAction` on the `AppAgent`
+interface, or write chunks with `appendDisplay(..., "inline")`. The
+`chat.generateResponse` action is the canonical streaming example. A
+future sub-guide will cover streaming in depth; for now see
+[`packages/agents/chat`](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/agents/chat).
+
+## Diagnostic data
+
+`appendDiagnosticData(data)` attaches structured diagnostic data to the
+current action. It is **not** shown to the user; hosts and dispatcher
+tests use it for logging and assertions. Use it for internal timing,
+retry counts, and provider responses that would be too noisy to display.
+
+## Related
+
+- [Build an agent](./index.md) - the overview for this section.
+- [Agent SDK README - Display](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/README.md#display-actioncontextactionio)
+  for the type-level reference.
+- [`display.ts`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/src/display.ts) -
+  the `ActionIO`, `DisplayContent`, and `DisplayAppendMode` definitions.
+- [`displayHelpers.ts`](https://github.com/microsoft/TypeAgent/blob/main/ts/packages/agentSdk/src/helpers/displayHelpers.ts) -
+  the helper functions imported from `@typeagent/agent-sdk/helpers/display`.

--- a/ts/docs/guides/index.md
+++ b/ts/docs/guides/index.md
@@ -1,12 +1,18 @@
 # Guides
 
-Task-oriented guides for **building on** TypeAgent — using its components as
+Task-oriented guides for **building on** TypeAgent, using its components as
 libraries inside your own application. These are how-tos for integrators and
 consumers, distinct from the [Architecture](../architecture/index.md)
 deep-dives (how it works internally) and [Contributing](../contributing/index.md)
 (how to change this repo and its wiki).
 
-- [Embedding the dispatcher](./embedding-dispatcher.md) — run the TypeAgent
-  dispatcher engine inside your own host process: `createDispatcher` options,
-  which package to depend on, and the three common setups (your own agents, the
-  ready-made default agents, or your own source).
+- [Build an agent](./build-an-agent/index.md): the canonical walkthrough for
+  authoring a TypeAgent application agent. Pick a pattern, scaffold, define
+  actions and grammar, iterate locally, and distribute via path, catalog, or
+  feed. Sub-guides in this section (starting with
+  [User interaction (`ActionIO`)](./build-an-agent/user-interaction.md)) go
+  deeper on individual topics.
+- [Embedding the dispatcher](./embedding-dispatcher.md): run the TypeAgent
+  dispatcher engine inside your own host process. `createDispatcher` options,
+  which package to depend on, and the three common setups (your own agents,
+  the ready-made default agents, or your own source).

--- a/ts/docs/guides/toc.yml
+++ b/ts/docs/guides/toc.yml
@@ -3,5 +3,14 @@
 
 - name: Guides
   href: index.md
+- name: Build an agent
+  href: build-an-agent/index.md
+  items:
+    - name: Overview
+      href: build-an-agent/index.md
+    - name: User interaction (ActionIO)
+      href: build-an-agent/user-interaction.md
+    - name: "Tutorial: Echo agent (standalone package)"
+      href: build-an-agent/tutorial-echo.md
 - name: Embedding the dispatcher
   href: embedding-dispatcher.md

--- a/ts/docs/overview/getting-started.md
+++ b/ts/docs/overview/getting-started.md
@@ -91,9 +91,12 @@ browser extension, Android, and the web API.
 ## Build your own agent
 
 To add action dispatch for your own scenario, create a **custom agent** that
-plugs into the Shell and routes through the dispatcher. The
-[Tutorial: build an agent](./tutorial-build-an-agent.md) walks through building
-an Echo agent as a standalone npm package, and the
+plugs into the Shell and routes through the dispatcher.
+[Build an agent](../guides/build-an-agent/index.md) is the canonical guide:
+picking a pattern, scaffolding, defining actions and grammar, iterating
+locally, and distributing via path / catalog / feed. The
+[Echo tutorial](../guides/build-an-agent/tutorial-echo.md) is a concrete
+standalone-package walkthrough. The
 [TypeAgent SDK](https://github.com/microsoft/TypeAgent/tree/main/ts/packages/agentSdk/)
 defines the interface between the dispatcher and an agent. See also
 [Add an agent](../contributing/add-an-agent.md) for how an agent surfaces in

--- a/ts/docs/overview/index.md
+++ b/ts/docs/overview/index.md
@@ -152,7 +152,8 @@ action dispatch.
 | [Architecture](../architecture/index.md) | Cross-cutting deep dives: the dispatcher, action grammar, cache, memory (Structured RAG), agent patterns, completion, the workflow system, and more. |
 | [Packages](../packages/index.md)         | Reference for every library and app package under `ts/packages/**` — the building blocks the agents and shell are composed from.                     |
 | [Agents](../agents/index.md)             | Reference for every application agent under `ts/packages/agents/**`, plus the nine agent patterns they follow.                                       |
-| [Contributing](../contributing/index.md) | How to build the wiki, add and edit pages, how new packages/agents flow in, the doc-autogen pipeline, and the style guide.                           |
+| [Guides](../guides/index.md)             | Task-oriented how-tos for **building on** TypeAgent: authoring your own application agent and embedding the dispatcher in your own host process.     |
+| [Contributing](../contributing/index.md) | How to contribute to the repo: development setup, and how to change the wiki (add pages, packages, agents, the doc-autogen pipeline, style guide).   |
 
 The rest of this Overview section: **[Getting started](./getting-started.md)**
 (build, configure, and run the Shell) and the

--- a/ts/docs/overview/toc.yml
+++ b/ts/docs/overview/toc.yml
@@ -18,8 +18,6 @@
       href: service-keys.md
     - name: Developer tips & troubleshooting
       href: developer-tips.md
-    - name: "Tutorial: build an agent"
-      href: tutorial-build-an-agent.md
 - name: Surfaces
   href: surfaces.md
 - name: Command reference


### PR DESCRIPTION
## Summary

Reorganize the TypeAgent wiki so that **building an agent** and **contributing to the repo** are each first-class, discoverable sections, and fold a code-consistency pass into the Echo tutorial.

Before: agent-authoring content was split between `overview/tutorial-build-an-agent.md` (Echo external-package walkthrough) and `contributing/add-an-agent.md` (which mixed wiki registration with distribution/packaging). `contributing/` only covered wiki mechanics, with no landing spot for repo-code contributors. `overview/index.md`'s "What's in this wiki" table didn't mention Guides at all.

After: `guides/build-an-agent/` is a new sub-section with an overview, a Topics list, the first sub-guide (User interaction / `ActionIO`), and the Echo tutorial moved in. `contributing/` now routes clearly between **contributing code** (new `development-setup.md`) and **contributing to the wiki** (existing pages). Every top-level index page cross-links appropriately.

## What changed

### `guides/`

- **New:** `guides/build-an-agent/index.md` (moved from `guides/build-an-agent.md`) as the section overview. Adds a **Topics** list enumerating the sub-guides that exist and those that are planned (actions/grammar, lifecycle, readiness & setup, commands, storage, streaming, dynamic display).
- **New:** `guides/build-an-agent/user-interaction.md` - the `ActionIO` and display walkthrough. Covers `setDisplay` / `appendDisplay` / `appendDiagnosticData`; `DisplayContent` shape (text/markdown/html/iframe, `alternates`, `kind`, `speak`); the four append modes; the five message kinds; the helpers from `@typeagent/agent-sdk/helpers/display`; a worked example adapted from `calendarActionHandlerV3.ts`.
- **Moved:** `overview/tutorial-build-an-agent.md` → `guides/build-an-agent/tutorial-echo.md` (git rename, ~87% similarity). Retitled *"Tutorial: build an Echo agent (standalone package)"*, repositioned as the concrete companion to the overview guide, and given a *"Where to go next"* section pointing back to patterns, user-interaction, and agent-sources.

### `contributing/`

- **New:** `contributing/development-setup.md` - repo-contributor entry point. Deliberately thin: routes into `overview/setup-*.md` and `overview/service-keys.md` for prereqs/build/run, and adds only the contributor-only material (single-test invocations via `jest-esm`, schema-change regeneration, code style, submitting changes / CLA / CoC / Security).
- **Rewritten:** `contributing/index.md` - top routes between *"Contributing code"* and *"Contributing to the wiki"*.
- **Trimmed:** `contributing/add-an-agent.md` - now the wiki-registration checklist only. The distribution/packaging content (path / catalog / feed) moved into the new guide.
- **Reorganized:** `contributing/toc.yml` - Development setup at the top; wiki mechanics grouped under a *"Contributing to the wiki"* node.

### Discoverability fixes

- `overview/index.md`: added a **Guides** row to the "What's in this wiki" table; updated the **Contributing** row to describe both development-setup and wiki mechanics.
- `overview/getting-started.md`: "Build your own agent" now leads with the guide and mentions the Echo tutorial as the concrete example.
- `agents/index.md`: "Adding an agent" now routes patterns → guides/build-an-agent → contributing/add-an-agent (marked repo-only), and calls out that standalone agents don't need to live in this repo. Removed the *"Anatomy of an agent"* section, which duplicated step 2 of the guide.
- `overview/toc.yml` and `guides/toc.yml`: reflect the tutorial move and the new sub-guide.

### Code-consistency pass on the Echo tutorial

Verified every command / import / config claim in `tutorial-echo.md` against the current code. Fixed:

| Before                        | After                                     | Verified against                                                                                     |
| ----------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| `@install echo <path>`        | `@package install echo <path>`            | `PACKAGE_AGENT_NAME = "package"` and `InstallCommandHandler` in `defaultAgentProvider/src/installSources/packageAgent.ts` |
| `@uninstall echo`             | `@package uninstall echo`                 | Same command family                                                                                  |
| `pnpm run cli interactive`    | `pnpm run cli connect`                    | `ts/packages/cli/src/commands/` has no `interactive` subcommand; the interactive REPL is `connect`   |
| `"keywords": []`              | `"keywords": ["typeagent-agent"]`         | `AGENT_KEYWORD` in `feedSource.ts`; matches the real `ts/examples/agentExamples/echo/package.json`   |

## Non-goals

- No content moved out of the wiki. Everything is authored in the same source-of-truth locations as before.
- No changes to the DocFX build config or `build-wiki.mjs`.
- `contributing/development-setup.md` deliberately deep-links into `overview/getting-started.md` for build/test/lint commands rather than restating them (single-source-of-truth rule from `wiki-structure.md`).

## Verification

- All internal relative links checked with grep. No broken links to the old locations remain.
- The Echo tutorial move is recorded by git as a rename (`overview/tutorial-build-an-agent.md` → `guides/build-an-agent/tutorial-echo.md`, 87% similarity), so history follows.
- Commands, SDK exports, and environment-variable names were spot-checked against the code (see the tutorial-fix table above). Not tested end-to-end.
