### PR TITLE
Add DevTunnel support to Android chat sample

### DIFF
--- a/android/samples/mobile-2/README.md
+++ b/android/samples/mobile-2/README.md
@@ -1,47 +1,61 @@
 # Mobile 2 - TypeAgent Android Chat Sample
 
-This sample shows a minimal Android Jetpack Compose chat client that connects to a local TypeAgent agent-server over WebSocket.
+An Android Jetpack Compose chat client that connects to a TypeAgent agent-server via [Microsoft DevTunnel][devtunnel].
 
 ## What this sample demonstrates
 
-- Jetpack Compose chat UI (message history, input, send button, connection status)
+- Jetpack Compose chat UI (message history, streaming bubbles, connection status, send button)
 - OkHttp WebSocket usage on Android
-- TypeAgent agent-server protocol handling:
-  - `joinConversation`
-  - `submitCommand`
-  - inbound `appendDisplay`, `setDisplayInfo`, and command completion events
-- Incremental assistant streaming into a single chat bubble per `requestId`
+- TypeAgent agent-server RPC protocol:
+  - `joinConversation` / `submitCommand`
+  - Inbound `appendDisplay`, `setDisplay`, `setDisplayInfo`, and command completion events
+- Incremental assistant response streaming into a single bubble per `requestId`
+- DevTunnel authentication via `X-Tunnel-Authorization` header
+- Build-time configuration via environment variables and `BuildConfig`
 
 ## Prerequisites
 
 - Android Studio (recent stable version)
-- Android emulator
-- A running TypeAgent agent-server on your host machine at `ws://localhost:8999`
+- A TypeAgent agent-server exposed via DevTunnel — see `TypeAgent/ts/examples/remoteClient/README.md` for server setup
+- [DevTunnel CLI][devtunnel-cli]
 
-## Run the TypeAgent server
+## Configuration
 
-From your TypeAgent workspace:
+Once your server is running and tunnelled, set these two environment variables **before building** the app:
+
+| Variable | Required | Description |
+|---|---|---|
+| `TYPEAGENT_SERVER_URL` | **Yes** | DevTunnel WebSocket URL (e.g. `wss://abc123xyz-8999.devtunnels.ms`) |
+| `TYPEAGENT_TUNNEL_TOKEN` | **Yes** | DevTunnel access token |
 
 ```powershell
-pnpm run start:agent-server
+# PowerShell (Windows)
+$env:TYPEAGENT_SERVER_URL  = "wss://abc123xyz-8999.devtunnels.ms"
+$env:TYPEAGENT_TUNNEL_TOKEN = "<your token>"
 ```
 
-## Run the Android sample
-
-1. Open this folder in Android Studio: `android/samples/mobile-2`
-2. Let Gradle sync finish.
-3. Start an Android emulator.
-4. Run the `app` module.
-
-The app connects to:
-
-```text
-ws://10.0.2.2:8999
+```bash
+# macOS / Linux
+export TYPEAGENT_SERVER_URL="wss://abc123xyz-8999.devtunnels.ms"
+export TYPEAGENT_TUNNEL_TOKEN="<your token>"
 ```
 
-`10.0.2.2` is the Android emulator alias for your host machine's localhost.
+## Build and run
 
-## Notes
+1. Open this folder (`android/samples/mobile-2`) in Android Studio
+2. Let Gradle sync finish
+3. Run **Build → Rebuild Project** to pick up the environment variables
+4. Run the `app` module on your device
 
-- Cleartext WebSocket (`ws://`) is enabled for local development in this sample.
-- If you test on a physical device, update the WebSocket URL in `WebSocketManager.kt` to your machine's LAN IP (for example `ws://192.168.1.10:8999`).
+The app connects automatically on launch. Tap **Retry** in the status bar if the connection fails.
+
+> Rebuild whenever you change `TYPEAGENT_SERVER_URL` or `TYPEAGENT_TUNNEL_TOKEN` — these values are embedded at compile time.
+
+## Security Notes
+
+- **Token storage**: `TYPEAGENT_TUNNEL_TOKEN` is compiled into `BuildConfig`. Do not distribute APKs built with a sensitive or long-lived token.
+- **Token transmission**: The token is sent only as an HTTP upgrade header and is never logged.
+
+[devtunnel]: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/
+[devtunnel-cli]: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
+

--- a/android/samples/mobile-2/app/build.gradle.kts
+++ b/android/samples/mobile-2/app/build.gradle.kts
@@ -3,6 +3,18 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+fun String.escapeForBuildConfig(): String =
+    replace("\\", "\\\\").replace("\"", "\\\"")
+
+val tunnelUrlFromEnv = providers.environmentVariable("TYPEAGENT_SERVER_URL")
+    .orElse("")
+    .get()
+    .escapeForBuildConfig()
+val tunnelTokenFromEnv = providers.environmentVariable("TYPEAGENT_TUNNEL_TOKEN")
+    .orElse("")
+    .get()
+    .escapeForBuildConfig()
+
 android {
     namespace = "com.example.typeagentchat"
     compileSdk {
@@ -19,6 +31,8 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "TYPEAGENT_SERVER_URL", "\"$tunnelUrlFromEnv\"")
+        buildConfigField("String", "TYPEAGENT_TUNNEL_TOKEN", "\"$tunnelTokenFromEnv\"")
     }
 
     buildTypes {
@@ -34,6 +48,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
@@ -51,15 +51,24 @@ import com.example.typeagentchat.ui.theme.TypeAgentChatTheme
 class MainActivity : ComponentActivity() {
 
     private val webSocketManager = WebSocketManager()
+    private val tunnelUrl = BuildConfig.TYPEAGENT_SERVER_URL.trim()
+    private val tunnelToken = BuildConfig.TYPEAGENT_TUNNEL_TOKEN.trim().ifBlank { null }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        webSocketManager.connect()
+        webSocketManager.connect(
+            url = tunnelUrl,
+            tunnelToken = tunnelToken
+        )
 
         setContent {
             TypeAgentChatTheme {
-                ChatApp(webSocketManager = webSocketManager)
+                ChatApp(
+                    webSocketManager = webSocketManager,
+                    tunnelUrl = tunnelUrl,
+                    tunnelToken = tunnelToken
+                )
             }
         }
     }
@@ -71,7 +80,11 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun ChatApp(webSocketManager: WebSocketManager) {
+private fun ChatApp(
+    webSocketManager: WebSocketManager,
+    tunnelUrl: String,
+    tunnelToken: String?
+) {
     val messages by webSocketManager.messages.collectAsState()
     val connectionStatus by webSocketManager.connectionStatus.collectAsState()
     var inputText by remember { mutableStateOf("") }
@@ -106,7 +119,12 @@ private fun ChatApp(webSocketManager: WebSocketManager) {
             ChatHeader()
             ConnectionStatusIndicator(
                 status = connectionStatus,
-                onReconnect = { webSocketManager.connect() }
+                onReconnect = {
+                    webSocketManager.connect(
+                        url = tunnelUrl,
+                        tunnelToken = tunnelToken
+                    )
+                }
             )
 
             Surface(

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -10,13 +10,17 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class WebSocketManager {
 
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+        .pingInterval(30, TimeUnit.SECONDS)
+        .build()
     private val lock = Any()
     private val nextCallId = AtomicInteger(0)
+    private val connectionGeneration = AtomicInteger(0)
     private val pendingInvokes = mutableMapOf<Int, PendingInvoke>()
 
     private var webSocket: WebSocket? = null
@@ -34,24 +38,43 @@ class WebSocketManager {
     )
     val connectionStatus: StateFlow<ConnectionStatus> = _connectionStatus
 
-    fun connect(url: String = DEFAULT_URL) {
+    fun connect(
+        url: String,
+        tunnelToken: String? = null
+    ) {
+        val targetUrl = url.trim()
+        if (targetUrl.isBlank()) {
+            val errorMessage = "Missing TYPEAGENT_SERVER_URL. Set it before building the app."
+            Log.e(TAG, errorMessage)
+            _connectionStatus.value = ConnectionStatus(
+                text = errorMessage,
+                state = ConnectionStatus.State.ERROR
+            )
+            return
+        }
+
         synchronized(lock) {
             pendingInvokes.clear()
             conversationId = null
             connectionId = null
         }
         webSocket?.cancel()
+        val generation = connectionGeneration.incrementAndGet()
         _connectionStatus.value = ConnectionStatus(
             text = "Connecting...",
             state = ConnectionStatus.State.CONNECTING
         )
 
-        val request = Request.Builder()
-            .url(url)
-            .build()
+        val requestBuilder = Request.Builder().url(targetUrl)
+        val trimmedToken = tunnelToken?.trim().orEmpty()
+        if (trimmedToken.isNotEmpty()) {
+            requestBuilder.header("X-Tunnel-Authorization", "tunnel $trimmedToken")
+        }
+        val request = requestBuilder.build()
 
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
+                if (connectionGeneration.get() != generation) return
                 Log.d(TAG, "WebSocket connected")
                 joinConversation()
             }
@@ -66,6 +89,7 @@ class WebSocketManager {
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                if (connectionGeneration.get() != generation) return
                 Log.d(TAG, "WebSocket disconnected: code=$code reason=$reason")
                 failPendingInvokes("Disconnected")
                 synchronized(lock) {
@@ -79,7 +103,12 @@ class WebSocketManager {
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                val errorMessage = t.message ?: "Unknown WebSocket error"
+                if (connectionGeneration.get() != generation) return
+                val responseCode = response?.code
+                val errorMessage = when (responseCode) {
+                    401, 403 -> "Tunnel auth failed. Check token."
+                    else -> t.message ?: "Unknown WebSocket error"
+                }
                 Log.e(TAG, "WebSocket error: $errorMessage", t)
                 failPendingInvokes(errorMessage)
                 _connectionStatus.value = ConnectionStatus(
@@ -416,10 +445,12 @@ class WebSocketManager {
     }
 
     private fun appendUserMessage(text: String) {
-        _messages.value = _messages.value + Message(
-            text = text,
-            isUser = true
-        )
+        synchronized(lock) {
+            _messages.value = _messages.value + Message(
+                text = text,
+                isUser = true
+            )
+        }
     }
 
     private fun appendAssistantContent(requestId: String?, content: String) {
@@ -518,10 +549,10 @@ class WebSocketManager {
             .put("message", message)
 
         if (!socket.send(envelope.toString())) {
-            synchronized(lock) {
-                pendingInvokes.remove(callId)
+            val removed = synchronized(lock) { pendingInvokes.remove(callId) }
+            if (removed != null) {
+                onError("Failed to send RPC invoke for $methodName.")
             }
-            onError("Failed to send RPC invoke for $methodName.")
         }
     }
 
@@ -672,7 +703,6 @@ class WebSocketManager {
 
     companion object {
         private const val TAG = "WebSocketManager"
-        private const val DEFAULT_URL = "ws://10.0.2.2:8999"
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val AGENT_SERVER_CHANNEL = "agent-server"
         private const val CLIENT_IO_CHANNEL_PREFIX = "clientio:"


### PR DESCRIPTION
## Summary

Adds DevTunnel support to the Android chat sample so physical Android devices and emulators can connect to a TypeAgent agent-server exposed through Microsoft DevTunnels.

## Changes

- Add TYPEAGENT_SERVER_URL configuration
- Add TYPEAGENT_TUNNEL_TOKEN configuration
- Send X-Tunnel-Authorization during WebSocket upgrade
- Update README with DevTunnel setup instructions

## Validation

- Verified connection to agent-server through DevTunnel
- Verified chat messages can be sent and received