### PR TITLE
Clarify action grammar documentation

### DIFF
--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -47,13 +47,13 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *
  *   <Expression> ::= ( <StringExpr> | <VariableExpr> | <RuleRefExpr> | <GroupExpr> )+
  *
- *   // <Char> is any character except special chars (| ( ) < > $ - ; { } [ ]) and backslash,
- *   // and not the start of a comment sequence ("//" or "/*").
- *   // A "flex space" is a separator position in the grammar source, created by any unescaped
- *   // whitespace or comment between sub-expressions.
- *   // When matching input, a flex space accepts any run of whitespace or punctuation characters.
- *   // The minimum number required is controlled by the per-rule spacing mode
- *   // annotation (see SpacingMode type above for the full semantics of each mode).
+ *   // A "flex space" is a boundary where input separators may occur. A boundary exists:
+ *   //   - between adjacent sub-expressions, even without source whitespace (e.g. hello$(x));
+ *   //   - between literal segments separated by unescaped whitespace; and
+ *   //   - where a comment splits literal text.
+ *   // A run of source whitespace creates one boundary. At runtime, a boundary matches
+ *   // JavaScript whitespace or Unicode punctuation. The spacing mode determines whether
+ *   // it matches exactly zero, zero or more, or one or more characters (see SpacingMode above).
  *   //
  *   // The spacing mode is set per-rule via a [spacing=<mode>] annotation immediately
  *   // after the rule name: <rule> [spacing=required] = ...;
@@ -61,8 +61,10 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   // Per-alternate annotations override the definition-level setting.
  *   // Omitting the annotation is equivalent to [spacing=auto].
  *   //
+ *   // <Char> is any character except special chars (| ( ) < > $ - ; { } [ ]) and backslash,
+ *   // and not the start of a comment sequence ("//" or "/*"). Escape a special character
+ *   // or comment opener to make it literal (e.g. \|, \//, or \/*).
  *   // An escaped space (e.g. "\ ") is treated as a literal character, not a flex space.
- *   // Special chars must be escaped with backslash to appear as literal text.
  *   <StringExpr> ::= ( <EscapeSequence> | <WS> | <Char> )+
  *   <EscapeSequence> ::= "\\"<EscapedChar>
  *   <EscapedChar> ::= "0"                        // null character \0
@@ -83,7 +85,6 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *   <UnicodeCodePoint> ::= [0-9A-Fa-f]+
  *   <VariableExpr> ::= "$(" <VariableSpecifier> ( ")" | ")?" )
  *
- *    // TODO: Support nested instead of just Rule Ref
  *   <VariableSpecifier> ::= <VarName> (":" (<TypeName> | <RuleName>))?
  *
  *   <RuleRefExpr> ::= <RuleName>


### PR DESCRIPTION
## Summary
This PR clarifies the BNF documentation comments in `grammarRuleParser.ts` for action grammar expression parsing.

Specifically, it:
- Rewrites the flex-space documentation to describe boundaries precisely (including adjacency without source whitespace, literal segment boundaries, and comment-split text).
- Clarifies runtime matching behavior for flex-space boundaries (whitespace/punctuation matching and spacing-mode cardinality).
- Moves and improves `<Char>` documentation so the exclusion and escaping rules are explicit.
- Replaces a generic special-character note with concrete escaping examples (`\\|`, `\\//`, `\\/*`).
- Removes an outdated TODO comment from the grammar docs section.

## Why
The prior comments were directionally correct but ambiguous in a few edge cases (especially around flex-space boundary creation and comment handling). The updated wording makes parser behavior easier to reason about when authoring grammars.

## Scope
- Documentation-only update in parser comments.
- No runtime logic changes.

## Diff
- 1 file changed: `ts/packages/actionGrammar/src/grammarRuleParser.ts`
- 10 insertions, 9 deletions
