### PR TITLE
Move source config summary into each install source; add feed debug tracing

### DIFF
--- a/ts/CLAUDE.md
+++ b/ts/CLAUDE.md
@@ -105,6 +105,16 @@ Agents implement `AppAgent` from `@typeagent/agent-sdk`:
   // Licensed under the MIT License.
   ```
 
+### Comments
+
+- Write comments in plain, direct language. Say what the code does and
+  why. Avoid "consultant speak" - filler like "owns its own X," "single
+  source of truth," "never has to know about Y," or restating a design
+  principle instead of explaining the code. Technical terms are fine; use
+  the precise word rather than talking around it.
+- Don't use em-dashes (—) in comments. Use `-`, `:`, parentheses, or two
+  sentences instead.
+
 ### Package references
 
 - Internal packages use `"workspace:*"` protocol in `package.json`

--- a/ts/packages/defaultAgentProvider/src/installSources/catalogSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/catalogSource.ts
@@ -175,6 +175,9 @@ export function createCatalogSource(
     return {
         name: config.name,
         kind: "catalog",
+        describe(): string {
+            return config.catalog;
+        },
         async find(
             ref: string,
             onWarn?: SourceWarning,

--- a/ts/packages/defaultAgentProvider/src/installSources/config.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/config.ts
@@ -388,4 +388,8 @@ export interface InstallSource {
      * throws the fetch error so the command can fail rather than guess from stale
      * data. Cacheless sources (path, catalog) omit this. */
     refresh?(onWarn?: SourceWarning): Promise<void>;
+    /** One-line summary of this source's config for `@package source list`
+     * (e.g. a feed's registry URL, a path's base dir). Each source formats
+     * its own config. */
+    describe(): string;
 }

--- a/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
@@ -777,6 +777,28 @@ export function createFeedSource(
         kind: "feed",
         find,
         findName,
+        describe(): string {
+            // Reuse the same resolution as find/materialize
+            // (resolveFeedRegistry / resolveFeedScopes), then annotate a value
+            // that came from an env var because the config omitted it.
+            const registry = resolveFeedRegistry(config) ?? "<unset>";
+            const registryDetail = config.registry
+                ? registry
+                : `${registry} (env: TYPEAGENT_FEED_REGISTRY)`;
+
+            const scopeList = resolveFeedScopes(config);
+            const scopes =
+                scopeList.length > 0
+                    ? `scopes: ${scopeList.join(", ")}`
+                    : "scopes: (none)";
+            const scopeDetail = config.scopes
+                ? scopes
+                : `${scopes} (env: TYPEAGENT_FEED_SCOPES)`;
+
+            return scopeDetail !== undefined
+                ? `${registryDetail}\n${scopeDetail}`
+                : registryDetail;
+        },
         async refresh(): Promise<void> {
             // Fetch fresh descriptors and atomically swap them in on success;
             // a fetch failure throws (leaving the prior cache intact) so

--- a/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import semver from "semver";
+import registerDebug from "debug";
 import {
     InstallSource,
     FeedSourceConfig,
@@ -24,6 +25,8 @@ import {
 } from "./feedAuth.js";
 
 const execFileAsync = promisify(execFile);
+
+const debug = registerDebug("typeagent:dispatcher:installSource:feed");
 
 // The sentinel keyword an app agent declares in its package.json.
 export const AGENT_KEYWORD = "typeagent-agent";
@@ -288,6 +291,9 @@ async function listScopedPackages(
         }
         const data = (await res.json()) as AzurePackagesResponse;
         const page = Array.isArray(data.value) ? data.value : [];
+        debug(
+            `listScopedPackages: GET ${url} -> ${res.status} ${res.statusText}, ${page.length} package(s)`,
+        );
         for (const pkg of page) {
             const nameValue = pkg.normalizedName ?? pkg.name;
             const name = typeof nameValue === "string" ? nameValue : undefined;
@@ -304,6 +310,9 @@ async function listScopedPackages(
         }
         skip += top;
     }
+    debug(
+        `listScopedPackages: ${names.length} package(s) matched scopes [${scopes.join(", ")}]: ${names.join(", ")}`,
+    );
     return names;
 }
 
@@ -320,11 +329,18 @@ async function isAgentPackage(
         headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) {
+        debug(
+            `isAgentPackage: GET ${url} -> ${res.status} ${res.statusText} (treated as non-agent)`,
+        );
         return false;
     }
     const packument = asRecord(await res.json());
     const keywords: unknown = packument?.keywords;
-    return Array.isArray(keywords) && keywords.includes(AGENT_KEYWORD);
+    const isAgent = Array.isArray(keywords) && keywords.includes(AGENT_KEYWORD);
+    debug(
+        `isAgentPackage: ${packageName} keywords=[${Array.isArray(keywords) ? keywords.join(", ") : ""}] -> ${isAgent}`,
+    );
+    return isAgent;
 }
 
 // Fetch and parse a package's packument. Returns undefined
@@ -342,10 +358,21 @@ async function fetchPackument(
             headers: { Authorization: `Bearer ${token}` },
         });
         if (!res.ok) {
+            debug(
+                `fetchPackument: GET ${url} -> ${res.status} ${res.statusText} (no packument)`,
+            );
             return undefined;
         }
-        return await res.json();
-    } catch {
+        const packument = await res.json();
+        const record = asRecord(packument);
+        const versions = asRecord(record?.versions);
+        const distTags = asRecord(record?.["dist-tags"]);
+        debug(
+            `fetchPackument: ${packageName} -> versions=[${versions ? Object.keys(versions).join(", ") : ""}] dist-tags=${JSON.stringify(distTags ?? {})}`,
+        );
+        return packument;
+    } catch (e) {
+        debug(`fetchPackument: ${packageName} failed: ${e}`);
         return undefined;
     }
 }
@@ -505,6 +532,14 @@ async function enumerateFeedAgentDescriptors(
         }
         descriptors.push(descriptor);
     }
+    debug(
+        `enumerateFeedAgentDescriptors: ${descriptors.length} agent package(s): ${descriptors
+            .map(
+                (d) =>
+                    `${d.packageName}@${d.latestVersion}${d.defaultAgentName ? ` (${d.defaultAgentName})` : ""}`,
+            )
+            .join(", ")}`,
+    );
     return descriptors;
 }
 

--- a/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
@@ -367,8 +367,9 @@ async function fetchPackument(
         const record = asRecord(packument);
         const versions = asRecord(record?.versions);
         const distTags = asRecord(record?.["dist-tags"]);
+        const versionCount = versions ? Object.keys(versions).length : 0;
         debug(
-            `fetchPackument: ${packageName} -> versions=[${versions ? Object.keys(versions).join(", ") : ""}] dist-tags=${JSON.stringify(distTags ?? {})}`,
+            `fetchPackument: ${packageName} -> ${versionCount} version(s), dist-tags=${JSON.stringify(distTags ?? {})}`,
         );
         return packument;
     } catch (e) {
@@ -779,25 +780,34 @@ export function createFeedSource(
         findName,
         describe(): string {
             // Reuse the same resolution as find/materialize
-            // (resolveFeedRegistry / resolveFeedScopes), then annotate a value
-            // that came from an env var because the config omitted it.
-            const registry = resolveFeedRegistry(config) ?? "<unset>";
-            const registryDetail = config.registry
-                ? registry
-                : `${registry} (env: TYPEAGENT_FEED_REGISTRY)`;
+            // (resolveFeedRegistry / resolveFeedScopes). Annotate a value with
+            // its env var only when the env var actually supplied it (config
+            // was silent AND the env var was set).
+            const resolvedRegistry = resolveFeedRegistry(config);
+            const registryFromEnv =
+                config.registry === undefined && resolvedRegistry !== undefined;
+            const registryDetail =
+                resolvedRegistry === undefined
+                    ? "<unset>"
+                    : registryFromEnv
+                      ? `${resolvedRegistry} (env: TYPEAGENT_FEED_REGISTRY)`
+                      : resolvedRegistry;
 
             const scopeList = resolveFeedScopes(config);
             const scopes =
                 scopeList.length > 0
                     ? `scopes: ${scopeList.join(", ")}`
                     : "scopes: (none)";
-            const scopeDetail = config.scopes
-                ? scopes
-                : `${scopes} (env: TYPEAGENT_FEED_SCOPES)`;
+            // Match resolveFeedScopes' check: an explicit `scopes: []` in
+            // config uses config, not env.
+            const scopesFromEnv =
+                config.scopes === undefined &&
+                process.env.TYPEAGENT_FEED_SCOPES !== undefined;
+            const scopeDetail = scopesFromEnv
+                ? `${scopes} (env: TYPEAGENT_FEED_SCOPES)`
+                : scopes;
 
-            return scopeDetail !== undefined
-                ? `${registryDetail}\n${scopeDetail}`
-                : registryDetail;
+            return `${registryDetail}\n${scopeDetail}`;
         },
         async refresh(): Promise<void> {
             // Fetch fresh descriptors and atomically swap them in on success;

--- a/ts/packages/defaultAgentProvider/src/installSources/pathSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/pathSource.ts
@@ -56,6 +56,9 @@ export function createPathSource(config: PathSourceConfig): InstallSource {
         name: config.name,
         kind: "path",
         find,
+        describe(): string {
+            return baseDir ?? "(default base)";
+        },
         async materialize(
             candidate: ResolvedCandidate,
         ): Promise<MaterializedInstallRecord> {

--- a/ts/packages/defaultAgentProvider/src/installSources/registry.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/registry.ts
@@ -278,23 +278,6 @@ export function createInstallSourceRegistry(
         return eligible.map((e) => e.source);
     }
 
-    // The host-rendered one-line summary the core shows for `@package source list`. This
-    // is where the kind is interpreted (the core never sees it).
-    function describe(config: InstallSourceConfig): string {
-        switch (config.kind) {
-            case "feed":
-                return config.registry ?? "(env: TYPEAGENT_FEED_REGISTRY)";
-            case "catalog":
-                return config.catalog;
-            case "path":
-                return config.baseDir ?? "(default base)";
-            default: {
-                const exhaustive: never = config;
-                return String(exhaustive);
-            }
-        }
-    }
-
     function addConfig(config: InstallSourceConfig): void {
         if (entries.has(config.name)) {
             throw new Error(`source '${config.name}' already exists`);
@@ -513,10 +496,11 @@ export function createInstallSourceRegistry(
 
     return {
         list(): InstallSourceInfo[] {
-            return Array.from(entries.values(), ({ config }) => ({
+            return Array.from(entries.values(), ({ config, source }) => ({
                 name: config.name,
                 kind: config.kind,
-                detail: describe(config),
+                // Each source formats its own config summary.
+                detail: source.describe(),
             }));
         },
         get(name: string): InstallSource | undefined {

--- a/ts/packages/defaultAgentProvider/src/installSources/registry.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/registry.ts
@@ -499,7 +499,6 @@ export function createInstallSourceRegistry(
             return Array.from(entries.values(), ({ config, source }) => ({
                 name: config.name,
                 kind: config.kind,
-                // Each source formats its own config summary.
                 detail: source.describe(),
             }));
         },

--- a/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
@@ -164,6 +164,7 @@ function createTestUpdateableSource(
         kind: "test-updateable",
         find,
         materialize,
+        describe: () => "(test-updateable)",
         async update(record) {
             if (record.path === undefined) {
                 throw new Error(
@@ -468,6 +469,7 @@ describe("getDefaultAppAgentSource", () => {
                 name: config.name,
                 kind: config.kind,
                 find: async () => undefined,
+                describe: () => "(test)",
                 materialize: async () => {
                     throw new Error("not used");
                 },


### PR DESCRIPTION
Small quality-of-life changes for install sources.

## What

**1. Push per-source config summary into each source (`describe()`).**
`@package source list` used to run through a `switch (config.kind)` in the registry to render the one-line detail. That switch has to be updated in a different file every time a new source kind is added, and it hard-codes source-specific formatting knowledge in the registry. Each source now implements `describe(): string` on `InstallSource` and returns its own summary; the registry just calls it.

**2. Debug tracing in the feed source.**
Adds a `typeagent:dispatcher:installSource:feed` debug channel and traces the Azure DevOps package-listing and packument-fetch paths so failures (auth, empty pages, keyword filtering, missing packument) are visible without adding logging on the hot path.

**3. `describe()` for the feed source is honest about where values came from.**
Registry and scopes are annotated with `(env: TYPEAGENT_FEED_*)` only when the env var actually supplied the value (config was silent and the env var was set). When neither config nor env has a registry, `describe()` prints `<unset>` instead of pretending an env var produced it. The scope-source check matches `resolveFeedScopes`'s `config.scopes === undefined` so an explicit `scopes: []` in config is treated as config, not env.

**4. CLAUDE.md comment style.**
Adds a short note discouraging "consultant speak" filler in comments and em-dashes.
