### PR TITLE
Add bypass mode and tighten direct handling

### DIFF
--- a/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-direct.ts
@@ -88,12 +88,27 @@ export async function handleDirect(input: HookInput): Promise<HookOutput> {
             return {};
         }
 
-        const responseContent =
-            responseCollector.messages.length > 0
-                ? responseCollector.messages.join("\n\n")
-                : result?.lastError
-                  ? `TypeAgent recognized the action but encountered an error: ${result.lastError}`
-                  : "Request processed successfully.";
+        // Debug: Log result details when action is recognized
+        console.error("DEBUG: Action recognized", {
+            prompt: input.prompt.substring(0, 100),
+            hasLastError: !!result?.lastError,
+            lastError: result?.lastError,
+            messageCount: responseCollector.messages.length,
+            actionNames: result?.actions?.map((a) => a.actionName),
+        });
+
+        // Check for failure indicators:
+        // 1. Action failed (result.lastError is set)
+        // 2. No messages were collected, indicating the action couldn't execute
+        if (result?.lastError || responseCollector.messages.length === 0) {
+            console.error("DEBUG: Returning unhandled due to error condition", {
+                hasLastError: !!result?.lastError,
+                hasMessages: responseCollector.messages.length > 0,
+            });
+            return {};
+        }
+
+        const responseContent = responseCollector.messages.join("\n\n");
 
         return {
             handled: true,

--- a/ts/packages/copilot-plugin/src/hooks/hook-router.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-router.ts
@@ -24,7 +24,7 @@ import { handleMcpRedirect } from "./hook-mcp-redirect.js";
 import { makeTurnId, writeDemoState } from "./demo-state.js";
 import type { HookInput, HookOutput } from "./types.js";
 
-type Mode = "direct" | "mcp";
+type Mode = "direct" | "mcp" | "bypass";
 
 interface PluginConfig {
     mode: Mode;
@@ -62,11 +62,15 @@ function writeConfig(config: PluginConfig): void {
 
 function getMode(): Mode {
     const envMode = process.env.TYPEAGENT_MODE;
-    if (envMode === "direct" || envMode === "mcp") {
+    if (envMode === "direct" || envMode === "mcp" || envMode === "bypass") {
         return envMode;
     }
     const config = readConfig();
-    if (config?.mode === "direct" || config?.mode === "mcp") {
+    if (
+        config?.mode === "direct" ||
+        config?.mode === "mcp" ||
+        config?.mode === "bypass"
+    ) {
         return config.mode;
     }
     return "direct";
@@ -95,8 +99,10 @@ function handleSlashCommand(
         });
     }
 
-    // @typeagent mode <direct|mcp>
-    const modeMatch = lower.match(/^@typeagent\s+mode(?:\s+(direct|mcp))?\s*$/);
+    // @typeagent mode <direct|mcp|bypass>
+    const modeMatch = lower.match(
+        /^@typeagent\s+mode(?:\s+(direct|mcp|bypass))?\s*$/,
+    );
     if (modeMatch) {
         const newMode = modeMatch[1] as Mode | undefined;
 
@@ -105,7 +111,7 @@ function handleSlashCommand(
             const current = getMode();
             return {
                 handled: true,
-                responseContent: `TypeAgent mode: **${current}**\n\nUse \`@typeagent mode direct\` or \`@typeagent mode mcp\` to switch.`,
+                responseContent: `TypeAgent mode: **${current}**\n\nUse \`@typeagent mode direct\`, \`@typeagent mode mcp\`, or \`@typeagent mode bypass\` to switch.`,
                 handledBy: "typeagent",
             };
         }
@@ -117,7 +123,9 @@ function handleSlashCommand(
         const description =
             newMode === "direct"
                 ? "Hook handles requests directly, bypassing the LLM. Fastest response."
-                : "Hook redirects to MCP tool. LLM calls TypeAgent with streaming display.";
+                : newMode === "mcp"
+                  ? "Hook redirects to MCP tool. LLM calls TypeAgent with streaming display."
+                  : "TypeAgent is disabled. All requests bypass TypeAgent routing and fall through to other handlers.";
 
         return {
             handled: true,
@@ -180,6 +188,7 @@ function handleSlashCommand(
                 "- `@typeagent run <command>` — send command directly to TypeAgent",
                 "- `@typeagent mode direct` — switch to direct mode",
                 "- `@typeagent mode mcp` — switch to MCP mode",
+                "- `@typeagent mode bypass` — disable TypeAgent routing",
                 "- `@typeagent powershell on/off` — toggle TypeAgent PowerShell redirect",
                 "- `@typeagent status` — show this info",
             ].join("  \n"),
@@ -230,7 +239,10 @@ async function main(): Promise<void> {
     const mode = getMode();
     let output: HookOutput;
 
-    if (mode === "mcp") {
+    if (mode === "bypass") {
+        // Bypass mode: return empty to fall through to other handlers
+        output = {};
+    } else if (mode === "mcp") {
         output = handleMcpRedirect(input);
     } else {
         output = await handleDirect(input);

--- a/ts/packages/copilot-plugin/src/mcp/server.ts
+++ b/ts/packages/copilot-plugin/src/mcp/server.ts
@@ -16,6 +16,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { Dispatcher, IAgentMessage } from "@typeagent/agent-server-client";
@@ -27,6 +30,42 @@ import {
     TYPEAGENT_URL,
 } from "../shared/typeagent-client.js";
 import { extractMessageText } from "../shared/message-formatter.js";
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+interface PluginConfig {
+    mode?: "direct" | "mcp" | "bypass";
+    [key: string]: unknown;
+}
+
+function getConfigDir(): string {
+    return (
+        process.env.TYPEAGENT_PLUGIN_DATA ??
+        process.env.CLAUDE_PLUGIN_DATA ??
+        join(homedir(), ".typeagent-copilot")
+    );
+}
+
+function getConfigPath(): string {
+    return join(getConfigDir(), "config.json");
+}
+
+function readConfig(): PluginConfig | undefined {
+    try {
+        return JSON.parse(readFileSync(getConfigPath(), "utf-8"));
+    } catch {
+        return undefined;
+    }
+}
+
+function isBypassMode(): boolean {
+    const envMode = process.env.TYPEAGENT_MODE;
+    if (envMode === "bypass") {
+        return true;
+    }
+    const config = readConfig();
+    return config?.mode === "bypass";
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -86,10 +125,19 @@ class TypeAgentMcpServer {
     async start(): Promise<void> {
         const transport = new StdioServerTransport();
         await this.server.connect(transport);
-        log(`TypeAgent MCP server started (target: ${TYPEAGENT_URL})`);
+        if (isBypassMode()) {
+            log("TypeAgent is in bypass mode — MCP tools are disabled");
+        } else {
+            log(`TypeAgent MCP server started (target: ${TYPEAGENT_URL})`);
+        }
     }
 
     private registerTools(): void {
+        // Skip tool registration if bypass mode is enabled
+        if (isBypassMode()) {
+            log("Skipping tool registration — bypass mode is active");
+            return;
+        }
         this.server.registerTool(
             "typeagent-processCommand",
             {


### PR DESCRIPTION
- Introduce a new `bypass` mode across the hook router and MCP server so TypeAgent can be fully disabled and requests/tools fall through cleanly.
- Add debug logging around recognized-action/error conditions.