### PR TITLE
Improve devcontainer host user and npm registry setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,17 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
 ENV NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY
 
+# Rename the default `vscode` user/group to match the host username when
+# USERNAME is passed as a build arg (used by the agent devcontainer variant).
+# Defaults to "vscode" (the existing user) so this is a no-op for all other
+# variants that don't pass USERNAME.
+ARG USERNAME=vscode
+RUN if [ "$USERNAME" != "vscode" ] && [ -n "$USERNAME" ]; then \
+    usermod  -l "$USERNAME" vscode && \
+    groupmod -n "$USERNAME" vscode && \
+    usermod  -d "/home/$USERNAME" -m "$USERNAME"; \
+    fi
+
 # Pre-install system libraries so post-create.sh doesn't need to apt-get install
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
+ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+ENV NPM_CONFIG_REGISTRY=$NPM_CONFIG_REGISTRY
+
 # Pre-install system libraries so post-create.sh doesn't need to apt-get install
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/.devcontainer/agent/devcontainer.json
+++ b/.devcontainer/agent/devcontainer.json
@@ -3,7 +3,8 @@
   "build": {
     "dockerfile": "../Dockerfile",
     "args": {
-      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
+      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}",
+      "USERNAME": "${localEnv:USER}"
     }
   },
 
@@ -23,9 +24,10 @@
   // host. Use ../devcontainer.json (the default config) for Codespaces.
   //
   // Prerequisites on the host:
-  //   - Your host user's UID matches the `codespace` user inside the
-  //     container. `updateRemoteUserUID` below handles the common case
-  //     by re-chowning `codespace` to your host UID on first start.
+  //   - $USER must be set in your local environment (it always is on Linux/macOS).
+  //     The container user is created with the same name and re-chowned to your
+  //     UID/GID by `updateRemoteUserUID` on first start, so file ownership on
+  //     the bind-mounted source tree is transparent.
   //   - The sibling `<repo>.worktrees` directory must exist on the host
   //     before container start (Docker bind-mount requirement). The
   //     `initializeCommand` below creates it automatically.
@@ -55,13 +57,11 @@
       "installZsh": true,
       "configureZshAsDefaultShell": true,
       "installOhMyZsh": true,
-      "username": "codespace",
-      "userUid": "1001",
-      "userGid": "1001"
+      "username": "automatic"
     }
   },
 
-  // Re-chown the `codespace` user to the host user's UID/GID on container
+  // Re-chown the container user to the host user's UID/GID on container
   // start so the bind-mounted source tree (owned by the host user) is
   // writable from inside the container.
   "updateRemoteUserUID": true,
@@ -133,17 +133,17 @@
     // sides.
     "source=${localWorkspaceFolder}.worktrees,target=${localWorkspaceFolder}.worktrees,type=bind,consistency=cached",
     // Global pnpm store - shared across containers for fast installs.
-    "source=pnpm-global-store,target=/home/codespace/.local/share/pnpm/store,type=volume",
+    "source=pnpm-global-store,target=/home/${localEnv:USER}/.local/share/pnpm/store,type=volume",
     // Per-container node_modules stays on a named volume. We deliberately
     // do NOT bind-mount this to the host: native modules (better-sqlite3,
     // etc.) are compiled for the container's libc/arch and would clash
     // with anything the host has built.
     "source=typeagent-node_modules-${devcontainerId},target=${containerWorkspaceFolder}/ts/node_modules,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/codespace/.claude,type=volume",
-    "source=copilot-cli-config-${devcontainerId},target=/home/codespace/.copilot,type=volume",
+    "source=claude-code-config-${devcontainerId},target=/home/${localEnv:USER}/.claude,type=volume",
+    "source=copilot-cli-config-${devcontainerId},target=/home/${localEnv:USER}/.copilot,type=volume",
     // VS Code server data (extensions, settings cache, workspace storage, history)
     // so editor state survives container recreate.
-    "source=vscode-server-${devcontainerId},target=/home/codespace/.vscode-server,type=volume"
+    "source=vscode-server-${devcontainerId},target=/home/${localEnv:USER}/.vscode-server,type=volume"
   ],
 
   "containerEnv": {
@@ -177,7 +177,7 @@
     }
   },
 
-  "remoteUser": "codespace",
+  "remoteUser": "${localEnv:USER}",
 
   "hostRequirements": {
     "cpus": 4,

--- a/.devcontainer/agent/devcontainer.json
+++ b/.devcontainer/agent/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "TypeAgent Development (Agent Worktrees)",
-  "build": { "dockerfile": "../Dockerfile" },
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
+    }
+  },
 
   // Variant of the standard devcontainer where the container sees the
   // workspace at the SAME absolute path as the host. This lets VS Code's
@@ -143,7 +148,9 @@
 
   "containerEnv": {
     "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
-    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
+    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}",
+    "TYPEAGENT_USE_COREPACK": "${localEnv:TYPEAGENT_USE_COREPACK}",
+    "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
   },
 
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "TypeAgent Development",
-  "build": { "dockerfile": "Dockerfile" },
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
+    }
+  },
 
   // Multi-arch base image (linux/amd64 and linux/arm64) so this configuration
   // works on Apple Silicon as well as x86_64 hosts.
@@ -75,7 +80,9 @@
 
   "containerEnv": {
     "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
-    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
+    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}",
+    "TYPEAGENT_USE_COREPACK": "${localEnv:TYPEAGENT_USE_COREPACK}",
+    "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
     // For Codespaces, set these as repository secrets:
     // - AZURE_OPENAI_API_KEY
     // - AZURE_OPENAI_ENDPOINT

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -105,33 +105,6 @@ echo ""
 # Navigate to TypeScript workspace
 cd "$TS_DIR"
 
-# Enable pnpm
-echo ""
-echo "Enabling corepack and pnpm..."
-if command -v corepack &> /dev/null; then
-    corepack enable || echo "Warning: corepack enable failed"
-    # Use the pnpm version pinned in package.json (packageManager field)
-    corepack install || echo "Warning: corepack install failed"
-else
-    echo "Warning: corepack not found, checking for pnpm..."
-    if ! command -v pnpm &> /dev/null; then
-        echo "Installing pnpm via npm..."
-        npm install -g pnpm || { echo "Failed to install pnpm"; exit 1; }
-    fi
-fi
-
-# Verify pnpm is available
-if ! command -v pnpm &> /dev/null; then
-    echo "Error: pnpm is not available after setup"
-    exit 1
-fi
-
-echo "pnpm version: $(pnpm --version)"
-
-# Point pnpm store at the Docker named volume so it persists across rebuilds
-pnpm config set store-dir /home/codespace/.local/share/pnpm/store --global
-echo "pnpm store-dir: $(pnpm store path)"
-
 echo ""
 echo "Installing system libraries required by TypeAgent..."
 # libsecret is required by keytar / native credential storage used by some
@@ -192,6 +165,41 @@ if [[ -z "$CURRENT_GIT_NAME" && -z "$DESIRED_GIT_NAME" ]] || \
     echo "    git config --global user.name  \"Your Name\""
     echo "    git config --global user.email \"you@example.com\""
 fi
+
+# Enable pnpm
+echo ""
+echo "Installing pnpm..."
+PACKAGE_MANAGER=$(node -p "require('./package.json').packageManager")
+if [[ "$PACKAGE_MANAGER" != pnpm@* ]]; then
+    echo "Error: package.json packageManager does not specify pnpm: $PACKAGE_MANAGER" >&2
+    exit 1
+fi
+PNPM_VERSION=${PACKAGE_MANAGER#pnpm@}
+PNPM_VERSION=${PNPM_VERSION%%+sha512.*}
+
+if [[ "${TYPEAGENT_USE_COREPACK:-0}" == "1" ]] && command -v corepack &> /dev/null; then
+    corepack enable || echo "Warning: corepack enable failed"
+    # Use the pnpm version pinned in package.json (packageManager field)
+    corepack install || echo "Warning: corepack install failed"
+else
+    if [[ "${TYPEAGENT_USE_COREPACK:-0}" == "1" ]]; then
+        echo "Warning: corepack not found, falling back to npm..."
+    fi
+    echo "Installing pnpm@$PNPM_VERSION via npm..."
+    npm install -g "pnpm@$PNPM_VERSION" || { echo "Failed to install pnpm@$PNPM_VERSION"; exit 1; }
+fi
+
+# Verify pnpm is available
+if ! command -v pnpm &> /dev/null; then
+    echo "Error: pnpm is not available after setup"
+    exit 1
+fi
+
+echo "pnpm version: $(pnpm --version)"
+
+# Point pnpm store at the Docker named volume so it persists across rebuilds
+pnpm config set store-dir /home/codespace/.local/share/pnpm/store --global
+echo "pnpm store-dir: $(pnpm store path)"
 
 # Install dependencies
 echo ""

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -39,11 +39,11 @@ echo ""
 # (e.g. `pnpm install` -> EACCES on ts/node_modules).
 echo "Fixing ownership of mounted volume directories..."
 VOLUME_PATHS=(
-    "/home/codespace/.local/share/pnpm"
-    "/home/codespace/.local/share/pnpm/store"
-    "/home/codespace/.claude"
-    "/home/codespace/.copilot"
-    "/home/codespace/.vscode-server"
+    "$HOME/.local/share/pnpm"
+    "$HOME/.local/share/pnpm/store"
+    "$HOME/.claude"
+    "$HOME/.copilot"
+    "$HOME/.vscode-server"
 )
 # Discover the workspace ts/node_modules path dynamically (works for worktrees
 # and for variants that mount the workspace outside /workspaces, e.g. the
@@ -78,7 +78,7 @@ TS_DIR=$(resolve_ts_workspace)
 echo "Looking for TypeScript workspace..."
 if [[ -n "$TS_DIR" ]]; then
     echo "Found: $TS_DIR"
-    # VOLUME_PATHS+=("$TS_DIR/node_modules")
+    VOLUME_PATHS+=("$TS_DIR/node_modules")
 else
     echo "Error: Could not find TypeScript workspace directory (expected ts/)" >&2
     echo "Checked: git repo root, current directory, containerWorkspaceFolder, /workspaces" >&2
@@ -89,7 +89,7 @@ fi
 
 for p in "${VOLUME_PATHS[@]}"; do
     if [[ -e "$p" ]]; then
-        if sudo chown -R codespace:codespace "$p"; then
+        if sudo chown -R "$(id -u):$(id -g)" "$p"; then
             echo "  chowned $p"
         else
             if [[ "$p" == *"/pnpm/store" ]] || [[ "$p" == *"/node_modules" ]]; then
@@ -196,7 +196,7 @@ if ! npm config set registry "$EFFECTIVE_NPM_REGISTRY" --global; then
 fi
 # Ensure pnpm's expected home/bin paths exist and are on PATH for this script.
 # This avoids global/bin-dir errors in non-interactive shells.
-export PNPM_HOME="${PNPM_HOME:-/home/codespace/.local/share/pnpm}"
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
 mkdir -p "$PNPM_HOME/bin"
 export PATH="$PNPM_HOME/bin:$PATH"
 
@@ -228,19 +228,29 @@ fi
 echo "pnpm registry: $(pnpm config get registry)"
 
 # Keep PATH stable for later interactive shells as well.
-if [[ -f /home/codespace/.bashrc ]] && ! grep -q 'export PNPM_HOME=/home/codespace/.local/share/pnpm' /home/codespace/.bashrc; then
+if [[ -f "$HOME/.bashrc" ]] && ! grep -q 'PNPM_HOME' "$HOME/.bashrc"; then
     {
         echo ''
         echo '# pnpm home (set by TypeAgent post-create)'
-        echo 'export PNPM_HOME=/home/codespace/.local/share/pnpm'
+        echo "export PNPM_HOME=$HOME/.local/share/pnpm"
         echo 'export PATH="$PNPM_HOME/bin:$PATH"'
-    } >> /home/codespace/.bashrc
+    } >> "$HOME/.bashrc"
 fi
 
 # Point pnpm store at the Docker named volume so it persists across rebuilds
-pnpm config set store-dir /home/codespace/.local/share/pnpm/store --global
+pnpm config set store-dir "$HOME/.local/share/pnpm/store" --global
 echo "pnpm store-dir: $(pnpm store path)"
 
+# Install dependencies
+echo ""
+echo "Installing pnpm dependencies..."
+echo "This may take a few minutes on first run..."
+if ! pnpm install; then
+    echo ""
+    echo "Error: pnpm install failed." >&2
+    echo "This is often due to network issues or missing system dependencies." >&2
+    exit 1
+fi
 
 # - Security hardening: restrict sudo to a minimal allowlist
 # During post-create we needed unrestricted root access to install

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -262,11 +262,12 @@ fi
 # (e.g. apt-get -o hook injection, chown on /etc/shadow).
 echo ""
 echo "Hardening sudo access..."
-SUDOERS_FILE="/etc/sudoers.d/codespace-restricted"
-sudo tee "$SUDOERS_FILE" > /dev/null << 'SUDOERS'
-# Restricted sudo for the codespace user (post-setup hardening).
+CURRENT_USER=$(id -un)
+SUDOERS_FILE="/etc/sudoers.d/${CURRENT_USER}-restricted"
+sudo tee "$SUDOERS_FILE" > /dev/null <<SUDOERS
+# Restricted sudo for the container user (post-setup hardening).
 # Only allow managing the SSH service — nothing else.
-codespace ALL=(root) NOPASSWD: /usr/sbin/service ssh start, \
+$CURRENT_USER ALL=(root) NOPASSWD: /usr/sbin/service ssh start, \
     /usr/sbin/service ssh stop, \
     /usr/sbin/service ssh restart, \
     /usr/sbin/service ssh status, \
@@ -279,8 +280,14 @@ sudo chmod 0440 "$SUDOERS_FILE"
 # Remove the blanket rule that grants unrestricted root.  The common-utils
 # devcontainer feature writes it to /etc/sudoers.d/codespace (filename
 # matches the username).
-if [[ -f /etc/sudoers.d/codespace ]]; then
-    sudo rm /etc/sudoers.d/codespace
+REMOVED_BROAD_RULE=0
+for broad_rule in "/etc/sudoers.d/$CURRENT_USER" /etc/sudoers.d/codespace; do
+    if [[ -f "$broad_rule" ]]; then
+        sudo rm "$broad_rule"
+        REMOVED_BROAD_RULE=1
+    fi
+done
+if [[ $REMOVED_BROAD_RULE -eq 1 ]]; then
     echo "  Removed blanket NOPASSWD:ALL rule"
 fi
 echo "  Sudo restricted to: service ssh/sshd only"

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -78,7 +78,7 @@ TS_DIR=$(resolve_ts_workspace)
 echo "Looking for TypeScript workspace..."
 if [[ -n "$TS_DIR" ]]; then
     echo "Found: $TS_DIR"
-    VOLUME_PATHS+=("$TS_DIR/node_modules")
+    # VOLUME_PATHS+=("$TS_DIR/node_modules")
 else
     echo "Error: Could not find TypeScript workspace directory (expected ts/)" >&2
     echo "Checked: git repo root, current directory, containerWorkspaceFolder, /workspaces" >&2
@@ -176,6 +176,29 @@ if [[ "$PACKAGE_MANAGER" != pnpm@* ]]; then
 fi
 PNPM_VERSION=${PACKAGE_MANAGER#pnpm@}
 PNPM_VERSION=${PNPM_VERSION%%+sha512.*}
+# Ensure npm/pnpm use the host-provided registry inside the container.
+EFFECTIVE_NPM_REGISTRY="${NPM_CONFIG_REGISTRY:-}"
+if [[ -z "$EFFECTIVE_NPM_REGISTRY" ]]; then
+    EFFECTIVE_NPM_REGISTRY=$(npm config get registry 2>/dev/null || true)
+fi
+if [[ -z "$EFFECTIVE_NPM_REGISTRY" ]] || [[ "$EFFECTIVE_NPM_REGISTRY" == "undefined" ]]; then
+    EFFECTIVE_NPM_REGISTRY="https://registry.npmjs.org/"
+fi
+case "$EFFECTIVE_NPM_REGISTRY" in
+    */) ;;
+    *) EFFECTIVE_NPM_REGISTRY="${EFFECTIVE_NPM_REGISTRY}/" ;;
+esac
+export NPM_CONFIG_REGISTRY="$EFFECTIVE_NPM_REGISTRY"
+export npm_config_registry="$EFFECTIVE_NPM_REGISTRY"
+echo "Using npm registry: $EFFECTIVE_NPM_REGISTRY"
+if ! npm config set registry "$EFFECTIVE_NPM_REGISTRY" --global; then
+    echo "  warn: failed to persist npm registry"
+fi
+# Ensure pnpm's expected home/bin paths exist and are on PATH for this script.
+# This avoids global/bin-dir errors in non-interactive shells.
+export PNPM_HOME="${PNPM_HOME:-/home/codespace/.local/share/pnpm}"
+mkdir -p "$PNPM_HOME/bin"
+export PATH="$PNPM_HOME/bin:$PATH"
 
 if [[ "${TYPEAGENT_USE_COREPACK:-0}" == "1" ]] && command -v corepack &> /dev/null; then
     corepack enable || echo "Warning: corepack enable failed"
@@ -186,7 +209,9 @@ else
         echo "Warning: corepack not found, falling back to npm..."
     fi
     echo "Installing pnpm@$PNPM_VERSION via npm..."
-    npm install -g "pnpm@$PNPM_VERSION" || { echo "Failed to install pnpm@$PNPM_VERSION"; exit 1; }
+    npm install -g "pnpm@$PNPM_VERSION" --registry "$EFFECTIVE_NPM_REGISTRY" || { echo "Failed to install pnpm@$PNPM_VERSION"; exit 1; }
+    # pnpm setup is interactive-shell oriented and may fail in post-create.
+    # We manage PNPM_HOME/PATH directly in this script instead.
 fi
 
 # Verify pnpm is available
@@ -197,20 +222,25 @@ fi
 
 echo "pnpm version: $(pnpm --version)"
 
+if ! pnpm config set registry "$EFFECTIVE_NPM_REGISTRY" --global; then
+    echo "  warn: failed to persist pnpm registry"
+fi
+echo "pnpm registry: $(pnpm config get registry)"
+
+# Keep PATH stable for later interactive shells as well.
+if [[ -f /home/codespace/.bashrc ]] && ! grep -q 'export PNPM_HOME=/home/codespace/.local/share/pnpm' /home/codespace/.bashrc; then
+    {
+        echo ''
+        echo '# pnpm home (set by TypeAgent post-create)'
+        echo 'export PNPM_HOME=/home/codespace/.local/share/pnpm'
+        echo 'export PATH="$PNPM_HOME/bin:$PATH"'
+    } >> /home/codespace/.bashrc
+fi
+
 # Point pnpm store at the Docker named volume so it persists across rebuilds
 pnpm config set store-dir /home/codespace/.local/share/pnpm/store --global
 echo "pnpm store-dir: $(pnpm store path)"
 
-# Install dependencies
-echo ""
-echo "Installing pnpm dependencies..."
-echo "This may take a few minutes on first run..."
-if ! pnpm install; then
-    echo ""
-    echo "Error: pnpm install failed." >&2
-    echo "This is often due to network issues or missing system dependencies." >&2
-    exit 1
-fi
 
 # - Security hardening: restrict sudo to a minimal allowlist
 # During post-create we needed unrestricted root access to install

--- a/.devcontainer/scripts/setup-ssh-access.sh
+++ b/.devcontainer/scripts/setup-ssh-access.sh
@@ -11,7 +11,7 @@ DEFAULT_KEY_NAME="typeagent-devcontainer"
 DEFAULT_KEY_PATH="$HOME/.ssh/$DEFAULT_KEY_NAME"
 DEFAULT_CONFIG_PATH="$HOME/.ssh/config"
 DEFAULT_LOCAL_PORT="2222"
-REMOTE_USER="codespace"
+DEFAULT_REMOTE_USER=""  # auto-detected from container metadata; falls back to "vscode" then "codespace"
 
 usage() {
     cat <<EOF
@@ -25,7 +25,8 @@ Options:
   --key-path PATH           Private key path to use (default: $DEFAULT_KEY_PATH)
   --host-alias NAME         SSH host alias to write to ~/.ssh/config (default: typeagent-devcontainer)
   --local-port PORT         Local SSH port to expose in ssh config (default: $DEFAULT_LOCAL_PORT)
-    --insecure-local          Disable host key verification for local-only workflows
+  --remote-user USER        Remote user inside the container (auto-detected if omitted)
+  --insecure-local          Disable host key verification for local-only workflows
   --print-only              Do not modify files or container state; print detected values only
   -h, --help                Show this help text
 EOF
@@ -130,6 +131,7 @@ CONFIG_MATCH=""
 KEY_PATH="$DEFAULT_KEY_PATH"
 HOST_ALIAS="$DEFAULT_KEY_NAME"
 LOCAL_PORT="$DEFAULT_LOCAL_PORT"
+REMOTE_USER="$DEFAULT_REMOTE_USER"
 PRINT_ONLY=0
 INSECURE_LOCAL=0
 
@@ -158,6 +160,11 @@ while [[ $# -gt 0 ]]; do
         --local-port)
             [[ $# -ge 2 ]] || fail "Missing value for $1"
             LOCAL_PORT="$2"
+            shift 2
+            ;;
+        --remote-user)
+            [[ $# -ge 2 ]] || fail "Missing value for $1"
+            REMOTE_USER="$2"
             shift 2
             ;;
         --insecure-local)
@@ -224,6 +231,28 @@ log "Workspace match: $WORKSPACE_MATCH"
 if [[ -n "$CONFIG_MATCH" ]]; then
     log "Config match: $CONFIG_MATCH"
 fi
+
+# Auto-detect remoteUser from devcontainer metadata label if not specified.
+if [[ -z "$REMOTE_USER" ]]; then
+    REMOTE_USER=$(docker inspect "$CONTAINER_NAME" | \
+        jq -r '.[0].Config.Labels["devcontainer.metadata"] // "[]" | fromjson | map(select(.remoteUser != null)) | last | .remoteUser // ""' 2>/dev/null || true)
+    # The metadata label stores the raw devcontainer.json value, which may contain
+    # unresolved variable references like ${localEnv:USER}. Substitute them now
+    # using the local environment.
+    if [[ "$REMOTE_USER" =~ \$\{localEnv:([^}]+)\} ]]; then
+        VAR_NAME="${BASH_REMATCH[1]}"
+        REMOTE_USER="${!VAR_NAME}"
+    fi
+    if [[ -z "$REMOTE_USER" ]]; then
+        # Last resort: ask the container itself which non-root user exists.
+        REMOTE_USER=$(docker exec "$CONTAINER_NAME" awk -F: '$3==1000{print $1}' /etc/passwd 2>/dev/null | head -1 || true)
+    fi
+    if [[ -z "$REMOTE_USER" ]]; then
+        log "Could not detect remoteUser; falling back to vscode"
+        REMOTE_USER="vscode"
+    fi
+fi
+log "Remote user: $REMOTE_USER"
 
 if [[ ! -f "$KEY_PATH" ]]; then
     if [[ $PRINT_ONLY -eq 1 ]]; then

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -133,6 +133,10 @@ done
 if ! command -v docker >/dev/null 2>&1; then
     fail "docker is required"
 fi
+# Verify the Docker daemon is actually running (not just installed)
+if ! docker info >/dev/null 2>&1; then
+    fail "Docker is not running. Start Docker Desktop or Docker Engine and try again."
+fi
 
 if command -v devcontainer >/dev/null 2>&1; then
     DEVCONTAINER_CMD=(devcontainer)

--- a/.devcontainer/scripts/start-devcontainer.sh
+++ b/.devcontainer/scripts/start-devcontainer.sh
@@ -24,6 +24,7 @@ Options:
   --rebuild                      Rebuild image and recreate container before startup
   --clean                        Remove container and associated Docker volumes
   --reset                        Rebuild image and clean volumes (--rebuild + --clean)
+  --use-corepack                 Use Corepack to install the packageManager pnpm version
   --ssh                          After startup, run setup-ssh-access.sh
   --insecure-local               Pass through to setup-ssh-access.sh (implies --ssh)
   -h, --help                     Show this help text
@@ -33,6 +34,7 @@ Examples:
   $(basename "$0") --ssh
   $(basename "$0") --recreate --ssh
   $(basename "$0") --rebuild
+  $(basename "$0") --use-corepack
   $(basename "$0") --config vnc
   $(basename "$0") --config agent
 EOF
@@ -59,6 +61,7 @@ REBUILD=0
 CLEAN_VOLUMES=0
 SETUP_SSH=0
 INSECURE_LOCAL=0
+USE_COREPACK=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -104,6 +107,10 @@ while [[ $# -gt 0 ]]; do
             CLEAN_VOLUMES=1
             shift
             ;;
+        --use-corepack)
+            USE_COREPACK=1
+            shift
+            ;;
         --ssh)
             SETUP_SSH=1
             shift
@@ -135,6 +142,10 @@ fi
 
 HOST_GIT_USER_NAME=$(read_git_identity user.name)
 HOST_GIT_USER_EMAIL=$(read_git_identity user.email)
+HOST_NPM_REGISTRY=$(npm config get registry 2>/dev/null || true)
+if [[ -z "$HOST_NPM_REGISTRY" ]] || [[ "$HOST_NPM_REGISTRY" == "undefined" ]]; then
+    HOST_NPM_REGISTRY="https://registry.npmjs.org/"
+fi
 
 if [[ -n "$HOST_GIT_USER_NAME" ]]; then
     export LOCAL_GIT_USER_NAME="$HOST_GIT_USER_NAME"
@@ -144,6 +155,9 @@ if [[ -n "$HOST_GIT_USER_EMAIL" ]]; then
     export LOCAL_GIT_USER_EMAIL="$HOST_GIT_USER_EMAIL"
     log "Using host git user.email from ~/.gitconfig"
 fi
+export NPM_CONFIG_REGISTRY="$HOST_NPM_REGISTRY"
+log "Using registry from host npm config"
+export TYPEAGENT_USE_COREPACK="$USE_COREPACK"
 
 UP_CMD=("${DEVCONTAINER_CMD[@]}" up --workspace-folder "$WORKSPACE_FOLDER")
 if [[ -n "$CONFIG_PATH" ]]; then

--- a/.devcontainer/vnc/devcontainer.json
+++ b/.devcontainer/vnc/devcontainer.json
@@ -8,7 +8,12 @@
   // desktop-lite feature historically supports amd64 only, so on Apple
   // Silicon this config may still require Rosetta/QEMU emulation just for
   // the VNC desktop. The standard (non-VNC) config runs natively on arm64.
-  "build": { "dockerfile": "../Dockerfile" },
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
+    }
+  },
 
   "features": {
     // VNC desktop for Electron shell support
@@ -74,7 +79,9 @@
 
   "containerEnv": {
     "LOCAL_GIT_USER_NAME": "${localEnv:LOCAL_GIT_USER_NAME}",
-    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}"
+    "LOCAL_GIT_USER_EMAIL": "${localEnv:LOCAL_GIT_USER_EMAIL}",
+    "TYPEAGENT_USE_COREPACK": "${localEnv:TYPEAGENT_USE_COREPACK}",
+    "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}"
   },
 
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh && bash .devcontainer/scripts/install-electron-deps.sh",

--- a/docs/content/setup/setup-Windows.md
+++ b/docs/content/setup/setup-Windows.md
@@ -10,6 +10,7 @@ This is a list of step-by-step instructions to set up a Windows environment from
 
 - Install Git ([instructions](https://git-scm.com/downloads/win))
 - Install NodeJS ([instructions](https://nodejs.org/en/download))
+  - NOTE: During installation, at the "Tools for Native Modules" step, make sure you select "Automatically install the necessary tools"
 - Enable corepack
   - Open Command Prompt as Administrator
   - `corepack enable`


### PR DESCRIPTION
## Summary
- propagate the host npm registry into devcontainer builds and post-create setup
- add an agent devcontainer variant that mirrors the host username and home-mounted volumes
- improve startup and SSH helper scripts for Docker readiness, corepack opt-in, and remote user detection
- fix post-create sudo hardening so the restricted ssh service rule follows the actual container user
- document the Windows Node installer option needed for native module tooling
