### PR TITLE
Modify path trigger to always run and filter out tests

### DIFF
--- a/pipelines/azure-smoke-tests.yml
+++ b/pipelines/azure-smoke-tests.yml
@@ -16,7 +16,7 @@
 #       - Forks > "Make secrets available to builds of forks" = ON, because
 #         every useful step needs a protected resource that fork builds are
 #         denied by default — the internal npm feed (even `pnpm install`), the
-#         MSOCTO-ADO-Service-Connection, and Key Vault. With it OFF a fork-PR
+#         $(azureSubscription), and Key Vault. With it OFF a fork-PR
 #         run fails at the first authenticated step.
 #       - Comment triggers > "Require a team member's comment before building a
 #         pull request" = "Only for pull requests from non-team members". A team
@@ -27,7 +27,14 @@
 #         forks without it would expose our secrets to arbitrary fork code.
 #   * "Setup Git LF" is dropped because .gitattributes already pins `* text
 #     eol=lf`, so checkout produces LF on every OS regardless of core.autocrlf.
-#   * dorny/paths-filter is replaced by the trigger `paths` filter below.
+#   * dorny/paths-filter is replaced by the detect_changes job below rather than
+#     a trigger `paths` filter. This pipeline is a REQUIRED status check for PRs
+#     to main (enforced via a repo ruleset). A trigger `paths` filter would keep
+#     the pipeline from running at all when a PR touches only non-ts files, which
+#     leaves the required check stuck pending forever (and stalls the merge
+#     queue). So the pipeline always runs and reports back; the detect_changes
+#     job then decides whether the expensive smoke-test job runs or is skipped —
+#     a skipped job still reports success, satisfying the required check.
 #   * azure/login (OIDC) is preserved via an Azure Resource Manager service
 #     connection that uses Workload Identity Federation. A single AzureCLI@2
 #     task performs the federated (secret-free) login, pulls the secrets, and
@@ -42,7 +49,7 @@
 #     StartRight (per the eng.ms integrate-ado guide). It lets Azure Pipelines
 #     read the repo AND report each run's status back to the PR. No YAML needed.
 #   * Azure Resource Manager service connection (Workload Identity Federation) -
-#     'MSOCTO-ADO-Service-Connection'. The Get Keys step's AzureCLI@2 task uses
+#     $(azureSubscription). The Get Keys step's AzureCLI@2 task uses
 #     it to log in without any stored secret or certificate. Its backing service
 #     principal must hold the 'Key Vault Secrets User' RBAC role on the
 #     'build-pipeline-kv' vault (the vault uses RBAC authorization, not access
@@ -55,7 +62,7 @@
 #     = ON, "Make secrets available to builds of forks" = ON, and "Require a team
 #     member's comment" = "Only for pull requests from non-team members" (see the
 #     fork-PR note above). Optionally add an Approvals & checks gate on
-#     MSOCTO-ADO-Service-Connection for defense in depth.
+#     $(azureSubscription) for defense in depth.
 
 trigger:
   branches:
@@ -67,10 +74,10 @@ trigger:
       # event, so include the queue branches in the CI trigger to make this
       # pipeline run (and report back) while a PR sits in the queue for main.
       - gh-readonly-queue/main/*      
-  paths:
-    include:
-      - ts/**
-      - pipelines/azure-smoke-tests.yml
+  # No `paths` filter: this pipeline is a required status check, so it must run
+  # (and report back) for every push — including merge-queue candidates that
+  # touch only non-ts files. Whether the expensive tests actually run is decided
+  # at runtime by the detect_changes job below.
 
 # Run on PRs targeting main so a failing smoke test blocks the PR. This
 # pipeline's source is a GitHub repo, so Azure Pipelines reports each PR run's
@@ -80,10 +87,9 @@ pr:
   branches:
     include:
       - main
-  paths:
-    include:
-      - ts/**
-      - pipelines/azure-smoke-tests.yml
+  # No `paths` filter here either — see the trigger note above. Every PR to main
+  # runs this pipeline so the required check always reports; detect_changes then
+  # skips the smoke-test job when nothing under ts/** changed.
 
 variables:
   - name: buildDirectory
@@ -98,8 +104,71 @@ variables:
     value: --max_old_space_size=8192
 
 jobs:
+  # Always-run gate. Computes whether anything under ts/** (or this pipeline
+  # file) changed and publishes it as an output variable. Because this job runs
+  # on every trigger, the pipeline always completes and reports a status back to
+  # GitHub, which is what the required check needs. It is deliberately cheap (a
+  # git checkout + one diff, no npm install / build).
+  - job: detect_changes
+    displayName: Detect ts changes
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      # Full history so merge-base / parent diffs resolve on both PR merge
+      # commits and merge-queue branches.
+      - checkout: self
+        fetchDepth: 0
+      - bash: |
+          set -uo pipefail
+          # Default to running the tests; only skip when we can positively
+          # confirm nothing under ts/** (or this pipeline file) changed. Any git
+          # weirdness errs on the side of running the tests.
+          TS_CHANGED=true
+          CHANGED=""
+          if [ "${BUILD_REASON:-}" = "PullRequest" ]; then
+            # Azure DevOps checks out the PR merge commit, so HEAD^1 is the
+            # target-branch tip; diffing it against HEAD yields the PR's changes.
+            if git rev-parse HEAD^1 >/dev/null 2>&1; then
+              CHANGED=$(git diff --name-only HEAD^1 HEAD)
+            fi
+          else
+            # CI build: a gh-readonly-queue/main/* merge-queue branch or a push
+            # to main. Diff against the merge-base with main.
+            git fetch --no-tags origin main || true
+            BASE=$(git merge-base HEAD FETCH_HEAD 2>/dev/null || true)
+            # A direct push to main leaves HEAD on main, so the merge-base is
+            # HEAD itself (empty diff); fall back to the previous commit.
+            if [ -z "$BASE" ] || [ "$BASE" = "$(git rev-parse HEAD)" ]; then
+              BASE=$(git rev-parse HEAD^ 2>/dev/null || true)
+            fi
+            if [ -n "$BASE" ]; then
+              CHANGED=$(git diff --name-only "$BASE" HEAD)
+            fi
+          fi
+
+          echo "Changed files considered:"
+          echo "$CHANGED"
+
+          if [ -n "$CHANGED" ]; then
+            if echo "$CHANGED" | grep -qE '^(ts/|pipelines/azure-smoke-tests\.yml)'; then
+              TS_CHANGED=true
+            else
+              TS_CHANGED=false
+            fi
+          fi
+
+          echo "tsChanged=$TS_CHANGED"
+          echo "##vso[task.setvariable variable=tsChanged;isOutput=true]$TS_CHANGED"
+        name: detect
+        displayName: Detect changes under ts/
+
   - job: shell_and_cli
     displayName: Shell & CLI smoke tests
+    # Only run the expensive smoke tests when detect_changes saw a relevant
+    # change. When it is skipped the job still reports "succeeded", so the
+    # required status check keeps passing on PRs that do not touch ts/**.
+    dependsOn: detect_changes
+    condition: and(succeeded(), eq(dependencies.detect_changes.outputs['detect.tsChanged'], 'true'))
     # Generous cap: the Linux leg can run the shell smoke (60m) + live (60m)
     # tests back to back. Requires purchased parallelism for hosted agents.
     timeoutInMinutes: 150
@@ -157,7 +226,7 @@ jobs:
       - task: AzureCLI@2
         displayName: Azure login + Get Keys
         inputs:
-          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          azureSubscription: $(azureSubscription)
           scriptType: pscore
           scriptLocation: inlineScript
           addSpnToEnvironment: true
@@ -190,7 +259,7 @@ jobs:
         timeoutInMinutes: 60
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
         inputs:
-          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          azureSubscription: $(azureSubscription)
           scriptType: pscore
           scriptLocation: inlineScript
           workingDirectory: $(buildDirectory)/packages/shell
@@ -205,7 +274,7 @@ jobs:
         timeoutInMinutes: 60
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
         inputs:
-          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          azureSubscription: $(azureSubscription)
           scriptType: bash
           scriptLocation: inlineScript
           workingDirectory: $(buildDirectory)/packages/shell
@@ -231,7 +300,7 @@ jobs:
         continueOnError: true
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
         inputs:
-          azureSubscription: 'MSOCTO-ADO-Service-Connection'
+          azureSubscription: $(azureSubscription)
           scriptType: bash
           scriptLocation: inlineScript
           workingDirectory: $(buildDirectory)


### PR DESCRIPTION
This pull request updates the `pipelines/azure-smoke-tests.yml` pipeline to improve how required status checks are handled for PRs and merge-queue candidates, and to make the pipeline configuration more flexible and robust. The main change is to always run the pipeline and use a new `detect_changes` job to conditionally run the expensive smoke tests only when relevant files change, ensuring the required check always completes. It also replaces hardcoded Azure service connection names with a variable for easier configuration.

**Pipeline logic and status checks:**

* Removed all `paths` filters from both `trigger` and `pr` sections to ensure the pipeline always runs and reports a status, even when PRs or pushes do not touch relevant files. The actual smoke tests are now conditionally triggered at runtime by the `detect_changes` job, which checks for changes under `ts/**` or the pipeline file itself. This prevents required checks from getting stuck and blocking merges. [[1]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL30-R37) [[2]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL70-R80) [[3]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL83-R92) [[4]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cR107-R171)

* Added a new `detect_changes` job that runs on every trigger, checks for changes under `ts/**` or the pipeline file, and sets an output variable used to decide if the expensive smoke tests should run. This job is lightweight and ensures the pipeline always completes and reports a status.

* Updated the `shell_and_cli` smoke test job to depend on `detect_changes` and only run when relevant files have changed, reducing unnecessary CI usage while keeping status checks reliable.

**Configuration and secrets management:**

* Replaced hardcoded Azure service connection names (`'MSOCTO-ADO-Service-Connection'`) with the `$(azureSubscription)` variable throughout the pipeline for improved flexibility and maintainability. [[1]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL19-R19) [[2]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL45-R52) [[3]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL58-R65) [[4]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL160-R229) [[5]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL193-R262) [[6]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL208-R277) [[7]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL234-R303)

**Documentation and comments:**

* Updated pipeline comments and documentation to explain the new always-run logic, the purpose of the `detect_changes` job, and the rationale for removing `paths` filters, making the pipeline easier to understand and maintain. [[1]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL30-R37) [[2]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL70-R80) [[3]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cL83-R92) [[4]](diffhunk://#diff-bee0b3e82d8d7a4c70934a7b29f7c1e7a1a2000ac76d97fd991b912e6faad31cR107-R171)

Let me know if you'd like to walk through the new `detect_changes` job or discuss how this improves the reliability of required status checks!