### PR TITLE
Update documentation pipeline to run biweekly and amend PRs

### DIFF
--- a/.github/actions/docs-generate/action.yml
+++ b/.github/actions/docs-generate/action.yml
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Composite action: the shared "generate" core used by both docs workflows -
+# docs-refresh.yml (scheduled sweep) and docs-pr-amend.yml (per-PR amender).
+# It sets up the toolchain, builds the docs-autogen CLI, and regenerates the
+# README.AUTOGEN.md companions for packages whose source changed since `since`,
+# authoring prose via GitHub Models.
+#
+# The CALLER is responsible for checking out the repository first and for
+# publishing the result afterwards (open a PR, or commit back to a branch).
+# This action only regenerates + formats the files in the working tree.
+# docs-autogen skips any package whose embedded content hash still matches its
+# inputs, so a re-run regenerates nothing.
+
+name: docs-generate
+description: Regenerate README.AUTOGEN.md companions for changed packages via GitHub Models.
+
+inputs:
+  since:
+    description: >-
+      Git ref/SHA to diff against; only packages whose source changed since it
+      are regenerated. Empty selects docs-autogen's smart default (full sweep).
+    required: false
+    default: ""
+  github-token:
+    description: "Token sent as the GitHub Models bearer credential (needs `models: read`)."
+    required: true
+  model:
+    description: GitHub Models model id used for authoring.
+    required: false
+    default: openai/gpt-4o
+  dry-run:
+    description: When "true", analyse and render only - never write to disk.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        package_json_file: ts/package.json
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: pnpm
+        cache-dependency-path: ts/pnpm-lock.yaml
+
+    - name: Install ts dependencies
+      shell: bash
+      working-directory: ts
+      run: |
+        corepack enable
+        pnpm install --frozen-lockfile
+
+    - name: Build docs-autogen tool
+      shell: bash
+      working-directory: ts
+      # Trailing `...` builds the tool AND its transitive workspace deps.
+      run: pnpm --filter '@typeagent/docs-autogen...' build
+
+    - name: Regenerate changed READMEs (GitHub Models)
+      shell: bash
+      working-directory: ts
+      env:
+        DEBUG: "docs-autogen:*"
+        # aiclient generic OpenAI path -> GitHub Models (no Azure OpenAI, no
+        # federated credential, no stored secret).
+        OPENAI_ENDPOINT: https://models.github.ai/inference/chat/completions
+        OPENAI_MODEL: ${{ inputs.model }}
+        OPENAI_MAX_CONCURRENCY: "1"
+        # Bearer credential for GitHub Models; never expanded into the command.
+        OPENAI_API_KEY: ${{ inputs.github-token }}
+        INPUT_SINCE: ${{ inputs.since }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -o pipefail
+        # No per-run cap: selection stays change-scoped via --since, and the
+        # content-hash gate drops any selected package whose inputs are
+        # unchanged.
+        ARGS=(--render --llm --max-packages 100000)
+        if [ "$INPUT_DRY_RUN" = "true" ]; then
+          ARGS+=(--dry-run)
+        else
+          ARGS+=(--write)
+        fi
+        if [ -n "$INPUT_SINCE" ]; then
+          ARGS+=(--since "$INPUT_SINCE")
+        fi
+        node tools/docsAutogen/bin/docs-autogen.cjs "${ARGS[@]}" \
+          | tee /tmp/docs-autogen.log
+
+    - name: Format generated docs with prettier
+      if: ${{ inputs.dry-run != 'true' }}
+      shell: bash
+      working-directory: ts
+      run: npx prettier --write 'packages/**/README.AUTOGEN.md'

--- a/.github/workflows/docs-pr-amend.yml
+++ b/.github/workflows/docs-pr-amend.yml
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Inline per-PR regeneration of package-level README.AUTOGEN.md companion
+# files. When a pull request changes a package's source, this workflow
+# regenerates that package's companion doc and commits it back onto the PR
+# branch, so the documentation update travels in the same PR that changed
+# the code - reviewed by the same person, gated by the same checks. This
+# replaces the standalone daily bot PR for the common case; docs-refresh.yml
+# now runs only twice a month as a backstop (forks, failed inline runs, and
+# repo-wide regenerations when the generator or templates change).
+#
+# No loop, by construction. The regenerated doc is committed with the
+# TypeAgent-Bot App token so the normal PR checks re-run on it (same reason
+# format-pr.yml uses that token). That commit re-triggers THIS workflow too,
+# but docs-autogen embeds a content hash of each package's deterministic
+# inputs and skips any package whose hash still matches - so the second run
+# regenerates nothing, commits nothing, and the cycle terminates. No path
+# exclusion or "skip my own commit" guard is needed; idempotency does it.
+#
+# Fork PRs are not handled here: a pull_request from a fork gets a read-only
+# token (cannot push back) and no `models: read` token. The twice-monthly
+# docs-refresh sweep regenerates fork-introduced drift after merge.
+
+name: docs-pr-amend
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "ts/packages/**"
+      - ".github/workflows/docs-pr-amend.yml"
+      - ".github/actions/docs-generate/**"
+
+# One in-flight run per PR; a new push supersedes the previous run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  # Push the regenerated companions back onto the PR branch.
+  contents: write
+  # Reach GitHub Models inference with the built-in GITHUB_TOKEN.
+  models: read
+
+jobs:
+  regenerate:
+    # Same-repo PRs only. Fork PRs get a read-only token (cannot push the
+    # commit back) and no models token; the docs-refresh sweep covers them.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      # `vars`/`secrets` cannot be used directly in step `if` conditions, so
+      # expose whether the App credentials are configured as a string. The
+      # App id is a repo variable and the private key a secret - the same
+      # convention docs-refresh.yml uses.
+      HAS_APP_CREDS: ${{ vars.DEPENDABOT_APP_ID != '' }}
+    steps:
+      - name: Setup Git LF
+        run: git config --global core.autocrlf false
+
+      # Mint a short-lived TypeAgent-Bot App token. Pushing the regenerated
+      # commit with it re-triggers the normal PR checks on that commit (the
+      # default GITHUB_TOKEN would not). When the App secrets are absent the
+      # step is skipped and the push falls back to GITHUB_TOKEN (the commit
+      # still lands, but downstream checks are not re-triggered on it).
+      - name: Generate app token
+        id: app-token
+        if: env.HAS_APP_CREDS == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          # Full history so the merge-base with the base branch resolves.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "$BASE_REF"
+
+      # Scope to exactly the packages this PR changed by diffing against the
+      # merge-base with the target branch (equivalent to the PR's three-dot
+      # diff). The content-hash gate then drops any of those whose inputs did
+      # not actually change, so a re-triggered run is a no-op.
+      - name: Resolve PR merge-base
+        id: base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          MERGE_BASE="$(git merge-base "origin/${BASE_REF}" HEAD)"
+          echo "since=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+          echo "Regenerating packages changed since merge-base $MERGE_BASE"
+
+      # Advisory: a docs hiccup (LLM error, rate limit, transient failure)
+      # must never block the code PR. The twice-monthly docs-refresh sweep is
+      # the authority/backstop, and docs-autogen preserves the existing AI
+      # body when a package's authoring fails. The shared composite installs
+      # deps, builds the CLI, runs it against GitHub Models, and prettier-
+      # formats the written files.
+      - name: Regenerate changed READMEs
+        continue-on-error: true
+        uses: ./.github/actions/docs-generate
+        with:
+          since: ${{ steps.base.outputs.since }}
+          github-token: ${{ github.token }}
+
+      # Commit only the regenerated companions back onto the PR branch. The
+      # action no-ops when nothing changed (e.g. every changed package was
+      # skipped by the content-hash gate), which is what makes a re-triggered
+      # run terminate instead of looping. README.md is never touched.
+      - name: Commit regenerated docs
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: regenerate README.AUTOGEN.md for changed packages"
+          commit_user_name: typeagent-bot
+          commit_user_email: typeagent-bot[bot]@users.noreply.github.com
+          commit_author: "typeagent-bot <typeagent-bot[bot]@users.noreply.github.com>"
+          file_pattern: "ts/packages/**/README.AUTOGEN.md"

--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -1,9 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Daily regeneration of package-level README.AUTOGEN.md companion files
-# under ts/packages/**, opened as a pull request by the TypeAgent-Bot
-# GitHub App.
+# Twice-monthly (1st & 15th) regeneration of package-level
+# README.AUTOGEN.md companion files under ts/packages/**, opened as a pull
+# request by the TypeAgent-Bot GitHub App.
+#
+# Per-PR regeneration is now handled inline by docs-pr-amend.yml, which
+# commits the companions for the packages a PR changed straight onto that
+# PR. This scheduled workflow is the backstop for what no single PR covers:
+# fork PRs (which cannot be pushed to inline), inline runs that failed or
+# were skipped, and repo-wide regenerations when the generator or its
+# templates change - that shifts every package's content hash, so the next
+# sweep refreshes them all. Because docs-autogen skips any package whose
+# embedded content hash still matches its inputs, a run only opens a PR when
+# something genuinely drifted.
 #
 # Why this shape (no federated credentials, no stored secrets):
 #
@@ -39,16 +49,16 @@
 #      refuses to open a PR if anything other than those files changed. A PR
 #      is opened only when at least one README.AUTOGEN.md actually changed.
 #
-#   4. Lifecycle. One daily run. A human reviewer merges the PR; if a new
-#      run produces a fresh PR first, the previous open bot PR is closed
-#      (--delete-branch) so only one is ever live.
+#   4. Lifecycle. One run on the 1st and 15th. A human reviewer merges the
+#      PR; if a new run produces a fresh PR first, the previous open bot PR
+#      is closed (--delete-branch) so only one is ever live.
 
-name: docs-generate
+name: docs-refresh
 
 on:
   schedule:
-    # Daily at 08:00 UTC.
-    - cron: "0 8 * * *"
+    # Twice a month: the 1st and 15th at 08:00 UTC.
+    - cron: "0 8 1,15 * *"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -78,16 +88,6 @@ permissions:
   # Reach GitHub Models inference with the built-in GITHUB_TOKEN.
   models: read
 
-env:
-  # aiclient generic OpenAI path -> GitHub Models. OPENAI_API_KEY is the
-  # job's GITHUB_TOKEN, injected per-step (never echoed). See the regen step.
-  OPENAI_ENDPOINT: https://models.github.ai/inference/chat/completions
-  OPENAI_MODEL: ${{ inputs.model || 'openai/gpt-4o' }}
-  # One in-flight completion at a time — orderly pacing for a possibly
-  # large (uncapped) run. The microsoft-tenant GitHub Models limits are
-  # ample, so this is courtesy, not necessity.
-  OPENAI_MAX_CONCURRENCY: "1"
-
 jobs:
   regenerate:
     runs-on: ubuntu-latest
@@ -98,31 +98,6 @@ jobs:
           # Full history so the --since baseline (last README.AUTOGEN.md
           # commit) resolves and the diff against it is complete.
           fetch-depth: 0
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          package_json_file: ts/package.json
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-          cache-dependency-path: ts/pnpm-lock.yaml
-
-      - name: Install ts dependencies
-        working-directory: ts
-        run: |
-          corepack enable
-          pnpm install --frozen-lockfile
-
-      - name: Build docs-autogen tool
-        working-directory: ts
-        # Trailing `...` builds the named package AND its transitive
-        # workspace dependencies (aiclient -> @typeagent/config, etc.) in
-        # topological order; without it tsc fails on missing workspace-dep
-        # type declarations. Same pattern as build-dotnet.yml.
-        run: pnpm --filter '@typeagent/docs-autogen...' build
 
       # Validate the free-text dispatch inputs that reach a shell before
       # they are used. Strict allowlists prevent shell-metachar injection
@@ -170,43 +145,16 @@ jobs:
             echo "No README.AUTOGEN.md history found — docs-autogen will do a first-run full sweep (bounded by --max-packages)."
           fi
 
-      - name: Regenerate README.AUTOGEN.md files (GitHub Models)
-        id: regen
-        working-directory: ts
-        env:
-          DEBUG: "docs-autogen:*"
-          # OPENAI_API_KEY = the job's GITHUB_TOKEN; aiclient sends it as a
-          # Bearer token to GitHub Models. Never expanded into the command
-          # line, only exported into the process environment.
-          OPENAI_API_KEY: ${{ github.token }}
-          INPUT_SINCE: ${{ steps.baseline.outputs.since }}
-          INPUT_DRY_RUN: ${{ inputs.dry-run }}
-        run: |
-          set -o pipefail
-          # No per-run package cap: pass a bound far above the workspace size
-          # so the tool's cost guard never truncates. Selection stays
-          # change-scoped via --since, so this only matters on the rare run
-          # where a large number of packages genuinely drifted.
-          ARGS=("--render" "--llm" "--max-packages" "100000")
-          if [ "$INPUT_DRY_RUN" = "true" ]; then
-            ARGS+=("--dry-run")
-          else
-            ARGS+=("--write")
-          fi
-          if [ -n "$INPUT_SINCE" ]; then
-            ARGS+=("--since" "$INPUT_SINCE")
-          fi
-          echo "Invoking docs-autogen with ${#ARGS[@]} args (model: $OPENAI_MODEL)"
-          node tools/docsAutogen/bin/docs-autogen.cjs "${ARGS[@]}" \
-            | tee /tmp/docs-autogen.log
-
-      # Re-format freshly written files with the workspace prettier so the
-      # resulting PR passes the repo's `prettier --check .` gate. Skipped on
-      # dry runs (nothing was written).
-      - name: Format generated docs with prettier
-        if: ${{ inputs.dry-run != true }}
-        working-directory: ts
-        run: npx prettier --write 'packages/**/README.AUTOGEN.md'
+      # Regenerate the companions for packages changed since the baseline.
+      # The shared composite installs deps, builds the docs-autogen CLI, runs
+      # it against GitHub Models, and prettier-formats the written files.
+      - name: Regenerate README.AUTOGEN.md files
+        uses: ./.github/actions/docs-generate
+        with:
+          since: ${{ steps.baseline.outputs.since }}
+          github-token: ${{ github.token }}
+          model: ${{ inputs.model || 'openai/gpt-4o' }}
+          dry-run: ${{ inputs.dry-run }}
 
       # Decide whether anything changed. README.md is never touched, so we
       # scope strictly to README.AUTOGEN.md. A clean tree => no PR.
@@ -275,7 +223,7 @@ jobs:
 
           git commit -m "docs: regenerate package README.AUTOGEN.md files ($(date +%Y-%m-%d))
 
-          Automated by the docs-generate workflow. AI body authored via
+          Automated by the docs-refresh workflow. AI body authored via
           GitHub Models; deterministic Reference computed from source.
 
           ${{ steps.detect.outputs.changed_files }} file(s) updated.

--- a/ts/tools/docsAutogen/src/assembleAutogen.ts
+++ b/ts/tools/docsAutogen/src/assembleAutogen.ts
@@ -57,7 +57,7 @@ export function assembleAutogenBlock(
 ): AssembledAutogen {
     const decision = decideCompact(inputs);
 
-    const hash = computeContentHash(hashInputs(inputs));
+    const hash = computeInputHash(inputs);
     const documentation = renderAiDocumentation(
         inputs,
         options.llmDocumentationBody,
@@ -89,6 +89,18 @@ export function assembleAutogenBlock(
     ].join("\n");
 
     return { body, hash, compact: decision.compact };
+}
+
+/**
+ * Compute the content hash for a package's inputs — the same digest
+ * `assembleAutogenBlock` embeds in the README.AUTOGEN.md body. Exposed
+ * so callers can decide whether regenerating a package would be
+ * meaningful (inputs changed) or pure churn (hash unchanged) WITHOUT
+ * rendering or calling the LLM. Covers deterministic prompt-input
+ * proxies, never the rendered output.
+ */
+export function computeInputHash(inputs: PackageInputs): string {
+    return computeContentHash(hashInputs(inputs));
 }
 
 /**

--- a/ts/tools/docsAutogen/src/cli.ts
+++ b/ts/tools/docsAutogen/src/cli.ts
@@ -18,7 +18,8 @@ import {
 } from "./workspaceGraph.js";
 import { detectChangedPackages } from "./changeDetection.js";
 import { gatherPackageInputs } from "./packageInputs.js";
-import { assembleAutogenBlock } from "./assembleAutogen.js";
+import { assembleAutogenBlock, computeInputHash } from "./assembleAutogen.js";
+import { parseHashComment } from "./contentHash.js";
 import { renderReferenceSection } from "./renderReference.js";
 import { decideCompact } from "./compactMode.js";
 import { generateDocumentation } from "./generateDocumentation.js";
@@ -517,6 +518,45 @@ async function renderSelected(
 
     for (const pkg of selected) {
         const inputs = await gatherPackageInputs(pkg, graph, monorepoRoot);
+        const autogenPath = path.join(pkg.dir, AUTOGEN_FILE_NAME);
+
+        // Idempotency gate. When writing, skip a package entirely (no LLM
+        // call, no write) if its README.AUTOGEN.md was generated from the
+        // same inputs. The embedded hash digests the deterministic prompt
+        // inputs, not the nondeterministic LLM prose, so an unchanged hash
+        // means a regenerated file would differ only by churn. This keeps
+        // the tool idempotent, so it can run on every pull request without
+        // the commit-back retriggering itself into a loop. First generation
+        // (no file / no hash) and stdout preview (no --write) fall through.
+        if (opts.write && !opts.dryRun) {
+            const existingHash = await readEmbeddedHash(autogenPath);
+            const currentHash = computeInputHash(inputs);
+            if (existingHash !== null && existingHash === currentHash) {
+                records.push({
+                    package: pkg.name,
+                    relDir: pkg.relDir,
+                    compact: decideCompact(inputs).compact,
+                    hash: currentHash,
+                    body: "",
+                    documentation: {
+                        mode: "skeleton",
+                        status: "unchanged-inputs",
+                        attempts: 0,
+                        isPlaceholder: false,
+                        wordCount: null,
+                        diagnostics: [],
+                    },
+                    links: { total: 0, broken: [], stripped: 0 },
+                    write: {
+                        attempted: false,
+                        verdict: "unchanged",
+                        note: "inputs unchanged (content-hash match); regeneration skipped",
+                        filePath: autogenPath,
+                    },
+                });
+                continue;
+            }
+        }
 
         let llmBody: string | undefined;
         let docMeta: RenderRecord["documentation"] = {
@@ -559,7 +599,6 @@ async function renderSelected(
         // Validate links against the file we'd be writing — link
         // resolution is anchored at the file's directory.
         const links = extractMarkdownLinks(block.body);
-        const autogenPath = path.join(pkg.dir, AUTOGEN_FILE_NAME);
         const validation = await validateLinks(links, autogenPath);
 
         // Recover gracefully from broken links: drop the link wrapper
@@ -742,6 +781,21 @@ async function verifyLinksMode(
     }
     const totalBroken = records.reduce((acc, r) => acc + r.broken.length, 0);
     return totalBroken === 0 ? 0 : 1;
+}
+
+/**
+ * Read the content hash embedded in an existing README.AUTOGEN.md, or
+ * null when the file is missing or carries no hash comment. Used by the
+ * idempotency gate in `renderSelected` to decide whether a package's
+ * inputs changed since it was last generated.
+ */
+async function readEmbeddedHash(filePath: string): Promise<string | null> {
+    try {
+        const content = await fsPromises.readFile(filePath, "utf8");
+        return parseHashComment(content);
+    } catch {
+        return null;
+    }
 }
 
 /**

--- a/ts/tools/docsAutogen/test/assembleAutogen.spec.ts
+++ b/ts/tools/docsAutogen/test/assembleAutogen.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { assembleAutogenBlock } from "../src/assembleAutogen.js";
+import {
+    assembleAutogenBlock,
+    computeInputHash,
+} from "../src/assembleAutogen.js";
+import { parseHashComment } from "../src/contentHash.js";
 import type { PackageInputs } from "../src/packageInputs.js";
 import type { WorkspacePackage } from "../src/workspaceGraph.js";
 
@@ -102,6 +106,37 @@ describe("assembleAutogenBlock", () => {
             { headSha: "x", isoDate: "d" },
         );
         expect(a.hash).not.toBe(b.hash);
+    });
+
+    // The idempotency gate in cli.ts computes computeInputHash(inputs) and
+    // compares it to the hash parsed out of the on-disk file. If these two
+    // ever diverge the gate silently stops skipping (or skips wrongly), so
+    // lock the invariant: the standalone hash equals the embedded comment.
+    it("computeInputHash equals the hash embedded in the body", () => {
+        const inputs = makeInputs();
+        const block = assembleAutogenBlock(inputs, {
+            headSha: "sha",
+            isoDate: "date",
+        });
+        expect(computeInputHash(inputs)).toBe(block.hash);
+        expect(computeInputHash(inputs)).toBe(parseHashComment(block.body));
+    });
+
+    it("computeInputHash ignores the LLM body and footer", () => {
+        const inputs = makeInputs();
+        const withLlm = assembleAutogenBlock(inputs, {
+            headSha: "x",
+            isoDate: "2026-01-01",
+            llmDocumentationBody: "## Overview\n\nSomething specific.",
+        });
+        const withoutLlm = assembleAutogenBlock(inputs, {
+            headSha: "y",
+            isoDate: "2099-12-31",
+        });
+        expect(parseHashComment(withLlm.body)).toBe(computeInputHash(inputs));
+        expect(parseHashComment(withoutLlm.body)).toBe(
+            computeInputHash(inputs),
+        );
     });
 
     it("embeds the LLM-authored body when supplied", () => {


### PR DESCRIPTION
This pull request introduces a major refactor to the documentation generation workflows and supporting CLI logic. The core change is to make per-PR regeneration of `README.AUTOGEN.md` files idempotent and more efficient, ensuring that documentation is only regenerated and committed when a package's inputs have actually changed. This is achieved through a content hash gate, which prevents unnecessary LLM calls and commit loops. The workflows are reorganized to split per-PR and scheduled (backstop) runs, and a shared composite action is introduced for maintainability.

The most important changes are:

**Workflow and Automation Improvements:**
- Added `.github/actions/docs-generate`, a shared composite GitHub Action that sets up the toolchain, builds the docs-autogen CLI, and regenerates `README.AUTOGEN.md` files for changed packages. This action is now used by both per-PR and scheduled workflows to DRY up logic and ensure consistency.
- Introduced `.github/workflows/docs-pr-amend.yml`, a new workflow that automatically regenerates and commits `README.AUTOGEN.md` files to the PR branch when package sources change, ensuring documentation stays in sync with code changes and eliminating the need for a daily bot PR for most cases.
- Renamed and refactored the scheduled workflow to `.github/workflows/docs-refresh.yml` (from `docs-generate.yml`), reducing its frequency to twice monthly and delegating per-PR updates to the new inline workflow. The scheduled workflow now acts as a backstop for fork PRs, failed inline runs, or repo-wide template changes. [[1]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL4-R16) [[2]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL42-R61)

**Idempotency and Efficiency Enhancements:**
- Implemented a content hash gate in the docs-autogen CLI: before regenerating a package's documentation, the CLI checks if the hash of the current inputs matches the hash embedded in the existing `README.AUTOGEN.md`. If unchanged, regeneration is skipped, preventing redundant LLM calls and commit churn. [[1]](diffhunk://#diff-f9165caffc5be29ec41d431adf5cc732c65780e01d73b3b5c647577bb927a327R521-R559) [[2]](diffhunk://#diff-f9165caffc5be29ec41d431adf5cc732c65780e01d73b3b5c647577bb927a327R786-R800) [[3]](diffhunk://#diff-5e4dc6c8d878da26748e6dad75c9c1be8e019438038d320982bf27c2a1fe4b04R94-R105)
- Exposed `computeInputHash` from `assembleAutogen.ts` for use in both the CLI and automation workflows, enabling hash-based change detection without rendering or LLM calls. [[1]](diffhunk://#diff-5e4dc6c8d878da26748e6dad75c9c1be8e019438038d320982bf27c2a1fe4b04R94-R105) [[2]](diffhunk://#diff-f9165caffc5be29ec41d431adf5cc732c65780e01d73b3b5c647577bb927a327L21-R22)

**Codebase Cleanup and Refactoring:**
- Refactored the docs-autogen CLI to use the new hash-checking logic, and moved dependency installation, build, and formatting steps into the shared composite action, simplifying workflow YAML files and reducing duplication. [[1]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL102-L126) [[2]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL173-R157)
- Updated documentation and workflow comments to clarify the new architecture, idempotency mechanism, and the division of responsibilities between per-PR and scheduled runs. [[1]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL4-R16) [[2]](diffhunk://#diff-707c5724b16eee6e2447eb5adbc70bb93789b29aa0451afc1b44f0126cbc24cfL278-R226)

These changes collectively make documentation generation more reliable, efficient, and maintainable, while preventing unnecessary workflow runs and ensuring that documentation updates travel with code changes in the same pull request.…y modify packages