### PR TITLE
fix bare optional/star/plus quantifiers on rule references

### DIFF
--- a/ts/packages/actionGrammar/src/builtInGrammarCategories.ts
+++ b/ts/packages/actionGrammar/src/builtInGrammarCategories.ts
@@ -10,7 +10,7 @@
  * the stored grammar is fully self-contained.
  *
  * Naming convention for prompt use: <CategoryName>
- * Usage in patterns: (<CategoryName>)?   (note: (<Name>)? not <Name>? — bare optional not yet supported)
+ * Usage in patterns: (<CategoryName>)? or bare <CategoryName>?
  */
 export interface BuiltInGrammarCategory {
     /** AGR rule name — used as <Name> in patterns */

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -1318,6 +1318,7 @@ function createGrammarRule(
                 // match time — no rule definition needed, no NFA state expansion.
                 // BUT: only use the phrase-set if the rule is NOT defined locally
                 // or via import (preserves grammars that define their own <Polite> etc.)
+                const { optional, repeat } = expr;
                 const isLocallyDefined =
                     context.ruleDefMap.has(expr.refName.name) ||
                     context.importedRuleMap.has(expr.refName.name);
@@ -1325,22 +1326,37 @@ function createGrammarRule(
                     !isLocallyDefined &&
                     globalPhraseSetRegistry.isPhraseSetName(expr.refName.name)
                 ) {
-                    parts.push(
-                        createPhraseSetPart(
-                            expr.refName.name,
-                            undefined,
-                            allocPartId(
-                                context,
-                                expr.pos,
-                                `<${expr.refName.name}>`,
-                            ),
+                    const phrasePart = createPhraseSetPart(
+                        expr.refName.name,
+                        undefined,
+                        allocPartId(
+                            context,
+                            expr.pos,
+                            `<${expr.refName.name}>`,
                         ),
                     );
+                    // PhraseSetPart cannot carry optional/repeat; wrap so bare
+                    // <Polite>? / <Polite>* / <Polite>+ match grouped form.
+                    if (optional || repeat) {
+                        parts.push(
+                            createRulesPart([{ parts: [phrasePart] }], {
+                                optional,
+                                repeat,
+                                partId: allocPartId(
+                                    context,
+                                    expr.pos,
+                                    `<${expr.refName.name}>${repeat ? (optional ? "*" : "+") : "?"}`,
+                                ),
+                            }),
+                        );
+                    } else {
+                        parts.push(phrasePart);
+                    }
                     // Phrase sets don't produce a captured value on their own.
                     // Use defaultValue=true so single-part rules using a phrase set
                     // don't trip the "Start rule does not produce a value" check.
                     defaultValue = true;
-                    consumedInput(); // phrase sets always consume input
+                    if (!optional) consumedInput(); // required / + still consume
                     break;
                 }
                 const record = createNamedGrammarRules(
@@ -1355,6 +1371,8 @@ function createGrammarRule(
                 parts.push(
                     createRulesPart(record.grammarRules, {
                         name: expr.refName.name,
+                        optional,
+                        repeat,
                         partId: allocPartId(
                             context,
                             expr.pos,
@@ -1362,14 +1380,16 @@ function createGrammarRule(
                         ),
                     }),
                 );
-                // RuleRefExpr has no optional modifier; it is always non-optional.
+                // Optional / * rule refs can be skipped — do not force non-null.
                 // === false: only clear when *definitely* non-nullable (same
                 // asymmetry as the variable ruleRef case above).
-                if (record.nullable === false) {
-                    currentEpr = new Set();
+                if (!optional) {
+                    if (record.nullable === false) {
+                        currentEpr = new Set();
+                    }
+                    // ?? false: treat undefined (back-ref) as non-nullable.
+                    ruleNullable = ruleNullable && (record.nullable ?? false);
                 }
-                // ?? false: treat undefined (back-ref) as non-nullable.
-                ruleNullable = ruleNullable && (record.nullable ?? false);
                 break;
             }
             case "rules": {

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -86,7 +86,7 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *    // TODO: Support nested instead of just Rule Ref
  *   <VariableSpecifier> ::= <VarName> (":" (<TypeName> | <RuleName>))?
  *
- *   <RuleRefExpr> ::= <RuleName>
+ *   <RuleRefExpr> ::= <RuleName> ( "?" | "*" | "+" )?
  *   <GroupExpr> ::= "(" <Rules> ( ")" | ")?" | ")*" | ")+" )
  *
  *   // ── Value (basic mode: enableValueExpressions=false) ──────────────────────────
@@ -231,6 +231,8 @@ export type CommentedName = {
 export type RuleRefExpr = {
     type: "ruleReference";
     refName: CommentedName;
+    optional?: boolean | undefined;
+    repeat?: boolean | undefined; // Kleene star/plus: zero-or-more / one-or-more
     pos?: number | undefined;
     leadingComments?: Comment[] | undefined;
 };
@@ -802,6 +804,20 @@ class GrammarRuleParser implements ValueExprParserContext {
                     refName: this.parseRuleName(),
                     pos,
                 };
+                // Bare quantifiers on rule refs: <Name>?, <Name>*, <Name>+
+                // (equivalent to (<Name>)?, (<Name>)*, (<Name>)+).
+                // Without this, "?" is parsed as a literal string part.
+                if (this.isAt("?")) {
+                    node.optional = true;
+                    this.skipWhitespace(1);
+                } else if (this.isAt("*")) {
+                    node.optional = true;
+                    node.repeat = true;
+                    this.skipWhitespace(1);
+                } else if (this.isAt("+")) {
+                    node.repeat = true;
+                    this.skipWhitespace(1);
+                }
                 attach(node);
                 expNodes.push(node);
                 continue;

--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -923,6 +923,11 @@ function writeSingleExpr(
         }
         case "ruleReference":
             writeBracketedName(result, expr.refName);
+            if (expr.repeat) {
+                result.write(expr.optional ? "*" : "+");
+            } else if (expr.optional) {
+                result.write("?");
+            }
             break;
         case "rules": {
             result.write("(");

--- a/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
+++ b/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
@@ -14,10 +14,7 @@ import { loadGrammarRules } from "../src/grammarLoader.js";
 import { writeGrammarRules } from "../src/grammarRuleWriter.js";
 import { describeForEachMatcher } from "./testUtils.js";
 
-function defNamed(
-    ast: ReturnType<typeof parseGrammarRules>,
-    name: string,
-) {
+function defNamed(ast: ReturnType<typeof parseGrammarRules>, name: string) {
     return ast.definitions.find((d) => d.definitionName.name === name)!;
 }
 

--- a/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
+++ b/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
@@ -234,7 +234,9 @@ describeForEachMatcher(
             expect(testMatchGrammar(g, "open the output panel")).toStrictEqual([
                 "panel",
             ]);
-            expect(testMatchGrammar(g, "open a output panel")).toStrictEqual([]);
+            expect(testMatchGrammar(g, "open a output panel")).toStrictEqual(
+                [],
+            );
         });
 
         it("group quantifiers ()? / ()* / ()+ stay independent of bare-ref fix", () => {
@@ -257,7 +259,9 @@ describeForEachMatcher(
                 "star",
             ]);
             expect(testMatchGrammar(g, "need")).toStrictEqual([]);
-            expect(testMatchGrammar(g, "need reviewer")).toStrictEqual(["plus"]);
+            expect(testMatchGrammar(g, "need reviewer")).toStrictEqual([
+                "plus",
+            ]);
         });
 
         it("wrong tails still fail when an optional rule ref is skipped or taken", () => {

--- a/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
+++ b/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Bare quantifiers on rule references: <Name>?, <Name>*, <Name>+
+ *
+ * Previously "?" after a rule ref was parsed as a literal string part, so
+ * `show <Owner>? files` failed to match `show files` while the grouped form
+ * `show (<Owner>)? files` worked. This suite locks the parse/compile/match
+ * behavior for bare optional/star/plus rule refs.
+ */
+import { parseGrammarRules } from "../src/grammarRuleParser.js";
+import { loadGrammarRules } from "../src/grammarLoader.js";
+import { writeGrammarRules } from "../src/grammarRuleWriter.js";
+import { describeForEachMatcher } from "./testUtils.js";
+
+function defNamed(
+    ast: ReturnType<typeof parseGrammarRules>,
+    name: string,
+) {
+    return ast.definitions.find((d) => d.definitionName.name === name)!;
+}
+
+describe("Bare optional / star / plus rule references", () => {
+    it("parses <Owner>? as optional ruleReference (not a literal '?')", () => {
+        const ast = parseGrammarRules(
+            "test.agr",
+            `
+            <Owner> = alice | bob;
+            <Start> = show <Owner>? files -> true;
+            `,
+            false,
+        );
+        const exprs = defNamed(ast, "Start").rules[0].expressions;
+        expect(exprs.map((e) => e.type)).toEqual([
+            "string",
+            "ruleReference",
+            "string",
+        ]);
+        const ref = exprs[1] as {
+            type: "ruleReference";
+            optional?: boolean;
+            repeat?: boolean;
+            refName: { name: string };
+        };
+        expect(ref.refName.name).toBe("Owner");
+        expect(ref.optional).toBe(true);
+        expect(ref.repeat).toBeUndefined();
+    });
+
+    it("parses <Owner>* and <Owner>+ with repeat flags", () => {
+        const star = parseGrammarRules(
+            "test.agr",
+            `<Owner> = a; <Start> = x <Owner>* y -> true;`,
+            false,
+        );
+        const starRef = defNamed(star, "Start").rules[0].expressions[1] as {
+            optional?: boolean;
+            repeat?: boolean;
+        };
+        expect(starRef.optional).toBe(true);
+        expect(starRef.repeat).toBe(true);
+
+        const plus = parseGrammarRules(
+            "test.agr",
+            `<Owner> = a; <Start> = x <Owner>+ y -> true;`,
+            false,
+        );
+        const plusRef = defNamed(plus, "Start").rules[0].expressions[1] as {
+            optional?: boolean;
+            repeat?: boolean;
+        };
+        expect(plusRef.optional).toBeUndefined();
+        expect(plusRef.repeat).toBe(true);
+    });
+
+    it("round-trips bare optional / star / plus rule refs through the writer", () => {
+        const src = `
+            <Owner> = alice | bob;
+            <Opt> = show <Owner>? files -> "opt";
+            <Star> = show <Owner>* files -> "star";
+            <Plus> = show <Owner>+ files -> "plus";
+        `;
+        const ast = parseGrammarRules("test.agr", src, false);
+        const written = writeGrammarRules(ast);
+        const reparsed = parseGrammarRules("roundtrip.agr", written, false);
+        const getRef = (name: string) =>
+            defNamed(reparsed, name).rules[0].expressions[1] as {
+                type: string;
+                optional?: boolean;
+                repeat?: boolean;
+            };
+        expect(getRef("Opt")).toMatchObject({
+            type: "ruleReference",
+            optional: true,
+        });
+        expect(getRef("Star")).toMatchObject({
+            type: "ruleReference",
+            optional: true,
+            repeat: true,
+        });
+        expect(getRef("Plus")).toMatchObject({
+            type: "ruleReference",
+            repeat: true,
+        });
+        expect(getRef("Plus").optional).toBeFalsy();
+    });
+});
+
+describeForEachMatcher(
+    "Bare optional rule ref matching",
+    (testMatchGrammar) => {
+        const ownerGrammar = `
+            <Owner> = alice | bob;
+            <Start> = show <Owner>? files -> "bare";
+        `;
+        const groupedGrammar = `
+            <Owner> = alice | bob;
+            <Start> = show (<Owner>)? files -> "grouped";
+        `;
+        const requiredGrammar = `
+            <Owner> = alice | bob;
+            <Start> = show <Owner> files -> "required";
+        `;
+
+        it("matches without the optional owner (bare <Owner>?)", () => {
+            const g = loadGrammarRules("test.agr", ownerGrammar);
+            expect(testMatchGrammar(g, "show files")).toStrictEqual(["bare"]);
+        });
+
+        it("matches with the optional owner present (bare <Owner>?)", () => {
+            const g = loadGrammarRules("test.agr", ownerGrammar);
+            expect(testMatchGrammar(g, "show alice files")).toStrictEqual([
+                "bare",
+            ]);
+            expect(testMatchGrammar(g, "show bob files")).toStrictEqual([
+                "bare",
+            ]);
+        });
+
+        it("bare <Owner>? is equivalent to grouped (<Owner>)?", () => {
+            const bare = loadGrammarRules("bare.agr", ownerGrammar);
+            const grouped = loadGrammarRules("grouped.agr", groupedGrammar);
+            for (const input of [
+                "show files",
+                "show alice files",
+                "show bob files",
+            ]) {
+                expect(testMatchGrammar(bare, input)).toStrictEqual(
+                    testMatchGrammar(grouped, input).map(() => "bare"),
+                );
+                // grouped returns "grouped"; compare match success only
+                expect(testMatchGrammar(bare, input).length).toBe(
+                    testMatchGrammar(grouped, input).length,
+                );
+            }
+        });
+
+        it("required <Owner> still rejects missing owner", () => {
+            const g = loadGrammarRules("test.agr", requiredGrammar);
+            expect(testMatchGrammar(g, "show files")).toStrictEqual([]);
+            expect(testMatchGrammar(g, "show alice files")).toStrictEqual([
+                "required",
+            ]);
+        });
+
+        it("bare <Owner>* matches zero or more owners", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <Owner> = alice | bob;
+                <Start> = show <Owner>* files -> "star";
+                `,
+            );
+            expect(testMatchGrammar(g, "show files")).toStrictEqual(["star"]);
+            expect(testMatchGrammar(g, "show alice files")).toStrictEqual([
+                "star",
+            ]);
+            expect(testMatchGrammar(g, "show alice bob files")).toStrictEqual([
+                "star",
+            ]);
+        });
+
+        it("bare <Owner>+ requires at least one owner", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <Owner> = alice | bob;
+                <Start> = show <Owner>+ files -> "plus";
+                `,
+            );
+            expect(testMatchGrammar(g, "show files")).toStrictEqual([]);
+            expect(testMatchGrammar(g, "show alice files")).toStrictEqual([
+                "plus",
+            ]);
+            expect(testMatchGrammar(g, "show alice bob files")).toStrictEqual([
+                "plus",
+            ]);
+        });
+    },
+);

--- a/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
+++ b/ts/packages/actionGrammar/test/optionalRuleRef.spec.ts
@@ -194,5 +194,92 @@ describeForEachMatcher(
                 "plus",
             ]);
         });
+
+        // --- Non-breaking / additive-only guards ---
+
+        it("grouped (<Owner>)? is unchanged (pre-existing supported form)", () => {
+            const g = loadGrammarRules("test.agr", groupedGrammar);
+            expect(testMatchGrammar(g, "show files")).toStrictEqual([
+                "grouped",
+            ]);
+            expect(testMatchGrammar(g, "show alice files")).toStrictEqual([
+                "grouped",
+            ]);
+            expect(testMatchGrammar(g, "show charlie files")).toStrictEqual([]);
+        });
+
+        it("required rule refs without quantifiers stay required", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <App> = outlook | teams | edge;
+                <Start> = open <App> -> "app";
+                `,
+            );
+            expect(testMatchGrammar(g, "open")).toStrictEqual([]);
+            expect(testMatchGrammar(g, "open outlook")).toStrictEqual(["app"]);
+            expect(testMatchGrammar(g, "open notepad")).toStrictEqual([]);
+        });
+
+        it("pre-existing (the)? string groups are unchanged", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <Start> = open (the)? output panel -> "panel";
+                `,
+            );
+            expect(testMatchGrammar(g, "open output panel")).toStrictEqual([
+                "panel",
+            ]);
+            expect(testMatchGrammar(g, "open the output panel")).toStrictEqual([
+                "panel",
+            ]);
+            expect(testMatchGrammar(g, "open a output panel")).toStrictEqual([]);
+        });
+
+        it("group quantifiers ()? / ()* / ()+ stay independent of bare-ref fix", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <Start> =
+                    mute (notifications)? -> "opt"
+                  | tag (bug | feature)* -> "star"
+                  | need (reviewer)+ -> "plus"
+                ;
+                `,
+            );
+            expect(testMatchGrammar(g, "mute")).toStrictEqual(["opt"]);
+            expect(testMatchGrammar(g, "mute notifications")).toStrictEqual([
+                "opt",
+            ]);
+            expect(testMatchGrammar(g, "tag")).toStrictEqual(["star"]);
+            expect(testMatchGrammar(g, "tag bug feature")).toStrictEqual([
+                "star",
+            ]);
+            expect(testMatchGrammar(g, "need")).toStrictEqual([]);
+            expect(testMatchGrammar(g, "need reviewer")).toStrictEqual(["plus"]);
+        });
+
+        it("wrong tails still fail when an optional rule ref is skipped or taken", () => {
+            const g = loadGrammarRules(
+                "test.agr",
+                `
+                <Polite> = please | can you;
+                <Start> = <Polite>? delete the production database -> "ok";
+                `,
+            );
+            expect(
+                testMatchGrammar(g, "delete the production database"),
+            ).toStrictEqual(["ok"]);
+            expect(
+                testMatchGrammar(g, "please delete the production database"),
+            ).toStrictEqual(["ok"]);
+            expect(
+                testMatchGrammar(g, "please delete the staging database"),
+            ).toStrictEqual([]);
+            expect(
+                testMatchGrammar(g, "open the production database"),
+            ).toStrictEqual([]);
+        });
     },
 );


### PR DESCRIPTION
Additive only: bare <Rule>?/*/+ now parse like grouped form; required refs, grouped (), and existing patterns unchanged.

We currently have many cases of "?" usage which represent optionality but are treated as literals.

```
<VideoPhrase> = <Polite>? <CreateVerb> <VideoTarget> <VideoContent>? | <VideoTarget> <FromFiles> | <NeedPhrase> <VideoTarget>;
```

https://github.com/microsoft/TypeAgent/blob/259622468be6e20e0812ca8df25f0797668933d0/ts/packages/agents/video/src/videoSchema.agr#L27

https://github.com/search?q=repo%3Amicrosoft%2FTypeAgent+%22%3E%3F%22+path%3A**%2F*.agr&type=code


On main right now,  we have below behavior. The PR fix this so that "?" is not treated as a literal

```
BARE grammar:

<Polite> = please | could you | can you | kindly;
<Start> = <Polite>? open outlook → "matched";

BARE Start expressions:

{
  "type": "ruleReference",
  "name": "Polite",
  "optional": false,
  "repeat": false
},
{
  "type": "string",
  "value": [
    "?",
    "open",
    "outlook"
  ]
}
```