### PR TITLE
fix CodeQL insecure randomness in endpoint pool pick

### DIFF
--- a/ts/packages/aiclient/src/endpointPool.ts
+++ b/ts/packages/aiclient/src/endpointPool.ts
@@ -12,17 +12,6 @@ import { FetchThrottler } from "./restClient.js";
 
 const debugPool = registerDebug("typeagent:pool");
 
-/**
- * Cryptographically secure uniform value in [0, 1).
- * Default for pickEndpoint so CodeQL does not flag Math.random; tests may
- * inject a deterministic rng instead.
- */
-function secureUnitInterval(): number {
-    // 32 bits is plenty for load-balancing endpoint selection.
-    // randomInt range must be < 2^48 (Node limit).
-    return randomInt(2 ** 32) / 2 ** 32;
-}
-
 export type EndpointMode = "PTU" | "PAYG" | "unknown";
 
 /**
@@ -465,7 +454,7 @@ export type PickResult =
 export function pickEndpoint(
     pool: EndpointPool,
     now: number = Date.now(),
-    rng: () => number = secureUnitInterval,
+    rng: () => number = () => randomInt(2 ** 32) / 2 ** 32,
 ): PickResult {
     if (pool.members.length === 0) {
         throw new Error(`pool ${pool.modelKey} has no members`);

--- a/ts/packages/aiclient/src/endpointPool.ts
+++ b/ts/packages/aiclient/src/endpointPool.ts
@@ -454,7 +454,7 @@ export type PickResult =
 export function pickEndpoint(
     pool: EndpointPool,
     now: number = Date.now(),
-    rng: () => number = () => randomInt(2 ** 32) / 2 ** 32,
+    rng: (n: number) => number = randomInt,
 ): PickResult {
     if (pool.members.length === 0) {
         throw new Error(`pool ${pool.modelKey} has no members`);
@@ -473,7 +473,7 @@ export function pickEndpoint(
             .get(tier)!
             .filter((m) => m.cooldownUntil <= now);
         if (ready.length > 0) {
-            const pick = ready[Math.floor(rng() * ready.length)];
+            const pick = ready[rng(ready.length)];
             return { kind: "ready", member: pick };
         }
     }

--- a/ts/packages/aiclient/src/endpointPool.ts
+++ b/ts/packages/aiclient/src/endpointPool.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { randomInt } from "node:crypto";
 import registerDebug from "debug";
 import { priorityQueue } from "async";
 import { azureApiSettingsFromEnv } from "./azureSettings.js";
@@ -10,6 +11,17 @@ import type { ApiSettings } from "./openai.js";
 import { FetchThrottler } from "./restClient.js";
 
 const debugPool = registerDebug("typeagent:pool");
+
+/**
+ * Cryptographically secure uniform value in [0, 1).
+ * Default for pickEndpoint so CodeQL does not flag Math.random; tests may
+ * inject a deterministic rng instead.
+ */
+function secureUnitInterval(): number {
+    // 32 bits is plenty for load-balancing endpoint selection.
+    // randomInt range must be < 2^48 (Node limit).
+    return randomInt(2 ** 32) / 2 ** 32;
+}
 
 export type EndpointMode = "PTU" | "PAYG" | "unknown";
 
@@ -453,7 +465,7 @@ export type PickResult =
 export function pickEndpoint(
     pool: EndpointPool,
     now: number = Date.now(),
-    rng: () => number = Math.random,
+    rng: () => number = secureUnitInterval,
 ): PickResult {
     if (pool.members.length === 0) {
         throw new Error(`pool ${pool.modelKey} has no members`);

--- a/ts/packages/aiclient/test/endpointPool.spec.ts
+++ b/ts/packages/aiclient/test/endpointPool.spec.ts
@@ -10,12 +10,12 @@ import {
 } from "../src/endpointPool.js";
 import { ModelType } from "../src/openai.js";
 
-// Deterministic RNG for reproducible random-within-tier selection.
-function seededRng(seed: number): () => number {
+// Deterministic index picker for reproducible random-within-tier selection.
+function seededRng(seed: number): (n: number) => number {
     let state = seed >>> 0;
-    return () => {
+    return (n: number) => {
         state = (state * 1664525 + 1013904223) >>> 0;
-        return state / 0xffffffff;
+        return Math.floor((state / 0xffffffff) * n);
     };
 }
 


### PR DESCRIPTION
- Replace `Math.random` default in `pickEndpoint` with `crypto.randomInt`-backed unit interval
- Resolves CodeQL **Insecure randomness** on `endpointPool.ts` endpoint selection
- Keeps injectable `rng` so seeded unit tests stay deterministic