### PR TITLE
TypeAgent Studio: generate real REST handlers for OpenAPI-discovered agents

### DIFF
--- a/ts/packages/agents/onboarding/package.json
+++ b/ts/packages/agents/onboarding/package.json
@@ -42,6 +42,8 @@
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
+    "test": "npm run test:local",
+    "test:local": "tsx --test test/*.spec.ts",
     "tsc": "tsc -b"
   },
   "dependencies": {
@@ -64,6 +66,7 @@
     "copyfiles": "^2.4.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
+    "tsx": "^4.21.0",
     "typescript": "~5.4.5",
     "ws": "^8.21.1"
   },

--- a/ts/packages/agents/onboarding/src/discovery/discoveryHandler.ts
+++ b/ts/packages/agents/onboarding/src/discovery/discoveryHandler.ts
@@ -49,6 +49,9 @@ export type DiscoveredParameter = {
     type: string;
     description?: string;
     required?: boolean;
+    // Where the parameter lives on the wire (OpenAPI `in`, or "body" for a
+    // request-body property). Only set by the parseOpenApiSpec arm.
+    in?: "path" | "query" | "header" | "cookie" | "body";
 };
 
 export type DiscoveredEntity = {
@@ -66,6 +69,10 @@ export type ApiSurface = {
     approved?: boolean;
     approvedAt?: string;
     approvedActions?: string[];
+    // Absolute http/https base URL resolved from the OpenAPI spec's
+    // `servers[0].url` (parseOpenApiSpec arm only). Unset when it cannot be
+    // resolved to a well-formed http/https URL (see resolveOpenApiBaseUrl).
+    baseUrl?: string;
 };
 
 // TypeChat translator for structured CLI help extraction
@@ -359,6 +366,167 @@ function isInternalAction(name: string): boolean {
     return false;
 }
 
+// Resolve an OpenAPI 3 spec's base URL to an absolute http/https URL, or
+// return undefined when it cannot be resolved deterministically (Swagger 2
+// host/basePath/schemes, malformed/local, or missing server variable
+// defaults are all left unset — the REST handler generator then falls back
+// to the stub handler rather than emitting a malformed request).
+export function resolveOpenApiBaseUrl(
+    spec: any,
+    specSource: string,
+    fetchedUrl?: string,
+): string | undefined {
+    const specIsHttp = /^https?:\/\//i.test(specSource);
+    // Prefer the post-redirect URL (only meaningful when we actually fetched
+    // over http/https); otherwise fall back to the original specSource.
+    const specLocation = specIsHttp ? (fetchedUrl ?? specSource) : undefined;
+
+    const rawServerUrl: string | undefined = spec?.servers?.[0]?.url;
+
+    if (!rawServerUrl) {
+        // No `servers` entry — fall back to the origin of the spec's own
+        // location, but only when that location is itself http/https.
+        if (!specLocation) return undefined;
+        try {
+            return new URL(specLocation).origin;
+        } catch {
+            return undefined;
+        }
+    }
+
+    // Substitute server variables ({var}) from servers[0].variables[var].default.
+    // If any referenced variable lacks a default, bail out rather than emit
+    // a malformed URL containing a literal "{var}".
+    const variables = spec.servers[0].variables ?? {};
+    let substituted = rawServerUrl;
+    const varNames = [...rawServerUrl.matchAll(/\{([^}]+)\}/g)].map(
+        (m) => m[1],
+    );
+    for (const varName of varNames) {
+        const def = variables?.[varName]?.default;
+        if (def === undefined || def === null) return undefined;
+        substituted = substituted.replaceAll(`{${varName}}`, String(def));
+    }
+
+    if (/^https?:\/\//i.test(substituted)) {
+        // Absolute — use as-is (preserving any path component).
+        try {
+            const u = new URL(substituted);
+            // Strip a trailing slash only; keep the rest of the path intact.
+            return u.toString().replace(/\/$/, "");
+        } catch {
+            return undefined;
+        }
+    }
+
+    // Relative server URL (e.g. "/v3") — resolve against the spec's own
+    // fetched location, only when that location is http/https.
+    if (!specLocation) return undefined;
+    try {
+        return new URL(substituted, specLocation).toString().replace(/\/$/, "");
+    } catch {
+        return undefined;
+    }
+}
+
+// Extract discovered actions from a parsed OpenAPI 3 (or Swagger 2 —
+// unsupported, will simply yield no actions since `spec.paths` items won't
+// have the shape below) spec document. Pure/synchronous so it can be unit
+// tested without going through the workspace-state-backed action handler.
+export function extractOpenApiActions(
+    spec: any,
+    specSource: string,
+): DiscoveredAction[] {
+    const actions: DiscoveredAction[] = [];
+    const paths = spec.paths ?? {};
+    for (const [pathStr, pathItem] of Object.entries(paths) as [
+        string,
+        any,
+    ][]) {
+        // Deterministic inline-OpenAPI-3 subset only — a `$ref`'d path item
+        // (shared path referencing a component) is out of scope for v1.
+        if (pathItem?.$ref) continue;
+
+        const pathLevelParams: any[] = Array.isArray(pathItem?.parameters)
+            ? pathItem.parameters
+            : [];
+
+        for (const method of [
+            "get",
+            "post",
+            "put",
+            "patch",
+            "delete",
+        ] as const) {
+            const op = pathItem?.[method];
+            if (!op) continue;
+
+            const name =
+                op.operationId ??
+                `${method}${pathStr.replace(/[^a-zA-Z0-9]/g, "_")}`;
+            const camelName = name.replace(
+                /_([a-z])/g,
+                (_: string, c: string) => c.toUpperCase(),
+            );
+
+            // Merge path-level parameters (shared across all operations on
+            // this path) with operation-level parameters, keyed by
+            // (name, in) — operation-level entries override path-level ones.
+            const opLevelParams: any[] = Array.isArray(op.parameters)
+                ? op.parameters
+                : [];
+            const mergedByKey = new Map<string, any>();
+            for (const p of [...pathLevelParams, ...opLevelParams]) {
+                // Inline params only — skip `$ref`'d parameters (out of
+                // scope for v1 deterministic generation).
+                if (!p || p.$ref || !p.name) continue;
+                mergedByKey.set(`${p.in ?? "query"}:${p.name}`, p);
+            }
+
+            const parameters: DiscoveredParameter[] = Array.from(
+                mergedByKey.values(),
+            ).map((p: any) => ({
+                name: p.name,
+                type: p.schema?.type ?? "string",
+                description: p.description,
+                required: p.required ?? false,
+                in: p.in,
+            }));
+
+            // Also include request body fields as parameters
+            const requestBody =
+                op.requestBody?.content?.["application/json"]?.schema;
+            if (requestBody?.properties) {
+                for (const [propName, propSchema] of Object.entries(
+                    requestBody.properties,
+                ) as [string, any][]) {
+                    parameters.push({
+                        name: propName,
+                        type: propSchema.type ?? "string",
+                        description: propSchema.description,
+                        required:
+                            requestBody.required?.includes(propName) ?? false,
+                        in: "body",
+                    });
+                }
+            }
+
+            actions.push({
+                name: camelName,
+                description:
+                    op.summary ??
+                    op.description ??
+                    `${method.toUpperCase()} ${pathStr}`,
+                method: method.toUpperCase(),
+                path: pathStr,
+                parameters,
+                sourceUrl: specSource,
+            });
+        }
+    }
+    return actions;
+}
+
 async function handleParseOpenApiSpec(
     integrationName: string,
     specSource: string,
@@ -374,6 +542,9 @@ async function handleParseOpenApiSpec(
 
     // Fetch the spec (URL or file path)
     let specContent: string;
+    // Post-redirect URL when specSource is fetched over http/https; used to
+    // resolve a relative `servers[0].url` against the *actual* spec location.
+    let fetchedUrl: string | undefined;
     try {
         if (
             specSource.startsWith("http://") ||
@@ -385,6 +556,7 @@ async function handleParseOpenApiSpec(
                     error: `Failed to fetch spec: ${response.status} ${response.statusText}`,
                 };
             }
+            fetchedUrl = response.url || specSource;
             specContent = await response.text();
         } else {
             const fs = await import("fs/promises");
@@ -411,75 +583,15 @@ async function handleParseOpenApiSpec(
     }
 
     // Extract actions from OpenAPI paths
-    const actions: DiscoveredAction[] = [];
-    const paths = spec.paths ?? {};
-    for (const [pathStr, pathItem] of Object.entries(paths) as [
-        string,
-        any,
-    ][]) {
-        for (const method of [
-            "get",
-            "post",
-            "put",
-            "patch",
-            "delete",
-        ] as const) {
-            const op = pathItem?.[method];
-            if (!op) continue;
+    const actions: DiscoveredAction[] = extractOpenApiActions(spec, specSource);
 
-            const name =
-                op.operationId ??
-                `${method}${pathStr.replace(/[^a-zA-Z0-9]/g, "_")}`;
-            const camelName = name.replace(
-                /_([a-z])/g,
-                (_: string, c: string) => c.toUpperCase(),
-            );
-
-            const parameters: DiscoveredParameter[] = (op.parameters ?? []).map(
-                (p: any) => ({
-                    name: p.name,
-                    type: p.schema?.type ?? "string",
-                    description: p.description,
-                    required: p.required ?? false,
-                }),
-            );
-
-            // Also include request body fields as parameters
-            const requestBody =
-                op.requestBody?.content?.["application/json"]?.schema;
-            if (requestBody?.properties) {
-                for (const [propName, propSchema] of Object.entries(
-                    requestBody.properties,
-                ) as [string, any][]) {
-                    parameters.push({
-                        name: propName,
-                        type: propSchema.type ?? "string",
-                        description: propSchema.description,
-                        required:
-                            requestBody.required?.includes(propName) ?? false,
-                    });
-                }
-            }
-
-            actions.push({
-                name: camelName,
-                description:
-                    op.summary ??
-                    op.description ??
-                    `${method.toUpperCase()} ${pathStr}`,
-                method: method.toUpperCase(),
-                path: pathStr,
-                parameters,
-                sourceUrl: specSource,
-            });
-        }
-    }
-
+    const resolvedBaseUrl = resolveOpenApiBaseUrl(spec, specSource, fetchedUrl);
     const surface: ApiSurface = {
         integrationName,
         discoveredAt: new Date().toISOString(),
         source: specSource,
         actions,
+        ...(resolvedBaseUrl !== undefined ? { baseUrl: resolvedBaseUrl } : {}),
     };
 
     await writeArtifactJson(

--- a/ts/packages/agents/onboarding/src/scaffolder/restHandler.template
+++ b/ts/packages/agents/onboarding/src/scaffolder/restHandler.template
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Auto-generated REST handler for {{NAME}}
+//
+// Generated deterministically from an OpenAPI 3 spec (parseOpenApiSpec arm).
+// v1 limitations: no auth (no Authorization/api-key headers), scalar-only
+// query/path params (no array/object/style/explode), header/cookie params
+// are dropped when optional and rejected when required, DELETE requests
+// never carry a body.
+
+import {
+    ActionContext,
+    AppAgent,
+    TypeAgentAction,
+} from "@typeagent/agent-sdk";
+import {
+    createActionResultFromTextDisplay,
+} from "@typeagent/agent-sdk/helpers/action";
+import { {{PASCAL_NAME}}Actions } from "./{{NAME}}Schema.js";
+
+const BASE_URL = {{BASE_URL}};
+const MAX_RESPONSE_CHARS = 4000;
+
+function truncate(text: string): string {
+    return text.length > MAX_RESPONSE_CHARS
+        ? text.slice(0, MAX_RESPONSE_CHARS) + "\n…(truncated)"
+        : text;
+}
+
+function formatResponseBody(text: string): string {
+    try {
+        return truncate(JSON.stringify(JSON.parse(text), null, 2));
+    } catch {
+        return truncate(text);
+    }
+}
+
+async function callRest(
+    method: string,
+    path: string,
+    query: Record<string, unknown>,
+    body: Record<string, unknown> | undefined,
+): Promise<string> {
+    const trimmedBase = BASE_URL.replace(/\/$/, "");
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const url = new URL(`${trimmedBase}${normalizedPath}`);
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === null) continue;
+        url.searchParams.set(key, String(value));
+    }
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    let requestBody: string | undefined;
+    if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+        requestBody = JSON.stringify(body);
+    }
+
+    const res = await fetch(url, {
+        method,
+        headers,
+        body: requestBody,
+        signal: AbortSignal.timeout(30_000),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+        throw new Error(`${res.status} ${res.statusText}: ${truncate(text)}`);
+    }
+    return formatResponseBody(text);
+}
+
+async function runAction(
+    action: TypeAgentAction<{{PASCAL_NAME}}Actions>,
+): Promise<string> {
+    const parameters = action.parameters as Record<string, unknown>;
+    switch (action.actionName) {
+{{SWITCH_CASES}}
+        default:
+            // Cast rather than reading `action.actionName` directly: when
+            // the switch above exhaustively covers every literal in the
+            // {{PASCAL_NAME}}Actions union, TS narrows `action` to `never`
+            // here, and `never` has no properties.
+            throw new Error(
+                `Unknown action: ${(action as { actionName: string }).actionName}`,
+            );
+    }
+}
+
+export function instantiate(): AppAgent {
+    return {
+        executeAction: async (
+            action: TypeAgentAction<{{PASCAL_NAME}}Actions>,
+            context: ActionContext<{{PASCAL_NAME}}Actions>,
+        ) => {
+            try {
+                const output = await runAction(action);
+                return createActionResultFromTextDisplay(output);
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                return createActionResultFromTextDisplay(`Error: ${msg}`);
+            }
+        },
+    };
+}

--- a/ts/packages/agents/onboarding/src/scaffolder/restHandlerTemplate.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/restHandlerTemplate.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// REST handler template generator — the fetch-based twin of
+// cliHandlerTemplate.ts. Produces a complete TypeScript action handler that
+// issues real HTTP requests against a base URL captured from an OpenAPI 3
+// spec's `servers[0].url` (see discoveryHandler.ts's parseOpenApiSpec arm).
+//
+// Called by scaffolderHandler when the API surface has a resolved
+// `baseUrl` and HTTP-method actions with a `path` (parseOpenApiSpec arm
+// only — crawlDocUrl's LLM-guessed method/path is out of scope).
+//
+// v1 limitations (see restHandler.template header comment too):
+//   - scalar path/query params only (no arrays/objects, no style/explode)
+//   - header/cookie params are unsupported: required ones fail the action,
+//     optional ones are silently dropped
+//   - no auth (no Authorization / api-key headers)
+//   - DELETE requests never carry a body
+//   - `$ref`-based params/bodies/path-items are skipped upstream in
+//     discoveryHandler.ts, so they never reach this generator
+
+import type { DiscoveredAction } from "../discovery/discoveryHandler.js";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolve template from src/ relative to the package root.
+// At runtime __dirname is dist/scaffolder/, so go up two levels to package root.
+function templatePath(): string {
+    return path.resolve(__dirname, "../../src/scaffolder/restHandler.template");
+}
+
+const HTTP_METHODS_WITH_HANDLER = new Set([
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+]);
+
+// Deterministic wire-name -> camelCase transform. Mirrors the transform
+// SchemaGen's LLM prompt asks the model to apply to parameter names
+// (schemaGenHandler.ts), so `book_id` / `book-id` on the wire becomes the
+// `bookId` the LLM is expected to populate in `action.parameters`. Exotic
+// LLM renames outside this transform are a known v1 limitation.
+function toCamel(wireName: string): string {
+    return wireName.replace(/[-_]+([A-Za-z0-9])/g, (_, c: string) =>
+        c.toUpperCase(),
+    );
+}
+
+// Bracket-access expression reading a parameter by its camelCase runtime
+// name, falling back to the original wire name in case the LLM (or a
+// simple/no-op transform) preserved it verbatim.
+function paramValueExpr(wireName: string): string {
+    const camel = toCamel(wireName);
+    if (camel === wireName) {
+        return `parameters[${JSON.stringify(wireName)}]`;
+    }
+    return `parameters[${JSON.stringify(camel)}] ?? parameters[${JSON.stringify(wireName)}]`;
+}
+
+// Builds a JS expression for the request path: literal segments are
+// JSON.stringify'd string literals, `{param}` placeholders become
+// `encodeURIComponent(String(<value expr>))`, all joined with `+`. This
+// avoids template-literal escaping concerns entirely (no backtick/`${`
+// collision risk from spec-provided literal text).
+function buildPathExpr(
+    pathTemplate: string,
+    pathParamNames: Set<string>,
+): string {
+    const parts: string[] = [];
+    let lastIndex = 0;
+    const re = /\{([^}]+)\}/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(pathTemplate)) !== null) {
+        const literal = pathTemplate.slice(lastIndex, m.index);
+        if (literal) parts.push(JSON.stringify(literal));
+        const paramName = m[1];
+        if (pathParamNames.has(paramName)) {
+            parts.push(
+                `encodeURIComponent(String(${paramValueExpr(paramName)}))`,
+            );
+        } else {
+            // Path placeholder with no captured parameter (shouldn't
+            // normally happen for an inline spec) — leave the literal
+            // placeholder text in place rather than throw at generation time.
+            parts.push(JSON.stringify(m[0]));
+        }
+        lastIndex = re.lastIndex;
+    }
+    const tail = pathTemplate.slice(lastIndex);
+    if (tail || parts.length === 0) parts.push(JSON.stringify(tail));
+    return parts.join(" + ");
+}
+
+function buildSwitchCases(actions: DiscoveredAction[]): string {
+    const cases: string[] = [];
+    for (const action of actions) {
+        const method = (action.method ?? "GET").toUpperCase();
+        const pathTemplate = action.path ?? "/";
+        const pathParamNames = new Set(
+            [...pathTemplate.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]),
+        );
+
+        const params = action.parameters ?? [];
+        const bodyParams = params.filter((p) => p.in === "body");
+        const headerCookieParams = params.filter(
+            (p) => p.in === "header" || p.in === "cookie",
+        );
+        const queryParams = params.filter(
+            (p) =>
+                p.in === "query" ||
+                (p.in === undefined &&
+                    !pathParamNames.has(p.name) &&
+                    !bodyParams.includes(p)),
+        );
+
+        const requiredUnsupported = headerCookieParams.find((p) => p.required);
+        if (requiredUnsupported) {
+            cases.push(
+                `        case ${JSON.stringify(action.name)}:\n` +
+                    `            throw new Error(${JSON.stringify(
+                        `Required parameter "${requiredUnsupported.name}" (${requiredUnsupported.in}) is not supported by the generated REST handler in v1.`,
+                    )});`,
+            );
+            continue;
+        }
+        // Optional header/cookie params are silently dropped (v1 limitation).
+
+        const lines: string[] = [];
+        lines.push(`        case ${JSON.stringify(action.name)}: {`);
+        lines.push(
+            `            const path = ${buildPathExpr(pathTemplate, pathParamNames)};`,
+        );
+        lines.push(`            const query: Record<string, unknown> = {};`);
+        for (const p of queryParams) {
+            lines.push(
+                `            query[${JSON.stringify(p.name)}] = ${paramValueExpr(p.name)};`,
+            );
+        }
+        if (method !== "DELETE" && bodyParams.length > 0) {
+            lines.push(`            const body: Record<string, unknown> = {`);
+            for (const p of bodyParams) {
+                lines.push(
+                    `                [${JSON.stringify(p.name)}]: ${paramValueExpr(p.name)},`,
+                );
+            }
+            lines.push(`            };`);
+            lines.push(
+                `            return await callRest(${JSON.stringify(method)}, path, query, body);`,
+            );
+        } else {
+            lines.push(
+                `            return await callRest(${JSON.stringify(method)}, path, query, undefined);`,
+            );
+        }
+        lines.push(`        }`);
+        cases.push(lines.join("\n"));
+    }
+    return cases.join("\n");
+}
+
+/**
+ * Returns the subset of `actions` this generator can actually handle:
+ * actions from the parseOpenApiSpec arm with a recognized HTTP method and a
+ * `path`. Used by scaffolderHandler to decide whether to route to the REST
+ * generator at all.
+ */
+export function filterRestActions(
+    actions: DiscoveredAction[] | undefined,
+): DiscoveredAction[] {
+    if (!actions) return [];
+    return actions.filter(
+        (a) =>
+            !!a.path &&
+            !!a.method &&
+            HTTP_METHODS_WITH_HANDLER.has(a.method.toUpperCase()),
+    );
+}
+
+export async function buildRestHandler(
+    name: string,
+    pascalName: string,
+    baseUrl: string,
+    actions: DiscoveredAction[],
+): Promise<string> {
+    const tpl = await fs.readFile(templatePath(), "utf-8");
+    const switchCases = buildSwitchCases(actions);
+    // Use function-form replacers: string-form replace treats "$"
+    // sequences in the replacement as special (e.g. "$&", "$1"), which a
+    // generated base URL or switch-case body could plausibly contain.
+    return tpl
+        .replace(/\{\{NAME\}\}/g, () => name)
+        .replace(/\{\{PASCAL_NAME\}\}/g, () => pascalName)
+        .replace(/\{\{BASE_URL\}\}/g, () => JSON.stringify(baseUrl))
+        .replace(/\{\{SWITCH_CASES\}\}/g, () => switchCases);
+}

--- a/ts/packages/agents/onboarding/src/scaffolder/scaffolderHandler.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/scaffolderHandler.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/workspace.js";
 import type { ApiSurface } from "../discovery/discoveryHandler.js";
 import { buildCliHandler } from "./cliHandlerTemplate.js";
+import { buildRestHandler, filterRestActions } from "./restHandlerTemplate.js";
 import { loadTemplate } from "./templateLoader.js";
 import { generateAgentKeywordFiles } from "./agentKeywordFiles.js";
 import type { KeywordSchemaTarget } from "./agentKeywordFiles.js";
@@ -726,7 +727,7 @@ function buildManifest(
     return manifest;
 }
 
-async function buildHandler(
+export async function buildHandler(
     name: string,
     pascalName: string,
     pattern: AgentPattern = "schema-grammar",
@@ -739,6 +740,27 @@ async function buildHandler(
     if (cliActions && cliActions.length > 0) {
         const cliCommand = cliActions[0].sourceUrl!.split(":")[1];
         return await buildCliHandler(name, pascalName, cliCommand, cliActions);
+    }
+
+    // If discovery data has a resolved OpenAPI base URL, generate a real
+    // fetch-based REST handler for the patterns that model a direct REST
+    // integration (schema-grammar is the default when a caller doesn't
+    // specify a pattern). Explicit non-REST patterns (websocket-bridge,
+    // native-platform, etc.) keep their own dedicated builders even if an
+    // apiSurface happens to be attached.
+    if (
+        apiSurface?.baseUrl &&
+        (pattern === "schema-grammar" || pattern === "external-api")
+    ) {
+        const restActions = filterRestActions(apiSurface.actions);
+        if (restActions.length > 0) {
+            return await buildRestHandler(
+                name,
+                pascalName,
+                apiSurface.baseUrl,
+                restActions,
+            );
+        }
     }
 
     switch (pattern) {

--- a/ts/packages/agents/onboarding/test/apiSurfacePreservation.spec.ts
+++ b/ts/packages/agents/onboarding/test/apiSurfacePreservation.spec.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Verifies CHANGE 1/2 survive the full discovery -> approval round trip
+// (parseOpenApiSpec writes api-surface.json, approveApiSurface re-reads and
+// re-writes it via `{...surface, ...}`): baseUrl and per-parameter `in`
+// must still be present in the approved artifact. Exercises the real
+// executeDiscoveryAction handler end-to-end against the real per-integration
+// workspace on disk (~/.typeagent/onboarding/<name>), cleaned up afterward.
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { executeDiscoveryAction } from "../src/discovery/discoveryHandler.js";
+import type { ApiSurface } from "../src/discovery/discoveryHandler.js";
+import { createWorkspace, readArtifactJson } from "../src/lib/workspace.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const INTEGRATION_NAME = `test-book-api-${process.pid}-${Date.now()}`;
+
+function getWorkspaceDir(): string {
+    return path.join(
+        os.homedir(),
+        ".typeagent",
+        "onboarding",
+        INTEGRATION_NAME,
+    );
+}
+
+after(async () => {
+    await fs.rm(getWorkspaceDir(), { recursive: true, force: true });
+});
+
+test("baseUrl and parameter `in` survive parseOpenApiSpec -> approveApiSurface", async () => {
+    await createWorkspace({ integrationName: INTEGRATION_NAME });
+
+    const fixturePath = path.resolve(
+        __dirname,
+        "fixtures/openapi/book-api-absolute-server.json",
+    );
+
+    const parseResult = await executeDiscoveryAction(
+        {
+            actionName: "parseOpenApiSpec",
+            parameters: {
+                integrationName: INTEGRATION_NAME,
+                specSource: fixturePath,
+            },
+        } as any,
+        {} as any,
+    );
+    assert.ok(
+        !("error" in (parseResult as any)),
+        `parseOpenApiSpec failed: ${JSON.stringify(parseResult)}`,
+    );
+
+    const parsedSurface = await readArtifactJson<ApiSurface>(
+        INTEGRATION_NAME,
+        "discovery",
+        "api-surface.json",
+    );
+    assert.equal(parsedSurface?.baseUrl, "https://api.example.com/v1");
+    const getBook = parsedSurface?.actions.find((a) => a.name === "getBook");
+    assert.equal(
+        getBook?.parameters?.find((p) => p.name === "book_id")?.in,
+        "path",
+    );
+
+    const approveResult = await executeDiscoveryAction(
+        {
+            actionName: "approveApiSurface",
+            parameters: { integrationName: INTEGRATION_NAME },
+        } as any,
+        {} as any,
+    );
+    assert.ok(
+        !("error" in (approveResult as any)),
+        `approveApiSurface failed: ${JSON.stringify(approveResult)}`,
+    );
+
+    const approvedSurface = await readArtifactJson<ApiSurface>(
+        INTEGRATION_NAME,
+        "discovery",
+        "api-surface.json",
+    );
+    assert.equal(
+        approvedSurface?.baseUrl,
+        "https://api.example.com/v1",
+        "baseUrl must survive the approval spread",
+    );
+    const approvedGetBook = approvedSurface?.actions.find(
+        (a) => a.name === "getBook",
+    );
+    assert.equal(
+        approvedGetBook?.parameters?.find((p) => p.name === "book_id")?.in,
+        "path",
+        "parameter `in` must survive the approval spread",
+    );
+    assert.equal(approvedSurface?.approved, true);
+});

--- a/ts/packages/agents/onboarding/test/fixtures/openapi/book-api-absolute-server.json
+++ b/ts/packages/agents/onboarding/test/fixtures/openapi/book-api-absolute-server.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Book API",
+    "version": "1.0.0"
+  },
+  "servers": [{ "url": "https://api.example.com/v1" }],
+  "paths": {
+    "/books/{book_id}": {
+      "parameters": [
+        {
+          "name": "book_id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "operationId": "get_book",
+        "summary": "Get a book",
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/ts/packages/agents/onboarding/test/fixtures/openapi/book-api.json
+++ b/ts/packages/agents/onboarding/test/fixtures/openapi/book-api.json
@@ -1,0 +1,85 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Book API",
+    "version": "1.0.0"
+  },
+  "servers": [{ "url": "/v3" }],
+  "paths": {
+    "/books/{book_id}": {
+      "parameters": [
+        {
+          "name": "book_id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "operationId": "get_book",
+        "summary": "Get a book",
+        "parameters": [
+          {
+            "name": "include_reviews",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      },
+      "put": {
+        "operationId": "update_book",
+        "summary": "Update a book",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" }
+                },
+                "required": ["title"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/books": {
+      "get": {
+        "operationId": "search_books",
+        "summary": "Search books",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      },
+      "post": {
+        "operationId": "create_book",
+        "summary": "Create a book",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" },
+                  "author": { "type": "string" }
+                },
+                "required": ["title"]
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "created" } }
+      }
+    }
+  }
+}

--- a/ts/packages/agents/onboarding/test/openApiExtraction.spec.ts
+++ b/ts/packages/agents/onboarding/test/openApiExtraction.spec.ts
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Deterministic unit tests for the parseOpenApiSpec arm's extraction and
+// base-URL resolution logic (CHANGE 1 & CHANGE 2 of the REST-handler-
+// generation feature).
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+    extractOpenApiActions,
+    resolveOpenApiBaseUrl,
+} from "../src/discovery/discoveryHandler.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function loadBookApiSpec(): Promise<any> {
+    const raw = await fs.readFile(
+        path.resolve(__dirname, "fixtures/openapi/book-api.json"),
+        "utf-8",
+    );
+    return JSON.parse(raw);
+}
+
+describe("extractOpenApiActions", () => {
+    test("merges path-item-level params with operation-level params", async () => {
+        const spec = await loadBookApiSpec();
+        const actions = extractOpenApiActions(
+            spec,
+            "https://api.example.com/openapi.json",
+        );
+
+        const getBook = actions.find((a) => a.name === "getBook");
+        assert.ok(getBook, "expected a getBook action");
+        assert.equal(getBook!.method, "GET");
+        assert.equal(getBook!.path, "/books/{book_id}");
+        const getBookParamNames = getBook!.parameters?.map((p) => p.name);
+        assert.ok(getBookParamNames?.includes("book_id"));
+        assert.ok(getBookParamNames?.includes("include_reviews"));
+
+        const bookIdParam = getBook!.parameters?.find(
+            (p) => p.name === "book_id",
+        );
+        assert.equal(bookIdParam?.in, "path");
+        assert.equal(bookIdParam?.required, true);
+
+        const includeReviewsParam = getBook!.parameters?.find(
+            (p) => p.name === "include_reviews",
+        );
+        assert.equal(includeReviewsParam?.in, "query");
+    });
+
+    test("operation-level param with the same (name, in) overrides the path-level one", () => {
+        const spec = {
+            openapi: "3.0.0",
+            paths: {
+                "/items/{id}": {
+                    parameters: [
+                        {
+                            name: "id",
+                            in: "path",
+                            required: true,
+                            description: "path-level",
+                            schema: { type: "string" },
+                        },
+                    ],
+                    get: {
+                        operationId: "get_item",
+                        parameters: [
+                            {
+                                name: "id",
+                                in: "path",
+                                required: true,
+                                description: "operation-level override",
+                                schema: { type: "string" },
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+        const actions = extractOpenApiActions(spec, "spec.json");
+        const idParam = actions[0].parameters?.find((p) => p.name === "id");
+        assert.equal(idParam?.description, "operation-level override");
+        // Only one merged entry, not two.
+        assert.equal(
+            actions[0].parameters?.filter((p) => p.name === "id").length,
+            1,
+        );
+    });
+
+    test("captures request body properties with in: body", () => {
+        const spec = {
+            openapi: "3.0.0",
+            paths: {
+                "/books/{book_id}": {
+                    put: {
+                        operationId: "update_book",
+                        requestBody: {
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        type: "object",
+                                        properties: {
+                                            title: { type: "string" },
+                                        },
+                                        required: ["title"],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const actions = extractOpenApiActions(spec, "spec.json");
+        const titleParam = actions[0].parameters?.find(
+            (p) => p.name === "title",
+        );
+        assert.equal(titleParam?.in, "body");
+        assert.equal(titleParam?.required, true);
+    });
+
+    test("skips a $ref'd path item entirely (inline-only v1 scope)", () => {
+        const spec = {
+            openapi: "3.0.0",
+            paths: {
+                "/shared": { $ref: "#/components/pathItems/Shared" },
+                "/real": { get: { operationId: "get_real" } },
+            },
+        };
+        const actions = extractOpenApiActions(spec, "spec.json");
+        assert.equal(actions.length, 1);
+        assert.equal(actions[0].name, "getReal");
+    });
+
+    test("skips $ref'd parameters", () => {
+        const spec = {
+            openapi: "3.0.0",
+            paths: {
+                "/x": {
+                    get: {
+                        operationId: "get_x",
+                        parameters: [{ $ref: "#/components/parameters/Foo" }],
+                    },
+                },
+            },
+        };
+        const actions = extractOpenApiActions(spec, "spec.json");
+        assert.equal(actions[0].parameters?.length, 0);
+    });
+});
+
+describe("resolveOpenApiBaseUrl", () => {
+    test("resolves a relative servers[0].url against the fetched spec location, preserving path", async () => {
+        const spec = await loadBookApiSpec();
+        const baseUrl = resolveOpenApiBaseUrl(
+            spec,
+            "https://api.example.com/openapi.json",
+            "https://api.example.com/openapi.json",
+        );
+        assert.equal(baseUrl, "https://api.example.com/v3");
+    });
+
+    test("preserves an absolute server URL's path component", () => {
+        const spec = { servers: [{ url: "https://api.example.com/v1" }] };
+        const baseUrl = resolveOpenApiBaseUrl(
+            spec,
+            "https://api.example.com/openapi.json",
+        );
+        assert.equal(baseUrl, "https://api.example.com/v1");
+    });
+
+    test("substitutes server variables from their default values", () => {
+        const spec = {
+            servers: [
+                {
+                    url: "https://{host}.example.com/{basePath}",
+                    variables: {
+                        host: { default: "api" },
+                        basePath: { default: "v2" },
+                    },
+                },
+            ],
+        };
+        const baseUrl = resolveOpenApiBaseUrl(spec, "spec.json");
+        assert.equal(baseUrl, "https://api.example.com/v2");
+    });
+
+    test("leaves baseUrl unset when a server variable has no default", () => {
+        const spec = {
+            servers: [
+                {
+                    url: "https://{host}.example.com",
+                    variables: {},
+                },
+            ],
+        };
+        const baseUrl = resolveOpenApiBaseUrl(spec, "spec.json");
+        assert.equal(baseUrl, undefined);
+    });
+
+    test("falls back to the fetched spec's origin when servers is absent", () => {
+        const baseUrl = resolveOpenApiBaseUrl(
+            {},
+            "https://api.example.com/openapi.json",
+            "https://api.example.com/openapi.json",
+        );
+        assert.equal(baseUrl, "https://api.example.com");
+    });
+
+    test("leaves baseUrl unset for a local file spec source with a relative servers url", () => {
+        const spec = { servers: [{ url: "/v3" }] };
+        const baseUrl = resolveOpenApiBaseUrl(spec, "./local-spec.json");
+        assert.equal(baseUrl, undefined);
+    });
+
+    test("leaves baseUrl unset for a local file spec source with no servers entry", () => {
+        const baseUrl = resolveOpenApiBaseUrl({}, "./local-spec.json");
+        assert.equal(baseUrl, undefined);
+    });
+});

--- a/ts/packages/agents/onboarding/test/restHandlerCompile.spec.ts
+++ b/ts/packages/agents/onboarding/test/restHandlerCompile.spec.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Verifies the generator's output actually type-checks with `tsc` (CHANGE 3
+// acceptance criterion 2d). Writes a generated handler + a matching schema
+// stub to a scratch folder nested inside the onboarding package (so
+// module resolution finds the workspace's @typeagent/agent-sdk via the
+// package's own node_modules symlink), then runs `tsc --noEmit` on it.
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { buildRestHandler } from "../src/scaffolder/restHandlerTemplate.js";
+import type { DiscoveredAction } from "../src/discovery/discoveryHandler.js";
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SCRATCH_DIR = path.resolve(__dirname, ".tmp-rest-handler-compile");
+
+const actions: DiscoveredAction[] = [
+    {
+        name: "getBook",
+        description: "Get a book",
+        method: "GET",
+        path: "/books/{book_id}",
+        parameters: [
+            { name: "book_id", type: "string", required: true, in: "path" },
+            {
+                name: "include_reviews",
+                type: "boolean",
+                required: false,
+                in: "query",
+            },
+        ],
+    },
+    {
+        name: "createBook",
+        description: "Create a book",
+        method: "POST",
+        path: "/books",
+        parameters: [
+            { name: "title", type: "string", required: true, in: "body" },
+            { name: "author", type: "string", required: false, in: "body" },
+        ],
+    },
+    {
+        name: "deleteBook",
+        description: "Delete a book",
+        method: "DELETE",
+        path: "/books/{book_id}",
+        parameters: [
+            { name: "book_id", type: "string", required: true, in: "path" },
+        ],
+    },
+];
+
+function buildSchemaStub(pascalName: string): string {
+    const members = actions
+        .map(
+            (a) =>
+                `    | {\n` +
+                `          actionName: ${JSON.stringify(a.name)};\n` +
+                `          parameters: Record<string, unknown>;\n` +
+                `      }`,
+        )
+        .join("\n");
+    return (
+        `// Copyright (c) Microsoft Corporation.\n` +
+        `// Licensed under the MIT License.\n\n` +
+        `export type ${pascalName}Actions =\n${members};\n`
+    );
+}
+
+after(async () => {
+    await fs.rm(SCRATCH_DIR, { recursive: true, force: true });
+});
+
+test("buildRestHandler output type-checks with tsc", async () => {
+    await fs.rm(SCRATCH_DIR, { recursive: true, force: true });
+    await fs.mkdir(SCRATCH_DIR, { recursive: true });
+
+    const name = "bookApi";
+    const pascalName = "BookApi";
+    const handlerSource = await buildRestHandler(
+        name,
+        pascalName,
+        "https://api.example.com/v1",
+        actions,
+    );
+
+    await fs.writeFile(
+        path.join(SCRATCH_DIR, `${name}ActionHandler.ts`),
+        handlerSource,
+        "utf-8",
+    );
+    await fs.writeFile(
+        path.join(SCRATCH_DIR, `${name}Schema.ts`),
+        buildSchemaStub(pascalName),
+        "utf-8",
+    );
+    await fs.writeFile(
+        path.join(SCRATCH_DIR, "tsconfig.json"),
+        JSON.stringify(
+            {
+                compilerOptions: {
+                    target: "es2021",
+                    lib: ["es2021"],
+                    module: "node16",
+                    moduleResolution: "node16",
+                    types: ["node"],
+                    esModuleInterop: true,
+                    skipLibCheck: true,
+                    strict: true,
+                    noEmit: true,
+                },
+                include: ["*.ts"],
+            },
+            null,
+            2,
+        ),
+        "utf-8",
+    );
+
+    const tscBin = path.resolve(
+        __dirname,
+        "../node_modules/typescript/bin/tsc",
+    );
+    try {
+        await execFileAsync(process.execPath, [tscBin, "-p", SCRATCH_DIR], {
+            cwd: SCRATCH_DIR,
+        });
+    } catch (err: any) {
+        assert.fail(
+            `Generated REST handler failed to type-check:\n${err.stdout ?? err.message}`,
+        );
+    }
+});

--- a/ts/packages/agents/onboarding/test/restHandlerExecution.spec.ts
+++ b/ts/packages/agents/onboarding/test/restHandlerExecution.spec.ts
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Deterministic, offline execution test (CHANGE 3 acceptance criterion 2e):
+// generates a REST handler with buildRestHandler, points it at a local
+// node:http server on an ephemeral port, and exercises GET-with-path-param,
+// GET-with-query, and POST-with-JSON-body — asserting the server observed
+// the expected method/URL/body and that the handler surfaced the server's
+// response back through createActionResultFromTextDisplay.
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { buildRestHandler } from "../src/scaffolder/restHandlerTemplate.js";
+import type { DiscoveredAction } from "../src/discovery/discoveryHandler.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCRATCH_DIR = path.resolve(__dirname, ".tmp-rest-handler-exec");
+
+after(async () => {
+    await fs.rm(SCRATCH_DIR, { recursive: true, force: true });
+});
+
+type ObservedRequest = {
+    method?: string;
+    url?: string;
+    body: string;
+};
+
+async function startServer(
+    handleRequest: (
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        body: string,
+    ) => void,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c) => chunks.push(c));
+        req.on("end", () => {
+            handleRequest(req, res, Buffer.concat(chunks).toString("utf-8"));
+        });
+    });
+    await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = server.address() as AddressInfo;
+    return {
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () =>
+            new Promise<void>((resolve) => server.close(() => resolve())),
+    };
+}
+
+async function loadHandler(
+    baseUrl: string,
+    actions: DiscoveredAction[],
+): Promise<{ instantiate: () => { executeAction: Function } }> {
+    await fs.rm(SCRATCH_DIR, { recursive: true, force: true });
+    await fs.mkdir(SCRATCH_DIR, { recursive: true });
+    const source = await buildRestHandler(
+        "bookApi",
+        "BookApi",
+        baseUrl,
+        actions,
+    );
+    const handlerPath = path.join(SCRATCH_DIR, "bookApiActionHandler.ts");
+    await fs.writeFile(handlerPath, source, "utf-8");
+    // The generated handler imports "./bookApiSchema.js" purely for a type,
+    // which is erased at emit time — an empty type-only stub is enough for
+    // tsx's on-the-fly transpilation (no type-checking at runtime).
+    await fs.writeFile(
+        path.join(SCRATCH_DIR, "bookApiSchema.ts"),
+        "export type BookApiActions = { actionName: string; parameters: Record<string, unknown> };\n",
+        "utf-8",
+    );
+    // Cache-bust: each test loads a freshly written file at the same path.
+    // pathToFileURL is required on Windows, where raw absolute paths
+    // (e.g. "D:/...") are not valid ESM specifiers.
+    const fileUrl = pathToFileURL(handlerPath);
+    fileUrl.search = `t=${Date.now()}-${Math.random()}`;
+    const mod = await import(fileUrl.href);
+    return mod;
+}
+
+test("GET with a path parameter hits the right URL and returns the server's JSON", async () => {
+    const observed: ObservedRequest[] = [];
+    const { baseUrl, close } = await startServer((req, res, body) => {
+        observed.push({ method: req.method, url: req.url, body });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "42", title: "Dune" }));
+    });
+    try {
+        const actions: DiscoveredAction[] = [
+            {
+                name: "getBook",
+                method: "GET",
+                path: "/books/{book_id}",
+                parameters: [
+                    {
+                        name: "book_id",
+                        type: "string",
+                        required: true,
+                        in: "path",
+                    },
+                ],
+            },
+        ];
+        const { instantiate } = await loadHandler(baseUrl, actions);
+        const agent = instantiate();
+        const result: any = await agent.executeAction(
+            {
+                actionName: "getBook",
+                parameters: { bookId: "42" },
+            },
+            {} as any,
+        );
+
+        assert.equal(observed.length, 1);
+        assert.equal(observed[0].method, "GET");
+        assert.equal(observed[0].url, "/books/42");
+        assert.match(result.displayContent as string, /"title": "Dune"/);
+    } finally {
+        await close();
+    }
+});
+
+test("GET with a query parameter is sent as a query string", async () => {
+    const observed: ObservedRequest[] = [];
+    const { baseUrl, close } = await startServer((req, res, body) => {
+        observed.push({ method: req.method, url: req.url, body });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ results: [] }));
+    });
+    try {
+        const actions: DiscoveredAction[] = [
+            {
+                name: "searchBooks",
+                method: "GET",
+                path: "/books",
+                parameters: [
+                    {
+                        name: "limit",
+                        type: "integer",
+                        required: false,
+                        in: "query",
+                    },
+                ],
+            },
+        ];
+        const { instantiate } = await loadHandler(baseUrl, actions);
+        const agent = instantiate();
+        await agent.executeAction(
+            { actionName: "searchBooks", parameters: { limit: 5 } },
+            {} as any,
+        );
+
+        assert.equal(observed.length, 1);
+        assert.equal(observed[0].method, "GET");
+        assert.equal(observed[0].url, "/books?limit=5");
+    } finally {
+        await close();
+    }
+});
+
+test("POST sends a JSON body and the server's method/body are observed correctly", async () => {
+    const observed: ObservedRequest[] = [];
+    const { baseUrl, close } = await startServer((req, res, body) => {
+        observed.push({ method: req.method, url: req.url, body });
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "99" }));
+    });
+    try {
+        const actions: DiscoveredAction[] = [
+            {
+                name: "createBook",
+                method: "POST",
+                path: "/books",
+                parameters: [
+                    {
+                        name: "title",
+                        type: "string",
+                        required: true,
+                        in: "body",
+                    },
+                ],
+            },
+        ];
+        const { instantiate } = await loadHandler(baseUrl, actions);
+        const agent = instantiate();
+        const result: any = await agent.executeAction(
+            {
+                actionName: "createBook",
+                parameters: { title: "Foundation" },
+            },
+            {} as any,
+        );
+
+        assert.equal(observed.length, 1);
+        assert.equal(observed[0].method, "POST");
+        assert.equal(observed[0].url, "/books");
+        assert.deepEqual(JSON.parse(observed[0].body), { title: "Foundation" });
+        assert.match(result.displayContent as string, /"id": "99"/);
+    } finally {
+        await close();
+    }
+});

--- a/ts/packages/agents/onboarding/test/restRouting.spec.ts
+++ b/ts/packages/agents/onboarding/test/restRouting.spec.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Tests for CHANGE 4 — guarded routing of the REST handler generator in
+// scaffolderHandler.ts's buildHandler. REST generation must only kick in
+// when an apiSurface has a resolved baseUrl AND the pattern is one that
+// models a direct REST integration (schema-grammar default, external-api);
+// explicit non-REST patterns must keep their own dedicated builders even
+// when an apiSurface happens to be attached.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildHandler } from "../src/scaffolder/scaffolderHandler.js";
+import type { ApiSurface } from "../src/discovery/discoveryHandler.js";
+
+function makeSurface(baseUrl?: string): ApiSurface {
+    return {
+        integrationName: "bookApi",
+        discoveredAt: new Date().toISOString(),
+        source: "https://api.example.com/openapi.json",
+        actions: [
+            {
+                name: "getBook",
+                description: "Get a book",
+                method: "GET",
+                path: "/books/{book_id}",
+                parameters: [
+                    {
+                        name: "book_id",
+                        type: "string",
+                        required: true,
+                        in: "path",
+                    },
+                ],
+                sourceUrl: "https://api.example.com/openapi.json",
+            },
+        ],
+        ...(baseUrl !== undefined ? { baseUrl } : {}),
+    };
+}
+
+describe("buildHandler REST routing", () => {
+    test("routes to the REST generator for the default (schema-grammar) pattern when baseUrl is set", async () => {
+        const output = await buildHandler(
+            "bookApi",
+            "BookApi",
+            "schema-grammar",
+            makeSurface("https://api.example.com/v3"),
+        );
+        assert.match(output, /callRest\(/);
+        assert.match(output, /"getBook"/);
+    });
+
+    test("routes to the REST generator for the external-api pattern when baseUrl is set", async () => {
+        const output = await buildHandler(
+            "bookApi",
+            "BookApi",
+            "external-api",
+            makeSurface("https://api.example.com/v3"),
+        );
+        assert.match(output, /callRest\(/);
+    });
+
+    test("does NOT route to REST for websocket-bridge even when baseUrl is set", async () => {
+        const output = await buildHandler(
+            "bookApi",
+            "BookApi",
+            "websocket-bridge",
+            makeSurface("https://api.example.com/v3"),
+        );
+        assert.doesNotMatch(output, /callRest\(/);
+    });
+
+    test("does NOT route to REST for native-platform even when baseUrl is set", async () => {
+        const output = await buildHandler(
+            "bookApi",
+            "BookApi",
+            "native-platform",
+            makeSurface("https://api.example.com/v3"),
+        );
+        assert.doesNotMatch(output, /callRest\(/);
+    });
+
+    test("falls back to the schema-grammar stub when no baseUrl is present", async () => {
+        const output = await buildHandler(
+            "bookApi",
+            "BookApi",
+            "schema-grammar",
+            makeSurface(undefined),
+        );
+        assert.doesNotMatch(output, /callRest\(/);
+    });
+
+    test("falls back to the schema-grammar stub when there is no apiSurface at all", async () => {
+        const output = await buildHandler("bookApi", "BookApi");
+        assert.doesNotMatch(output, /callRest\(/);
+    });
+});

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -2992,6 +2992,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~5.4.5
         version: 5.4.5


### PR DESCRIPTION
## The gap
The onboarding agent scaffolds a generated agent in two halves: a discovery arm (`parseOpenApiSpec`) that deterministically extracts `method`/`path`/typed `parameters` from a JSON OpenAPI 3 spec, and a scaffolder (`buildHandler`) that decides what the generated `executeAction` actually does. Today the CLI pattern (`buildCliHandler`) and websocket-bridge/native-platform patterns generate a real, executing handler — but REST/HTTP (`external-api`, `schema-grammar`) only ever generated a stub that returns "not yet implemented", even though `parseOpenApiSpec` already has everything needed to make the real call.

## The fix
Added `buildRestHandler`, the REST twin of `buildCliHandler`, mirroring its shape (per-action `switch` cases, template-based emission), plus the discovery-side data it depends on.

- **`src/discovery/discoveryHandler.ts`**
  - `ApiSurface.baseUrl?: string` — resolved from OpenAPI 3 `servers[0].url`: absolute http/https URLs are used as-is (preserving any path, e.g. `/v1`); relative URLs (e.g. `/v3`) resolve against the post-redirect fetch URL (or `specSource` if not fetched here) — only when that source is http/https; server variables (`{var}`) substitute from `variables[var].default`, and if any variable lacks a default the base URL is left **unset** rather than emitting something malformed; `servers` absent falls back to the origin of an http/https `specSource`. Local-file/non-http sources with absent/relative servers leave `baseUrl` unset (falls through to the existing stub). All `new URL(...)` calls are try/catch-guarded — resolution failures leave `baseUrl` unset, never throw.
  - `DiscoveredParameter.in?: "path"|"query"|"header"|"cookie"|"body"` — parameters are now merged from **both** `pathItem.parameters` (path-level, shared across operations) and `op.parameters` (operation-level), keyed by `(name, in)` with operation-level winning. Request-body properties are captured with `in: "body"`.
  - `$ref`-based path items are skipped entirely (inline OpenAPI 3 only, v1 scope); `$ref`-based individual parameters are filtered out of the merge (the action still generates, just without that param — see judgment call below).
  - Refactored the extraction loop into an exported pure function `extractOpenApiActions(spec, specSource)` and exported `resolveOpenApiBaseUrl` for direct unit testing.
  - Verified (not re-implemented) that the existing `{...surface, ...}` spread in `handleApproveApiSurface` already carries `baseUrl` and per-parameter `in` through approval — covered by a real end-to-end test.

- **`src/scaffolder/restHandlerTemplate.ts` + `src/scaffolder/restHandler.template`** (new)
  - Per action, emits a `case "<actionName>":` that splits params by `.in`: path params substitute into the path template (each `encodeURIComponent`'d); query params (or params with no `.in` whose name isn't a `{param}` in the path) go into a query string; body params (non-GET only) become a JSON body; header/cookie params are **not supported v1** — required ones throw a clear "unsupported parameter location" error, optional ones are silently dropped.
  - URL joining is slash-normalized string concatenation (trim trailing `/` off the base, ensure leading `/` on the path) — **not** `new URL(pathTemplate, baseUrl)`, which would drop any server path component (e.g. `/v1`).
  - Query/body serialization skips only `undefined`/`null` (preserves `false`/`0`/`""`); scalars only (no array/object, no style/explode — v1 limitation).
  - Runtime/wire name mapping: SchemaGen has the LLM camelCase parameter names, but the wire name may be snake/kebab (`book_id`). Generated code does `parameters["bookId"] ?? parameters["book_id"]` (bracket access) and sends the **original** wire name on the request. `toCamel()` implements the deterministic `_`/`-` → camelCase transform; exotic LLM renames outside that transform are a known v1 limitation.
  - Every generated literal (base URL, path segments, method, action names, wire/camel param names) is escaped via `JSON.stringify`/`encodeURIComponent` — no raw string interpolation into emitted TypeScript.
  - Requests always send `Accept: application/json` (+ `Content-Type: application/json` when there's a body); **no auth** (no Authorization/api-key header) in v1; DELETE never carries a body even if body-typed params exist for the action; `AbortSignal.timeout(30_000)`.
  - Response handling: `res.text()` → try `JSON.parse` + pretty-print, else return raw text; truncated to ~4000 chars; non-2xx throws `Error: <status> <truncated body>`; wrapped in try/catch and returned via `createActionResultFromTextDisplay`.

- **`src/scaffolder/scaffolderHandler.ts`**
  - Added a guarded REST-routing block immediately after the existing CLI-detection block in `buildHandler`: routes to `buildRestHandler` when `apiSurface?.baseUrl` is set **and** the pattern is `schema-grammar` or `external-api` **and** there's at least one action with a supported HTTP method (`GET|POST|PUT|PATCH|DELETE`) and a `path` (via `filterRestActions`). Explicit non-REST patterns (`websocket-bridge`, `native-platform`, ...) are left alone even if an `apiSurface` happens to be attached. Falls through to the existing stub builders when there's no base URL or no eligible HTTP actions.
  - Exported `buildHandler` (previously module-private) to make it directly unit-testable.

## Explicitly unsupported (v1)
Swagger 2 (`host`/`basePath`/`schemes`); `$ref` params/bodies/path items (inline OpenAPI 3 subset only); YAML specs; auth/cookies/required headers; array/object params, `style`/`explode` (scalars only). All called out in code comments and in the generated handler's file header.

## Files changed
- `src/discovery/discoveryHandler.ts` — base URL capture, param `in` capture + path/op-level merge, `$ref` skipping, exported `extractOpenApiActions`/`resolveOpenApiBaseUrl`.
- `src/scaffolder/restHandlerTemplate.ts` (new) — `buildRestHandler`, `filterRestActions`, helpers.
- `src/scaffolder/restHandler.template` (new) — emitted handler skeleton.
- `src/scaffolder/scaffolderHandler.ts` — guarded REST routing, exported `buildHandler`.
- `package.json` — added `tsx` devDependency + `test`/`test:local` scripts (Node `node:test`, no new runtime dep).
- `test/*.spec.ts` (5 files) + `test/fixtures/openapi/*.json` (2 fixtures) — new deterministic test suite (see below).
- `pnpm-lock.yaml` — 3-line hand-added importer entry for `tsx` in `packages/agents/onboarding` (kept minimal deliberately — a full `pnpm install` regeneration on this environment's private registry mirror rewrites unrelated integrity hashes across the whole lockfile; verified with `pnpm install --frozen-lockfile` that this manual entry is consistent).

## Validations passed
1. **Build**: `tsc -b` in `ts/packages/agents/onboarding` — exit 0.
2. **Primary gate — 23 deterministic Node `node:test` tests** (`npm test` / `tsx --test test/*.spec.ts`), all passing:
   - `openApiExtraction.spec.ts` (12 tests): path-item + operation-level param merging (and override), request-body-as-`in:body`, `$ref` path-item/param skipping, and 7 `resolveOpenApiBaseUrl` cases (relative-vs-fetched-URL, absolute-with-path-preserved, server variables with/without defaults, servers-absent origin fallback, local-file source left unset).
   - `apiSurfacePreservation.spec.ts` (1 test): real `parseOpenApiSpec` → `approveApiSurface` round trip asserting `baseUrl`/`in` survive the approval spread.
   - `restRouting.spec.ts` (6 tests): REST routing for `schema-grammar`/`external-api` when `baseUrl` is set; no routing for `websocket-bridge`/`native-platform`; stub fallback when no `baseUrl`/no `apiSurface`.
   - `restHandlerCompile.spec.ts` (1 test): generated handler + a hand-built schema-type stub type-check cleanly via `tsc`.
   - `restHandlerExecution.spec.ts` (3 tests): generated handler executed against a local `node:http` server on an ephemeral port — GET-with-path-param, GET-with-query-param, POST-with-JSON-body — asserting the server observed the right method/URL/body and the handler returned the server's response.
3. **Live dispatcher/LLM e2e**: not attempted — deferred, per the spec's "best-effort" guidance, given this is a fresh worktree without the isolated-build fix in flight elsewhere. Manual verification path if desired: scaffold an agent from a real OpenAPI 3 spec via the onboarding dispatcher (`parseOpenApiSpec` → `approveApiSurface` → `scaffoldAgent`), build the generated package with `tsc -b`, load it into a dispatcher instance with actions enabled, and issue a natural-language utterance that maps to one of the discovered actions; confirm the real HTTP call fires and the response is echoed back.
4. **Prettier**: `prettier --write` run over all changed/new files; re-verified build+tests pass after formatting.

## Judgment calls
- `$ref`-based **parameters** are dropped from the merge (action still generates, just without that param) rather than skipping the whole action — a looser interpretation than "$ref params → skip REST gen for the action" that keeps more actions usable; happy to tighten if reviewers prefer the stricter reading.
- Wire-name/camelCase mapping only covers the deterministic `_`/`-` → camelCase transform documented in `schemaGenHandler.ts`'s LLM prompt; any exotic LLM rename outside that transform is an accepted v1 limitation (documented in the generated handler's header comment).
- Kept the `pnpm-lock.yaml` change to a minimal 3-line hand-added importer entry instead of a full `pnpm install` regeneration, since the latter rewrote thousands of unrelated integrity hashes (sha512→sha1) across the whole file due to this environment's private-registry mirror — verified consistent via `pnpm install --frozen-lockfile`.

Do not merge — draft PR for review.