### PR TITLE
 Add inbox agent-server profile and packaging defaults

### DIFF
--- a/pipelines/azure-build-publish-all.yml
+++ b/pipelines/azure-build-publish-all.yml
@@ -63,7 +63,7 @@ parameters:
     displayName: "agent-server variant (external = lean, full = bundled CLIs)"
   - name: profile
     type: string
-    default: service
+    default: inbox
     displayName: "agent-server provider profile"
   - name: publishOptionalAgents
     type: boolean

--- a/ts/packages/defaultAgentProvider/data/config.inbox.json
+++ b/ts/packages/defaultAgentProvider/data/config.inbox.json
@@ -1,0 +1,77 @@
+{
+  "description": "Inbox profile for the installed agent-server",
+  "agents": {
+    "chat": {
+      "name": "@typeagent/chat-agent",
+      "execMode": "dispatcher"
+    },
+    "list": {
+      "name": "@typeagent/list-agent"
+    },
+    "timer": {
+      "name": "@typeagent/timer-agent"
+    },
+    "player": {
+      "name": "@typeagent/music"
+    },
+    "powershell": {
+      "name": "@typeagent/powershell-typeagent"
+    },
+    "utility": {
+      "name": "@typeagent/utility-typeagent"
+    },
+    "taskflow": {
+      "name": "@typeagent/taskflow-typeagent",
+      "execMode": "dispatcher"
+    },
+    "browser": {
+      "name": "@typeagent/browser"
+    },
+    "code": {
+      "name": "@typeagent/code-agent"
+    },
+    "visualStudio": {
+      "name": "@typeagent/visualstudio-agent"
+    },
+    "github-cli": {
+      "name": "@typeagent/github-cli-agent"
+    },
+    "calendar": {
+      "name": "@typeagent/calendar"
+    },
+    "email": {
+      "name": "@typeagent/email"
+    },
+    "greeting": {
+      "name": "greeting-agent",
+      "execMode": "dispatcher"
+    }
+  },
+  "mcpServers": {
+    "mcpfilesystem": {
+      "emojiChar": "📁",
+      "description": "Local file system agent — reads, writes, edits, and organizes files and folders on the local disk within a set of allowed directories. Use this for requests to read a file's text or contents, read an image or media file, read several files at once, create or overwrite a file, make line-based edits to a file, create a folder or directory, list the contents of a directory (optionally with file sizes), show a recursive directory tree, move or rename a file or folder, search for files by name or pattern, get file metadata (size, timestamps, permissions), or list the directories it is allowed to access.",
+      "defaultEnabled": false,
+      "serverScript": "./node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
+      "serverScriptArgs": {
+        "allowedDirectories": {
+          "description": "Allowed directories for the file system agent to access",
+          "type": "string",
+          "multiple": true
+        }
+      }
+    }
+  },
+  "explainers": {
+    "v5": {
+      "constructions": {
+        "data": ["./data/explainer/v5/data/player/basic.json"],
+        "file": "./data/explainer/v5/constructions.json"
+      }
+    }
+  },
+  "tests": [
+    "./test/data/explanations/**/**/*.json",
+    "./test/repo/explanations/**/**/*.json"
+  ]
+}

--- a/ts/packages/defaultAgentProvider/test/providerConfig.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/providerConfig.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getProviderConfig } from "../src/utils/config.js";
+
+describe("provider configurations", () => {
+    it("loads the inbox profile with the expected bundled agents", () => {
+        const config = getProviderConfig("inbox");
+
+        expect(Object.keys(config.agents)).toEqual([
+            "chat",
+            "list",
+            "timer",
+            "player",
+            "powershell",
+            "utility",
+            "taskflow",
+            "browser",
+            "code",
+            "visualStudio",
+            "github-cli",
+            "calendar",
+            "email",
+            "greeting",
+        ]);
+        expect(config.agents.chat.execMode).toBe("dispatcher");
+        expect(config.agents.taskflow.execMode).toBe("dispatcher");
+        expect(config.agents.greeting.execMode).toBe("dispatcher");
+        expect(config.explainers.v5.constructions?.data).toEqual([
+            "./data/explainer/v5/data/player/basic.json",
+        ]);
+    });
+});

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -93,7 +93,7 @@ pnpm run build
 node tools/scripts/deployAgentServer.mjs `
   --out "$env:TEMP\typeagent-msi-stage\agent-server" `
   --platform win32 --arch x64 `
-  --profile service
+  --profile inbox
 ```
 
 #### 3. Stage copilot-plugin

--- a/ts/tools/scripts/packageOptionalAgents.mjs
+++ b/ts/tools/scripts/packageOptionalAgents.mjs
@@ -7,7 +7,7 @@
  * self-contained, installable bundles — Option 3 from
  * codeDocs .../2026-06-11_typeagent-plugin-agent-distribution.
  *
- * The lean service profile (config.<profile>.json) drops some agents; this packs
+ * The lean inbox profile (config.<profile>.json) drops some agents; this packs
  * each dropped agent so users can reinstall it on demand. Each agent is produced
  * via `pnpm deploy` (a folder with the agent + its full dep closure bundled in
  * node_modules, and its manifest/grammar data files intact), then foreign-arch
@@ -21,7 +21,7 @@
  * (M1) required.
  *
  * Usage (from ts/):
- *   node tools/scripts/packageOptionalAgents.mjs --out <dir> [--profile service]
+ *   node tools/scripts/packageOptionalAgents.mjs --out <dir> [--profile inbox]
  *        [--agents code-agent,markdown-agent] [--platform win32] [--arch x64]
  *        [--skip-prune]
  */
@@ -35,7 +35,7 @@ const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const tsRoot = path.resolve(scriptsDir, "..", "..");
 
 function parseArgs(argv) {
-    const args = { profile: "service", skipPrune: false };
+    const args = { profile: "inbox", skipPrune: false };
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
         if (a === "--out") args.out = argv[++i];

--- a/ts/tools/scripts/policyChecks/agentKeyword.mjs
+++ b/ts/tools/scripts/policyChecks/agentKeyword.mjs
@@ -17,6 +17,7 @@ const PROVIDER_CONFIG_FILES = [
     "config.json",
     "config.all.json",
     "config.agent.json",
+    "config.inbox.json",
     "config.service.json",
     "config.test.json",
 ];

--- a/ts/tools/scripts/pruneUnusedAgents.mjs
+++ b/ts/tools/scripts/pruneUnusedAgents.mjs
@@ -28,14 +28,14 @@
  * pruned artifact (e.g. `node dist/server.js --config <profile>`) to confirm.
  *
  * Usage:
- *   node tools/scripts/pruneUnusedAgents.mjs --dir <deployDir> [--profile service] [--dry-run]
+ *   node tools/scripts/pruneUnusedAgents.mjs --dir <deployDir> [--profile inbox] [--dry-run]
  */
 
 import fs from "node:fs";
 import path from "node:path";
 
 function parseArgs(argv) {
-    const args = { profile: "service", dryRun: false };
+    const args = { profile: "inbox", dryRun: false };
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
         if (a === "--dir") args.dir = argv[++i];

--- a/ts/tools/scripts/typeagent-serve.mjs
+++ b/ts/tools/scripts/typeagent-serve.mjs
@@ -141,8 +141,8 @@ function spawnDaemon(port) {
     const idle = arg("--idle-timeout");
     const args = [serverEntry, "--port", String(port)];
     if (idle) args.push("--idle-timeout", idle);
-    // Agent profile: a reduced provider config (e.g. "service" ->
-    // data/config.service.json) so the daemon loads only the agents this
+    // Agent profile: a reduced provider config (e.g. "inbox" ->
+    // data/config.inbox.json) so the daemon loads only the agents this
     // deployment ships. Precedence: --config arg > env > the .typeagent-profile
     // marker written by deployAgentServer when the artifact was profile-pruned
     // (the pruned artifact CANNOT load excluded agents, so this default is


### PR DESCRIPTION
Adds a new 14-agent  inbox  profile for agent-server deployments and makes it the default publishing profile. This give a usable inbox experience while still trimming install size, service startup etc.

Updates pruning, optional-agent packaging, policy checks, tests, and installer documentation to support the new profile while retaining  greeting  for Electron shell startup