### PR TITLE
Fix intermittent heal job failure from pnpm cache post-step

### DIFF
--- a/.github/workflows/heal-generated-files.yml
+++ b/.github/workflows/heal-generated-files.yml
@@ -92,11 +92,19 @@ jobs:
         with:
           package_json_file: ts/package.json
 
+      # No pnpm store cache here.  This job never runs a full `pnpm install`:
+      # it only trial-merges main and, when the lockfile conflicts, runs
+      # `pnpm install --lockfile-only` (dependency-graph resolution that writes
+      # the lockfile without populating the store).  With `cache: pnpm`,
+      # setup-node's post-step tries to save the pnpm store on a cache miss and
+      # fails with "Path(s) specified in the action for caching do(es) not
+      # exist" because nothing ever populated it - so the job passed or failed
+      # purely on whether another workflow had already cached that lockfile
+      # hash.  The store cache gives no benefit to a lockfile-only resolve, so
+      # dropping it makes the job deterministic.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
-          cache-dependency-path: ts/pnpm-lock.yaml
 
       - name: Heal conflicted generated files
         if: env.HAS_APP_CREDS == 'true'


### PR DESCRIPTION
## Problem

The `heal` job in `Heal Generated Files` fails intermittently at the **`Post Run actions/setup-node@v4`** step with:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

### Root cause

The job configures `setup-node` with `cache: "pnpm"` / `cache-dependency-path: ts/pnpm-lock.yaml`, but it **never runs a full `pnpm install`**. It only trial-merges `main` and, *when the lockfile conflicts*, runs `pnpm install --lockfile-only --ignore-scripts` — which resolves the dependency graph to rewrite the lockfile **without populating the pnpm store**. On the common `no conflict - skipping` path it installs nothing at all.

So on a cache **miss**, setup-node's post-step tries to *save* a pnpm store directory that was never created and errors out. On a cache **hit** it logs `Cache hit ... not saving cache` and skips the save. The result: the job's success depended entirely on whether some *other* workflow had already cached that exact lockfile hash — a race, hence the flakiness.

Confirmed across runs on the same branch: an 07‑23 run **missed** the cache and failed; a later run after merging `main` **hit** a cache populated by main's build jobs and passed — neither ran an install.

## Fix

Remove `cache: "pnpm"` and `cache-dependency-path` from the `setup-node` step. The pnpm store cache provides no benefit to a `--lockfile-only` resolve (no tarballs are downloaded), and the job is a fast trial-merge that doesn't build. Dropping it removes the failing post-step and makes the job deterministic.