### PR TITLE
Fix PowerShell grammar misroutes for memory/cpu hogs and IP config

### DIFF
--- a/ts/packages/agents/powershell/src/namespaces/network/networkSchema.agr
+++ b/ts/packages/agents/powershell/src/namespaces/network/networkSchema.agr
@@ -45,7 +45,10 @@ import { PowerShellNetworkActions } from "./networkActionsSchema.mts";
       -> { actionName: "networkAdapters", parameters: { name } };
 
 <IpConfig> =
-    (show|get|my) ip (address|config|configuration)?
+    // "show my ip address" — needs both "show" and "my" (not covered by (show|get|my) alone)
+    (show|get) (me)? my ip (address|config|configuration)?
+      -> { actionName: "ipConfig", parameters: {} }
+  | (show|get|my) ip (address|config|configuration)?
       -> { actionName: "ipConfig", parameters: {} }
   | ipconfig
       -> { actionName: "ipConfig", parameters: {} }

--- a/ts/packages/agents/powershell/src/namespaces/processes/processesSchema.agr
+++ b/ts/packages/agents/powershell/src/namespaces/processes/processesSchema.agr
@@ -26,6 +26,9 @@ import { PowerShellProcessesActions } from "./processesActionsSchema.mts";
 <ProcessMemory> =
     (show|what's|what is) (using)? (the)? (most)? memory
       -> { actionName: "processMemory", parameters: {} }
+  // "show top 5 memory hogs" — needs both "show" and "top" (not covered by (top|show) alone)
+  | show top $(topN:number) memory (hogs|usage|consumers|processes)?
+      -> { actionName: "processMemory", parameters: { topN } }
   | (top|show) $(topN:number)? memory (hogs|usage|consumers)
       -> { actionName: "processMemory", parameters: { topN } }
   | processes (sorted)? by memory (usage)?
@@ -36,6 +39,9 @@ import { PowerShellProcessesActions } from "./processesActionsSchema.mts";
 <ProcessCpu> =
     (show|what's|what is) (using)? (the)? (most)? cpu
       -> { actionName: "processCpu", parameters: {} }
+  // "show top 10 cpu hogs" — needs both "show" and "top"
+  | show top $(topN:number) cpu (hogs|usage|consumers|processes)?
+      -> { actionName: "processCpu", parameters: { topN } }
   | (top|show) $(topN:number)? cpu (hogs|usage|consumers)
       -> { actionName: "processCpu", parameters: { topN } }
   | processes (sorted)? by cpu (usage)?


### PR DESCRIPTION
Additive only: new PowerShell grammar alternates for show-top memory/cpu and show-my-ip; existing patterns kept.