### PR TITLE
Update optional agent bundle names to align with azure folder names

### DIFF
--- a/pipelines/azure-build-publish-all.yml
+++ b/pipelines/azure-build-publish-all.yml
@@ -632,6 +632,11 @@ stages:
                   for dir in "$(Pipeline.Workspace)"/optional-agents-$(platform)-$(arch)/*/; do
                     [ -d "$dir" ] || continue
                     name="$(basename "$dir")"
+                    if ! printf '%s' "$name" | grep -Eq '^[a-z0-9]+([._-][a-z0-9]+)*$'; then
+                      echo "ERROR: '$name' (from $dir) is not a valid universal-package name segment." >&2
+                      echo "Optional-agent bundle folders must be scope-stripped (e.g. 'code-agent') by packageOptionalAgents.mjs." >&2
+                      exit 1
+                    fi
                     echo "Publishing ${name}.${RID} v$(packageVersion)"
                     az artifacts universal publish \
                       --organization "$(adoOrgUrl)" --project "$(adoProject)" --scope project \

--- a/ts/tools/scripts/packageOptionalAgents.mjs
+++ b/ts/tools/scripts/packageOptionalAgents.mjs
@@ -74,6 +74,19 @@ function agentNames(cfg) {
         .filter((n) => typeof n === "string");
 }
 
+// Map an npm package name to a bundle-folder / universal-package name.
+// Azure Artifacts universal package names must be lowercase and contain only
+// alphanumeric segments separated by '-', '.', or '_' — the npm scope
+// ('@typeagent/') is invalid there. Stripping the scope yields a valid, stable
+// identity matching the pre-scoping bundle name (e.g. '@typeagent/code-agent'
+// -> 'code-agent'). The scoped name is still used for `pnpm --filter`.
+function toBundleName(npmName) {
+    return npmName
+        .replace(/^@[^/]+\//, "")
+        .replace(/[^a-zA-Z0-9._-]/g, "-")
+        .toLowerCase();
+}
+
 // Resolve an exports subpath target from a package.json (handles string or
 // conditional-object export entries).
 function exportTarget(pkg, key) {
@@ -122,7 +135,24 @@ function main() {
     const prof = readJson(path.join(dataDir, `config.${args.profile}.json`));
     const profileNames = new Set(agentNames(prof));
     let excluded = agentNames(full).filter((n) => !profileNames.has(n));
-    if (args.agents) excluded = excluded.filter((n) => args.agents.includes(n));
+    if (args.agents)
+        excluded = excluded.filter(
+            (n) =>
+                args.agents.includes(n) ||
+                args.agents.includes(toBundleName(n)),
+        );
+
+    // Universal-package names must be unique after scope stripping.
+    const seen = new Map();
+    for (const n of excluded) {
+        const b = toBundleName(n);
+        if (seen.has(b))
+            throw new Error(
+                `Bundle name collision: '${seen.get(b)}' and '${n}' both map ` +
+                    `to universal-package name '${b}'.`,
+            );
+        seen.set(b, n);
+    }
 
     console.log(
         `Packaging ${excluded.length} optional agent(s) for profile ` +
@@ -132,8 +162,9 @@ function main() {
 
     const results = [];
     for (const npmName of excluded) {
-        const dest = path.join(args.out, npmName);
-        console.log(`\n[${npmName}] deploying...`);
+        const bundleName = toBundleName(npmName);
+        const dest = path.join(args.out, bundleName);
+        console.log(`\n[${npmName}] deploying -> ${bundleName}/ ...`);
         fs.rmSync(dest, { recursive: true, force: true });
         run(
             "pnpm",
@@ -166,13 +197,14 @@ function main() {
         console.log(
             `[${npmName}] validated (manifest + handlers + agent-sdk present).`,
         );
-        results.push(npmName);
+        results.push(bundleName);
     }
 
     console.log(
         `\nPackaged ${results.length} optional agent bundle(s) under ${args.out}.\n` +
+            `Bundle folders (== universal-package names): ${results.join(", ")}\n` +
             `Each is installable via the dispatcher:  @install <name> <bundle-folder>\n` +
-            `or publishable per-RID:  az artifacts universal publish --name <name> --path <bundle-folder>`,
+            `or publishable per-RID:  az artifacts universal publish --name <bundle-folder> --path <bundle-folder>`,
     );
 }
 


### PR DESCRIPTION
Update optional-agent packaging to convert npm package names (including scoped names like @typeagent/...) into Azure-compatible bundle folder names, then publish those names as universal packages. Adds collision detection after scope stripping, allows --agents filtering by either npm or bundle name, and updates output messaging. The pipeline now validates bundle folder names before publish and fails fast with a clear error if an invalid name slips through.