### PR TITLE
Fix short flags being consumed as string values

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/command/parameters.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/parameters.ts
@@ -85,8 +85,8 @@ function invalidValueToken(valueToken: string) {
     if (
         valueToken.length === 2 &&
         valueToken[0] === "-" &&
-        valueToken.charCodeAt(1) < 48 /* "0" */ &&
-        valueToken.charCodeAt(1) > 57 /* "9" */
+        (valueToken.charCodeAt(1) < 48 /* "0" */ ||
+            valueToken.charCodeAt(1) > 57) /* "9" */
     ) {
         return true;
     }

--- a/ts/packages/dispatcher/dispatcher/test/flags.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/flags.spec.ts
@@ -13,6 +13,20 @@ describe("Flag parsing", () => {
             obj: { description: "testing", type: "json" },
         },
     } as const;
+    const shortFlags = {
+        flags: {
+            output: {
+                description: "output",
+                type: "string",
+                char: "o",
+            },
+            verbose: {
+                description: "verbose",
+                type: "boolean",
+                char: "v",
+            },
+        },
+    } as const;
     const o1 = { hello: "str", num: 11, bool: true };
     const o2 = { ...o1, obj: o1, arr: [o1, o1] };
     it("type", () => {
@@ -255,6 +269,20 @@ describe("Flag parsing", () => {
         } catch (e: any) {
             expect(e.message).toStrictEqual("Invalid flag '-n'");
         }
+    });
+
+    it("does not consume a following short flag as a string value", () => {
+        expect(() => parseParams("-o -v", shortFlags)).toThrow(
+            "Missing value for flag '-o'",
+        );
+    });
+
+    it("accepts a negative numeric-looking string as a short flag value", () => {
+        expect(parseParams("-o -1", shortFlags).flags.output).toBe("-1");
+    });
+
+    it("accepts a quoted short-flag-looking string as a short flag value", () => {
+        expect(parseParams("-o '-v'", shortFlags).flags.output).toBe("-v");
     });
 
     it("Duplicate flags", () => {


### PR DESCRIPTION
A string-valued short flag could incorrectly consume the next short flag as its value. Here, `-m` expects a match string while `-v` is a separate boolean flag.

```console
> @const list -m -v

Input:
  -m -> expects a string value
  -v -> verbose boolean flag

Before:
  parsed match -> "-v"
  parsed verbose -> false
  output -> no result

After:
  -v is recognized as another flag, leaving -m without a value
  output -> Missing value for flag '-m'
```

The short-flag check used an impossible condition (`character < "0" && character > "9"`). Changing it to `||` rejects unquoted flag tokens as string values while still allowing negative numeric values such as `-1` and quoted values such as `'-v'`.

https://github.com/user-attachments/assets/23fc609d-8c9c-443b-9ced-f605387b1662
