### PR TITLE
Revamp MSI install flow and shell fallback

### DIFF
--- a/pipelines/azure-build-publish-all.yml
+++ b/pipelines/azure-build-publish-all.yml
@@ -750,6 +750,26 @@ stages:
                     storage: $(azureStorageAccountName)
                     ContainerName: $(azureStorageContainerName)
 
+                # Also publish the win shell to the Azure Artifacts feed as a
+                # Universal Package (in addition to blob storage). The MSI's
+                # "install the shell" option downloads this via
+                # `az artifacts universal download` when the (authenticated)
+                # blob download is unavailable. Package contents = the channel
+                # .yml + NSIS setup exe already staged in shell-win.
+                - pwsh: |
+                    az extension add --name azure-devops --only-show-errors | Out-Null
+                    $pkg = "typeagent-shell.win32-x64"
+                    Write-Host "Publishing $pkg v$(packageVersion) to feed $(adoFeed)"
+                    az artifacts universal publish `
+                      --organization "$(adoOrgUrl)" --project "$(adoProject)" --scope project `
+                      --feed "$(adoFeed)" `
+                      --name "$pkg" --version "$(packageVersion)" `
+                      --path "$(Pipeline.Workspace)/shell-win" `
+                      --description "TypeAgent Shell (win32-x64), channel $(resolvedChannel)"
+                  displayName: "Publish shell-win to Universal feed"
+                  env:
+                    AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
                 # macOS artifact — optional. The build uses continueOnError,
                 # so a failed mac build still reports SucceededWithIssues and
                 # produces no artifact; keep these steps non-fatal so a missing
@@ -910,6 +930,14 @@ stages:
                 --plugin-dir "$pluginDir" `
                 --version "$(packageVersion)" `
                 --plugin-version "$(packageVersion)" `
+                --shell-storage "$(azureStorageAccountName)" `
+                --shell-container "$(azureStorageContainerName)" `
+                --shell-channel "lkg" `
+                --shell-feed "$(adoFeed)" `
+                --shell-package "typeagent-shell.$(msiRid)" `
+                --shell-feed-version "$(packageVersion)" `
+                --shell-org "$(adoOrgUrl)" `
+                --shell-project "$(adoProject)" `
                 --output "$(MSI_BUILD_DIR)"
             displayName: "Build MSI"
 

--- a/ts/packages/agents/utility/package.json
+++ b/ts/packages/agents/utility/package.json
@@ -15,7 +15,7 @@
   "author": "Microsoft",
   "type": "module",
   "exports": {
-    "./agent/manifest": "./manifest.json",
+    "./agent/manifest": "./src/manifest.json",
     "./agent/handlers": "./dist/actionHandler.mjs"
   },
   "files": [

--- a/ts/packages/agents/utility/src/manifest.json
+++ b/ts/packages/agents/utility/src/manifest.json
@@ -4,9 +4,9 @@
   "defaultEnabled": true,
   "schema": {
     "description": "Utility operations: search the web, fetch page content, read and write files",
-    "originalSchemaFile": "./src/utilitySchema.mts",
-    "schemaFile": "./dist/utilitySchema.pas.json",
-    "grammarFile": "./dist/utilitySchema.ag.json",
+    "originalSchemaFile": "./utilitySchema.mts",
+    "schemaFile": "../dist/utilitySchema.pas.json",
+    "grammarFile": "../dist/utilitySchema.ag.json",
     "schemaType": "UtilityAction"
   }
 }

--- a/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/feedSource.ts
@@ -42,6 +42,19 @@ export const AGENT_KEYWORD = "typeagent-agent";
 // case-insensitive (see listScopedPackages).
 export const DEFAULT_FEED_SCOPES = ["@typeagent", "@secretagents"];
 
+// The name of the first-party seed feed (see getSeedInstallSources). Only this
+// well-known feed falls back to DEFAULT_FEED_REGISTRY; user-defined feeds must
+// specify their own registry (or set TYPEAGENT_FEED_REGISTRY) as before.
+export const SEED_FEED_NAME = "typeagent";
+
+// Compiled production default for the first-party feed's npm registry. Shipped
+// builds (e.g. the MSI) resolve on-demand agent discovery without a repo-local
+// config.local.yaml. Precedence is config.registry > TYPEAGENT_FEED_REGISTRY >
+// this default, so both config and env still override it. Not a secret — the
+// URL is public; access is authorized per-call via `az account get-access-token`.
+export const DEFAULT_FEED_REGISTRY =
+    "https://pkgs.dev.azure.com/msctoproj/AI_Systems/_packaging/typeagent-feed/npm/registry/";
+
 const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000; // ~1h
 
 function resolveFeedRegistry(config: FeedSourceConfig): string | undefined {
@@ -50,7 +63,13 @@ function resolveFeedRegistry(config: FeedSourceConfig): string | undefined {
         return fromConfig;
     }
     const fromEnv = process.env.TYPEAGENT_FEED_REGISTRY?.trim();
-    return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+    if (fromEnv && fromEnv.length > 0) {
+        return fromEnv;
+    }
+    if (config.name === SEED_FEED_NAME) {
+        return DEFAULT_FEED_REGISTRY;
+    }
+    return undefined;
 }
 
 function resolveFeedScopes(config: FeedSourceConfig): string[] {

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -255,11 +255,11 @@ runs these deferred, impersonated custom actions (each **non-fatal** so a hiccup
 never rolls back the agent-server install; issues surface as warnings + the
 ExitDialog reminder):
 
-| Action | Property gate | What it does |
-| ------ | ------------- | ------------ |
-| `InstallPrereqs` | — | Runs `install-prereqs.ps1`: installs `claude` (`@anthropic-ai/claude-code`) and `copilot` (`@github/copilot`) via `npm i -g` when missing, and warns if Node < 22. Mirrors `install-typeagent.ps1`. |
-| `StartAgentServer` | `STARTSERVER=1` (default) | `node typeagent-serve.mjs start` — starts the daemon. |
-| `EnableAutostart` | `AUTOSTART=1` (default) | `node typeagent-serve.mjs autostart enable` — registers a per-user logon Scheduled Task. Removed on uninstall (`DisableAutostart`). |
+| Action             | Property gate             | What it does                                                                                                                                                                                        |
+| ------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `InstallPrereqs`   | —                         | Runs `install-prereqs.ps1`: installs `claude` (`@anthropic-ai/claude-code`) and `copilot` (`@github/copilot`) via `npm i -g` when missing, and warns if Node < 22. Mirrors `install-typeagent.ps1`. |
+| `StartAgentServer` | `STARTSERVER=1` (default) | `node typeagent-serve.mjs start` — starts the daemon.                                                                                                                                               |
+| `EnableAutostart`  | `AUTOSTART=1` (default)   | `node typeagent-serve.mjs autostart enable` — registers a per-user logon Scheduled Task. Removed on uninstall (`DisableAutostart`).                                                                 |
 
 ```powershell
 # Skip starting/autostarting the daemon (e.g. provisioning happens later)
@@ -282,12 +282,12 @@ fresh machine without extra input. If a build ships with no location and
 `SHELL=1` is requested, the `ShellLocationMissing` action **aborts loudly** with
 a clear message rather than silently skipping.
 
-| Property         | Values / example                                      | Default          | Notes                                                                        |
-| ---------------- | ----------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------- |
-| `SHELL`          | `0`, `1`                                              | `0`              | `1` enables the optional shell download + silent install.                    |
-| `SHELLCHANNEL`   | `lkg`, `test`, `ci`                                   | build default (`lkg`) | electron-updater channel to read (`<channel>-<arch>.yml`).            |
-| `SHELLSTORAGE`   | Azure Storage account name                            | build default    | Used with the Azure CLI (`az login`) to read the shell blobs.                |
-| `SHELLCONTAINER` | Azure Storage container name                          | build default    | Defaults to `SHELLSTORAGE` if omitted.                                       |
+| Property         | Values / example                                      | Default                                        | Notes                                                                        |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- |
+| `SHELL`          | `0`, `1`                                              | `0`                                            | `1` enables the optional shell download + silent install.                    |
+| `SHELLCHANNEL`   | `lkg`, `test`, `ci`                                   | build default (`lkg`)                          | electron-updater channel to read (`<channel>-<arch>.yml`).                   |
+| `SHELLSTORAGE`   | Azure Storage account name                            | build default                                  | Used with the Azure CLI (`az login`) to read the shell blobs.                |
+| `SHELLCONTAINER` | Azure Storage container name                          | build default                                  | Defaults to `SHELLSTORAGE` if omitted.                                       |
 | `SHELLBASEURL`   | `https://<account>.blob.core.windows.net/<container>` | build default (derived from storage/container) | Anonymous HTTPS base for a **public** container; when set, `az` is not used. |
 
 ```powershell

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -20,7 +20,10 @@ ts/tools/scripts/
   └── getCert.mjs            # (existing) Manage dev certs in Key Vault
 
 ts/tools/installers/wix/
-  └── TypeAgent-AgentServer.wxs   # WiX project definition
+  ├── TypeAgent-AgentServer.wxs   # WiX project definition
+  ├── extract-payload.ps1         # Deferred CA: unpack payload/*.zip at install time
+  ├── install-prereqs.ps1         # Deferred CA: npm i -g claude+copilot, warn on Node<22
+  └── register-plugin.ps1         # Deferred CA: register/unregister the Copilot CLI plugin
 
 pipelines/
   └── azure-build-publish-all.yml   # ADO pipeline (build_sign_publish_msi job)
@@ -72,7 +75,7 @@ The pipeline handles this automatically via:
 
 ## Local Build & Test
 
-Use the local source build to validate WiX changes before pushing to CI. This is the recommended path for catching `LGHT`/`CANDLE` errors early — it runs the same WiX heat → candle → light pipeline that CI does, but stages the artifacts from your local repo build instead of downloading from the ADO feed. No Azure CLI login required.
+Use the local source build to validate WiX changes before pushing to CI. This is the recommended path for catching `LGHT`/`CANDLE` errors early — it runs the same WiX zip → candle → light pipeline that CI does, but stages the artifacts from your local repo build instead of downloading from the ADO feed. No Azure CLI login required.
 
 ### Option A: Build from local repo (recommended for WiX development)
 
@@ -232,11 +235,39 @@ The UI is a custom scheme (`WixUI_TypeAgent`): WelcomeDlg → LicenseAgreementDl
 custom action runs `node "[INSTALLFOLDER]typeagent-serve.mjs" provision --provider
 [PROVIDER] --embedding [EMBEDDING] --ollama-host [OLLAMAHOST] --force` as the
 installing user, writing `config.local.yaml` to `~/.typeagent`. For `AISYSTEMS`
-(the default), config provisioning remains an interactive post-install step
-(`az login` + `getKeys`), since it requires browser/device authentication that a
-silent installer cannot perform. Fine-grained overrides (chat model, embedding
-endpoint, API keys) are available on the `provision`/`generate-selfhost-config`
-CLI; re-run provisioning post-install to adjust them.
+(the default), the MSI **attempts** provisioning during install via a deferred,
+impersonated (interactive) custom action `ProvisionAiSystemsConfig` that runs
+`node "[INSTALLFOLDER]typeagent-serve.mjs" provision` (browser/device sign-in as
+the installing user). It is **non-fatal**: if sign-in is unavailable during the
+install, the final page (ExitDialog) reminds the user to run `provision`
+manually. Because the embedding config for `AISYSTEMS` comes from Key Vault, the
+embedding radio and Ollama host field are **disabled** in the dialog when
+`PROVIDER=AISYSTEMS` (they apply only to the self-host providers). Fine-grained
+overrides (chat model, embedding endpoint, API keys) are available on the
+`provision`/`generate-selfhost-config` CLI; re-run provisioning post-install to
+adjust them.
+
+## Agent-server prerequisites & lifecycle
+
+The MSI ships the **external** agent-server variant, which resolves the `claude`
+and `copilot` CLIs from `PATH` at runtime. After extracting the payload the MSI
+runs these deferred, impersonated custom actions (each **non-fatal** so a hiccup
+never rolls back the agent-server install; issues surface as warnings + the
+ExitDialog reminder):
+
+| Action | Property gate | What it does |
+| ------ | ------------- | ------------ |
+| `InstallPrereqs` | — | Runs `install-prereqs.ps1`: installs `claude` (`@anthropic-ai/claude-code`) and `copilot` (`@github/copilot`) via `npm i -g` when missing, and warns if Node < 22. Mirrors `install-typeagent.ps1`. |
+| `StartAgentServer` | `STARTSERVER=1` (default) | `node typeagent-serve.mjs start` — starts the daemon. |
+| `EnableAutostart` | `AUTOSTART=1` (default) | `node typeagent-serve.mjs autostart enable` — registers a per-user logon Scheduled Task. Removed on uninstall (`DisableAutostart`). |
+
+```powershell
+# Skip starting/autostarting the daemon (e.g. provisioning happens later)
+msiexec /i TypeAgent-<version>-win32-x64.msi STARTSERVER=0 AUTOSTART=0
+```
+
+Both CLIs require a one-time interactive sign-in (`claude`, then `copilot`)
+before agent actions work; the ExitDialog reminds the user of this.
 
 ## Optional: install the TypeAgent Shell (desktop app)
 
@@ -244,15 +275,20 @@ The MSI can optionally download and silently install the **TypeAgent Shell**
 (the Electron desktop app) from the same Azure Blob Storage container used by the
 shell's auto-update feed. This is off by default. During an interactive install
 a checkbox on **ProviderDlg** ("Also install the TypeAgent Shell desktop app")
-enables it; silently, set the public properties:
+enables it; silently, set the public properties. **The download location is
+baked at build time** (`build-msi.mjs --shell-storage/--shell-container`; the
+pipeline passes the shell storage account/container), so the checkbox works on a
+fresh machine without extra input. If a build ships with no location and
+`SHELL=1` is requested, the `ShellLocationMissing` action **aborts loudly** with
+a clear message rather than silently skipping.
 
-| Property         | Values / example                                      | Default | Notes                                                                        |
-| ---------------- | ----------------------------------------------------- | ------- | ---------------------------------------------------------------------------- |
-| `SHELL`          | `0`, `1`                                              | `0`     | `1` enables the optional shell download + silent install.                    |
-| `SHELLCHANNEL`   | `lkg`, `test`, `ci`                                   | `lkg`   | electron-updater channel to read (`<channel>-<arch>.yml`).                   |
-| `SHELLSTORAGE`   | Azure Storage account name                            | —       | Used with the Azure CLI (`az login`) to read the shell blobs.                |
-| `SHELLCONTAINER` | Azure Storage container name                          | —       | Defaults to `SHELLSTORAGE` if omitted.                                       |
-| `SHELLBASEURL`   | `https://<account>.blob.core.windows.net/<container>` | —       | Anonymous HTTPS base for a **public** container; when set, `az` is not used. |
+| Property         | Values / example                                      | Default          | Notes                                                                        |
+| ---------------- | ----------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------- |
+| `SHELL`          | `0`, `1`                                              | `0`              | `1` enables the optional shell download + silent install.                    |
+| `SHELLCHANNEL`   | `lkg`, `test`, `ci`                                   | build default (`lkg`) | electron-updater channel to read (`<channel>-<arch>.yml`).            |
+| `SHELLSTORAGE`   | Azure Storage account name                            | build default    | Used with the Azure CLI (`az login`) to read the shell blobs.                |
+| `SHELLCONTAINER` | Azure Storage container name                          | build default    | Defaults to `SHELLSTORAGE` if omitted.                                       |
+| `SHELLBASEURL`   | `https://<account>.blob.core.windows.net/<container>` | build default (derived from storage/container) | Anonymous HTTPS base for a **public** container; when set, `az` is not used. |
 
 ```powershell
 # Authenticated (az login) blob read from a private container
@@ -390,7 +426,12 @@ az account show  # Verify
 
 ### WiX Best Practices
 
-- Use `heat.exe dir` to auto-generate component trees (currently manual)
+- The agent-server and copilot-plugin payloads ship as single zip files
+  (`payload\*.zip`) that a deferred custom action (`extract-payload.ps1`) unpacks
+  at install time. This avoids harvesting a flat `node_modules` into tens of
+  thousands of components, which made the installer's "Computing space
+  requirements" (CostFinalize) step take minutes. Do **not** reintroduce
+  `heat.exe dir` harvesting for these trees.
 - Store WiX includes (`.wxi`) in `ts/tools/installers/wix/includes/`
 - Keep `.wxs` files simple; delegate complexity to `.wxi` includes
 - Test locally before pushing to main (MSI builds are slow)

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -4,17 +4,30 @@
 <!--
   TypeAgent MSI — installs:
     %LOCALAPPDATA%\TypeAgent\
-      agent-server\       ← agent-server.<rid> artifact (all files from heat)
-      copilot-plugin\     ← typeagent-copilot-plugin artifact (all files from heat)
+      payload\
+        agent-server.zip   ← agent-server.<rid> artifact, zipped at build time
+        copilot-plugin.zip ← typeagent-copilot-plugin artifact, zipped at build time
+      agent-server\       ← extracted from payload\agent-server.zip at install time
+      copilot-plugin\     ← extracted from payload\copilot-plugin.zip at install time
       .github\plugin\marketplace.json  ← for `copilot plugin marketplace add`
       register-plugin.ps1 ← run after install to register the Copilot CLI plugin
 
+  The two payloads are shipped as single zip files (one File component each)
+  rather than harvested with heat (one Component per file). A node_modules tree
+  produced tens of thousands of components, which made the Windows Installer
+  "Computing space requirements" (CostFinalize) step take minutes. A deferred
+  custom action (extract-payload.ps1) unpacks the zips at install time.
+
   Build variables required (passed via candle -d):
-    ProductVersion         e.g. 0.0.1-12345
-    AgentServerArtifactDir path to downloaded agent-server artifact
-    CopilotPluginArtifactDir path to downloaded copilot-plugin artifact
-    MarketplaceDir         path to directory containing the generated marketplace.json
-    InstallerSourceDir     path to this file's directory (for register-plugin.ps1)
+    ProductVersion      e.g. 0.0.1-12345
+    AgentServerZip      path to the built agent-server.zip
+    CopilotPluginZip    path to the built copilot-plugin.zip
+    MarketplaceDir      path to directory containing the generated marketplace.json
+    InstallerSourceDir  path to this file's directory (for register-plugin.ps1)
+    ShellBaseUrl        default SHELLBASEURL (anonymous blob base for the shell); may be ""
+    ShellStorage        default SHELLSTORAGE (blob account for the shell); may be ""
+    ShellContainer      default SHELLCONTAINER (blob container for the shell); may be ""
+    ShellChannel        default SHELLCHANNEL (electron-updater channel, e.g. lkg)
 -->
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
@@ -52,6 +65,15 @@
     <Property Id="OLLAMAHOST" Value="http://localhost:11434" Secure="yes" />
 
     <!-- ═══════════════════════════════════════════════
+         Agent-server lifecycle
+         STARTSERVER=1 starts the daemon after install; AUTOSTART=1 registers a
+         per-user logon Scheduled Task (mirrors install-typeagent.ps1). Pass
+         STARTSERVER=0 / AUTOSTART=0 on the command line to opt out.
+         ═══════════════════════════════════════════════ -->
+    <Property Id="STARTSERVER" Value="1" Secure="yes" />
+    <Property Id="AUTOSTART" Value="1" Secure="yes" />
+
+    <!-- ═══════════════════════════════════════════════
          Optional TypeAgent Shell install (Electron app)
          SHELL=1 downloads and silently installs the shell's NSIS installer
          from Azure Blob Storage (same container as the shell auto-update feed)
@@ -60,10 +82,59 @@
          are used with the Azure CLI (az login).
          ═══════════════════════════════════════════════ -->
     <Property Id="SHELL" Value="0" Secure="yes" />
+    <!-- Shell download coordinates: baked from build vars when provided, else
+         left undefined. candle rejects Value="" (CNDL0006), so only emit Value
+         when the build var is non-empty (preprocessor comparison). -->
+    <?if $(var.ShellStorage) = "" ?>
     <Property Id="SHELLSTORAGE" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLSTORAGE" Value="$(var.ShellStorage)" Secure="yes" />
+    <?endif?>
+    <?if $(var.ShellContainer) = "" ?>
     <Property Id="SHELLCONTAINER" Secure="yes" />
-    <Property Id="SHELLCHANNEL" Value="lkg" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLCONTAINER" Value="$(var.ShellContainer)" Secure="yes" />
+    <?endif?>
+    <Property Id="SHELLCHANNEL" Value="$(var.ShellChannel)" Secure="yes" />
+    <?if $(var.ShellBaseUrl) = "" ?>
     <Property Id="SHELLBASEURL" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLBASEURL" Value="$(var.ShellBaseUrl)" Secure="yes" />
+    <?endif?>
+    <!-- Azure Artifacts Universal Package fallback for the shell download. When
+         the authenticated blob download fails, install-shell.ps1 pulls the shell
+         from the feed (az artifacts universal download). -->
+    <?if $(var.ShellFeed) = "" ?>
+    <Property Id="SHELLFEED" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLFEED" Value="$(var.ShellFeed)" Secure="yes" />
+    <?endif?>
+    <?if $(var.ShellPackage) = "" ?>
+    <Property Id="SHELLPACKAGE" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLPACKAGE" Value="$(var.ShellPackage)" Secure="yes" />
+    <?endif?>
+    <?if $(var.ShellFeedVersion) = "" ?>
+    <Property Id="SHELLFEEDVERSION" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLFEEDVERSION" Value="$(var.ShellFeedVersion)" Secure="yes" />
+    <?endif?>
+    <?if $(var.ShellOrg) = "" ?>
+    <Property Id="SHELLORG" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLORG" Value="$(var.ShellOrg)" Secure="yes" />
+    <?endif?>
+    <?if $(var.ShellProject) = "" ?>
+    <Property Id="SHELLPROJECT" Secure="yes" />
+    <?else?>
+    <Property Id="SHELLPROJECT" Value="$(var.ShellProject)" Secure="yes" />
+    <?endif?>
+
+    <!-- Post-install guidance shown on the final page (WixUI ExitDialog). Points
+         at the manual provisioning/sign-in steps the MSI can only attempt, so a
+         fresh machine knows what to finish if agents don't respond. -->
+    <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Secure="yes"
+              Value="Finish setup: the claude and copilot CLIs need a one-time sign-in (run 'claude' then 'copilot'). If agents don't respond, provision config with: node &quot;%LOCALAPPDATA%\TypeAgent\agent-server\typeagent-serve.mjs&quot; provision  (sign in when prompted)." />
 
     <!-- ═══════════════════════════════════════════════
          Directory layout
@@ -73,6 +144,7 @@
         <Directory Id="TYPEAGENTROOT" Name="TypeAgent">
           <Directory Id="INSTALLFOLDER" Name="agent-server" />
           <Directory Id="PLUGINFOLDER" Name="copilot-plugin" />
+          <Directory Id="PAYLOADFOLDER" Name="payload" />
           <Directory Id="GITHUBFOLDER" Name=".github">
             <Directory Id="PLUGINREGFOLDER" Name="plugin" />
           </Directory>
@@ -84,13 +156,17 @@
          Features
          ═══════════════════════════════════════════════ -->
     <Feature Id="ProductFeature" Title="TypeAgent" Level="1">
-      <!-- Files harvested by heat from the artifact directories -->
-      <ComponentGroupRef Id="AgentServerComponents" />
-      <ComponentGroupRef Id="CopilotPluginComponents" />
+      <!-- Payload archives (extracted at install time by ExtractPayload) -->
+      <ComponentRef Id="AgentServerZipComponent" />
+      <ComponentRef Id="CopilotPluginZipComponent" />
       <!-- Static files and registry -->
       <ComponentRef Id="MarketplaceJsonComponent" />
       <ComponentRef Id="RegisterPluginPs1Component" />
       <ComponentRef Id="RegisterPluginMjsComponent" />
+      <ComponentRef Id="ExtractPayloadPs1Component" />
+      <ComponentRef Id="InstallPrereqsPs1Component" />
+      <ComponentRef Id="ResolveNodePs1Component" />
+      <ComponentRef Id="RunServePs1Component" />
       <ComponentRef Id="InstallShellPs1Component" />
       <ComponentRef Id="RegistryComponent" />
     </Feature>
@@ -98,6 +174,21 @@
     <!-- ═══════════════════════════════════════════════
          Static components
          ═══════════════════════════════════════════════ -->
+
+    <!-- Payload archives — one File component each, extracted at install time.
+         Shipping the two node_modules-bearing trees as single zips (instead of
+         heat's one-Component-per-file) is what keeps CostFinalize fast. -->
+    <DirectoryRef Id="PAYLOADFOLDER">
+      <Component Id="AgentServerZipComponent" Guid="*">
+        <File Id="AgentServerZip" Name="agent-server.zip"
+              Source="$(var.AgentServerZip)" KeyPath="yes" />
+      </Component>
+      <Component Id="CopilotPluginZipComponent" Guid="*">
+        <File Id="CopilotPluginZip" Name="copilot-plugin.zip"
+              Source="$(var.CopilotPluginZip)" KeyPath="yes" />
+        <RemoveFolder Id="RemovePayloadFolder" Directory="PAYLOADFOLDER" On="uninstall" />
+      </Component>
+    </DirectoryRef>
 
     <!-- marketplace.json — enables `copilot plugin marketplace add <TYPEAGENTROOT>` -->
     <DirectoryRef Id="PLUGINREGFOLDER">
@@ -124,6 +215,22 @@
         <File Id="InstallShellPs1" Name="install-shell.ps1"
               Source="$(var.InstallerSourceDir)\..\..\scripts\install-shell.ps1" />
       </Component>
+      <Component Id="ExtractPayloadPs1Component" Guid="*">
+        <File Id="ExtractPayloadPs1" Name="extract-payload.ps1"
+              Source="$(var.InstallerSourceDir)\extract-payload.ps1" />
+      </Component>
+      <Component Id="InstallPrereqsPs1Component" Guid="*">
+        <File Id="InstallPrereqsPs1" Name="install-prereqs.ps1"
+              Source="$(var.InstallerSourceDir)\install-prereqs.ps1" />
+      </Component>
+      <Component Id="ResolveNodePs1Component" Guid="*">
+        <File Id="ResolveNodePs1" Name="resolve-node.ps1"
+              Source="$(var.InstallerSourceDir)\resolve-node.ps1" />
+      </Component>
+      <Component Id="RunServePs1Component" Guid="*">
+        <File Id="RunServePs1" Name="run-serve.ps1"
+              Source="$(var.InstallerSourceDir)\run-serve.ps1" />
+      </Component>
     </DirectoryRef>
 
     <!-- HKCU registry entries for config and tool discovery -->
@@ -137,6 +244,39 @@
         </RegistryKey>
       </Component>
     </DirectoryRef>
+
+    <!-- ═══════════════════════════════════════════════
+         Custom actions — payload extraction
+         Unpacks payload\agent-server.zip and payload\copilot-plugin.zip into
+         INSTALLFOLDER/PLUGINFOLDER. Runs as the installing user (impersonated)
+         so it writes under the user's LocalAppData. Fatal on failure
+         (Return="check") since the rest of the install depends on the files.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="ExtractPayload"
+           Before="ExtractPayload"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot;" />
+
+    <CustomAction Id="ExtractPayload"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="yes" />
+
+    <!-- Remove the extracted directories on uninstall (they are created at
+         runtime and not tracked by the MSI file table). -->
+    <SetProperty Id="CleanupPayload"
+           Before="CleanupPayload"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -Uninstall -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot;" />
+
+    <CustomAction Id="CleanupPayload"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
 
     <!-- ═══════════════════════════════════════════════
          Custom actions — Copilot CLI plugin registration
@@ -181,7 +321,7 @@
     <SetProperty Id="ProvisionSelfHostConfig"
            Before="ProvisionSelfHostConfig"
            Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command &quot;&amp; node '[INSTALLFOLDER]typeagent-serve.mjs' provision --provider '[PROVIDER]' --embedding '[EMBEDDING]' --ollama-host '[OLLAMAHOST]' --force&quot;" />
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]run-serve.ps1&quot; -ServePath &quot;[INSTALLFOLDER]typeagent-serve.mjs&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-serve.log&quot; provision --provider &quot;[PROVIDER]&quot; --embedding &quot;[EMBEDDING]&quot; --ollama-host &quot;[OLLAMAHOST]&quot; --force" />
 
     <CustomAction Id="ProvisionSelfHostConfig"
                   BinaryKey="WixCA"
@@ -189,6 +329,102 @@
                   Execute="deferred"
                   Return="ignore"
                   Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom action — external-CLI + Node prerequisites
+         The MSI ships the 'external' agent-server variant, which resolves the
+         claude/copilot CLIs from PATH. Install them per-user (npm i -g) and warn
+         on a missing/old Node. Impersonated (writes the user's npm prefix) and
+         non-fatal (Return="ignore") — a prerequisite hiccup must not roll back
+         the agent-server install; issues surface as warnings + the ExitDialog.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="InstallPrereqs"
+           Before="InstallPrereqs"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-prereqs.ps1&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-install-prereqs.log&quot;" />
+
+    <CustomAction Id="InstallPrereqs"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom action — AISYSTEMS config provisioning
+         For PROVIDER=AISYSTEMS, download config.local.yaml from Key Vault via
+         getKeys (interactive browser sign-in as the impersonated user). Non-fatal
+         (Return="ignore"): if sign-in is unavailable during install, the
+         ExitDialog reminds the user to run 'provision' manually.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="ProvisionAiSystemsConfig"
+           Before="ProvisionAiSystemsConfig"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -File &quot;[TYPEAGENTROOT]run-serve.ps1&quot; -ServePath &quot;[INSTALLFOLDER]typeagent-serve.mjs&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-serve.log&quot; provision" />
+
+    <CustomAction Id="ProvisionAiSystemsConfig"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom action — start the agent-server daemon
+         For STARTSERVER=1, launch the daemon (mirrors install-typeagent.ps1).
+         Impersonated so 'node' resolves from the user PATH and the daemon runs
+         as the user. Non-fatal: a start failure (e.g. config not yet
+         provisioned) must not fail the install.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="StartAgentServer"
+           Before="StartAgentServer"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]run-serve.ps1&quot; -ServePath &quot;[INSTALLFOLDER]typeagent-serve.mjs&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-serve.log&quot; start" />
+
+    <CustomAction Id="StartAgentServer"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom action — register/unregister autostart (per-user Scheduled Task)
+         For AUTOSTART=1, register a logon-triggered Scheduled Task so the daemon
+         restarts at sign-in (mirrors install-typeagent.ps1 autostart enable).
+         Removed on uninstall. Impersonated + non-fatal.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="EnableAutostart"
+           Before="EnableAutostart"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]run-serve.ps1&quot; -ServePath &quot;[INSTALLFOLDER]typeagent-serve.mjs&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-serve.log&quot; autostart enable" />
+
+    <CustomAction Id="EnableAutostart"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <SetProperty Id="DisableAutostart"
+           Before="DisableAutostart"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]run-serve.ps1&quot; -ServePath &quot;[INSTALLFOLDER]typeagent-serve.mjs&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-serve.log&quot; autostart disable" />
+
+    <CustomAction Id="DisableAutostart"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom action — fail loudly if the shell was requested with no location
+         SHELL=1 needs a download location (SHELLBASEURL or SHELLSTORAGE). Rather
+         than silently no-op (the previous behavior masked by Return="ignore"),
+         abort with a clear message so the user knows the shell was not installed.
+         ═══════════════════════════════════════════════ -->
+    <CustomAction Id="ShellLocationMissing" Error="Installing the TypeAgent Shell requires a download location, but none was configured in this package. Re-run with SHELLBASEURL=https://&lt;account&gt;.blob.core.windows.net/&lt;container&gt;/ (or SHELLSTORAGE + SHELLCONTAINER), or clear the shell option." />
 
     <!-- ═══════════════════════════════════════════════
          Custom action — optional TypeAgent Shell install
@@ -201,7 +437,7 @@
     <SetProperty Id="InstallTypeAgentShell"
            Before="InstallTypeAgentShell"
            Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-shell.ps1&quot; -Storage &quot;[SHELLSTORAGE]&quot; -Container &quot;[SHELLCONTAINER]&quot; -Channel &quot;[SHELLCHANNEL]&quot; -BlobBaseUrl &quot;[SHELLBASEURL]&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-install-shell.log&quot;" />
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-shell.ps1&quot; -Storage &quot;[SHELLSTORAGE]&quot; -Container &quot;[SHELLCONTAINER]&quot; -Channel &quot;[SHELLCHANNEL]&quot; -BlobBaseUrl &quot;[SHELLBASEURL]&quot; -Feed &quot;[SHELLFEED]&quot; -FeedPackage &quot;[SHELLPACKAGE]&quot; -FeedVersion &quot;[SHELLFEEDVERSION]&quot; -Organization &quot;[SHELLORG]&quot; -Project &quot;[SHELLPROJECT]&quot; -SkipTypeAgentCheck -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-install-shell.log&quot;" />
 
     <CustomAction Id="InstallTypeAgentShell"
                   BinaryKey="WixCA"
@@ -211,10 +447,20 @@
                   Impersonate="yes" />
 
     <InstallExecuteSequence>
-      <Custom Action="RegisterCopilotPlugin"   After="InstallFiles">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="ExtractPayload"          After="InstallFiles">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="RegisterCopilotPlugin"   After="ExtractPayload">NOT REMOVE~="ALL"</Custom>
       <Custom Action="ProvisionSelfHostConfig" After="RegisterCopilotPlugin">(NOT REMOVE~="ALL") AND (PROVIDER&lt;&gt;"AISYSTEMS")</Custom>
-      <Custom Action="InstallTypeAgentShell"   After="ProvisionSelfHostConfig">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
+      <Custom Action="ProvisionAiSystemsConfig" After="ProvisionSelfHostConfig">(NOT REMOVE~="ALL") AND (PROVIDER="AISYSTEMS")</Custom>
+      <!-- Prereqs (claude/copilot from the feed) run AFTER provisioning so the
+           AISYSTEMS az login has established a session the feed token reuses. -->
+      <Custom Action="InstallPrereqs"          After="ProvisionAiSystemsConfig">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="StartAgentServer"        After="InstallPrereqs">(NOT REMOVE~="ALL") AND (STARTSERVER="1")</Custom>
+      <Custom Action="EnableAutostart"         After="StartAgentServer">(NOT REMOVE~="ALL") AND (AUTOSTART="1")</Custom>
+      <Custom Action="ShellLocationMissing"    After="EnableAutostart">(NOT REMOVE~="ALL") AND (SHELL="1") AND (NOT SHELLBASEURL) AND (NOT SHELLSTORAGE) AND (NOT SHELLFEED)</Custom>
+      <Custom Action="InstallTypeAgentShell"   After="ShellLocationMissing">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
+      <Custom Action="DisableAutostart"        Before="UnregisterCopilotPlugin">REMOVE~="ALL"</Custom>
       <Custom Action="UnregisterCopilotPlugin" Before="RemoveFiles">REMOVE~="ALL"</Custom>
+      <Custom Action="CleanupPayload"          After="UnregisterCopilotPlugin">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
 
     <!-- UI: custom sequence adding a provider/embedding selection dialog -->
@@ -277,7 +523,10 @@
 
         <Control Id="EmbeddingLabel" Type="Text" X="20" Y="128" Width="330" Height="12"
                  Transparent="yes" NoPrefix="yes"
-                 Text="{\WixUI_Font_Title}Embedding provider (Ollama / Copilot only)" />
+                 Text="{\WixUI_Font_Title}Embedding provider (Ollama / Copilot only)">
+          <Condition Action="disable">PROVIDER="AISYSTEMS"</Condition>
+          <Condition Action="enable">PROVIDER&lt;&gt;"AISYSTEMS"</Condition>
+        </Control>
         <Control Id="EmbeddingRadio" Type="RadioButtonGroup" X="24" Y="143"
                  Width="326" Height="52" Property="EMBEDDING">
           <RadioButtonGroup Property="EMBEDDING">
@@ -290,12 +539,23 @@
             <RadioButton Value="NONE" X="0" Y="42" Width="322" Height="14"
                          Text="None — disable embeddings (semantic features degrade gracefully)" />
           </RadioButtonGroup>
+          <!-- AISYSTEMS sources embeddings from Key Vault config, so this choice
+               is ignored (ProvisionSelfHostConfig runs only for self-host
+               providers). Grey it out to avoid a misleading active selection. -->
+          <Condition Action="disable">PROVIDER="AISYSTEMS"</Condition>
+          <Condition Action="enable">PROVIDER&lt;&gt;"AISYSTEMS"</Condition>
         </Control>
 
         <Control Id="OllamaHostLabel" Type="Text" X="20" Y="205" Width="70" Height="14"
-                 Transparent="yes" NoPrefix="yes" Text="Ollama host:" />
+                 Transparent="yes" NoPrefix="yes" Text="Ollama host:">
+          <Condition Action="disable">PROVIDER="AISYSTEMS"</Condition>
+          <Condition Action="enable">PROVIDER&lt;&gt;"AISYSTEMS"</Condition>
+        </Control>
         <Control Id="OllamaHostEdit" Type="Edit" X="92" Y="203" Width="258" Height="16"
-                 Property="OLLAMAHOST" Text="{80}" />
+                 Property="OLLAMAHOST" Text="{80}">
+          <Condition Action="disable">PROVIDER="AISYSTEMS"</Condition>
+          <Condition Action="enable">PROVIDER&lt;&gt;"AISYSTEMS"</Condition>
+        </Control>
 
         <Control Id="ShellCheckBox" Type="CheckBox" X="20" Y="221" Width="340" Height="12"
                  Property="SHELL" CheckBoxValue="1"

--- a/ts/tools/installers/wix/extract-payload.ps1
+++ b/ts/tools/installers/wix/extract-payload.ps1
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Extracts (or on uninstall removes) the TypeAgent payload archives bundled by
+  the MSI. The MSI ships agent-server and copilot-plugin as single zip files
+  under <Root>\payload instead of tens of thousands of individually-tracked
+  files. Harvesting node_modules as one Component per file made the Windows
+  Installer "Computing space requirements" (CostFinalize) step take minutes;
+  collapsing each tree into one File component makes that step trivial, and this
+  script does the unpack at install time (outside the cost calculation).
+
+.PARAMETER Root
+  TYPEAGENTROOT, e.g. %LOCALAPPDATA%\TypeAgent\. Contains payload\*.zip and is
+  the parent of the agent-server\ and copilot-plugin\ extraction targets.
+
+.PARAMETER Uninstall
+  Remove the extracted directories instead of creating them.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [string]$LogPath,
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Log([string]$message) {
+    $line = "{0} {1}" -f (Get-Date -Format "s"), $message
+    Write-Host $line
+    if ($LogPath) {
+        try {
+            $dir = Split-Path -Parent $LogPath
+            if ($dir -and -not (Test-Path $dir)) {
+                New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+            Add-Content -Path $LogPath -Value $line
+        } catch {
+            # Logging must never fail the install.
+        }
+    }
+}
+
+# <target-dir-name> = <zip-file-name> under <Root>\payload
+$payloads = @(
+    @{ Name = "agent-server";   Zip = "agent-server.zip" },
+    @{ Name = "copilot-plugin"; Zip = "copilot-plugin.zip" }
+)
+
+$payloadDir = Join-Path $Root "payload"
+
+try {
+    if ($Uninstall) {
+        foreach ($p in $payloads) {
+            $target = Join-Path $Root $p.Name
+            if (Test-Path $target) {
+                Write-Log "Removing $target"
+                Remove-Item -Recurse -Force $target
+            }
+        }
+        Write-Log "Payload cleanup complete."
+        exit 0
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    foreach ($p in $payloads) {
+        $zip = Join-Path $payloadDir $p.Zip
+        $target = Join-Path $Root $p.Name
+
+        if (-not (Test-Path $zip)) {
+            throw "Payload archive not found: $zip"
+        }
+
+        # Clean the target so upgrades don't leave stale files behind.
+        if (Test-Path $target) {
+            Write-Log "Clearing existing $target"
+            Remove-Item -Recurse -Force $target
+        }
+        New-Item -ItemType Directory -Force -Path $target | Out-Null
+
+        Write-Log "Extracting $zip -> $target"
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $target)
+    }
+
+    Write-Log "Payload extraction complete."
+    exit 0
+} catch {
+    Write-Log "ERROR: $($_.Exception.Message)"
+    exit 1
+}

--- a/ts/tools/installers/wix/install-prereqs.ps1
+++ b/ts/tools/installers/wix/install-prereqs.ps1
@@ -1,0 +1,196 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Provisions the runtime prerequisites the external agent-server variant needs:
+  the Claude Code and GitHub Copilot CLIs (resolved from PATH at runtime), plus
+  a Node.js >= 22 check. Mirrors the external-CLI step in install-typeagent.ps1
+  so an MSI install matches the standalone installer.
+
+.DESCRIPTION
+  The MSI ships the 'external' agent-server variant, which prunes the bundled
+  Claude/Copilot runtimes and expects `claude` and `copilot` on PATH. This
+  script installs them per-user via `npm i -g` when missing. It is intentionally
+  lightweight (no winget/admin/UAC): npm global installs land in the user's npm
+  prefix, so it runs impersonated as the installing user. Every failure is
+  non-fatal (logged + warned) so a prerequisite hiccup never rolls back the MSI;
+  the agent-server install itself succeeds and the user is told what to fix.
+
+.PARAMETER LogPath
+  Optional log file; the script also writes to stdout (captured by the MSI log).
+#>
+param(
+    [string]$LogPath,
+    # Authoritative Azure Artifacts npm registry the CLIs are pulled through
+    # (public npmjs is blocked by policy; this feed proxies it as upstream).
+    # Overridable so the MSI can bake an org-specific feed if needed.
+    [string]$FeedRegistry = "https://pkgs.dev.azure.com/msctoproj/AI_Systems/_packaging/typeagent-feed/npm/registry/"
+)
+
+$ErrorActionPreference = "Continue"
+
+# Azure DevOps resource GUID (audience for the npm feed bearer token). Matches
+# packages/defaultAgentProvider/src/installSources/feedAuth.ts.
+$AdoResource = "499b84ac-1321-427f-aa17-267ca6975798"
+
+. (Join-Path $PSScriptRoot "resolve-node.ps1")
+
+function Write-Log([string]$message) {
+    $line = "{0} {1}" -f (Get-Date -Format "s"), $message
+    Write-Host $line
+    if ($LogPath) {
+        try {
+            $dir = Split-Path -Parent $LogPath
+            if ($dir -and -not (Test-Path $dir)) {
+                New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+            Add-Content -Path $LogPath -Value $line
+        } catch {
+            # Logging must never fail the install.
+        }
+    }
+}
+
+function Test-Command([string]$name) {
+    return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+# Resolve the Azure CLI (az.cmd) from an MSI service context. PATH was already
+# refreshed from the registry by Resolve-NodeExe; add the well-known install dir
+# as a fallback so a machine-wide `az` is found even if PATH still lags.
+function Resolve-AzCmd {
+    $cmd = Get-Command az -ErrorAction SilentlyContinue
+    if ($cmd -and $cmd.Source) { return $cmd.Source }
+    foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:ProgramW6432)) {
+        if (-not $base) { continue }
+        $p = Join-Path $base "Microsoft SDKs\Azure\CLI2\wbin\az.cmd"
+        if (Test-Path $p) { return $p }
+    }
+    return $null
+}
+
+# Mint a short-lived Azure DevOps bearer token for the feed (feedAuth.ts
+# pattern). Non-interactive when an `az` session exists; attempts a one-time
+# `az login` (browser) fallback otherwise. Returns the token or $null.
+function Get-FeedToken([string]$azCmd) {
+    if (-not $azCmd) { return $null }
+    function Invoke-AzToken {
+        try {
+            $out = & $azCmd account get-access-token --resource $AdoResource --output json 2>$null | Out-String
+            if ($LASTEXITCODE -ne 0 -or -not $out) { return $null }
+            $t = ($out | ConvertFrom-Json).accessToken
+            if ($t) { return $t }
+        } catch { }
+        return $null
+    }
+    $token = Invoke-AzToken
+    if ($token) { return $token }
+    Write-Log "  No active 'az' session; attempting 'az login' for feed access."
+    try {
+        & $azCmd login --only-show-errors 2>&1 | ForEach-Object { Write-Log "    $_" }
+    } catch {
+        Write-Log "  WARNING: 'az login' failed: $($_.Exception.Message)"
+    }
+    return (Invoke-AzToken)
+}
+
+# Write a throwaway npm userconfig (.npmrc) carrying the bearer token scoped to
+# the feed. Returns the file path; caller removes its directory when done.
+function New-TransientNpmrc([string]$registry, [string]$token) {
+    $authKey = $registry -replace '^https:', ''
+    $base = $registry -replace 'registry/?$', ''
+    $dir = Join-Path $env:TEMP ("ta-npmauth-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $file = Join-Path $dir ".npmrc"
+    $content = "$($base):_authToken=$token`n$($authKey):_authToken=$token`n$($authKey):always-auth=true`n"
+    Set-Content -Path $file -Value $content -NoNewline -Encoding ascii
+    return $file
+}
+
+# npm global installs of the CLIs. Non-fatal: warn and continue on any failure.
+# Pulls through the Azure feed with the transient auth config so no persistent
+# credential/broker interaction is required in the installer service context.
+function Install-Cli([string]$command, [string]$package, [string]$friendly, [string]$registry, [string]$userconfig) {
+    if (Test-Command $command) {
+        Write-Log "  $friendly already on PATH: $((Get-Command $command).Source)"
+        return
+    }
+    Write-Log "  Installing $friendly (npm i -g $package)"
+    $npmArgs = @("install", "-g", $package)
+    if ($registry -and $userconfig) {
+        $npmArgs += @("--registry", $registry, "--userconfig", $userconfig)
+    }
+    try {
+        & npm @npmArgs 2>&1 | ForEach-Object { Write-Log "    $_" }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log "  WARNING: '$package' install exited with code $LASTEXITCODE. Install it manually: npm i -g $package"
+            return
+        }
+    } catch {
+        Write-Log "  WARNING: '$package' install failed: $($_.Exception.Message). Install it manually: npm i -g $package"
+        return
+    }
+    if (Test-Command $command) {
+        Write-Log "  ${friendly}: $((Get-Command $command).Source)"
+    } else {
+        Write-Log "  WARNING: '$command' not found on PATH after install (open a new session, or install manually: npm i -g $package)."
+    }
+}
+
+Write-Log "Provisioning external-CLI prerequisites (claude, copilot)."
+
+# Resolve node from an MSI service context (refreshes PATH + probes managers),
+# so a bare `node`/`npm` on the interactive PATH is found here too.
+$nodeExe = Resolve-NodeExe
+
+# --- Node.js >= 22 (warn only; the MSI does not bundle Node) ------------------
+if (-not $nodeExe) {
+    Write-Log "  WARNING: Node.js >= 22 was not found. The agent-server requires it. Install it (e.g. 'winget install OpenJS.NodeJS.LTS') and re-run provisioning."
+} else {
+    $nodeMajor = Get-NodeMajor $nodeExe
+    if ($nodeMajor -lt 22) {
+        Write-Log "  WARNING: Node.js >= 22 required; found $(& $nodeExe --version) at $nodeExe. Upgrade (e.g. 'winget install OpenJS.NodeJS.LTS')."
+    } else {
+        Write-Log "  Node $(& $nodeExe --version) ($nodeExe)"
+    }
+}
+
+# --- External CLIs (claude, copilot) -----------------------------------------
+if (-not (Test-Command npm)) {
+    Write-Log "  WARNING: npm (ships with Node.js) was not found; cannot install claude/copilot. Install Node.js >= 22, then run: npm i -g @anthropic-ai/claude-code @github/copilot"
+} else {
+    # Authenticate to the Azure feed non-interactively (public npmjs is blocked
+    # by policy; the feed proxies it). The interactive broker tokenHelper in the
+    # user's ~/.npmrc cannot run in the installer service (session 0), so we mint
+    # a bearer token via the Azure CLI and pass a transient auth config instead.
+    $registry = $null
+    $userconfig = $null
+    $azCmd = Resolve-AzCmd
+    if (-not $azCmd) {
+        Write-Log "  WARNING: Azure CLI ('az') not found; cannot authenticate to the package feed. CLIs may fail to install. Install az + run 'az login', then: npm i -g @anthropic-ai/claude-code @github/copilot"
+    } else {
+        $token = Get-FeedToken $azCmd
+        if ($token) {
+            $registry = $FeedRegistry
+            $userconfig = New-TransientNpmrc $registry $token
+            Write-Log "  Feed auth ready (registry: $registry)"
+        } else {
+            Write-Log "  WARNING: could not obtain a feed access token from 'az'. CLIs may fail to install. Run 'az login', then: npm i -g @anthropic-ai/claude-code @github/copilot"
+        }
+    }
+
+    try {
+        Install-Cli "claude" "@anthropic-ai/claude-code" "Claude Code CLI" $registry $userconfig
+        Install-Cli "copilot" "@github/copilot" "GitHub Copilot CLI" $registry $userconfig
+    } finally {
+        if ($userconfig) {
+            try { Remove-Item (Split-Path -Parent $userconfig) -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+        }
+    }
+    Write-Log "  NOTE: both CLIs require a one-time sign-in (run 'claude' and 'copilot' once) before agent actions work."
+}
+
+Write-Log "Prerequisite provisioning complete."
+# Always succeed: prerequisite issues are surfaced as warnings, not install failures.
+exit 0

--- a/ts/tools/installers/wix/register-plugin.ps1
+++ b/ts/tools/installers/wix/register-plugin.ps1
@@ -18,6 +18,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "resolve-node.ps1")
+
 function Test-Command {
     param([Parameter(Mandatory = $true)][string]$Name)
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
@@ -124,5 +126,11 @@ if ($Uninstall) {
     $args += "--uninstall"
 }
 
-& node @args
+$nodeExe = Resolve-NodeExe
+if (-not $nodeExe) {
+    Write-Host "[TypeAgent] Registration failed. Node.js was not found (needed to run register-plugin.mjs)."
+    exit 1
+}
+
+& $nodeExe @args
 exit $LASTEXITCODE

--- a/ts/tools/installers/wix/resolve-node.ps1
+++ b/ts/tools/installers/wix/resolve-node.ps1
@@ -1,0 +1,114 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Shared helper (dot-source it) that locates a usable node.exe from an MSI
+  deferred custom-action context.
+
+.DESCRIPTION
+  MSI deferred custom actions run under the Windows Installer service, whose
+  environment block is a stale snapshot captured when the service started. It
+  therefore does NOT reflect a bare `node` on the user's interactive PATH —
+  neither a Program Files\nodejs entry added to the machine PATH after the
+  service started, nor (especially) a Node provided by a version manager such
+  as fnm / nvm / Volta, which inject node into the *session* PATH only.
+
+  Resolve-NodeExe fixes this by (1) refreshing $env:PATH and a few manager env
+  vars from the registry (Machine + User) and (2) probing the well-known
+  install locations of Node itself and the common version managers. On success
+  it prepends node's directory to $env:PATH (so npm/npx and child `node`
+  invocations resolve too) and returns the full path to node.exe. Returns $null
+  when no Node can be found, letting callers warn-and-continue rather than fail.
+#>
+
+function Update-PathFromRegistry {
+    # Rebuild $env:PATH from the persisted Machine + User values so nodes
+    # installed to Program Files\nodejs (official installer / winget) are seen
+    # even if the installer service's environment predates them.
+    try {
+        $machine = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+        $user = [System.Environment]::GetEnvironmentVariable("Path", "User")
+        $combined = @($machine, $user) | Where-Object { $_ } | ForEach-Object { $_ }
+        if ($combined) {
+            $env:PATH = ($combined -join ';') + ';' + $env:PATH
+        }
+    } catch {
+        # Best effort only.
+    }
+    # Version managers keep their root in a user env var; surface them too.
+    foreach ($name in @("FNM_DIR", "NVM_HOME", "NVM_SYMLINK", "VOLTA_HOME")) {
+        if (-not [System.Environment]::GetEnvironmentVariable($name, "Process")) {
+            $val = [System.Environment]::GetEnvironmentVariable($name, "User")
+            if (-not $val) { $val = [System.Environment]::GetEnvironmentVariable($name, "Machine") }
+            if ($val) { Set-Item -Path "Env:$name" -Value $val -ErrorAction SilentlyContinue }
+        }
+    }
+}
+
+function Get-NodeMajor([string]$nodeExe) {
+    try {
+        $v = & $nodeExe -e "process.stdout.write(String(process.versions.node.split('.')[0]))" 2>$null
+        return [int]$v
+    } catch {
+        return 0
+    }
+}
+
+function Resolve-NodeExe {
+    Update-PathFromRegistry
+
+    $found = @()
+
+    # 1) PATH (now refreshed) — cheapest, and honors an explicit install.
+    $cmd = Get-Command node.exe -ErrorAction SilentlyContinue
+    if (-not $cmd) { $cmd = Get-Command node -ErrorAction SilentlyContinue }
+    if ($cmd -and $cmd.Source -and (Test-Path $cmd.Source)) { $found += $cmd.Source }
+
+    # 2) Official installer / winget: Program Files\nodejs.
+    foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:ProgramW6432)) {
+        if ($base) { $found += (Join-Path $base "nodejs\node.exe") }
+    }
+
+    # 3) fnm — default alias first, then the highest installed version.
+    $fnmRoots = @($env:FNM_DIR, (Join-Path $env:APPDATA "fnm"), (Join-Path $env:LOCALAPPDATA "fnm")) |
+        Where-Object { $_ } | Select-Object -Unique
+    foreach ($root in $fnmRoots) {
+        $found += (Join-Path $root "aliases\default\installation\node.exe")
+        $versionsDir = Join-Path $root "node-versions"
+        if (Test-Path $versionsDir) {
+            Get-ChildItem $versionsDir -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match '^v?\d+\.' } |
+                Sort-Object { [version]($_.Name -replace '^v', '') } -Descending |
+                ForEach-Object { $found += (Join-Path $_.FullName "installation\node.exe") }
+        }
+    }
+
+    # 4) nvm-windows — symlink target or highest version under NVM_HOME.
+    if ($env:NVM_SYMLINK) { $found += (Join-Path $env:NVM_SYMLINK "node.exe") }
+    if ($env:NVM_HOME -and (Test-Path $env:NVM_HOME)) {
+        Get-ChildItem $env:NVM_HOME -Directory -Filter "v*" -ErrorAction SilentlyContinue |
+            Sort-Object { [version]($_.Name -replace '^v', '') } -Descending |
+            ForEach-Object { $found += (Join-Path $_.FullName "node.exe") }
+    }
+
+    # 5) Volta.
+    $voltaHome = if ($env:VOLTA_HOME) { $env:VOLTA_HOME } else { Join-Path $env:LOCALAPPDATA "Volta" }
+    $voltaImg = Join-Path $voltaHome "tools\image\node"
+    if (Test-Path $voltaImg) {
+        Get-ChildItem $voltaImg -Directory -ErrorAction SilentlyContinue |
+            Sort-Object { [version]($_.Name -replace '^v', '') } -Descending |
+            ForEach-Object { $found += (Join-Path $_.FullName "node.exe") }
+    }
+
+    foreach ($candidate in ($found | Where-Object { $_ } | Select-Object -Unique)) {
+        if (Test-Path $candidate) {
+            # Prefer Node >= 22 but accept anything usable as a last resort.
+            $dir = Split-Path -Parent $candidate
+            $env:PATH = "$dir;$env:PATH"
+            return $candidate
+        }
+    }
+
+    return $null
+}

--- a/ts/tools/installers/wix/run-serve.ps1
+++ b/ts/tools/installers/wix/run-serve.ps1
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Runs `node typeagent-serve.mjs <args>` from an MSI deferred custom-action
+  context, resolving node.exe robustly first.
+
+.DESCRIPTION
+  The agent-server lifecycle custom actions (provision / start / autostart)
+  invoke the typeagent-serve.mjs launcher with node. Because those actions run
+  under the Windows Installer service, a bare `node` is frequently unresolvable
+  (see resolve-node.ps1). This wrapper locates node via Resolve-NodeExe, then
+  runs the requested serve subcommand. It is intentionally non-fatal: if Node
+  cannot be found the step is skipped with a warning (the ExitDialog and
+  documentation tell the user to run it manually) rather than rolling back the
+  agent-server install.
+
+.PARAMETER ServePath
+  Full path to typeagent-serve.mjs (the agent-server launcher).
+
+.PARAMETER LogPath
+  Optional log file; output is also written to stdout (captured by the MSI log).
+
+.PARAMETER Rest
+  The serve subcommand and its arguments, e.g. `start`, `provision`,
+  `autostart enable`.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$ServePath,
+    [string]$LogPath,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$Rest
+)
+
+# Health-check tuning for the 'start' subcommand (see below). Kept as script
+# locals, not params, so the positional 'start' argument passed by the MSI
+# custom action is not accidentally bound to them.
+$ServerPort = 8999
+$StartTimeoutSeconds = 45
+
+$ErrorActionPreference = "Continue"
+
+function Write-Log([string]$message) {
+    $line = "{0} {1}" -f (Get-Date -Format "s"), $message
+    Write-Host $line
+    if ($LogPath) {
+        try {
+            $dir = Split-Path -Parent $LogPath
+            if ($dir -and -not (Test-Path $dir)) {
+                New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+            Add-Content -Path $LogPath -Value $line
+        } catch {
+            # Logging must never fail the install.
+        }
+    }
+}
+
+. (Join-Path $PSScriptRoot "resolve-node.ps1")
+
+$serveArgs = @($Rest)
+$label = ($serveArgs -join ' ')
+
+if (-not (Test-Path $ServePath)) {
+    Write-Log "WARNING: agent-server launcher not found: $ServePath. Skipping 'typeagent-serve $label'."
+    exit 0
+}
+
+$node = Resolve-NodeExe
+if (-not $node) {
+    Write-Log "WARNING: Node.js was not found; cannot run 'typeagent-serve $label'. Install Node.js >= 22 and run it manually from '$ServePath'."
+    exit 0
+}
+
+Write-Log "Using node: $node"
+Write-Log "Running: typeagent-serve $label"
+
+# The 'start' subcommand launches a DETACHED daemon that must outlive this
+# custom action. The trap: any launch that redirects streams or shares our
+# console (Start-Process -RedirectStandard*/-NoNewWindow, or a `| ForEach-Object`
+# pipeline) is created with bInheritHandles=TRUE, so the daemon inherits THIS
+# process's stdout handle -- which under WixQuietExec64 is the installer's
+# capture pipe. The daemon then holds that pipe open forever, the custom action
+# never sees EOF, and the MSI hangs (observed as "time remaining: 2 seconds"
+# stuck for many minutes). Launch via ShellExecute instead (no redirection, no
+# -NoNewWindow, no -Wait): that path uses bInheritHandles=FALSE and gives the
+# daemon a fresh console, so nothing leaks. We then poll the health port to
+# confirm startup rather than waiting on the (intentionally detached) process.
+$isStart = ($serveArgs.Count -gt 0 -and $serveArgs[0] -eq 'start')
+if ($isStart) {
+    try {
+        # Quote every argument so paths containing spaces survive.
+        $argLine = (@($ServePath) + $serveArgs | ForEach-Object { '"' + $_ + '"' }) -join ' '
+        # No -RedirectStandard*, no -NoNewWindow, no -Wait => ShellExecute launch
+        # with a hidden window and NO handle inheritance.
+        $proc = Start-Process -FilePath $node -ArgumentList $argLine -WindowStyle Hidden -PassThru
+        $launchPid = if ($proc) { $proc.Id } else { "?" }
+        Write-Log "Launched agent-server launcher (pid $launchPid); polling port $ServerPort for up to $StartTimeoutSeconds s..."
+
+        $deadline = (Get-Date).AddSeconds($StartTimeoutSeconds)
+        $listening = $false
+        while ((Get-Date) -lt $deadline) {
+            $client = $null
+            try {
+                $client = New-Object System.Net.Sockets.TcpClient
+                $async = $client.BeginConnect('127.0.0.1', $ServerPort, $null, $null)
+                if ($async.AsyncWaitHandle.WaitOne(1000) -and $client.Connected) {
+                    $listening = $true
+                }
+            } catch {
+                # Not up yet; keep polling.
+            } finally {
+                if ($client) { $client.Close() }
+            }
+            if ($listening) { break }
+            Start-Sleep -Milliseconds 500
+        }
+
+        if ($listening) {
+            Write-Log "Agent-server is listening on port $ServerPort."
+        } else {
+            Write-Log "WARNING: agent-server did not report listening on port $ServerPort within $StartTimeoutSeconds s. It may still be starting; autostart will also launch it at next sign-in."
+        }
+    } catch {
+        Write-Log "WARNING: 'typeagent-serve $label' launch failed: $($_.Exception.Message)."
+    }
+} else {
+    try {
+        & $node $ServePath @serveArgs 2>&1 | ForEach-Object { Write-Log "  $_" }
+        Write-Log "typeagent-serve $label exited with code $LASTEXITCODE."
+    } catch {
+        Write-Log "WARNING: 'typeagent-serve $label' failed: $($_.Exception.Message)."
+    }
+}
+
+# Always succeed: lifecycle hiccups are surfaced as warnings, not install failures.
+exit 0

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -10,7 +10,7 @@
  * Orchestrates the TypeAgent MSI build:
  * 1. Resolve artifact inputs (pipeline default: pre-staged local directories via --skip-download)
  * 2. Generate marketplace.json for Copilot CLI plugin registration
- * 3. Harvest file components with heat.exe (one pass per artifact dir)
+ * 3. Zip each artifact dir into a single payload archive (extracted at install time)
  * 4. Compile WiX (candle) + link to MSI (light)
  *
  * Usage:
@@ -35,6 +35,21 @@ let outputDir = "./msi-out";
 let skipDownload = false;
 let stagedAgentDir = "";
 let stagedPluginDir = "";
+// Optional TypeAgent Shell download coordinates, baked into the MSI as the
+// SHELLBASEURL / SHELLSTORAGE / SHELLCONTAINER / SHELLCHANNEL property defaults
+// so the "install the shell" option has a location on a fresh machine.
+let shellBaseUrl = "";
+let shellStorage = "";
+let shellContainer = "";
+let shellChannel = "lkg";
+// Optional Azure Artifacts Universal Package fallback for the shell download,
+// baked into the MSI so the installer can pull the shell from the feed when the
+// blob download fails (e.g. the account disallows anonymous access).
+let shellFeed = "";
+let shellPackage = "";
+let shellFeedVersion = "";
+let shellOrg = "";
+let shellProject = "";
 
 for (let i = 0; i < args.length; i++) {
     if (args[i] === "--rid") rid = args[++i];
@@ -44,6 +59,15 @@ for (let i = 0; i < args.length; i++) {
     else if (args[i] === "--skip-download") skipDownload = true;
     else if (args[i] === "--agent-dir") stagedAgentDir = args[++i];
     else if (args[i] === "--plugin-dir") stagedPluginDir = args[++i];
+    else if (args[i] === "--shell-base-url") shellBaseUrl = args[++i];
+    else if (args[i] === "--shell-storage") shellStorage = args[++i];
+    else if (args[i] === "--shell-container") shellContainer = args[++i];
+    else if (args[i] === "--shell-channel") shellChannel = args[++i];
+    else if (args[i] === "--shell-feed") shellFeed = args[++i];
+    else if (args[i] === "--shell-package") shellPackage = args[++i];
+    else if (args[i] === "--shell-feed-version") shellFeedVersion = args[++i];
+    else if (args[i] === "--shell-org") shellOrg = args[++i];
+    else if (args[i] === "--shell-project") shellProject = args[++i];
 }
 
 console.log(`📦 Building TypeAgent MSI`);
@@ -53,6 +77,21 @@ console.log(`   Plugin version: ${pluginVersion}`);
 console.log(`   Output:         ${outputDir}`);
 if (stagedAgentDir) console.log(`   Agent dir:      ${stagedAgentDir}`);
 if (stagedPluginDir) console.log(`   Plugin dir:     ${stagedPluginDir}`);
+
+// The shell download is authenticated: install-shell.ps1 uses `az storage blob
+// download --auth-mode login` first, then the Azure Artifacts feed as a
+// fallback. We intentionally do NOT derive an anonymous blob base URL here
+// (the storage account disallows anonymous access, and org policy requires
+// authenticated access). -shell-base-url may still be passed explicitly for a
+// public container in standalone scenarios.
+if (shellBaseUrl || shellStorage) {
+    console.log(`   Shell base URL: ${shellBaseUrl || "(none)"}`);
+    console.log(`   Shell storage:  ${shellStorage || "(none)"}/${shellContainer || "(none)"}`);
+    console.log(`   Shell channel:  ${shellChannel}`);
+}
+if (shellFeed && shellPackage) {
+    console.log(`   Shell feed:     ${shellFeed} / ${shellPackage} v${shellFeedVersion || "(latest)"}`);
+}
 
 if (rid !== "win32-x64") {
     console.error(
@@ -68,8 +107,9 @@ const outputPath = path.resolve(outputDir);
 const agentArtifactDir = path.join(outputPath, "artifact", "agent-server");
 const pluginArtifactDir = path.join(outputPath, "artifact", "copilot-plugin");
 const marketplaceDir = path.join(outputPath, "marketplace");
-const agentHeatFile = path.join(outputPath, "AgentServerFiles.wxs");
-const pluginHeatFile = path.join(outputPath, "CopilotPluginFiles.wxs");
+const payloadDir = path.join(outputPath, "payload");
+const agentZipFile = path.join(payloadDir, "agent-server.zip");
+const pluginZipFile = path.join(payloadDir, "copilot-plugin.zip");
 
 if (!fs.existsSync(outputPath)) fs.mkdirSync(outputPath, { recursive: true });
 
@@ -300,49 +340,46 @@ fs.writeFileSync(
 );
 console.log(`✅ Generated marketplace.json`);
 
-// ── Step 3: Harvest file components with heat.exe ─────────────────────────────
-const heatExe = wixTool("heat.exe");
+// ── Step 3: Zip payload archives ──────────────────────────────────────────────
+// Ship agent-server and copilot-plugin as single zip files (one MSI File
+// component each) instead of harvesting them with heat (one Component per
+// file). A flat node_modules produced tens of thousands of components, which
+// made the installer's "Computing space requirements" (CostFinalize) step take
+// minutes. A deferred custom action (extract-payload.ps1) unpacks the zips at
+// install time.
 const candleExe = wixTool("candle.exe");
 const lightExe = wixTool("light.exe");
 
-function runHeat(dir, componentGroup, dirRef, varName, outFile) {
-    console.log(`\n🔥 Harvesting ${componentGroup} from ${dir}...`);
-    runCommand(heatExe, [
-        "dir",
-        dir,
-        "-cg",
-        componentGroup,
-        "-dr",
-        dirRef,
-        "-var",
-        `var.${varName}`,
-        "-gg", // generate stable GUIDs per file path
-        "-scom", // suppress COM harvesting (avoids SelfReg DLL warnings for native binaries)
-        "-sreg", // suppress registry harvesting
-        "-srd", // suppress root directory element
-        "-sfrag", // suppress fragment wrapping (use our own Product.wxs structure)
-        "-indent",
-        "2",
-        "-o",
-        outFile,
+function zipDirectory(sourceDir, zipFile, label) {
+    console.log(`\n🗜️  Zipping ${label} -> ${zipFile}...`);
+    if (fs.existsSync(zipFile)) fs.rmSync(zipFile);
+    const psScript =
+        `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
+        // includeBaseDirectory=$false so the zip root holds the payload files
+        // directly, and they extract straight into INSTALLFOLDER/PLUGINFOLDER.
+        `[System.IO.Compression.ZipFile]::CreateFromDirectory(` +
+        `'${sourceDir.replace(/'/g, "''")}', ` +
+        `'${zipFile.replace(/'/g, "''")}', ` +
+        `[System.IO.Compression.CompressionLevel]::Optimal, $false)`;
+    runCommand("powershell.exe", [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        psScript,
     ]);
-    console.log(`✅ Harvested: ${outFile}`);
+    if (!fs.existsSync(zipFile)) {
+        console.error(`❌ Failed to create ${label} archive: ${zipFile}`);
+        process.exit(1);
+    }
+    const sizeMb = (fs.statSync(zipFile).size / 1024 / 1024).toFixed(1);
+    console.log(`✅ Zipped ${label}: ${zipFile} (${sizeMb} MB)`);
 }
 
-runHeat(
-    agentArtifactDir,
-    "AgentServerComponents",
-    "INSTALLFOLDER",
-    "AgentServerArtifactDir",
-    agentHeatFile,
-);
-runHeat(
-    pluginArtifactDir,
-    "CopilotPluginComponents",
-    "PLUGINFOLDER",
-    "CopilotPluginArtifactDir",
-    pluginHeatFile,
-);
+fs.mkdirSync(payloadDir, { recursive: true });
+zipDirectory(agentArtifactDir, agentZipFile, "agent-server");
+zipDirectory(pluginArtifactDir, pluginZipFile, "copilot-plugin");
 
 // ── Step 4: Compile WiX (candle.exe) ─────────────────────────────────────────
 console.log(`\n🕯️  Compiling WiX...`);
@@ -350,17 +387,24 @@ console.log(`\n🕯️  Compiling WiX...`);
 const wixobjDir = outputPath;
 runCommand(candleExe, [
     `-dProductVersion=${wixProductVersion}`,
-    `-dAgentServerArtifactDir=${agentArtifactDir}`,
-    `-dCopilotPluginArtifactDir=${pluginArtifactDir}`,
+    `-dAgentServerZip=${agentZipFile}`,
+    `-dCopilotPluginZip=${pluginZipFile}`,
     `-dMarketplaceDir=${marketplaceDir}`,
     `-dInstallerSourceDir=${wxsDir}`,
+    `-dShellBaseUrl=${shellBaseUrl}`,
+    `-dShellStorage=${shellStorage}`,
+    `-dShellContainer=${shellContainer}`,
+    `-dShellChannel=${shellChannel}`,
+    `-dShellFeed=${shellFeed}`,
+    `-dShellPackage=${shellPackage}`,
+    `-dShellFeedVersion=${shellFeedVersion}`,
+    `-dShellOrg=${shellOrg}`,
+    `-dShellProject=${shellProject}`,
     `-arch`,
     `x64`,
     `-o`,
     `${wixobjDir}\\`,
     wxsFile,
-    agentHeatFile,
-    pluginHeatFile,
 ]);
 console.log(`✅ Compiled WiX objects`);
 
@@ -375,19 +419,17 @@ runCommand(lightExe, [
     `WixUIExtension`,
     `-ext`,
     `WixUtilExtension`,
-    // Per-user install under LocalAppData intentionally triggers ICE38 on
-    // file-keypath components harvested by heat; suppress that specific ICE.
+    // Per-user install under LocalAppData intentionally uses File keypaths on
+    // the payload components, which triggers ICE38; suppress that specific ICE.
     `-sice:ICE38`,
-    // ICE64 flags every harvested directory under the user profile that lacks
-    // a RemoveFile entry.  For per-user installs with hundreds of auto-
-    // harvested subdirectories this is expected and safe to suppress.
+    // ICE64 flags user-profile directories that lack a RemoveFile entry
+    // (INSTALLFOLDER/PLUGINFOLDER are populated at runtime by ExtractPayload and
+    // cleaned up by CleanupPayload); safe to suppress for this per-user install.
     `-sice:ICE64`,
     `-cultures:en-us`,
     `-o`,
     msiOutputPath,
     path.join(wixobjDir, "TypeAgent-AgentServer.wixobj"),
-    path.join(wixobjDir, "AgentServerFiles.wixobj"),
-    path.join(wixobjDir, "CopilotPluginFiles.wixobj"),
 ]);
 
 if (!fs.existsSync(msiOutputPath)) {

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -86,11 +86,15 @@ if (stagedPluginDir) console.log(`   Plugin dir:     ${stagedPluginDir}`);
 // public container in standalone scenarios.
 if (shellBaseUrl || shellStorage) {
     console.log(`   Shell base URL: ${shellBaseUrl || "(none)"}`);
-    console.log(`   Shell storage:  ${shellStorage || "(none)"}/${shellContainer || "(none)"}`);
+    console.log(
+        `   Shell storage:  ${shellStorage || "(none)"}/${shellContainer || "(none)"}`,
+    );
     console.log(`   Shell channel:  ${shellChannel}`);
 }
 if (shellFeed && shellPackage) {
-    console.log(`   Shell feed:     ${shellFeed} / ${shellPackage} v${shellFeedVersion || "(latest)"}`);
+    console.log(
+        `   Shell feed:     ${shellFeed} / ${shellPackage} v${shellFeedVersion || "(latest)"}`,
+    );
 }
 
 if (rid !== "win32-x64") {

--- a/ts/tools/scripts/install-shell.ps1
+++ b/ts/tools/scripts/install-shell.ps1
@@ -32,6 +32,16 @@ param(
     # https://<account>.blob.core.windows.net/<container>. When set, the Azure
     # CLI is not used.
     [string]$BlobBaseUrl = "",
+    # Optional Azure Artifacts Universal Package fallback. When the blob
+    # download(s) fail (e.g. the storage account disallows anonymous access),
+    # the shell is pulled from the feed instead via `az artifacts universal
+    # download` (authenticated with the caller's `az login`). The feed is
+    # published to alongside blob storage by the release pipeline.
+    [string]$Feed = "",
+    [string]$FeedPackage = "",
+    [string]$FeedVersion = "",
+    [string]$Organization = "",
+    [string]$Project = "",
     [string]$LogPath = "$env:LOCALAPPDATA\TypeAgent\logs\install-shell.log",
     # Do not launch the shell after install.
     [switch]$NoStart,
@@ -92,25 +102,28 @@ function Test-Command {
 function Get-BlobFile {
     param(
         [Parameter(Mandatory = $true)][string]$Name,
-        [Parameter(Mandatory = $true)][string]$Destination
+        [Parameter(Mandatory = $true)][string]$Destination,
+        # Force the anonymous HTTPS path (requires -BlobBaseUrl).
+        [switch]$Anonymous
     )
 
-    if ($BlobBaseUrl) {
+    if ($Anonymous) {
+        if (-not $BlobBaseUrl) { throw "No -BlobBaseUrl provided for anonymous download." }
         $url = "$($BlobBaseUrl.TrimEnd('/'))/$Name"
-        Write-Log "Downloading $url"
+        Write-Log "Downloading (anonymous) $url"
         Invoke-WebRequest -Uri $url -OutFile $Destination -UseBasicParsing
         return
     }
 
     if (-not (Test-Command az)) {
-        Fail "Azure CLI ('az') not found and no -BlobBaseUrl provided. Install Azure CLI or pass -BlobBaseUrl for a public container."
+        throw "Azure CLI ('az') not found for authenticated blob download."
     }
     if (-not $Storage) {
-        Fail "-Storage is required when -BlobBaseUrl is not provided."
+        throw "-Storage is required for an authenticated blob download."
     }
 
     $containerName = if ($Container) { $Container } else { $Storage }
-    Write-Log "Downloading blob '$Name' from $Storage/$containerName"
+    Write-Log "Downloading (az) blob '$Name' from $Storage/$containerName"
     & az storage blob download `
         --account-name $Storage `
         --container-name $containerName `
@@ -119,7 +132,39 @@ function Get-BlobFile {
         --auth-mode login `
         --overwrite 2>&1 | ForEach-Object { Write-Log "az> $_" }
     if ($LASTEXITCODE -ne 0) {
-        Fail "Failed to download '$Name' from $Storage/$containerName. Ensure 'az login' has access to the account."
+        throw "az storage blob download failed for '$Name' from $Storage/$containerName."
+    }
+}
+
+# Download the whole shell Universal Package (channel .yml + setup exe) from the
+# Azure Artifacts feed into $Destination. Authenticated via the caller's
+# `az login`; policy-compliant (no anonymous access, no public npmjs).
+function Get-ShellFromFeed {
+    param([Parameter(Mandatory = $true)][string]$Destination)
+
+    if (-not (Test-Command az)) {
+        throw "Azure CLI ('az') not found; cannot download the shell from the feed."
+    }
+    if (-not $Organization) {
+        throw "-Organization is required for a feed download."
+    }
+    # `az artifacts universal download` lives in the azure-devops extension.
+    & az extension add --name azure-devops --only-show-errors 2>&1 | ForEach-Object { Write-Log "az> $_" }
+
+    $ver = if ($FeedVersion) { $FeedVersion } else { "*" }
+    Write-Log "Downloading universal package '$FeedPackage' v$ver from feed '$Feed'"
+    $azArgs = @(
+        "artifacts", "universal", "download",
+        "--organization", $Organization,
+        "--feed", $Feed,
+        "--name", $FeedPackage,
+        "--version", $ver,
+        "--path", $Destination
+    )
+    if ($Project) { $azArgs += @("--project", $Project, "--scope", "project") }
+    & az @azArgs 2>&1 | ForEach-Object { Write-Log "az> $_" }
+    if ($LASTEXITCODE -ne 0) {
+        throw "az artifacts universal download failed for '$FeedPackage' v$ver from feed '$Feed'."
     }
 }
 
@@ -166,8 +211,8 @@ if (-not $SkipTypeAgentCheck) {
     }
 }
 
-if (-not $BlobBaseUrl -and -not $Storage) {
-    Fail "Provide either -Storage (with optional -Container) or -BlobBaseUrl."
+if (-not $BlobBaseUrl -and -not $Storage -and -not ($Feed -and $FeedPackage)) {
+    Fail "Provide a shell source: -Storage (with optional -Container), -BlobBaseUrl, or -Feed with -FeedPackage/-Organization."
 }
 
 $arch = Get-Arch
@@ -184,14 +229,65 @@ New-Item -ItemType Directory -Force -Path $dest | Out-Null
 
 try {
     $ymlPath = Join-Path $dest $ymlName
-    Get-BlobFile -Name $ymlName -Destination $ymlPath
+    $script:packagePath = $null
 
-    $packageName = Get-PackagePathFromYml -YmlPath $ymlPath
-    Write-Log "Resolved shell package: $packageName"
+    # Try each configured source in order until one yields the channel .yml AND
+    # the setup package it references. Authenticated az-blob first, then the
+    # feed as a fallback. An explicit -BlobBaseUrl (anonymous, standalone
+    # public-container use) is only tried as a last resort.
+    $sources = @()
+    if ($Storage) { $sources += "az-blob" }
+    if ($Feed -and $FeedPackage) { $sources += "feed" }
+    if ($BlobBaseUrl) { $sources += "anon-blob" }
 
-    $packagePath = Join-Path $dest $packageName
-    Get-BlobFile -Name $packageName -Destination $packagePath
+    $obtained = $false
+    foreach ($src in $sources) {
+        try {
+            Write-Log "Attempting shell download via '$src'."
+            switch ($src) {
+                "anon-blob" {
+                    Get-BlobFile -Name $ymlName -Destination $ymlPath -Anonymous
+                    $packageName = Get-PackagePathFromYml -YmlPath $ymlPath
+                    Write-Log "Resolved shell package: $packageName"
+                    $script:packagePath = Join-Path $dest $packageName
+                    Get-BlobFile -Name $packageName -Destination $script:packagePath -Anonymous
+                }
+                "az-blob" {
+                    Get-BlobFile -Name $ymlName -Destination $ymlPath
+                    $packageName = Get-PackagePathFromYml -YmlPath $ymlPath
+                    Write-Log "Resolved shell package: $packageName"
+                    $script:packagePath = Join-Path $dest $packageName
+                    Get-BlobFile -Name $packageName -Destination $script:packagePath
+                }
+                "feed" {
+                    Get-ShellFromFeed -Destination $dest
+                    if (-not (Test-Path $ymlPath)) {
+                        throw "Feed package did not contain the channel metadata '$ymlName'."
+                    }
+                    $packageName = Get-PackagePathFromYml -YmlPath $ymlPath
+                    Write-Log "Resolved shell package: $packageName"
+                    $script:packagePath = Join-Path $dest $packageName
+                    if (-not (Test-Path $script:packagePath)) {
+                        throw "Feed package did not contain the setup package '$packageName'."
+                    }
+                }
+            }
+            if ($script:packagePath -and (Test-Path $script:packagePath)) {
+                $obtained = $true
+                Write-Log "Shell payload obtained via '$src'."
+                break
+            }
+        } catch {
+            Write-Log "WARNING: shell download via '$src' failed: $($_.Exception.Message)"
+            Remove-Item $ymlPath -Force -ErrorAction SilentlyContinue
+        }
+    }
 
+    if (-not $obtained) {
+        Fail "Could not download the TypeAgent Shell from any configured source (tried: $($sources -join ', ')). Ensure network access and 'az login', or verify the -BlobBaseUrl/-Feed coordinates."
+    }
+
+    $packagePath = $script:packagePath
     if (-not (Test-Path $packagePath)) {
         Fail "Shell package not found after download: $packagePath"
     }


### PR DESCRIPTION
Reworked the Windows installer to ship agent-server/plugin as zipped payloads extracted at install time, replacing heat-harvested file trees to avoid long CostFinalize times. Added new MSI custom actions and scripts for node resolution, prerequisite CLI install, daemon start/autostart, AISYSTEMS provisioning behavior, and clearer shell install failure handling. Wired shell download defaults and Azure Artifacts Universal Package fallback through build/pipeline, and updated docs accordingly. Also moved the utility agent manifest under src and added a compiled default registry fallback for the seed feed.