### PR TITLE
Integrate androidMobile set-alarm action in mobile-2 sample

### DIFF
--- a/android/samples/mobile-2/app/src/main/AndroidManifest.xml
+++ b/android/samples/mobile-2/app/src/main/AndroidManifest.xml
@@ -6,10 +6,14 @@
         <intent>
             <action android:name="android.speech.RecognitionService" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.SET_ALARM" />
+        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 
     <application
         android:allowBackup="true"

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AlarmActionParser.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AlarmActionParser.kt
@@ -1,0 +1,33 @@
+package com.example.typeagentchat
+
+import org.json.JSONObject
+
+internal data class SetAlarmAction(
+    val originalRequest: String,
+    val hour: Int,
+    val minute: Int
+)
+
+private val alarmTimeRegex = Regex("""^\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2})(?::\d{2})?$""")
+
+internal fun parseSetAlarmActionPayload(data: Any?): SetAlarmAction? {
+    val payload = data as? JSONObject ?: return null
+    val originalRequest = payload.optString("originalRequest").trim()
+    val time = payload.optString("time").trim()
+    if (time.isBlank()) {
+        return null
+    }
+
+    val match = alarmTimeRegex.matchEntire(time) ?: return null
+    val hour = match.groupValues[1].toIntOrNull() ?: return null
+    val minute = match.groupValues[2].toIntOrNull() ?: return null
+    if (hour !in 0..23 || minute !in 0..59) {
+        return null
+    }
+
+    return SetAlarmAction(
+        originalRequest = originalRequest,
+        hour = hour,
+        minute = minute
+    )
+}

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/DisplayContentParser.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/DisplayContentParser.kt
@@ -81,9 +81,7 @@ private fun fallbackTypedContent(
     val fallbackText = messageContentToText(content, declaredType)
     return when (declaredType) {
         "html", "iframe" -> ParsedDisplayContent(
-            text = stripHtmlTags(fallbackText).ifBlank {
-                "Rich content is not supported in this client yet."
-            },
+            text = htmlFallbackText(fallbackText),
             format = MessageFormat.TEXT
         )
 
@@ -197,6 +195,22 @@ private fun stripHtmlTags(value: String): String {
         .replace(Regex("<[^>]*>"), " ")
         .replace(Regex("\\s+"), " ")
         .trim()
+}
+
+private fun htmlFallbackText(value: String): String {
+    if (isReasoningTrace(value)) {
+        return ""
+    }
+    return stripHtmlTags(value).ifBlank {
+        "Rich content is not supported in this client yet."
+    }
+}
+
+private fun isReasoningTrace(value: String): Boolean {
+    val normalized = value.lowercase()
+    return normalized.contains("reasoning-tools-call") ||
+        normalized.contains("execute_actions") ||
+        normalized.contains("discover-actions")
 }
 
 private fun JSONObject.optNullable(name: String): Any? {

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
@@ -6,8 +6,10 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.provider.AlarmClock
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -73,6 +75,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        webSocketManager.setClientActionHandler { action ->
+            runOnUiThread {
+                launchSetAlarmIntent(action)
+            }
+        }
         webSocketManager.connect(
             url = tunnelUrl,
             tunnelToken = tunnelToken
@@ -90,8 +97,52 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        webSocketManager.setClientActionHandler(null)
         webSocketManager.disconnect()
         super.onDestroy()
+    }
+
+    private fun launchSetAlarmIntent(action: SetAlarmAction) {
+        val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
+            putExtra(AlarmClock.EXTRA_HOUR, action.hour)
+            putExtra(AlarmClock.EXTRA_MINUTES, action.minute)
+            putExtra(AlarmClock.EXTRA_SKIP_UI, true)
+            if (action.originalRequest.isNotBlank()) {
+                putExtra(AlarmClock.EXTRA_MESSAGE, action.originalRequest)
+            }
+        }
+        val target = intent.resolveActivity(packageManager)
+        Log.d(
+            TAG,
+            "Launching set-alarm intent hour=${action.hour} minute=${action.minute} target=${target?.flattenToShortString() ?: "none"}"
+        )
+        try {
+            startActivity(intent)
+            Log.d(TAG, "set-alarm intent dispatched to clock app")
+            Toast.makeText(
+                this,
+                "Alarm set for %02d:%02d".format(action.hour, action.minute),
+                Toast.LENGTH_SHORT
+            ).show()
+        } catch (_: ActivityNotFoundException) {
+            Log.e(TAG, "No alarm app available to handle set-alarm intent")
+            Toast.makeText(
+                this,
+                "No alarm app is available on this device.",
+                Toast.LENGTH_SHORT
+            ).show()
+        } catch (error: SecurityException) {
+            Log.e(TAG, "Missing permission to set alarm", error)
+            Toast.makeText(
+                this,
+                "This app is not allowed to set alarms.",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    private companion object {
+        private const val TAG = "MainActivity"
     }
 }
 

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -27,6 +27,7 @@ class WebSocketManager {
     private var conversationId: String? = null
     private var connectionId: String? = null
     private var pendingUserInteraction: PendingUserInteraction? = null
+    private var clientActionHandler: ClientActionHandler? = null
 
     private val _messages = MutableStateFlow<List<Message>>(emptyList())
     val messages: StateFlow<List<Message>> = _messages
@@ -40,6 +41,12 @@ class WebSocketManager {
         )
     )
     val connectionStatus: StateFlow<ConnectionStatus> = _connectionStatus
+
+    internal fun setClientActionHandler(handler: ClientActionHandler?) {
+        synchronized(lock) {
+            clientActionHandler = handler
+        }
+    }
 
     fun connect(
         url: String,
@@ -350,6 +357,9 @@ class WebSocketManager {
             TAG,
             "RPC call channel=$channelName method=$methodName argCount=${args.length()}"
         )
+        if (methodName == "takeAction") {
+            Log.d(TAG, "RPC call raw takeAction args=$args")
+        }
         when {
             channelName.startsWith(CLIENT_IO_CHANNEL_PREFIX) -> handleClientIoCall(methodName, args)
             else -> Log.d(TAG, "Unhandled RPC call channel=$channelName method=$methodName")
@@ -364,13 +374,9 @@ class WebSocketManager {
             TAG,
             "RPC invoke channel=$channelName method=$methodName callId=$callId argCount=${args.length()}"
         )
-        // Note: agentServer's sharedDispatcher never forwards a raw "question" invoke to
-        // connected clients; it converts ClientIO.question() into a requestInteraction
-        // broadcast (type "question") instead, handled in handleRequestInteractionCall.
-        // If a "question" invoke ever does arrive here, respond with an error below
-        // rather than silently guessing an answer.
         val result = when (methodName) {
             "getUserContext" -> JSONObject.NULL
+            "question" -> handleQuestionInvoke(args)
             else -> null
         }
 
@@ -495,6 +501,10 @@ class WebSocketManager {
                 }
             }
 
+            "takeAction" -> {
+                handleTakeActionCall(args)
+            }
+
             else -> {
                 val requestId = extractRequestId(args.opt(0))
                 logInboundEvent(
@@ -504,6 +514,47 @@ class WebSocketManager {
                 )
             }
         }
+    }
+
+    private fun handleTakeActionCall(args: JSONArray) {
+        val requestId = extractRequestId(args.opt(0))
+        val actionName = args.optString(1).orEmpty()
+        val actionData = args.optNullable(2)
+        logInboundEvent(
+            type = "take-action:$actionName",
+            requestId = requestId,
+            content = stringifyDisplayValue(actionData)
+        )
+        Log.d(
+            TAG,
+            "takeAction received action=$actionName requestId=${requestId.orEmpty()} data=${stringifyDisplayValue(actionData)}"
+        )
+        if (actionName != "set-alarm") {
+            Log.d(TAG, "takeAction ignored: unsupported action=$actionName")
+            return
+        }
+
+        val alarm = parseSetAlarmActionPayload(actionData)
+        if (alarm == null) {
+            Log.e(
+                TAG,
+                "Invalid set-alarm payload: ${stringifyDisplayValue(actionData)}"
+            )
+            return
+        }
+        val handler = synchronized(lock) { clientActionHandler }
+        if (handler == null) {
+            Log.e(
+                TAG,
+                "set-alarm parsed (hour=${alarm.hour} minute=${alarm.minute}) but no client action handler is registered"
+            )
+            return
+        }
+        Log.d(
+            TAG,
+            "Dispatching set-alarm to client handler hour=${alarm.hour} minute=${alarm.minute}"
+        )
+        handler.onSetAlarm(alarm)
     }
 
     private fun handleDisplayLogEvent(event: JSONObject) {
@@ -862,6 +913,29 @@ class WebSocketManager {
         }
     }
 
+    private fun handleQuestionInvoke(args: JSONArray): Int {
+        val requestId = extractRequestId(args.opt(0))
+        val choicesArray = args.optJSONArray(2) ?: JSONArray()
+        val choices = buildList {
+            for (index in 0 until choicesArray.length()) {
+                val choice = choicesArray.optString(index).orEmpty()
+                if (choice.isNotBlank()) {
+                    add(choice)
+                }
+            }
+        }
+        val defaultIndex = args.optInt(3, 0)
+        Log.d(
+            TAG,
+            "ClientIO.question requestId=${requestId.orEmpty()} defaultIndex=$defaultIndex"
+        )
+
+        if (choices.isEmpty()) {
+            return 0
+        }
+        return defaultIndex.coerceIn(0, choices.lastIndex)
+    }
+
     private fun tryHandlePendingInteractionResponse(message: String, currentConversationId: String): Boolean {
         val pending = synchronized(lock) { pendingUserInteraction } ?: return false
         val response = when (pending) {
@@ -1094,6 +1168,10 @@ class WebSocketManager {
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val AGENT_SERVER_CHANNEL = "agent-server"
         private const val CLIENT_IO_CHANNEL_PREFIX = "clientio:"
+    }
+
+    internal fun interface ClientActionHandler {
+        fun onSetAlarm(action: SetAlarmAction)
     }
 }
 

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AlarmActionParserTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AlarmActionParserTest.kt
@@ -1,0 +1,44 @@
+package com.example.typeagentchat
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AlarmActionParserTest {
+    @Test
+    fun `parses set-alarm payload`() {
+        val alarm = parseSetAlarmActionPayload(
+            JSONObject()
+                .put("originalRequest", "Wake me up at 6:30")
+                .put("time", "2026-07-30T06:30:00")
+        )
+
+        requireNotNull(alarm)
+        assertEquals("Wake me up at 6:30", alarm.originalRequest)
+        assertEquals(6, alarm.hour)
+        assertEquals(30, alarm.minute)
+    }
+
+    @Test
+    fun `rejects invalid set-alarm payload format`() {
+        val alarm = parseSetAlarmActionPayload(
+            JSONObject()
+                .put("originalRequest", "Set alarm")
+                .put("time", "06:30")
+        )
+
+        assertNull(alarm)
+    }
+
+    @Test
+    fun `rejects out of range time`() {
+        val alarm = parseSetAlarmActionPayload(
+            JSONObject()
+                .put("originalRequest", "Set alarm")
+                .put("time", "2026-07-30T25:75:00")
+        )
+
+        assertNull(alarm)
+    }
+}

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/DisplayContentParserTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/DisplayContentParserTest.kt
@@ -64,6 +64,24 @@ class DisplayContentParserTest {
     }
 
     @Test
+    fun `suppresses reasoning tool traces in html content`() {
+        val display = extractAgentMessageContent(
+            JSONObject()
+                .put(
+                    "message",
+                    JSONObject()
+                        .put("type", "html")
+                        .put(
+                            "content",
+                            "<summary>Thinking</summary>reasoning-tools-call tool=discover-actions then execute_actions androidMobile.setAlarm"
+                        )
+                )
+        )
+
+        assertEquals("", display.text)
+    }
+
+    @Test
     fun `returns friendly fallback for structured content without alternates`() {
         val display = extractAgentMessageContent(
             JSONObject()


### PR DESCRIPTION
Handle the TypeAgent clientIO takeAction RPC in WebSocketManager and route the androidMobile set-alarm callback to the Android system alarm intent.

- Parse and validate set-alarm payloads (AlarmActionParser)
- Dispatch alarms to the Activity via a client action handler that is registered in onCreate and cleared in onDestroy
- Launch AlarmClock.ACTION_SET_ALARM and declare the SET_ALARM permission and package visibility query
- Suppress reasoning/tool-trace HTML from the chat transcript
- Add unit tests for alarm payload parsing and trace suppression