### PR TITLE
Add search-nearby action support to the Android mobile-2 sample

### DIFF
--- a/android/samples/mobile-2/app/src/main/AndroidManifest.xml
+++ b/android/samples/mobile-2/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
         <intent>
             <action android:name="android.intent.action.SET_TIMER" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="geo" />
+        </intent>
     </queries>
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.provider.AlarmClock
 import android.speech.RecognizerIntent
@@ -86,6 +87,10 @@ class MainActivity : ComponentActivity() {
             override fun onSetTimer(action: SetTimerAction) {
                 runOnUiThread { launchSetTimerIntent(action) }
             }
+
+            override fun onSearchNearby(action: SearchNearbyAction) {
+                runOnUiThread { launchSearchNearbyIntent(action) }
+            }
         })
         webSocketManager.connect(
             url = tunnelUrl,
@@ -118,7 +123,7 @@ class MainActivity : ComponentActivity() {
                 putExtra(AlarmClock.EXTRA_MESSAGE, action.originalRequest)
             }
         }
-        launchClockIntent(
+        launchExternalIntent(
             intent = intent,
             actionName = "set-alarm",
             detail = "hour=${action.hour} minute=${action.minute}",
@@ -138,7 +143,7 @@ class MainActivity : ComponentActivity() {
      * passes false; we diverge deliberately so a voice/chat request never
      * yanks the user out of the conversation. The confirmation toast is then
      * the only in-app feedback, so it is not optional - and it must not claim
-     * success when the launch was refused. See [launchClockIntent].
+     * success when the launch was refused. See [launchExternalIntent].
      */
     private fun launchSetTimerIntent(action: SetTimerAction) {
         val intent = Intent(AlarmClock.ACTION_SET_TIMER).apply {
@@ -148,7 +153,7 @@ class MainActivity : ComponentActivity() {
                 putExtra(AlarmClock.EXTRA_MESSAGE, action.originalRequest)
             }
         }
-        launchClockIntent(
+        launchExternalIntent(
             intent = intent,
             actionName = "set-timer",
             detail = "durationInSeconds=${action.durationInSeconds}",
@@ -160,7 +165,27 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Starts a clock intent and reports the outcome truthfully.
+     * Opens the device maps app on a local search. The intent is left implicit
+     * rather than pinned to `com.google.android.apps.maps` as TypeAgent's
+     * `JavaScriptInterface.searchNearby` does, so it still resolves on devices
+     * without Google Maps.
+     */
+    private fun launchSearchNearbyIntent(action: SearchNearbyAction) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(buildGeoSearchUri(action.searchTerm)))
+        launchExternalIntent(
+            intent = intent,
+            actionName = "search-nearby",
+            detail = "searchTerm=${action.searchTerm}",
+            successMessage = "Searching nearby for ${action.searchTerm}",
+            missingAppMessage = "No maps app is available on this device.",
+            deniedMessage = "This app is not allowed to open the maps app.",
+            backgroundMessage = "Could not open maps while the app was in the background."
+        )
+    }
+
+    /**
+     * Starts an intent handled by another app and reports the outcome
+     * truthfully.
      *
      * Two failure modes are checked up front because neither raises an
      * exception:
@@ -172,8 +197,11 @@ class MainActivity : ComponentActivity() {
      *   warning. Without this guard the success toast would fire while no
      *   alarm or timer was created, and with `EXTRA_SKIP_UI` that toast is the
      *   user's only feedback.
+     *
+     * `resolveActivity` returns null on API 30+ unless the intent is declared
+     * in the manifest's `<queries>` block, so every new action needs an entry.
      */
-    private fun launchClockIntent(
+    private fun launchExternalIntent(
         intent: Intent,
         actionName: String,
         detail: String,
@@ -203,7 +231,7 @@ class MainActivity : ComponentActivity() {
         }
         try {
             startActivity(intent)
-            Log.d(TAG, "$actionName intent dispatched to clock app")
+            Log.d(TAG, "$actionName intent dispatched")
             Toast.makeText(this, successMessage, Toast.LENGTH_SHORT).show()
         } catch (_: ActivityNotFoundException) {
             Log.e(TAG, "No app available to handle $actionName intent")

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/SearchNearbyActionParser.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/SearchNearbyActionParser.kt
@@ -1,0 +1,80 @@
+package com.example.typeagentchat
+
+import org.json.JSONObject
+
+internal data class SearchNearbyAction(
+    val originalRequest: String,
+    val searchTerm: String
+)
+
+/**
+ * Keeps intent data well under the ~1 MB binder budget; an oversized value
+ * makes `startActivity` throw `TransactionTooLargeException`, so a hostile or
+ * buggy server cannot crash the app from the network.
+ */
+private const val MAX_ORIGINAL_REQUEST_CHARS = 256
+private const val MAX_SEARCH_TERM_CHARS = 256
+
+private val controlCharRegex = Regex("""\p{Cntrl}""")
+private val whitespaceRunRegex = Regex("""\s+""")
+
+/**
+ * Parses `takeAction("search-nearby", ...)` from the androidMobile agent:
+ * `{ originalRequest: string; searchTerm: string }`. Re-validated here because
+ * `takeAction` is fire-and-forget and carries no schema guarantee over the wire.
+ */
+internal fun parseSearchNearbyActionPayload(data: Any?): SearchNearbyAction? {
+    val payload = data as? JSONObject ?: return null
+    // `opt(...) as? String`, not `optString`: org.json renders a JSON null as
+    // the literal string "null", which would be searched for verbatim.
+    val searchTerm = sanitize((payload.opt("searchTerm") as? String).orEmpty())
+        .take(MAX_SEARCH_TERM_CHARS)
+        .trim()
+    if (searchTerm.isEmpty()) {
+        return null
+    }
+    val originalRequest = sanitize((payload.opt("originalRequest") as? String).orEmpty())
+        .take(MAX_ORIGINAL_REQUEST_CHARS)
+        .trim()
+
+    return SearchNearbyAction(
+        originalRequest = originalRequest,
+        searchTerm = searchTerm
+    )
+}
+
+/**
+ * Folds control characters and whitespace runs into single spaces so a
+ * multi-line term does not become a URI full of `%0A`.
+ */
+private fun sanitize(raw: String): String =
+    raw.replace(controlCharRegex, " ")
+        .replace(whitespaceRunRegex, " ")
+        .trim()
+
+/**
+ * `geo:0,0?q=<term>` searches without coordinates - `0,0` makes the maps app
+ * substitute the device's current location, i.e. the "nearby" semantic.
+ *
+ * The term is percent-encoded rather than interpolated (as TypeAgent's
+ * `JavaScriptInterface.searchNearby` does), which would corrupt any term
+ * containing `&`, `#` or `?`. Hand-rolled because `Uri.encode` is unavailable
+ * in JVM unit tests and `URLEncoder` emits `+` for spaces.
+ */
+internal fun buildGeoSearchUri(searchTerm: String): String =
+    "geo:0,0?q=${percentEncode(searchTerm)}"
+
+private fun percentEncode(value: String): String {
+    val builder = StringBuilder()
+    for (byte in value.toByteArray(Charsets.UTF_8)) {
+        val char = (byte.toInt() and 0xFF).toChar()
+        val unreserved = char in 'A'..'Z' || char in 'a'..'z' || char in '0'..'9' ||
+            char == '-' || char == '_' || char == '.' || char == '~'
+        if (unreserved) {
+            builder.append(char)
+        } else {
+            builder.append('%').append("%02X".format(byte))
+        }
+    }
+    return builder.toString()
+}

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -554,6 +554,7 @@ class WebSocketManager {
         when (actionName) {
             "set-alarm" -> handleSetAlarmAction(actionData)
             "set-timer" -> handleSetTimerAction(actionData)
+            "search-nearby" -> handleSearchNearbyAction(actionData)
             else -> Log.d(TAG, "takeAction ignored: unsupported action=$actionName")
         }
     }
@@ -596,6 +597,26 @@ class WebSocketManager {
             "Dispatching set-timer to client handler durationInSeconds=${timer.durationInSeconds}"
         )
         handler.onSetTimer(timer)
+    }
+
+    private fun handleSearchNearbyAction(actionData: Any?) {
+        val search = parseSearchNearbyActionPayload(actionData)
+        if (search == null) {
+            Log.e(
+                TAG,
+                "Invalid search-nearby payload: ${stringifyDisplayValue(actionData)}"
+            )
+            return
+        }
+        val handler = requireClientActionHandler(
+            "search-nearby",
+            "searchTerm=${search.searchTerm}"
+        ) ?: return
+        Log.d(
+            TAG,
+            "Dispatching search-nearby to client handler searchTerm=${search.searchTerm}"
+        )
+        handler.onSearchNearby(search)
     }
 
     private fun requireClientActionHandler(
@@ -1277,6 +1298,7 @@ class WebSocketManager {
     internal interface ClientActionHandler {
         fun onSetAlarm(action: SetAlarmAction)
         fun onSetTimer(action: SetTimerAction)
+        fun onSearchNearby(action: SearchNearbyAction)
     }
 }
 

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/SearchNearbyActionParserTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/SearchNearbyActionParserTest.kt
@@ -1,0 +1,127 @@
+package com.example.typeagentchat
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SearchNearbyActionParserTest {
+
+    private fun payload(
+        searchTerm: Any,
+        request: String = "Find coffee shops near me"
+    ) = JSONObject()
+        .put("originalRequest", request)
+        .put("searchTerm", searchTerm)
+
+    @Test
+    fun `parses search-nearby payload`() {
+        val search = parseSearchNearbyActionPayload(payload("coffee shops"))
+
+        requireNotNull(search)
+        assertEquals("Find coffee shops near me", search.originalRequest)
+        assertEquals("coffee shops", search.searchTerm)
+    }
+
+    @Test
+    fun `trims and collapses whitespace in the search term`() {
+        val search = parseSearchNearbyActionPayload(payload("  italian   restaurants \n"))
+
+        requireNotNull(search)
+        assertEquals("italian restaurants", search.searchTerm)
+    }
+
+    @Test
+    fun `folds control characters out of the search term`() {
+        val search = parseSearchNearbyActionPayload(payload("gas\u0000stations\tnearby"))
+
+        requireNotNull(search)
+        assertEquals("gas stations nearby", search.searchTerm)
+    }
+
+    @Test
+    fun `rejects a blank or missing search term`() {
+        assertNull(parseSearchNearbyActionPayload(payload("")))
+        assertNull(parseSearchNearbyActionPayload(payload("   ")))
+        assertNull(
+            parseSearchNearbyActionPayload(JSONObject().put("originalRequest", "Find coffee"))
+        )
+    }
+
+    @Test
+    fun `rejects a non-string search term`() {
+        // org.json would render these as "null"/"42" via optString, which would
+        // be searched for verbatim.
+        assertNull(parseSearchNearbyActionPayload(payload(JSONObject.NULL)))
+        assertNull(parseSearchNearbyActionPayload(payload(42)))
+    }
+
+    @Test
+    fun `rejects a non-object payload`() {
+        assertNull(parseSearchNearbyActionPayload(null))
+        assertNull(parseSearchNearbyActionPayload("coffee"))
+    }
+
+    @Test
+    fun `caps an oversized search term`() {
+        val search = parseSearchNearbyActionPayload(payload("a".repeat(10_000)))
+
+        requireNotNull(search)
+        assertEquals(256, search.searchTerm.length)
+    }
+
+    @Test
+    fun `tolerates a missing or null originalRequest`() {
+        val missing = parseSearchNearbyActionPayload(JSONObject().put("searchTerm", "pharmacy"))
+        requireNotNull(missing)
+        assertEquals("", missing.originalRequest)
+
+        val explicitNull = parseSearchNearbyActionPayload(
+            JSONObject()
+                .put("originalRequest", JSONObject.NULL)
+                .put("searchTerm", "pharmacy")
+        )
+        requireNotNull(explicitNull)
+        assertEquals("", explicitNull.originalRequest)
+    }
+
+    @Test
+    fun `caps an oversized originalRequest`() {
+        val search = parseSearchNearbyActionPayload(payload("pharmacy", "a".repeat(10_000)))
+
+        requireNotNull(search)
+        assertEquals(256, search.originalRequest.length)
+    }
+
+    @Test
+    fun `builds a geo search uri`() {
+        assertEquals("geo:0,0?q=pharmacy", buildGeoSearchUri("pharmacy"))
+    }
+
+    @Test
+    fun `percent-encodes spaces rather than emitting plus`() {
+        // URLEncoder would emit "coffee+shops", which a maps app reads as a
+        // literal '+' in the query rather than a separator.
+        assertEquals("geo:0,0?q=coffee%20shops", buildGeoSearchUri("coffee shops"))
+    }
+
+    @Test
+    fun `percent-encodes characters that would corrupt the query`() {
+        assertEquals(
+            "geo:0,0?q=bed%20%26%20breakfast",
+            buildGeoSearchUri("bed & breakfast")
+        )
+        assertEquals("geo:0,0?q=%231%20pizza", buildGeoSearchUri("#1 pizza"))
+        assertEquals("geo:0,0?q=a%3Db%3Fc", buildGeoSearchUri("a=b?c"))
+    }
+
+    @Test
+    fun `percent-encodes non-ascii search terms as utf-8`() {
+        assertEquals("geo:0,0?q=caf%C3%A9", buildGeoSearchUri("café"))
+    }
+
+    @Test
+    fun `leaves unreserved characters unescaped`() {
+        assertEquals("geo:0,0?q=A-Z_a.z~9", buildGeoSearchUri("A-Z_a.z~9"))
+    }
+}


### PR DESCRIPTION
# Summary

Handle the `search-nearby` action emitted by the `androidMobile` agent so a
location request opens the device maps app, instead of being received over the
WebSocket and silently dropped. Follows the parse -> dispatch -> intent pattern
already established for `set-alarm` and `set-timer`.

The search term is percent-encoded rather than interpolated into the `geo:` URI,
so terms containing `&`, `#` or `?` no longer corrupt the query, and the `geo`
scheme is declared in `<queries>` so `resolveActivity` still resolves on API 30+.
`launchClockIntent` is renamed `launchExternalIntent` since it is no longer clock
specific; behavior for `set-alarm` and `set-timer` is unchanged.

# Example
## Before

```text
> show coffee shops on the map

D/WebSocketManager: takeAction received action=search-nearby
                    data={"originalRequest":"show coffee shops on the map","searchTerm":"coffee shops"}
D/WebSocketManager: takeAction ignored: unsupported action=search-nearby

(nothing happens on the device)
```
## After
```
> show coffee shops on the map

D/WebSocketManager: takeAction received action=search-nearby
                    data={"originalRequest":"show coffee shops on the map","searchTerm":"coffee shops"}
D/WebSocketManager: Dispatching search-nearby to client handler searchTerm=coffee shops
D/MainActivity:     Launching search-nearby intent searchTerm=coffee shops
                    target=com.google.android.apps.maps/.MapsActivity
D/MainActivity:     search-nearby intent dispatched

Maps opens on "coffee shops"; toast: "Searching nearby for coffee shops"
```