### PR TITLE
Improve test reliability and add force exit option

### DIFF
--- a/ts/packages/defaultAgentProvider/package.json
+++ b/ts/packages/defaultAgentProvider/package.json
@@ -28,7 +28,7 @@
     "prettier": "prettier --check . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
     "test": "pnpm run jest-esm",
-    "test:live": "pnpm run jest-esm --testPathPattern=\".*[.]test[.]js\"",
+    "test:live": "pnpm run jest-esm --testPathPattern=\".*[.]test[.]js\" --forceExit",
     "test:live:debug": "node --inspect-brk --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js --testPathPattern=\".*\\.test\\.js\"",
     "test:local": "pnpm run jest-esm --testPathPattern=\".*[.]spec[.]js\" --testPathIgnorePatterns=\"grammarNfaIntegration[.]spec[.]js\"",
     "test:local:debug": "node --inspect-brk --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js --testPathPattern=\".*\\.spec\\.js\"",

--- a/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
+++ b/ts/packages/defaultAgentProvider/test/data/translate-history-e2e.json
@@ -80,10 +80,7 @@
               "schemaName": "browser.lookupAndAnswer",
               "actionName": "lookupAndAnswerInternet",
               "parameters": {
-                "originalRequest": "look up the ingredient for shepherd's pie for me please",
-                "internetLookups": [
-                  "ingredient for shepherd's pie"
-                ]
+                "originalRequest": "look up the ingredient for shepherd's pie for me please"
               }
             },
             "partial": true

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -153,10 +153,19 @@ async function detectRunningAgentServer(port: number): Promise<boolean> {
 // latter would fail to acquire the shared instance-directory lock and abort
 // startup with "Another agent-server (or shell) is already using the instance
 // directory".
+//
+// Never probe in test mode (--test). The smoke/e2e harness launches its own
+// isolated instance (per-worker INSTANCE_NAME/PORT, --mock-greetings) and must
+// stay hermetic: if the probe found any agent-server on the default port — e.g.
+// the detached background server the CLI smoke step leaves on 8999, or a
+// developer's dogfooding session — the test shell would connect to that foreign
+// server instead of hosting its own, never reach the expected ready state, and
+// time out.
 let effectiveConnect = parsedArgs.connect;
 if (
     effectiveConnect === undefined &&
     !isProd &&
+    !isTest &&
     parsedArgs.data === undefined &&
     !parsedArgs.clean &&
     !parsedArgs.reset &&


### PR DESCRIPTION
This pull request includes improvements to the test harness reliability and test data, as well as a minor update to the test script configuration. The main focus is to ensure test isolation and prevent interference from other running instances during testing.

**Test harness reliability and isolation:**
* Updated the agent server startup logic in `index.ts` to never probe for a running agent server when in test mode (`--test`), ensuring that each test run uses its own isolated instance and does not accidentally connect to a pre-existing server.

**Test data maintenance:**
* Simplified a test case in `translate-history-e2e.json` by removing the unused `internetLookups` field from the `parameters` object, likely to reflect changes in expected behavior or schema.

**Test script configuration:**
* Added the `--forceExit` flag to the `test:live` script in `package.json` to ensure that Jest exits cleanly after tests complete, preventing hanging processes during live testing.