### PR TITLE
Run command files without interactive console setup

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
+++ b/ts/packages/dispatcher/dispatcher/src/helpers/console.ts
@@ -658,31 +658,34 @@ export async function processCommands<T>(
         ".typeagent",
         "command_history.json",
     );
-    if (fs.existsSync(historyFile)) {
-        const hh = JSON.parse(
-            fs.readFileSync(historyFile, { encoding: "utf-8" }),
-        );
-        history = hh.commands;
+    let rl: readline.promises.Interface | undefined;
+    if (inputs === undefined) {
+        if (fs.existsSync(historyFile)) {
+            const hh = JSON.parse(
+                fs.readFileSync(historyFile, { encoding: "utf-8" }),
+            );
+            history = hh.commands;
+        }
+
+        rl = createInterface({
+            input: process.stdin,
+            output: process.stdout,
+            history,
+            terminal: true,
+        });
+        process.stdin.setRawMode(true);
+        process.stdin.resume();
     }
-
-    const rl = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-        history,
-        terminal: true,
-    });
-
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
 
     while (true) {
         const prompt =
             typeof interactivePrompt === "function"
                 ? await interactivePrompt(context)
                 : interactivePrompt;
-        const request = inputs
-            ? getNextInput(prompt, inputs)
-            : await question(promptColor(prompt), rl, history);
+        const request =
+            inputs !== undefined
+                ? getNextInput(prompt, inputs)
+                : await question(promptColor(prompt), rl, history);
         if (request.length) {
             if (
                 request.toLowerCase() === "quit" ||
@@ -702,10 +705,12 @@ export async function processCommands<T>(
         console.log("");
 
         // save command history
-        fs.writeFileSync(
-            historyFile,
-            JSON.stringify({ commands: (rl as any).history }),
-        );
+        if (rl !== undefined) {
+            fs.writeFileSync(
+                historyFile,
+                JSON.stringify({ commands: (rl as any).history }),
+            );
+        }
     }
 }
 

--- a/ts/packages/dispatcher/dispatcher/test/console.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/console.spec.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, jest } from "@jest/globals";
+import fs from "node:fs";
+import { PassThrough } from "node:stream";
+import { processCommands } from "../src/helpers/console.js";
+
+describe("processCommands", () => {
+    it("processes batch inputs without initializing an interactive console", async () => {
+        const realStdin = process.stdin;
+        const fakeStdin = new PassThrough();
+        Object.defineProperty(fakeStdin, "isTTY", { value: false });
+        const resumeSpy = jest.spyOn(fakeStdin, "resume");
+        const historyExistsSpy = jest.spyOn(fs, "existsSync");
+        const historyReadSpy = jest.spyOn(fs, "readFileSync");
+        const historyWriteSpy = jest.spyOn(fs, "writeFileSync");
+        jest.spyOn(console, "log").mockImplementation(() => {});
+        Object.defineProperty(process, "stdin", {
+            value: fakeStdin,
+            writable: true,
+            configurable: true,
+        });
+
+        try {
+            const processed: string[] = [];
+            await processCommands(
+                "test> ",
+                async (request) => {
+                    processed.push(request);
+                },
+                {},
+                ["# comment", "", "@display first", "@display second"],
+            );
+
+            expect(processed).toEqual(["@display first", "@display second"]);
+            expect(resumeSpy).not.toHaveBeenCalled();
+            expect(fakeStdin.listenerCount("data")).toBe(0);
+            expect(historyExistsSpy).not.toHaveBeenCalled();
+            expect(historyReadSpy).not.toHaveBeenCalled();
+            expect(historyWriteSpy).not.toHaveBeenCalled();
+        } finally {
+            Object.defineProperty(process, "stdin", {
+                value: realStdin,
+                writable: true,
+                configurable: true,
+            });
+            fakeStdin.destroy();
+            jest.restoreAllMocks();
+        }
+    });
+});


### PR DESCRIPTION
Skips interactive console and history setup for command-file inputs so detached servers can execute CLI command files.

## Setup

translation-evaluation.txt
```
# Evaluate routing and translation across player and calendar schemas.

@config schema -x *
@config schema player calendar

@dispatcher translate Please play Nocturne No. 2 by Chopin.
@dispatcher translate Schedule a design review tomorrow at 2 PM.
@dispatcher translate Play Anti-Hero and schedule lunch for noon Friday.

@display EVALUATION-BATCH-COMPLETE
```
Command

```
node packages/cli/bin/run.js connect translation-evaluation.txt \
  --hidden --port 19248 --no-resume --no-exit
```
## Before
```

Connecting to existing TypeAgent server on port 19248...
Connected to conversation 'CLI'.
ERROR: process.stdin.setRawMode is not a function
```
No evaluation case runs.
## After
```
Connecting to existing TypeAgent server on port 19249...
Connected to conversation 'CLI'.

@dispatcher translate Please play Nocturne No. 2 by Chopin.
[Player translation result]

@dispatcher translate Schedule a design review tomorrow at 2 PM.
[Calendar translation result]

@dispatcher translate Play Anti-Hero and schedule lunch for noon Friday.
[Multi-action translation result]

EVALUATION-BATCH-COMPLETE
```