### PR TITLE
Clear chat history when opening a session

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/sessionCommandHandlers.ts
@@ -103,6 +103,7 @@ class SessionOpenCommandHandler implements CommandHandler {
             systemContext.indexingServiceRegistry,
         );
         await setSessionOnCommandHandlerContext(systemContext, session);
+        systemContext.chatHistory.clear();
         displaySuccess(`Session opened: ${params.args.session}`, context);
     }
 }

--- a/ts/packages/shell/test/sessionCommands.spec.ts
+++ b/ts/packages/shell/test/sessionCommands.spec.ts
@@ -192,22 +192,56 @@ test.describe("@session Commands", () => {
                 mainWindow,
             );
             expect(msg.toLowerCase()).toContain("new session created: ");
+            const currentSession = /new session created:\s*(\S+)/i.exec(
+                msg,
+            )?.[1];
+            expect(
+                currentSession,
+                "Current session name was not returned.",
+            ).toBeDefined();
 
             // get the session list
             msg = await sendUserRequestAndWaitForCompletion(
                 `@session list`,
                 mainWindow,
             );
-            const sessions: string[] = msg.split("\n");
+            const sessions: string[] = msg.split("\n").filter(Boolean);
+            const sessionToOpen = sessions.find(
+                (session) => session !== currentSession,
+            );
+            expect(
+                sessionToOpen,
+                "No earlier session was available to open.",
+            ).toBeDefined();
+
+            // Add a deterministic entry without requiring an LLM call.
+            const marker = "BLUEBIRD-743";
+            msg = await sendUserRequestAndWaitForCompletion(
+                `@history insert {"user":"Please remember ${marker}.","assistant":{"text":"I will remember ${marker}.","source":"system"}}`,
+                mainWindow,
+            );
+            expect(msg).toContain("Inserted 1 input entries");
+
+            msg = await sendUserRequestAndWaitForCompletion(
+                `@history`,
+                mainWindow,
+            );
+            expect(msg).toContain(marker);
 
             // open the earlier session
             msg = await sendUserRequestAndWaitForCompletion(
-                `@session open ${sessions[0]}`,
+                `@session open ${sessionToOpen}`,
                 mainWindow,
             );
             expect(msg, `Unexpected session opened!`).toBe(
-                `Session opened: ${sessions[0]}`,
+                `Session opened: ${sessionToOpen}`,
             );
+
+            msg = await sendUserRequestAndWaitForCompletion(
+                `@history`,
+                mainWindow,
+            );
+            expect(msg, "History was not cleared.").toBe("");
 
             // close the application
         });


### PR DESCRIPTION
Clears in-memory chat history after @session open switches sessions, with an Electron regression test preventing cross-session context leakage.

Not sure why openining a new session doesn’t clear the chat history. It's a bit annoying as most other harnesses clear the chat history


Input file: session-demo-commands.txt
```
# Create a new session, add a visible chat-history marker, then reopen the earlier session.

@session new --persist
@history insert {"user":"Please remember marker BLUEBIRD-743.","assistant":{"text":"I will remember BLUEBIRD-743.","source":"system"}}
@history
@session list
@session open 20260727_0
@history
```
Before
```
node packages/cli/bin/run.js connect session-demo-commands.txt \
  --hidden --port 19246 --no-resume --no-exit
Session opened: 20260727_0
0: {
  "role": "user",
  "text": "Please remember marker BLUEBIRD-743."
}
1: {
  "role": "assistant",
  "text": "I will remember BLUEBIRD-743."
}
```
The final @history incorrectly displays history from the previous session.
After
```
node packages/cli/bin/run.js connect session-demo-commands.txt \
  --hidden --port 19247 --no-resume --no-exit
Session opened: 20260727_0
```
The final @history correctly displays no entries.