### PR TITLE
Fix Spotify history loading, configuration guidance, and player autocompletion

### DIFF
--- a/docs/content/help/commandReference.md
+++ b/docs/content/help/commandReference.md
@@ -1044,7 +1044,7 @@ Usage: `@player spotify load <file>`
 
 ### Arguments:
 
-- &lt;file&gt; - File to load (type: string)
+- &lt;file&gt; - File or directory to load (a directory loads all Spotify streaming history .json files in it) (type: string)
 
 ## @player spotify login - Login to Spotify
 

--- a/ts/CLAUDE.md
+++ b/ts/CLAUDE.md
@@ -52,6 +52,23 @@ first** and run it only after they approve, or let the user run it.
 
 This is a **pnpm monorepo** rooted at `ts/`. All commands run from the `ts/` directory.
 
+### First step in a new session/worktree: provision the npm registry
+
+The public npm registry is blocked; packages come from an internal Azure Artifacts
+feed configured by `ts/.npmrc`, which is gitignored (so it is missing in every fresh
+clone/worktree). **Before running `pnpm install` — or any command that may install
+packages, such as `npx` — run:**
+
+```bash
+cd ts
+npm run getNPMRC      # or: node tools/scripts/getNPMRC.mjs
+```
+
+This pulls `ts/.npmrc` from Key Vault and installs feed auth (requires `az login`).
+Symptoms of skipping it: `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE` or timeouts
+against `registry.npmjs.org`. Also prefer `pnpm exec <tool>` over `npx <tool>`,
+since `npx` will try to download from the public registry.
+
 ```bash
 # Install & build
 pnpm i

--- a/ts/CLAUDE.md
+++ b/ts/CLAUDE.md
@@ -52,23 +52,6 @@ first** and run it only after they approve, or let the user run it.
 
 This is a **pnpm monorepo** rooted at `ts/`. All commands run from the `ts/` directory.
 
-### First step in a new session/worktree: provision the npm registry
-
-The public npm registry is blocked; packages come from an internal Azure Artifacts
-feed configured by `ts/.npmrc`, which is gitignored (so it is missing in every fresh
-clone/worktree). **Before running `pnpm install` — or any command that may install
-packages, such as `npx` — run:**
-
-```bash
-cd ts
-npm run getNPMRC      # or: node tools/scripts/getNPMRC.mjs
-```
-
-This pulls `ts/.npmrc` from Key Vault and installs feed auth (requires `az login`).
-Symptoms of skipping it: `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE` or timeouts
-against `registry.npmjs.org`. Also prefer `pnpm exec <tool>` over `npx <tool>`,
-since `npx` will try to download from the public registry.
-
 ```bash
 # Install & build
 pnpm i

--- a/ts/docs/overview/command-reference.md
+++ b/ts/docs/overview/command-reference.md
@@ -2228,7 +2228,7 @@ Usage: `@player spotify load <file>`
 
 ### Arguments:
 
-- &lt;file&gt; - File to load (type: string)
+- &lt;file&gt; - File or directory to load (a directory loads all Spotify streaming history .json files in it) (type: string)
 
 ## @player spotify login - Login to Spotify
 

--- a/ts/packages/actionGrammar/src/dfaMatcher.ts
+++ b/ts/packages/actionGrammar/src/dfaMatcher.ts
@@ -876,9 +876,6 @@ export interface DFACompletionResult {
      * cross-rule merging which the DFA already encodes).
      */
     tookWildcard?: boolean;
-
-    /** Token index where the active wildcard at the frontier began. */
-    activeWildcardStartTokenIndex?: number;
 }
 
 /**
@@ -919,7 +916,6 @@ export function getDFACompletions(
     let skipCount = 0;
     let consumed = 0;
     let tookWildcard = false;
-    let activeWildcardStartTokenIndex: number | undefined;
     for (let pi = 0; pi < tokens.length; pi++) {
         if (skipCount > 0) {
             skipCount--;
@@ -953,9 +949,6 @@ export function getDFACompletions(
         if (nextStateId === undefined && currentState.wildcardTransition) {
             nextStateId = currentState.wildcardTransition.to;
             tookWildcard = true;
-            activeWildcardStartTokenIndex ??= pi;
-        } else if (nextStateId !== undefined) {
-            activeWildcardStartTokenIndex = undefined;
         }
 
         // Try phraseSet transitions
@@ -1153,9 +1146,6 @@ export function getDFACompletions(
         consumedTokenCount: consumed,
         tookWildcard,
     };
-    if (activeWildcardStartTokenIndex !== undefined) {
-        result.activeWildcardStartTokenIndex = activeWildcardStartTokenIndex;
-    }
     if (properties.length > 0) {
         result.properties = properties;
     }
@@ -1203,15 +1193,11 @@ export function getDFACompletionsFromInput(
         canRewind &&
         (direction === "backward" ||
             (exhaustedAllInput && forwardFrontierEmpty));
-    let partialValueStartTokenIndex: number | undefined;
     if (shouldRewind) {
-        const rewindTokenCount =
-            forwardRaw.activeWildcardStartTokenIndex ?? forwardConsumed - 1;
-        partialValueStartTokenIndex = forwardRaw.activeWildcardStartTokenIndex;
-        const rewoundTokens = tokens.slice(0, rewindTokenCount);
+        const rewoundTokens = tokens.slice(0, forwardConsumed - 1);
         raw = getDFACompletions(dfa, rewoundTokens);
         matchedPrefixLength =
-            rewindTokenCount > 0 ? ends[rewindTokenCount - 1] : 0;
+            forwardConsumed > 1 ? ends[forwardConsumed - 2] : 0;
     }
     // Silence unused-variable warning when `starts` isn't otherwise used
     // (it's destructured for symmetry with the NFA implementation).
@@ -1242,23 +1228,12 @@ export function getDFACompletionsFromInput(
         afterWildcard,
     };
     if (raw.properties && raw.properties.length > 0) {
-        const partialValue =
-            (partialValueStartTokenIndex ??
-                raw.activeWildcardStartTokenIndex) === undefined
-                ? ""
-                : input.substring(
-                      starts[
-                          (partialValueStartTokenIndex ??
-                              raw.activeWildcardStartTokenIndex)!
-                      ],
-                  );
         result.properties = raw.properties.map((p) => ({
             match: p.actionName
                 ? { actionName: p.actionName, parameters: {} }
                 : {},
             propertyNames: [p.propertyPath],
             separatorMode: "autoSpacePunctuation",
-            partialValue,
         }));
     }
     return result;

--- a/ts/packages/actionGrammar/src/dfaMatcher.ts
+++ b/ts/packages/actionGrammar/src/dfaMatcher.ts
@@ -876,6 +876,9 @@ export interface DFACompletionResult {
      * cross-rule merging which the DFA already encodes).
      */
     tookWildcard?: boolean;
+
+    /** Token index where the active wildcard at the frontier began. */
+    activeWildcardStartTokenIndex?: number;
 }
 
 /**
@@ -916,6 +919,7 @@ export function getDFACompletions(
     let skipCount = 0;
     let consumed = 0;
     let tookWildcard = false;
+    let activeWildcardStartTokenIndex: number | undefined;
     for (let pi = 0; pi < tokens.length; pi++) {
         if (skipCount > 0) {
             skipCount--;
@@ -949,6 +953,9 @@ export function getDFACompletions(
         if (nextStateId === undefined && currentState.wildcardTransition) {
             nextStateId = currentState.wildcardTransition.to;
             tookWildcard = true;
+            activeWildcardStartTokenIndex ??= pi;
+        } else if (nextStateId !== undefined) {
+            activeWildcardStartTokenIndex = undefined;
         }
 
         // Try phraseSet transitions
@@ -1146,6 +1153,9 @@ export function getDFACompletions(
         consumedTokenCount: consumed,
         tookWildcard,
     };
+    if (activeWildcardStartTokenIndex !== undefined) {
+        result.activeWildcardStartTokenIndex = activeWildcardStartTokenIndex;
+    }
     if (properties.length > 0) {
         result.properties = properties;
     }
@@ -1193,11 +1203,15 @@ export function getDFACompletionsFromInput(
         canRewind &&
         (direction === "backward" ||
             (exhaustedAllInput && forwardFrontierEmpty));
+    let partialValueStartTokenIndex: number | undefined;
     if (shouldRewind) {
-        const rewoundTokens = tokens.slice(0, forwardConsumed - 1);
+        const rewindTokenCount =
+            forwardRaw.activeWildcardStartTokenIndex ?? forwardConsumed - 1;
+        partialValueStartTokenIndex = forwardRaw.activeWildcardStartTokenIndex;
+        const rewoundTokens = tokens.slice(0, rewindTokenCount);
         raw = getDFACompletions(dfa, rewoundTokens);
         matchedPrefixLength =
-            forwardConsumed > 1 ? ends[forwardConsumed - 2] : 0;
+            rewindTokenCount > 0 ? ends[rewindTokenCount - 1] : 0;
     }
     // Silence unused-variable warning when `starts` isn't otherwise used
     // (it's destructured for symmetry with the NFA implementation).
@@ -1228,12 +1242,23 @@ export function getDFACompletionsFromInput(
         afterWildcard,
     };
     if (raw.properties && raw.properties.length > 0) {
+        const partialValue =
+            (partialValueStartTokenIndex ??
+                raw.activeWildcardStartTokenIndex) === undefined
+                ? ""
+                : input.substring(
+                      starts[
+                          (partialValueStartTokenIndex ??
+                              raw.activeWildcardStartTokenIndex)!
+                      ],
+                  );
         result.properties = raw.properties.map((p) => ({
             match: p.actionName
                 ? { actionName: p.actionName, parameters: {} }
                 : {},
             propertyNames: [p.propertyPath],
             separatorMode: "autoSpacePunctuation",
+            partialValue,
         }));
     }
     return result;

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -294,6 +294,8 @@ export type GrammarCompletionProperty = {
     match: unknown;
     propertyNames: string[];
     separatorMode: SeparatorMode;
+    /** Text already entered for the property currently being completed. */
+    partialValue?: string | undefined;
 };
 
 // Describes how the grammar rules that produced completions at this
@@ -377,6 +379,7 @@ function getGrammarCompletionProperty(
     state: MatchState,
     valueId: number,
     spacingMode: CompiledSpacingMode,
+    partialValue: string,
 ): GrammarCompletionProperty | undefined {
     const temp = { ...state };
 
@@ -401,6 +404,7 @@ function getGrammarCompletionProperty(
         match,
         propertyNames: wildcardPropertyNames,
         separatorMode: spacingModeToSeparatorMode(spacingMode),
+        partialValue,
     };
 }
 
@@ -1636,6 +1640,12 @@ function materializeCandidates(
                 c.state,
                 c.valueId,
                 c.spacingMode,
+                getWildcardStr(
+                    input,
+                    c.state.pendingWildcard?.start ?? ctx.maxPrefixLength,
+                    input.length,
+                    c.spacingMode,
+                ) ?? "",
             );
             if (completionProperty !== undefined) {
                 properties.push(completionProperty);
@@ -1713,6 +1723,12 @@ function materializeCandidates(
                     c.state,
                     c.valueId,
                     c.spacingMode,
+                    getWildcardStr(
+                        input,
+                        ctx.maxPrefixLength,
+                        input.length,
+                        c.spacingMode,
+                    ) ?? "",
                 );
                 if (completionProperty !== undefined) {
                     properties.push(completionProperty);

--- a/ts/packages/actionGrammar/src/grammarCompletion.ts
+++ b/ts/packages/actionGrammar/src/grammarCompletion.ts
@@ -294,8 +294,6 @@ export type GrammarCompletionProperty = {
     match: unknown;
     propertyNames: string[];
     separatorMode: SeparatorMode;
-    /** Text already entered for the property currently being completed. */
-    partialValue?: string | undefined;
 };
 
 // Describes how the grammar rules that produced completions at this
@@ -379,7 +377,6 @@ function getGrammarCompletionProperty(
     state: MatchState,
     valueId: number,
     spacingMode: CompiledSpacingMode,
-    partialValue: string,
 ): GrammarCompletionProperty | undefined {
     const temp = { ...state };
 
@@ -404,7 +401,6 @@ function getGrammarCompletionProperty(
         match,
         propertyNames: wildcardPropertyNames,
         separatorMode: spacingModeToSeparatorMode(spacingMode),
-        partialValue,
     };
 }
 
@@ -1640,12 +1636,6 @@ function materializeCandidates(
                 c.state,
                 c.valueId,
                 c.spacingMode,
-                getWildcardStr(
-                    input,
-                    c.state.pendingWildcard?.start ?? ctx.maxPrefixLength,
-                    input.length,
-                    c.spacingMode,
-                ) ?? "",
             );
             if (completionProperty !== undefined) {
                 properties.push(completionProperty);
@@ -1723,12 +1713,6 @@ function materializeCandidates(
                     c.state,
                     c.valueId,
                     c.spacingMode,
-                    getWildcardStr(
-                        input,
-                        ctx.maxPrefixLength,
-                        input.length,
-                        c.spacingMode,
-                    ) ?? "",
                 );
                 if (completionProperty !== undefined) {
                     properties.push(completionProperty);

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -177,7 +177,10 @@ export {
     normalizeToken,
     type NFAGrammarMatchResult,
 } from "./nfaMatcher.js";
-export { computeNFACompletions } from "./nfaCompletion.js";
+export {
+    computeNFACompletions,
+    computeNFACompletionsFromInput,
+} from "./nfaCompletion.js";
 
 // DFA system
 export type {
@@ -203,6 +206,7 @@ export {
     matchDFAToASTWithSplitting,
     evaluateMatchAST,
     getDFACompletions,
+    getDFACompletionsFromInput,
     printDFA,
     type DFAMatchResult,
     type DFAASTMatchResult,

--- a/ts/packages/actionGrammar/src/index.ts
+++ b/ts/packages/actionGrammar/src/index.ts
@@ -177,10 +177,7 @@ export {
     normalizeToken,
     type NFAGrammarMatchResult,
 } from "./nfaMatcher.js";
-export {
-    computeNFACompletions,
-    computeNFACompletionsFromInput,
-} from "./nfaCompletion.js";
+export { computeNFACompletions } from "./nfaCompletion.js";
 
 // DFA system
 export type {
@@ -206,7 +203,6 @@ export {
     matchDFAToASTWithSplitting,
     evaluateMatchAST,
     getDFACompletions,
-    getDFACompletionsFromInput,
     printDFA,
     type DFAMatchResult,
     type DFAASTMatchResult,

--- a/ts/packages/actionGrammar/src/nfaCompletion.ts
+++ b/ts/packages/actionGrammar/src/nfaCompletion.ts
@@ -130,6 +130,157 @@ interface CapturedSlot {
     startTokenIndex: number;
 }
 
+interface WildcardCaptureUpdate {
+    activeCapture: CapturedSlot | undefined;
+    stepCapture: CapturedSlot | undefined;
+}
+
+function findWildcardCaptureStart(
+    nfa: NFA,
+    stateIds: number[],
+    tokenIndex: number,
+): CapturedSlot | undefined {
+    for (const stateId of stateIds) {
+        const state = nfa.states[stateId];
+        if (state === undefined) continue;
+        for (const transition of state.transitions) {
+            if (
+                transition.type === "wildcard" &&
+                transition.propertyPath !== undefined
+            ) {
+                return {
+                    propertyPath: transition.propertyPath,
+                    text: "",
+                    startTokenIndex: tokenIndex,
+                };
+            }
+        }
+    }
+    return undefined;
+}
+
+function updateWildcardCapture(
+    nfa: NFA,
+    stateIds: number[],
+    isWildcardStep: boolean,
+    activeCapture: CapturedSlot | undefined,
+    tokens: string[],
+    starts: number[],
+    tokenIndex: number,
+    input?: string,
+): WildcardCaptureUpdate {
+    if (!isWildcardStep) {
+        return { activeCapture: undefined, stepCapture: undefined };
+    }
+
+    const capture =
+        findWildcardCaptureStart(nfa, stateIds, tokenIndex) ?? activeCapture;
+    if (capture === undefined) {
+        return { activeCapture: undefined, stepCapture: undefined };
+    }
+
+    const captureEnd = starts[tokenIndex] + tokens[tokenIndex].length;
+    const stepCapture: CapturedSlot = {
+        propertyPath: capture.propertyPath,
+        startTokenIndex: capture.startTokenIndex,
+        text:
+            input !== undefined
+                ? input.substring(starts[capture.startTokenIndex], captureEnd)
+                : tokens
+                      .slice(capture.startTokenIndex, tokenIndex + 1)
+                      .join(" "),
+    };
+    return { activeCapture: stepCapture, stepCapture };
+}
+
+interface TransitionMatches {
+    tokenMatched: number[];
+    wildcardMatched: number[];
+    matchedDisplayLength: number;
+    matchedInputTokenCount: number;
+}
+
+function findMatchingTransitions(
+    nfa: NFA,
+    stateIds: number[],
+    tokens: string[],
+    tokenIndex: number,
+): TransitionMatches {
+    const token = tokens[tokenIndex];
+    const lowerToken = token.toLowerCase();
+    const tokenMatched: number[] = [];
+    const wildcardMatched: number[] = [];
+    let matchedDisplayLength = token.length;
+    let matchedInputTokenCount = 1;
+
+    for (const stateId of stateIds) {
+        const state = nfa.states[stateId];
+        if (state === undefined) continue;
+
+        for (const transition of state.transitions) {
+            if (transition.type === "wildcard") {
+                debugCompletion(
+                    `  walkPrefix: state ${stateId} --*${transition.variable || ""}:${transition.typeName || "any"}--> ${transition.to} (wildcard candidate "${token}")`,
+                );
+                wildcardMatched.push(transition.to);
+                continue;
+            }
+            if (transition.type !== "token" || !transition.tokens) continue;
+
+            let matchIndex = transition.tokens.findIndex(
+                (candidate) => candidate.toLowerCase() === lowerToken,
+            );
+            let spanConsumed = 1;
+            if (matchIndex === -1) {
+                for (
+                    let grammarIndex = 0;
+                    grammarIndex < transition.tokens.length;
+                    grammarIndex++
+                ) {
+                    const grammarToken = transition.tokens[grammarIndex];
+                    if (!/\s/.test(grammarToken)) continue;
+                    const wordCount = grammarToken
+                        .split(/\s+/)
+                        .filter(Boolean).length;
+                    if (
+                        wordCount < 2 ||
+                        tokenIndex + wordCount > tokens.length
+                    ) {
+                        continue;
+                    }
+                    const inputSpan = tokens
+                        .slice(tokenIndex, tokenIndex + wordCount)
+                        .map((inputToken) => inputToken.toLowerCase())
+                        .join(" ");
+                    if (inputSpan === grammarToken.toLowerCase()) {
+                        matchIndex = grammarIndex;
+                        spanConsumed = wordCount;
+                        break;
+                    }
+                }
+            }
+            if (matchIndex === -1) continue;
+
+            debugCompletion(
+                `  walkPrefix: state ${stateId} --[${transition.tokens.join("|")}]--> ${transition.to} (token matched, span=${spanConsumed})`,
+            );
+            tokenMatched.push(transition.to);
+            const displayToken =
+                transition.displayTokens?.[matchIndex] ??
+                transition.tokens[matchIndex];
+            matchedDisplayLength = displayToken.length;
+            matchedInputTokenCount = spanConsumed;
+        }
+    }
+
+    return {
+        tokenMatched,
+        wildcardMatched,
+        matchedDisplayLength,
+        matchedInputTokenCount,
+    };
+}
+
 function walkPrefixTokens(
     nfa: NFA,
     tokens: string[],
@@ -169,75 +320,12 @@ function walkPrefixTokens(
     let activeCapture: CapturedSlot | undefined;
     while (consumed < tokens.length) {
         const token = tokens[consumed];
-        const tokenMatched: number[] = [];
-        const wildcardMatched: number[] = [];
-        const lowerToken = token.toLowerCase();
-        // Capture the matched display token's length so the caller can
-        // compute matchedPrefixLength precisely.  Default to the input
-        // token's length when no display info is available.
-        let matchedDisplayLength = token.length;
-        // Most grammar transitions consume one input token.  A grammar
-        // token with internal whitespace (escape-space authoring, e.g.
-        // `hello world`) consumes a span of multiple consecutive input
-        // tokens (`hello`, `world`).
-        let matchedInputTokenCount = 1;
-
-        for (const stateId of currentStates) {
-            const state = nfa.states[stateId];
-            if (!state) continue;
-
-            for (const trans of state.transitions) {
-                if (trans.type === "token" && trans.tokens) {
-                    // Try single-token match first (the common case).
-                    let matchIdx = trans.tokens.findIndex(
-                        (t) => t.toLowerCase() === lowerToken,
-                    );
-                    let spanConsumed = 1;
-                    // Then try multi-token match for grammar tokens
-                    // containing internal whitespace (escape-space).
-                    if (matchIdx === -1) {
-                        for (let gi = 0; gi < trans.tokens.length; gi++) {
-                            const gt = trans.tokens[gi];
-                            if (!/\s/.test(gt)) continue;
-                            const wordCount = gt
-                                .split(/\s+/)
-                                .filter(Boolean).length;
-                            if (
-                                wordCount < 2 ||
-                                consumed + wordCount > tokens.length
-                            ) {
-                                continue;
-                            }
-                            const inputSpan = tokens
-                                .slice(consumed, consumed + wordCount)
-                                .map((t) => t.toLowerCase())
-                                .join(" ");
-                            if (inputSpan === gt.toLowerCase()) {
-                                matchIdx = gi;
-                                spanConsumed = wordCount;
-                                break;
-                            }
-                        }
-                    }
-                    if (matchIdx !== -1) {
-                        debugCompletion(
-                            `  walkPrefix: state ${stateId} --[${trans.tokens.join("|")}]--> ${trans.to} (token matched, span=${spanConsumed})`,
-                        );
-                        tokenMatched.push(trans.to);
-                        const displayTok =
-                            trans.displayTokens?.[matchIdx] ??
-                            trans.tokens[matchIdx];
-                        matchedDisplayLength = displayTok.length;
-                        matchedInputTokenCount = spanConsumed;
-                    }
-                } else if (trans.type === "wildcard") {
-                    debugCompletion(
-                        `  walkPrefix: state ${stateId} --*${trans.variable || ""}:${trans.typeName || "any"}--> ${trans.to} (wildcard candidate "${token}")`,
-                    );
-                    wildcardMatched.push(trans.to);
-                }
-            }
-        }
+        const {
+            tokenMatched,
+            wildcardMatched,
+            matchedDisplayLength,
+            matchedInputTokenCount,
+        } = findMatchingTransitions(nfa, currentStates, tokens, consumed);
 
         // Prefer token transitions; fall back to wildcard only when no token matches
         const nextStates =
@@ -306,47 +394,18 @@ function walkPrefixTokens(
         // Wildcard entry transitions identify the property. Self-loop
         // transitions are unannotated, so carry the active property forward
         // and snapshot the complete span on every wildcard step.
-        let stepCapture: CapturedSlot | undefined;
-        if (isWildcardStep) {
-            outer: for (const sid of currentStates) {
-                const st = nfa.states[sid];
-                if (!st) continue;
-                for (const t of st.transitions) {
-                    if (t.type === "wildcard" && t.propertyPath !== undefined) {
-                        stepCapture = {
-                            propertyPath: t.propertyPath,
-                            text: "",
-                            startTokenIndex: consumed,
-                        };
-                        break outer;
-                    }
-                }
-            }
-            activeCapture = stepCapture ?? activeCapture;
-            if (activeCapture !== undefined) {
-                const captureEnd = spanStart + token.length;
-                stepCapture = {
-                    propertyPath: activeCapture.propertyPath,
-                    startTokenIndex: activeCapture.startTokenIndex,
-                    text:
-                        input !== undefined
-                            ? input.substring(
-                                  starts[activeCapture.startTokenIndex],
-                                  captureEnd,
-                              )
-                            : tokens
-                                  .slice(
-                                      activeCapture.startTokenIndex,
-                                      consumed + 1,
-                                  )
-                                  .join(" "),
-                };
-                activeCapture = stepCapture;
-            }
-        } else {
-            activeCapture = undefined;
-        }
-        capturedSlotsPerStep.push(stepCapture);
+        const captureUpdate = updateWildcardCapture(
+            nfa,
+            currentStates,
+            isWildcardStep,
+            activeCapture,
+            tokens,
+            starts,
+            consumed,
+            input,
+        );
+        activeCapture = captureUpdate.activeCapture;
+        capturedSlotsPerStep.push(captureUpdate.stepCapture);
         // Compute the input position where this step ends.  For token
         // matches: span start + grammar display length (capped at input
         // length).  For wildcard matches: end of the (single) input token

--- a/ts/packages/actionGrammar/src/nfaCompletion.ts
+++ b/ts/packages/actionGrammar/src/nfaCompletion.ts
@@ -127,6 +127,7 @@ interface WalkResult {
 interface CapturedSlot {
     propertyPath: string;
     text: string;
+    startTokenIndex: number;
 }
 
 function walkPrefixTokens(
@@ -134,6 +135,7 @@ function walkPrefixTokens(
     tokens: string[],
     starts?: number[],
     inputLength?: number,
+    input?: string,
 ): WalkResult {
     // Legacy callers (token-only entry point) don't have character offsets;
     // synthesize them assuming single-space separators.  matchedPrefixLength
@@ -164,6 +166,7 @@ function walkPrefixTokens(
     const stepIsWildcard: boolean[] = [];
     const endPosPerStep: number[] = [];
     const capturedSlotsPerStep: (CapturedSlot | undefined)[] = [];
+    let activeCapture: CapturedSlot | undefined;
     while (consumed < tokens.length) {
         const token = tokens[consumed];
         const tokenMatched: number[] = [];
@@ -299,12 +302,10 @@ function walkPrefixTokens(
         }
         prevStatesPerStep.push(currentStates);
         stepIsWildcard.push(isWildcardStep);
-        // When this step is a wildcard, look at the wildcard transitions that
-        // could have fired and capture the first one carrying a propertyPath
-        // annotation along with the input text it consumed.  Loop self-
-        // transitions don't carry propertyPath (see nfaCompiler), so only the
-        // initial entry transition contributes a capture — multi-token
-        // wildcard captures truncate to the first token in this MVP.
+        const spanStart = starts[consumed];
+        // Wildcard entry transitions identify the property. Self-loop
+        // transitions are unannotated, so carry the active property forward
+        // and snapshot the complete span on every wildcard step.
         let stepCapture: CapturedSlot | undefined;
         if (isWildcardStep) {
             outer: for (const sid of currentStates) {
@@ -314,19 +315,42 @@ function walkPrefixTokens(
                     if (t.type === "wildcard" && t.propertyPath !== undefined) {
                         stepCapture = {
                             propertyPath: t.propertyPath,
-                            text: token,
+                            text: "",
+                            startTokenIndex: consumed,
                         };
                         break outer;
                     }
                 }
             }
+            activeCapture = stepCapture ?? activeCapture;
+            if (activeCapture !== undefined) {
+                const captureEnd = spanStart + token.length;
+                stepCapture = {
+                    propertyPath: activeCapture.propertyPath,
+                    startTokenIndex: activeCapture.startTokenIndex,
+                    text:
+                        input !== undefined
+                            ? input.substring(
+                                  starts[activeCapture.startTokenIndex],
+                                  captureEnd,
+                              )
+                            : tokens
+                                  .slice(
+                                      activeCapture.startTokenIndex,
+                                      consumed + 1,
+                                  )
+                                  .join(" "),
+                };
+                activeCapture = stepCapture;
+            }
+        } else {
+            activeCapture = undefined;
         }
         capturedSlotsPerStep.push(stepCapture);
         // Compute the input position where this step ends.  For token
         // matches: span start + grammar display length (capped at input
         // length).  For wildcard matches: end of the (single) input token
         // consumed.
-        const spanStart = starts[consumed];
         if (isWildcardStep) {
             endPos = spanStart + token.length;
         } else {
@@ -662,7 +686,7 @@ export function computeNFACompletionsFromInput(
         return finalizeCompletionResult(nfa, reachable, 0, false);
     }
 
-    const walk = walkPrefixTokens(nfa, tokens, starts, input.length);
+    const walk = walkPrefixTokens(nfa, tokens, starts, input.length, input);
     const {
         states,
         consumed,
@@ -702,24 +726,34 @@ export function computeNFACompletionsFromInput(
         consumed > 0 && !hasTrailingSeparator && prevStatesPerStep.length > 0;
 
     // Helper: build the rewound result.  matchedPrefixLength backs up to
-    // the END of the previous token (or 0 if rewinding off the first
-    // token), so the user can "delete the separator + retype the last
-    // word" with the position pinned just past the prior word.
+    // the END of the previous grammar part. A multi-token wildcard rewinds
+    // as one part while retaining its full text as the property partial.
     const buildRewound = (): GrammarCompletionResult => {
-        // Rewind by one GRAMMAR STEP (which may have spanned multiple
-        // input tokens for escape-space matches).
-        const lastStepIdx = stepCount - 1;
-        const rewoundStates = prevStatesPerStep[lastStepIdx];
+        let rewindStepIdx = stepCount - 1;
+        const rewindingWildcard = stepIsWildcard[rewindStepIdx];
+        while (
+            rewindingWildcard &&
+            rewindStepIdx > 0 &&
+            stepIsWildcard[rewindStepIdx - 1]
+        ) {
+            rewindStepIdx--;
+        }
+        const rewoundStates = prevStatesPerStep[rewindStepIdx];
         const rewoundPrefixLength =
-            lastStepIdx > 0 ? endPosPerStep[lastStepIdx - 1] : 0;
+            rewindStepIdx > 0 ? endPosPerStep[rewindStepIdx - 1] : 0;
         const rewoundTookWildcard = stepIsWildcard
-            .slice(0, lastStepIdx)
+            .slice(0, rewindStepIdx)
             .some(Boolean);
         const rewoundCaptures = collectCaptures(
-            capturedSlotsPerStep.slice(0, lastStepIdx),
+            rewindingWildcard
+                ? capturedSlotsPerStep
+                : capturedSlotsPerStep.slice(0, rewindStepIdx),
         );
+        const currentPartialValue = rewindingWildcard
+            ? input.substring(rewoundPrefixLength).replace(/^[\s\p{P}]+/u, "")
+            : undefined;
         debugCompletion(
-            `  rewind: step ${lastStepIdx} states=[${rewoundStates.join(", ")}] mpl=${rewoundPrefixLength} (was wildcard step? ${stepIsWildcard[lastStepIdx]})`,
+            `  rewind: step ${rewindStepIdx} states=[${rewoundStates.join(", ")}] mpl=${rewoundPrefixLength} (was wildcard step? ${rewindingWildcard})`,
         );
         return finalizeCompletionResult(
             nfa,
@@ -727,6 +761,7 @@ export function computeNFACompletionsFromInput(
             rewoundPrefixLength,
             rewoundTookWildcard,
             rewoundCaptures,
+            currentPartialValue,
         );
     };
 
@@ -787,6 +822,7 @@ function finalizeCompletionResult(
     matchedPrefixLength: number,
     tookWildcard: boolean,
     capturedSlots: CapturedSlot[] = [],
+    currentPartialValue?: string,
 ): GrammarCompletionResult {
     // directionSensitive: per canonical (grammarCompletion.ts:1690),
     // `matchedPrefixLength > 0` is the signal — any prefix consumption
@@ -822,6 +858,7 @@ function finalizeCompletionResult(
         nfa,
         properties,
         capturedSlots,
+        currentPartialValue,
     );
     // closedSet: the listed completions are exhaustive iff no property
     // completion arises at the frontier.  A frontier wildcard without
@@ -870,6 +907,7 @@ function buildGrammarProperties(
     nfa: NFA,
     properties: PropertyCompletion[],
     capturedSlots: CapturedSlot[],
+    currentPartialValue?: string,
 ): GrammarCompletionProperty[] {
     if (properties.length === 0) return [];
 
@@ -897,11 +935,24 @@ function buildGrammarProperties(
             setPathValue(match, capture.propertyPath, capture.text);
         }
 
-        result.push({
+        let partialValue: string | undefined;
+        for (let i = capturedSlots.length - 1; i >= 0; i--) {
+            if (capturedSlots[i].propertyPath === prop.propertyPath) {
+                partialValue = capturedSlots[i].text;
+                break;
+            }
+        }
+        const completionProperty: GrammarCompletionProperty = {
             match,
             propertyNames: [prop.propertyPath],
             separatorMode: "autoSpacePunctuation",
-        });
+        };
+        if (partialValue !== undefined) {
+            completionProperty.partialValue = partialValue;
+        } else if (currentPartialValue !== undefined) {
+            completionProperty.partialValue = currentPartialValue;
+        }
+        result.push(completionProperty);
     }
 
     return result;

--- a/ts/packages/actionGrammar/src/nfaCompletion.ts
+++ b/ts/packages/actionGrammar/src/nfaCompletion.ts
@@ -127,158 +127,6 @@ interface WalkResult {
 interface CapturedSlot {
     propertyPath: string;
     text: string;
-    startTokenIndex: number;
-}
-
-interface WildcardCaptureUpdate {
-    activeCapture: CapturedSlot | undefined;
-    stepCapture: CapturedSlot | undefined;
-}
-
-function findWildcardCaptureStart(
-    nfa: NFA,
-    stateIds: number[],
-    tokenIndex: number,
-): CapturedSlot | undefined {
-    for (const stateId of stateIds) {
-        const state = nfa.states[stateId];
-        if (state === undefined) continue;
-        for (const transition of state.transitions) {
-            if (
-                transition.type === "wildcard" &&
-                transition.propertyPath !== undefined
-            ) {
-                return {
-                    propertyPath: transition.propertyPath,
-                    text: "",
-                    startTokenIndex: tokenIndex,
-                };
-            }
-        }
-    }
-    return undefined;
-}
-
-function updateWildcardCapture(
-    nfa: NFA,
-    stateIds: number[],
-    isWildcardStep: boolean,
-    activeCapture: CapturedSlot | undefined,
-    tokens: string[],
-    starts: number[],
-    tokenIndex: number,
-    input?: string,
-): WildcardCaptureUpdate {
-    if (!isWildcardStep) {
-        return { activeCapture: undefined, stepCapture: undefined };
-    }
-
-    const capture =
-        findWildcardCaptureStart(nfa, stateIds, tokenIndex) ?? activeCapture;
-    if (capture === undefined) {
-        return { activeCapture: undefined, stepCapture: undefined };
-    }
-
-    const captureEnd = starts[tokenIndex] + tokens[tokenIndex].length;
-    const stepCapture: CapturedSlot = {
-        propertyPath: capture.propertyPath,
-        startTokenIndex: capture.startTokenIndex,
-        text:
-            input !== undefined
-                ? input.substring(starts[capture.startTokenIndex], captureEnd)
-                : tokens
-                      .slice(capture.startTokenIndex, tokenIndex + 1)
-                      .join(" "),
-    };
-    return { activeCapture: stepCapture, stepCapture };
-}
-
-interface TransitionMatches {
-    tokenMatched: number[];
-    wildcardMatched: number[];
-    matchedDisplayLength: number;
-    matchedInputTokenCount: number;
-}
-
-function findMatchingTransitions(
-    nfa: NFA,
-    stateIds: number[],
-    tokens: string[],
-    tokenIndex: number,
-): TransitionMatches {
-    const token = tokens[tokenIndex];
-    const lowerToken = token.toLowerCase();
-    const tokenMatched: number[] = [];
-    const wildcardMatched: number[] = [];
-    let matchedDisplayLength = token.length;
-    let matchedInputTokenCount = 1;
-
-    for (const stateId of stateIds) {
-        const state = nfa.states[stateId];
-        if (state === undefined) continue;
-
-        for (const transition of state.transitions) {
-            if (transition.type === "wildcard") {
-                debugCompletion(
-                    `  walkPrefix: state ${stateId} --*${transition.variable || ""}:${transition.typeName || "any"}--> ${transition.to} (wildcard candidate "${token}")`,
-                );
-                wildcardMatched.push(transition.to);
-                continue;
-            }
-            if (transition.type !== "token" || !transition.tokens) continue;
-
-            let matchIndex = transition.tokens.findIndex(
-                (candidate) => candidate.toLowerCase() === lowerToken,
-            );
-            let spanConsumed = 1;
-            if (matchIndex === -1) {
-                for (
-                    let grammarIndex = 0;
-                    grammarIndex < transition.tokens.length;
-                    grammarIndex++
-                ) {
-                    const grammarToken = transition.tokens[grammarIndex];
-                    if (!/\s/.test(grammarToken)) continue;
-                    const wordCount = grammarToken
-                        .split(/\s+/)
-                        .filter(Boolean).length;
-                    if (
-                        wordCount < 2 ||
-                        tokenIndex + wordCount > tokens.length
-                    ) {
-                        continue;
-                    }
-                    const inputSpan = tokens
-                        .slice(tokenIndex, tokenIndex + wordCount)
-                        .map((inputToken) => inputToken.toLowerCase())
-                        .join(" ");
-                    if (inputSpan === grammarToken.toLowerCase()) {
-                        matchIndex = grammarIndex;
-                        spanConsumed = wordCount;
-                        break;
-                    }
-                }
-            }
-            if (matchIndex === -1) continue;
-
-            debugCompletion(
-                `  walkPrefix: state ${stateId} --[${transition.tokens.join("|")}]--> ${transition.to} (token matched, span=${spanConsumed})`,
-            );
-            tokenMatched.push(transition.to);
-            const displayToken =
-                transition.displayTokens?.[matchIndex] ??
-                transition.tokens[matchIndex];
-            matchedDisplayLength = displayToken.length;
-            matchedInputTokenCount = spanConsumed;
-        }
-    }
-
-    return {
-        tokenMatched,
-        wildcardMatched,
-        matchedDisplayLength,
-        matchedInputTokenCount,
-    };
 }
 
 function walkPrefixTokens(
@@ -286,7 +134,6 @@ function walkPrefixTokens(
     tokens: string[],
     starts?: number[],
     inputLength?: number,
-    input?: string,
 ): WalkResult {
     // Legacy callers (token-only entry point) don't have character offsets;
     // synthesize them assuming single-space separators.  matchedPrefixLength
@@ -317,15 +164,77 @@ function walkPrefixTokens(
     const stepIsWildcard: boolean[] = [];
     const endPosPerStep: number[] = [];
     const capturedSlotsPerStep: (CapturedSlot | undefined)[] = [];
-    let activeCapture: CapturedSlot | undefined;
     while (consumed < tokens.length) {
         const token = tokens[consumed];
-        const {
-            tokenMatched,
-            wildcardMatched,
-            matchedDisplayLength,
-            matchedInputTokenCount,
-        } = findMatchingTransitions(nfa, currentStates, tokens, consumed);
+        const tokenMatched: number[] = [];
+        const wildcardMatched: number[] = [];
+        const lowerToken = token.toLowerCase();
+        // Capture the matched display token's length so the caller can
+        // compute matchedPrefixLength precisely.  Default to the input
+        // token's length when no display info is available.
+        let matchedDisplayLength = token.length;
+        // Most grammar transitions consume one input token.  A grammar
+        // token with internal whitespace (escape-space authoring, e.g.
+        // `hello world`) consumes a span of multiple consecutive input
+        // tokens (`hello`, `world`).
+        let matchedInputTokenCount = 1;
+
+        for (const stateId of currentStates) {
+            const state = nfa.states[stateId];
+            if (!state) continue;
+
+            for (const trans of state.transitions) {
+                if (trans.type === "token" && trans.tokens) {
+                    // Try single-token match first (the common case).
+                    let matchIdx = trans.tokens.findIndex(
+                        (t) => t.toLowerCase() === lowerToken,
+                    );
+                    let spanConsumed = 1;
+                    // Then try multi-token match for grammar tokens
+                    // containing internal whitespace (escape-space).
+                    if (matchIdx === -1) {
+                        for (let gi = 0; gi < trans.tokens.length; gi++) {
+                            const gt = trans.tokens[gi];
+                            if (!/\s/.test(gt)) continue;
+                            const wordCount = gt
+                                .split(/\s+/)
+                                .filter(Boolean).length;
+                            if (
+                                wordCount < 2 ||
+                                consumed + wordCount > tokens.length
+                            ) {
+                                continue;
+                            }
+                            const inputSpan = tokens
+                                .slice(consumed, consumed + wordCount)
+                                .map((t) => t.toLowerCase())
+                                .join(" ");
+                            if (inputSpan === gt.toLowerCase()) {
+                                matchIdx = gi;
+                                spanConsumed = wordCount;
+                                break;
+                            }
+                        }
+                    }
+                    if (matchIdx !== -1) {
+                        debugCompletion(
+                            `  walkPrefix: state ${stateId} --[${trans.tokens.join("|")}]--> ${trans.to} (token matched, span=${spanConsumed})`,
+                        );
+                        tokenMatched.push(trans.to);
+                        const displayTok =
+                            trans.displayTokens?.[matchIdx] ??
+                            trans.tokens[matchIdx];
+                        matchedDisplayLength = displayTok.length;
+                        matchedInputTokenCount = spanConsumed;
+                    }
+                } else if (trans.type === "wildcard") {
+                    debugCompletion(
+                        `  walkPrefix: state ${stateId} --*${trans.variable || ""}:${trans.typeName || "any"}--> ${trans.to} (wildcard candidate "${token}")`,
+                    );
+                    wildcardMatched.push(trans.to);
+                }
+            }
+        }
 
         // Prefer token transitions; fall back to wildcard only when no token matches
         const nextStates =
@@ -390,26 +299,34 @@ function walkPrefixTokens(
         }
         prevStatesPerStep.push(currentStates);
         stepIsWildcard.push(isWildcardStep);
-        const spanStart = starts[consumed];
-        // Wildcard entry transitions identify the property. Self-loop
-        // transitions are unannotated, so carry the active property forward
-        // and snapshot the complete span on every wildcard step.
-        const captureUpdate = updateWildcardCapture(
-            nfa,
-            currentStates,
-            isWildcardStep,
-            activeCapture,
-            tokens,
-            starts,
-            consumed,
-            input,
-        );
-        activeCapture = captureUpdate.activeCapture;
-        capturedSlotsPerStep.push(captureUpdate.stepCapture);
+        // When this step is a wildcard, look at the wildcard transitions that
+        // could have fired and capture the first one carrying a propertyPath
+        // annotation along with the input text it consumed.  Loop self-
+        // transitions don't carry propertyPath (see nfaCompiler), so only the
+        // initial entry transition contributes a capture — multi-token
+        // wildcard captures truncate to the first token in this MVP.
+        let stepCapture: CapturedSlot | undefined;
+        if (isWildcardStep) {
+            outer: for (const sid of currentStates) {
+                const st = nfa.states[sid];
+                if (!st) continue;
+                for (const t of st.transitions) {
+                    if (t.type === "wildcard" && t.propertyPath !== undefined) {
+                        stepCapture = {
+                            propertyPath: t.propertyPath,
+                            text: token,
+                        };
+                        break outer;
+                    }
+                }
+            }
+        }
+        capturedSlotsPerStep.push(stepCapture);
         // Compute the input position where this step ends.  For token
         // matches: span start + grammar display length (capped at input
         // length).  For wildcard matches: end of the (single) input token
         // consumed.
+        const spanStart = starts[consumed];
         if (isWildcardStep) {
             endPos = spanStart + token.length;
         } else {
@@ -745,7 +662,7 @@ export function computeNFACompletionsFromInput(
         return finalizeCompletionResult(nfa, reachable, 0, false);
     }
 
-    const walk = walkPrefixTokens(nfa, tokens, starts, input.length, input);
+    const walk = walkPrefixTokens(nfa, tokens, starts, input.length);
     const {
         states,
         consumed,
@@ -785,34 +702,24 @@ export function computeNFACompletionsFromInput(
         consumed > 0 && !hasTrailingSeparator && prevStatesPerStep.length > 0;
 
     // Helper: build the rewound result.  matchedPrefixLength backs up to
-    // the END of the previous grammar part. A multi-token wildcard rewinds
-    // as one part while retaining its full text as the property partial.
+    // the END of the previous token (or 0 if rewinding off the first
+    // token), so the user can "delete the separator + retype the last
+    // word" with the position pinned just past the prior word.
     const buildRewound = (): GrammarCompletionResult => {
-        let rewindStepIdx = stepCount - 1;
-        const rewindingWildcard = stepIsWildcard[rewindStepIdx];
-        while (
-            rewindingWildcard &&
-            rewindStepIdx > 0 &&
-            stepIsWildcard[rewindStepIdx - 1]
-        ) {
-            rewindStepIdx--;
-        }
-        const rewoundStates = prevStatesPerStep[rewindStepIdx];
+        // Rewind by one GRAMMAR STEP (which may have spanned multiple
+        // input tokens for escape-space matches).
+        const lastStepIdx = stepCount - 1;
+        const rewoundStates = prevStatesPerStep[lastStepIdx];
         const rewoundPrefixLength =
-            rewindStepIdx > 0 ? endPosPerStep[rewindStepIdx - 1] : 0;
+            lastStepIdx > 0 ? endPosPerStep[lastStepIdx - 1] : 0;
         const rewoundTookWildcard = stepIsWildcard
-            .slice(0, rewindStepIdx)
+            .slice(0, lastStepIdx)
             .some(Boolean);
         const rewoundCaptures = collectCaptures(
-            rewindingWildcard
-                ? capturedSlotsPerStep
-                : capturedSlotsPerStep.slice(0, rewindStepIdx),
+            capturedSlotsPerStep.slice(0, lastStepIdx),
         );
-        const currentPartialValue = rewindingWildcard
-            ? input.substring(rewoundPrefixLength).replace(/^[\s\p{P}]+/u, "")
-            : undefined;
         debugCompletion(
-            `  rewind: step ${rewindStepIdx} states=[${rewoundStates.join(", ")}] mpl=${rewoundPrefixLength} (was wildcard step? ${rewindingWildcard})`,
+            `  rewind: step ${lastStepIdx} states=[${rewoundStates.join(", ")}] mpl=${rewoundPrefixLength} (was wildcard step? ${stepIsWildcard[lastStepIdx]})`,
         );
         return finalizeCompletionResult(
             nfa,
@@ -820,7 +727,6 @@ export function computeNFACompletionsFromInput(
             rewoundPrefixLength,
             rewoundTookWildcard,
             rewoundCaptures,
-            currentPartialValue,
         );
     };
 
@@ -881,7 +787,6 @@ function finalizeCompletionResult(
     matchedPrefixLength: number,
     tookWildcard: boolean,
     capturedSlots: CapturedSlot[] = [],
-    currentPartialValue?: string,
 ): GrammarCompletionResult {
     // directionSensitive: per canonical (grammarCompletion.ts:1690),
     // `matchedPrefixLength > 0` is the signal — any prefix consumption
@@ -917,7 +822,6 @@ function finalizeCompletionResult(
         nfa,
         properties,
         capturedSlots,
-        currentPartialValue,
     );
     // closedSet: the listed completions are exhaustive iff no property
     // completion arises at the frontier.  A frontier wildcard without
@@ -966,7 +870,6 @@ function buildGrammarProperties(
     nfa: NFA,
     properties: PropertyCompletion[],
     capturedSlots: CapturedSlot[],
-    currentPartialValue?: string,
 ): GrammarCompletionProperty[] {
     if (properties.length === 0) return [];
 
@@ -994,24 +897,11 @@ function buildGrammarProperties(
             setPathValue(match, capture.propertyPath, capture.text);
         }
 
-        let partialValue: string | undefined;
-        for (let i = capturedSlots.length - 1; i >= 0; i--) {
-            if (capturedSlots[i].propertyPath === prop.propertyPath) {
-                partialValue = capturedSlots[i].text;
-                break;
-            }
-        }
-        const completionProperty: GrammarCompletionProperty = {
+        result.push({
             match,
             propertyNames: [prop.propertyPath],
             separatorMode: "autoSpacePunctuation",
-        };
-        if (partialValue !== undefined) {
-            completionProperty.partialValue = partialValue;
-        } else if (currentPartialValue !== undefined) {
-            completionProperty.partialValue = currentPartialValue;
-        }
-        result.push(completionProperty);
+        });
     }
 
     return result;

--- a/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
@@ -2,7 +2,90 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import { describeForEachCompletion, expectMetadata } from "./testUtils.js";
+import {
+    createTestCompletion,
+    describeForEachCompletion,
+    expectMetadata,
+    type CompletionVariant,
+} from "./testUtils.js";
+
+const terminalWildcardGrammar = loadGrammarRules(
+    "test.grammar",
+    `<Start> = play $(trackName:wildcard) -> { actionName: "playTrack", parameters: { trackName } };`,
+);
+
+describe.each<CompletionVariant>(["grammar", "nfa", "dfa"])(
+    "Terminal wildcard partial propagation [%s]",
+    (variant) => {
+        it("preserves the full multiword partial value", () => {
+            const result = createTestCompletion(variant)(
+                terminalWildcardGrammar,
+                "play Bohemian Rhap",
+            );
+
+            expect(result.properties).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        propertyNames: ["parameters.trackName"],
+                        partialValue: "Bohemian Rhap",
+                    }),
+                ]),
+            );
+        });
+    },
+);
+
+it("NFA carries a nested wildcard's full partial to its outer property", () => {
+    const nestedTerminalGrammar = loadGrammarRules(
+        "test.grammar",
+        [
+            `<Start> = play $(trackName:<TrackName>) -> { actionName: "playTrack", parameters: { trackName } };`,
+            `<TrackName> = $(x:wildcard);`,
+        ].join("\n"),
+    );
+
+    const result = createTestCompletion("nfa")(
+        nestedTerminalGrammar,
+        "play Bohemian Rhap",
+    );
+
+    expect(result.properties).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                propertyNames: ["parameters.trackName"],
+                partialValue: "Bohemian Rhap",
+            }),
+        ]),
+    );
+});
+
+it("NFA preserves earlier multiword slots while completing a later slot", () => {
+    const grammar = loadGrammarRules(
+        "test.grammar",
+        `<Start> = play $(trackName:wildcard) by $(artist:wildcard) -> { actionName: "playTrack", parameters: { trackName, artist } };`,
+    );
+
+    const result = createTestCompletion("nfa")(
+        grammar,
+        "play Bohemian Rhapsody by Que",
+        undefined,
+        "backward",
+    );
+    const artist = result.properties?.find((property) =>
+        property.propertyNames.includes("parameters.artist"),
+    );
+
+    expect(artist).toEqual(
+        expect.objectContaining({
+            match: expect.objectContaining({
+                parameters: expect.objectContaining({
+                    trackName: "Bohemian Rhapsody",
+                }),
+            }),
+            partialValue: "Que",
+        }),
+    );
+});
 
 describeForEachCompletion(
     "Grammar Completion - nested wildcard through rules",
@@ -59,6 +142,26 @@ describeForEachCompletion(
                             },
                         },
                         propertyNames: ["parameters.trackName"],
+                    },
+                ],
+            });
+        });
+
+        it("propagates the full multiword partial for a terminal wildcard", () => {
+            const result = matchGrammarCompletion(
+                terminalWildcardGrammar,
+                "play Bohemian Rhap",
+            );
+
+            expectMetadata(result, {
+                properties: [
+                    {
+                        match: {
+                            actionName: "playTrack",
+                            parameters: { trackName: undefined },
+                        },
+                        propertyNames: ["parameters.trackName"],
+                        partialValue: "Bohemian Rhap",
                     },
                 ],
             });

--- a/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarCompletionNestedWildcard.spec.ts
@@ -2,90 +2,7 @@
 // Licensed under the MIT License.
 
 import { loadGrammarRules } from "../src/grammarLoader.js";
-import {
-    createTestCompletion,
-    describeForEachCompletion,
-    expectMetadata,
-    type CompletionVariant,
-} from "./testUtils.js";
-
-const terminalWildcardGrammar = loadGrammarRules(
-    "test.grammar",
-    `<Start> = play $(trackName:wildcard) -> { actionName: "playTrack", parameters: { trackName } };`,
-);
-
-describe.each<CompletionVariant>(["grammar", "nfa", "dfa"])(
-    "Terminal wildcard partial propagation [%s]",
-    (variant) => {
-        it("preserves the full multiword partial value", () => {
-            const result = createTestCompletion(variant)(
-                terminalWildcardGrammar,
-                "play Bohemian Rhap",
-            );
-
-            expect(result.properties).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        propertyNames: ["parameters.trackName"],
-                        partialValue: "Bohemian Rhap",
-                    }),
-                ]),
-            );
-        });
-    },
-);
-
-it("NFA carries a nested wildcard's full partial to its outer property", () => {
-    const nestedTerminalGrammar = loadGrammarRules(
-        "test.grammar",
-        [
-            `<Start> = play $(trackName:<TrackName>) -> { actionName: "playTrack", parameters: { trackName } };`,
-            `<TrackName> = $(x:wildcard);`,
-        ].join("\n"),
-    );
-
-    const result = createTestCompletion("nfa")(
-        nestedTerminalGrammar,
-        "play Bohemian Rhap",
-    );
-
-    expect(result.properties).toEqual(
-        expect.arrayContaining([
-            expect.objectContaining({
-                propertyNames: ["parameters.trackName"],
-                partialValue: "Bohemian Rhap",
-            }),
-        ]),
-    );
-});
-
-it("NFA preserves earlier multiword slots while completing a later slot", () => {
-    const grammar = loadGrammarRules(
-        "test.grammar",
-        `<Start> = play $(trackName:wildcard) by $(artist:wildcard) -> { actionName: "playTrack", parameters: { trackName, artist } };`,
-    );
-
-    const result = createTestCompletion("nfa")(
-        grammar,
-        "play Bohemian Rhapsody by Que",
-        undefined,
-        "backward",
-    );
-    const artist = result.properties?.find((property) =>
-        property.propertyNames.includes("parameters.artist"),
-    );
-
-    expect(artist).toEqual(
-        expect.objectContaining({
-            match: expect.objectContaining({
-                parameters: expect.objectContaining({
-                    trackName: "Bohemian Rhapsody",
-                }),
-            }),
-            partialValue: "Que",
-        }),
-    );
-});
+import { describeForEachCompletion, expectMetadata } from "./testUtils.js";
 
 describeForEachCompletion(
     "Grammar Completion - nested wildcard through rules",
@@ -142,26 +59,6 @@ describeForEachCompletion(
                             },
                         },
                         propertyNames: ["parameters.trackName"],
-                    },
-                ],
-            });
-        });
-
-        it("propagates the full multiword partial for a terminal wildcard", () => {
-            const result = matchGrammarCompletion(
-                terminalWildcardGrammar,
-                "play Bohemian Rhap",
-            );
-
-            expectMetadata(result, {
-                properties: [
-                    {
-                        match: {
-                            actionName: "playTrack",
-                            parameters: { trackName: undefined },
-                        },
-                        propertyNames: ["parameters.trackName"],
-                        partialValue: "Bohemian Rhap",
                     },
                 ],
             });

--- a/ts/packages/actionGrammar/test/testUtils.ts
+++ b/ts/packages/actionGrammar/test/testUtils.ts
@@ -268,9 +268,6 @@ function normalizeCompletionResult(r: GrammarCompletionResult) {
     return {
         ...r,
         groups: normalizeGroups(r.groups),
-        properties: r.properties?.map(({ partialValue: _, ...property }) => ({
-            ...property,
-        })),
     };
 }
 
@@ -686,23 +683,24 @@ export function expectMetadata(
                     ),
             );
 
-        // Optional metadata is stripped when omitted from expectations so
-        // existing tests can focus on the fields relevant to their scenario.
+        // When the expected property objects omit separatorMode, strip it
+        // from actuals so existing tests don't break.  Tests that want to
+        // assert separatorMode include it explicitly.
         const checkSeparatorMode = (expected.properties ?? []).some(
             (p) => "separatorMode" in p,
         );
-        const checkPartialValue = (expected.properties ?? []).some(
-            (p) => "partialValue" in p,
-        );
-        const stripped = (result.properties ?? []).map((property) => {
-            const copy: Partial<GrammarCompletionProperty> = { ...property };
-            if (!checkSeparatorMode) delete copy.separatorMode;
-            if (!checkPartialValue) delete copy.partialValue;
-            return copy;
-        });
-        expect(sortProps(stripped)).toEqual(
-            sortProps(expected.properties ?? []),
-        );
+        if (checkSeparatorMode) {
+            expect(sortProps(result.properties ?? [])).toEqual(
+                sortProps(expected.properties ?? []),
+            );
+        } else {
+            const stripped = (result.properties ?? []).map(
+                ({ separatorMode: _, ...rest }) => rest,
+            );
+            expect(sortProps(stripped)).toEqual(
+                sortProps(expected.properties ?? []),
+            );
+        }
     }
 }
 

--- a/ts/packages/actionGrammar/test/testUtils.ts
+++ b/ts/packages/actionGrammar/test/testUtils.ts
@@ -268,6 +268,9 @@ function normalizeCompletionResult(r: GrammarCompletionResult) {
     return {
         ...r,
         groups: normalizeGroups(r.groups),
+        properties: r.properties?.map(({ partialValue: _, ...property }) => ({
+            ...property,
+        })),
     };
 }
 
@@ -683,24 +686,23 @@ export function expectMetadata(
                     ),
             );
 
-        // When the expected property objects omit separatorMode, strip it
-        // from actuals so existing tests don't break.  Tests that want to
-        // assert separatorMode include it explicitly.
+        // Optional metadata is stripped when omitted from expectations so
+        // existing tests can focus on the fields relevant to their scenario.
         const checkSeparatorMode = (expected.properties ?? []).some(
             (p) => "separatorMode" in p,
         );
-        if (checkSeparatorMode) {
-            expect(sortProps(result.properties ?? [])).toEqual(
-                sortProps(expected.properties ?? []),
-            );
-        } else {
-            const stripped = (result.properties ?? []).map(
-                ({ separatorMode: _, ...rest }) => rest,
-            );
-            expect(sortProps(stripped)).toEqual(
-                sortProps(expected.properties ?? []),
-            );
-        }
+        const checkPartialValue = (expected.properties ?? []).some(
+            (p) => "partialValue" in p,
+        );
+        const stripped = (result.properties ?? []).map((property) => {
+            const copy: Partial<GrammarCompletionProperty> = { ...property };
+            if (!checkSeparatorMode) delete copy.separatorMode;
+            if (!checkPartialValue) delete copy.partialValue;
+            return copy;
+        });
+        expect(sortProps(stripped)).toEqual(
+            sortProps(expected.properties ?? []),
+        );
     }
 }
 

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -125,6 +125,10 @@ export function createRpc<
                             type: "invokeError",
                             callId: message.callId,
                             error: error.message,
+                            errorMarkdown:
+                                typeof error?.markdown === "string"
+                                    ? error.markdown
+                                    : undefined,
                             stack: debugError.enabled ? error.stack : undefined,
                         });
                     },
@@ -145,7 +149,15 @@ export function createRpc<
             r.resolve(message.result);
         } else {
             debugError("Invoke error", message.stack);
-            r.reject(new Error(message.error));
+            const error: Error & { markdown?: string } = new Error(
+                message.error,
+            );
+            // Only `message` survives structured cloning, so re-attach the
+            // rich display the far side asked for.
+            if (message.errorMarkdown !== undefined) {
+                error.markdown = message.errorMarkdown;
+            }
+            r.reject(error);
         }
     };
     const bindChannel = (newChannel: RpcChannel) => {
@@ -268,6 +280,7 @@ type InvokeError = {
     type: "invokeError";
     callId: number;
     error: string;
+    errorMarkdown?: string; // Rich display for hosts that render markdown.
     stack?: string; // Optional stack trace for debugging.
 };
 

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -153,6 +153,48 @@ describe("createRpc default (non-rebindable)", () => {
             "rpc was not created as rebindable",
         );
     });
+
+    it("carries an error's markdown display across the channel", async () => {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+
+        const clientRpc = createRpc<EchoInvoke>("client", client);
+        createRpc<{}, {}, EchoInvoke>("server", server, {
+            echo: async () => {
+                const e: Error & { markdown?: string } = new Error("nope");
+                e.markdown = "**nope**";
+                throw e;
+            },
+        });
+
+        const e = await clientRpc.invoke("echo", 1).then(
+            () => undefined,
+            (e: any) => e,
+        );
+        expect(e.message).toBe("nope");
+        expect(e.markdown).toBe("**nope**");
+    });
+
+    it("leaves markdown undefined for a plain error", async () => {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+
+        const clientRpc = createRpc<EchoInvoke>("client", client);
+        createRpc<{}, {}, EchoInvoke>("server", server, {
+            echo: async () => {
+                throw new Error("plain");
+            },
+        });
+
+        const e = await clientRpc.invoke("echo", 1).then(
+            () => undefined,
+            (e: any) => e,
+        );
+        expect(e.message).toBe("plain");
+        expect(e.markdown).toBeUndefined();
+    });
 });
 
 describe("createRpc rebindable", () => {

--- a/ts/packages/agentSdk/src/action.ts
+++ b/ts/packages/agentSdk/src/action.ts
@@ -35,6 +35,10 @@ export type SerializedError = {
 export type ActionResultError = {
     error: string;
     fallbackToReasoning?: boolean | undefined;
+    // Rich display to show in place of the plain `error` text (e.g. setup
+    // instructions with a config snippet, which need markdown to survive
+    // rendering). Optional — clients fall back to `error` when absent.
+    errorDisplayContent?: DisplayContent | undefined;
     // Structured snapshot of the underlying exception when this error came
     // from a thrown value (populated by the dispatcher's action executor).
     // Optional - `undefined` for errors created from a plain message.

--- a/ts/packages/agents/agentUtils/graphUtils/package.json
+++ b/ts/packages/agents/agentUtils/graphUtils/package.json
@@ -37,6 +37,7 @@
     "@typeagent/agent-sdk": "workspace:*",
     "@typeagent/aiclient": "workspace:*",
     "@typeagent/common-utils": "workspace:*",
+    "@typeagent/config": "workspace:*",
     "chalk": "^5.4.1",
     "date-fns": "^4.1.0",
     "debug": "^4.4.0",

--- a/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
@@ -28,7 +28,7 @@ import lockfile from "proper-lockfile";
 import registerDebug from "debug";
 import chalk from "chalk";
 import os from "os";
-import { configSetupError } from "@typeagent/config";
+import { configSetupError, tryReloadConfigSync } from "@typeagent/config";
 import { EventEmitter } from "node:events";
 
 try {
@@ -170,6 +170,10 @@ const invalidSettings: AppSettings = {
 };
 
 function loadMSGraphSettings(envPrefix: string = "MSGRAPH_APP"): AppSettings {
+    // Forked agent processes hold a snapshot of process.env, so re-read the
+    // config files: otherwise settings the user added after startup (and
+    // confirmed with `@config agent refresh`) stay invisible to login.
+    tryReloadConfigSync();
     const authModeRaw = (
         process.env[`${envPrefix}_AUTH_MODE`] ?? "browser"
     ).toLowerCase();

--- a/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
@@ -28,6 +28,7 @@ import lockfile from "proper-lockfile";
 import registerDebug from "debug";
 import chalk from "chalk";
 import os from "os";
+import { configSetupHint } from "@typeagent/config";
 import { EventEmitter } from "node:events";
 
 try {
@@ -564,7 +565,12 @@ export class GraphClient extends EventEmitter {
 
         const settings = this._settings;
         if (settings === invalidSettings) {
-            throw new Error("Missing graph settings in environment variables");
+            throw new Error(
+                `Microsoft Graph is not configured.\n${configSetupHint(
+                    ["MSGRAPH_APP_CLIENTID", "MSGRAPH_APP_TENANTID"],
+                    "Values come from your app registration in the Azure portal.",
+                )}`,
+            );
         }
         if (settings.username && settings.password) {
             return await this.initializeGraphFromUserCred();

--- a/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
@@ -28,7 +28,8 @@ import lockfile from "proper-lockfile";
 import registerDebug from "debug";
 import chalk from "chalk";
 import os from "os";
-import { configSetupError, tryReloadConfigSync } from "@typeagent/config";
+import { configSetupError, tryReloadConfigKeysSync } from "@typeagent/config";
+import { GRAPH_CONFIG_KEYS } from "./readiness.js";
 import { EventEmitter } from "node:events";
 
 try {
@@ -173,7 +174,7 @@ function loadMSGraphSettings(envPrefix: string = "MSGRAPH_APP"): AppSettings {
     // Forked agent processes hold a snapshot of process.env, so re-read the
     // config files: otherwise settings the user added after startup (and
     // confirmed with `@config agent refresh`) stay invisible to login.
-    tryReloadConfigSync();
+    tryReloadConfigKeysSync(GRAPH_CONFIG_KEYS);
     const authModeRaw = (
         process.env[`${envPrefix}_AUTH_MODE`] ?? "browser"
     ).toLowerCase();

--- a/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/graphClient.ts
@@ -28,7 +28,7 @@ import lockfile from "proper-lockfile";
 import registerDebug from "debug";
 import chalk from "chalk";
 import os from "os";
-import { configSetupHint } from "@typeagent/config";
+import { configSetupError } from "@typeagent/config";
 import { EventEmitter } from "node:events";
 
 try {
@@ -565,11 +565,10 @@ export class GraphClient extends EventEmitter {
 
         const settings = this._settings;
         if (settings === invalidSettings) {
-            throw new Error(
-                `Microsoft Graph is not configured.\n${configSetupHint(
-                    ["MSGRAPH_APP_CLIENTID", "MSGRAPH_APP_TENANTID"],
-                    "Values come from your app registration in the Azure portal.",
-                )}`,
+            throw configSetupError(
+                "Microsoft Graph is not configured.",
+                ["MSGRAPH_APP_CLIENTID", "MSGRAPH_APP_TENANTID"],
+                "Values come from your app registration in the Azure portal.",
             );
         }
         if (settings.username && settings.password) {

--- a/ts/packages/agents/agentUtils/graphUtils/src/index.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/index.ts
@@ -86,6 +86,7 @@ export {
     GraphReadinessProbe,
     evaluateGraphReadiness,
     graphProviderSetupHint,
+    graphProviderSetupError,
     probeGraphConfig,
     probeCurrentGraphConfig,
 } from "./readiness.js";

--- a/ts/packages/agents/agentUtils/graphUtils/src/index.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/index.ts
@@ -85,5 +85,6 @@ export {
     GraphAgentName,
     GraphReadinessProbe,
     evaluateGraphReadiness,
+    graphProviderSetupHint,
     probeGraphConfig,
 } from "./readiness.js";

--- a/ts/packages/agents/agentUtils/graphUtils/src/index.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/index.ts
@@ -87,4 +87,5 @@ export {
     evaluateGraphReadiness,
     graphProviderSetupHint,
     probeGraphConfig,
+    probeCurrentGraphConfig,
 } from "./readiness.js";

--- a/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
@@ -9,7 +9,11 @@
 // for the pattern this mirrors.
 
 import type { ReadinessReport } from "@typeagent/agent-sdk";
-import { configSetupHint, tryReloadConfigSync } from "@typeagent/config";
+import {
+    ConfigSetupError,
+    configSetupHint,
+    tryReloadConfigSync,
+} from "@typeagent/config";
 
 export type GraphAgentName = "calendar" | "email";
 
@@ -87,6 +91,23 @@ export function graphProviderSetupHint(agentName: GraphAgentName): string {
         "",
         `Then run \`@config agent refresh ${agentName}\`.`,
     ].join("\n");
+}
+
+// The same hint as a throwable error.
+//
+// `configSetupError` can't be used here: it takes a single var list, while
+// this hint offers two alternative provider blocks. Throwing (rather than
+// returning a plain-string error result) is what gets the markdown rendered
+// — the dispatcher only attaches `errorDisplayContent` on the throw path.
+export function graphProviderSetupError(
+    agentName: GraphAgentName,
+): ConfigSetupError {
+    const Agent = agentName[0].toUpperCase() + agentName.slice(1);
+    const message = `${Agent} agent has no provider configured.`;
+    return new ConfigSetupError(
+        message,
+        `${message}\n\n${graphProviderSetupHint(agentName)}`,
+    );
 }
 
 // Pure decision: probe → ReadinessReport.

--- a/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
@@ -12,10 +12,22 @@ import type { ReadinessReport } from "@typeagent/agent-sdk";
 import {
     ConfigSetupError,
     configSetupHint,
-    tryReloadConfigSync,
+    getConfigProblems,
+    tryReloadConfigKeysSync,
 } from "@typeagent/config";
 
 export type GraphAgentName = "calendar" | "email";
+export const GRAPH_CONFIG_KEYS = [
+    "MSGRAPH_APP_CLIENTID",
+    "MSGRAPH_APP_CLIENTSECRET",
+    "MSGRAPH_APP_TENANTID",
+    "MSGRAPH_APP_USERNAME",
+    "MSGRAPH_APP_PASSWD",
+    "MSGRAPH_APP_AUTH_MODE",
+    "MSGRAPH_APP_REDIRECT_PORT",
+    "GOOGLE_CALENDAR_CLIENT_ID",
+    "GOOGLE_CALENDAR_CLIENT_SECRET",
+] as const;
 
 // Inputs for the readiness decision. All three slots are independent so the
 // pure evaluator can be unit-tested without env or provider mocking.
@@ -37,6 +49,7 @@ export type GraphReadinessProbe = {
     // Used only for nicer messaging ("Microsoft 365" vs "Google"); the
     // decision logic doesn't depend on it.
     providerName: string | undefined;
+    configProblem?: string;
 };
 
 // Cheap env probe — pulls just the booleans the evaluator needs.
@@ -68,9 +81,16 @@ export function probeGraphConfig(env: NodeJS.ProcessEnv): {
 export function probeCurrentGraphConfig(): {
     msGraphConfigured: boolean;
     googleConfigured: boolean;
+    configProblem?: string;
 } {
-    tryReloadConfigSync();
-    return probeGraphConfig(process.env);
+    tryReloadConfigKeysSync(GRAPH_CONFIG_KEYS);
+    const result = probeGraphConfig(process.env);
+    const problem = getConfigProblems().find(
+        ({ section }) => section === "msGraph" || section === "googleCalendar",
+    );
+    return problem === undefined
+        ? result
+        : { ...result, configProblem: problem.message };
 }
 
 // The "no provider configured" instructions, shared by the readiness
@@ -125,6 +145,14 @@ export function evaluateGraphReadiness(
     probe: GraphReadinessProbe,
 ): ReadinessReport {
     const Agent = agentName[0].toUpperCase() + agentName.slice(1);
+
+    if (probe.configProblem !== undefined) {
+        return {
+            state: "setup-required",
+            message: `${Agent} configuration is invalid: ${probe.configProblem}`,
+            details: graphProviderSetupHint(agentName),
+        };
+    }
 
     if (!probe.msGraphConfigured && !probe.googleConfigured) {
         return {

--- a/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
@@ -3,12 +3,13 @@
 
 // Shared readiness/setup helpers for the calendar and email agents.
 // Both agents speak to Microsoft Graph (or Google) through the same provider
-// abstraction in this package, gated on the same env vars, and want the same
+// abstraction in this package, gated on the same settings, and want the same
 // "configured? signed-in?" state machine. This module factors that decision
 // out so both agents stay thin wrappers — see the desktop agent's readiness.ts
 // for the pattern this mirrors.
 
 import type { ReadinessReport } from "@typeagent/agent-sdk";
+import { configSetupHint } from "@typeagent/config";
 
 export type GraphAgentName = "calendar" | "email";
 
@@ -52,12 +53,32 @@ export function probeGraphConfig(env: NodeJS.ProcessEnv): {
     };
 }
 
+// The "no provider configured" instructions, shared by the readiness
+// report and by the agents' own login/setup paths so both point at the
+// same YAML keys.
+export function graphProviderSetupHint(agentName: GraphAgentName): string {
+    return [
+        "Microsoft Graph (Outlook / Microsoft 365):",
+        "",
+        configSetupHint(["MSGRAPH_APP_CLIENTID", "MSGRAPH_APP_TENANTID"]),
+        "",
+        "OR Google:",
+        "",
+        configSetupHint([
+            "GOOGLE_CALENDAR_CLIENT_ID",
+            "GOOGLE_CALENDAR_CLIENT_SECRET",
+        ]),
+        "",
+        `Then run \`@config agent refresh ${agentName}\`.`,
+    ].join("\n");
+}
+
 // Pure decision: probe → ReadinessReport.
 //
 // Three states, in order of severity:
-//   - No provider configured at all → "setup-required" with env-var hint.
-//     This is a manual-config case (edit ts/.env, then refresh); the
-//     `setup` hook can't help.
+//   - No provider configured at all → "setup-required" with a config hint.
+//     This is a manual-config case (edit config.local.yaml, then refresh);
+//     the `setup` hook can't help.
 //   - Configured but not signed in → "setup-required" with sign-in hint.
 //     The `setup` hook CAN drive this — it kicks off the device-code or
 //     OAuth flow via the existing provider.login() path.
@@ -72,17 +93,7 @@ export function evaluateGraphReadiness(
         return {
             state: "setup-required",
             message: `${Agent} agent has no provider configured.`,
-            details: [
-                `Set environment variables in \`ts/.env\` and run \`@config agent refresh ${agentName}\`:`,
-                "",
-                "Microsoft Graph (Outlook / Microsoft 365):",
-                "  - MSGRAPH_APP_CLIENTID",
-                "  - MSGRAPH_APP_TENANTID",
-                "",
-                "OR Google:",
-                "  - GOOGLE_CALENDAR_CLIENT_ID",
-                "  - GOOGLE_CALENDAR_CLIENT_SECRET",
-            ].join("\n"),
+            details: graphProviderSetupHint(agentName),
         };
     }
 

--- a/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
+++ b/ts/packages/agents/agentUtils/graphUtils/src/readiness.ts
@@ -9,7 +9,7 @@
 // for the pattern this mirrors.
 
 import type { ReadinessReport } from "@typeagent/agent-sdk";
-import { configSetupHint } from "@typeagent/config";
+import { configSetupHint, tryReloadConfigSync } from "@typeagent/config";
 
 export type GraphAgentName = "calendar" | "email";
 
@@ -51,6 +51,22 @@ export function probeGraphConfig(env: NodeJS.ProcessEnv): {
             env.GOOGLE_CALENDAR_CLIENT_ID && env.GOOGLE_CALENDAR_CLIENT_SECRET
         ),
     };
+}
+
+// The probe an agent should use at runtime: re-reads the config files
+// first, then probes `process.env`.
+//
+// Agent processes are forked with a snapshot of `process.env`, so without
+// the reload a user who adds MSGRAPH_APP_CLIENTID to config.local.yaml and
+// runs `@config agent refresh email` would keep being told the agent has
+// no provider configured. `probeGraphConfig` stays pure so the decision
+// logic remains testable without touching the filesystem.
+export function probeCurrentGraphConfig(): {
+    msGraphConfigured: boolean;
+    googleConfigured: boolean;
+} {
+    tryReloadConfigSync();
+    return probeGraphConfig(process.env);
 }
 
 // The "no provider configured" instructions, shared by the readiness

--- a/ts/packages/agents/browserExtension/src/extension/views/chatPanel.ts
+++ b/ts/packages/agents/browserExtension/src/extension/views/chatPanel.ts
@@ -33,6 +33,11 @@ function extractThreadId(requestId: any): string | undefined {
 // Platform adapter: open links in a real Chrome tab
 const platformAdapter: PlatformAdapter = {
     handleLinkClick(href: string, _target: string | null) {
+        // Local-file links only make sense in the desktop/VS Code hosts;
+        // the extension can't open a path on the user's machine.
+        if (href.startsWith("typeagent-file:")) {
+            return;
+        }
         // Rewrite typeagent-browser:// URLs to the actual extension URL
         if (href.startsWith("typeagent-browser://")) {
             const path = href.replace("typeagent-browser://", "");

--- a/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
@@ -42,7 +42,7 @@ import {
     evaluateGraphReadiness,
     getAvailableProviders,
     GoogleCalendarClient,
-    graphProviderSetupHint,
+    graphProviderSetupError,
     probeCurrentGraphConfig,
 } from "@typeagent/graph-utils";
 import {
@@ -77,6 +77,13 @@ export class CalendarClientLoginCommandHandler
         const providerType = context.sessionContext.agentContext.providerType;
 
         if (provider === undefined) {
+            // No provider at all usually means nothing is configured yet, so
+            // point at the config keys instead of an opaque "not initialized".
+            // Thrown (not returned) so the dispatcher renders the markdown.
+            const config = probeCurrentGraphConfig();
+            if (!config.msGraphConfigured && !config.googleConfigured) {
+                throw graphProviderSetupError("calendar");
+            }
             throw new Error("Calendar provider not initialized");
         }
 
@@ -1290,9 +1297,10 @@ async function offerCalendarLogin(
     const ctx = actionContext.sessionContext.agentContext;
     const config = probeCurrentGraphConfig();
     if (!config.msGraphConfigured && !config.googleConfigured) {
-        return createActionResultFromError(
-            `No calendar provider configured.\n${graphProviderSetupHint("calendar")}`,
-        );
+        // Thrown rather than returned: the dispatcher only attaches
+        // `errorDisplayContent` on the throw path, and without it the hint's
+        // markdown renders as literal text.
+        throw graphProviderSetupError("calendar");
     }
     if (!ctx.calendarProvider) {
         ctx.calendarProvider = createCalendarProviderFromConfig();

--- a/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
@@ -42,6 +42,7 @@ import {
     evaluateGraphReadiness,
     getAvailableProviders,
     GoogleCalendarClient,
+    graphProviderSetupHint,
     probeGraphConfig,
 } from "@typeagent/graph-utils";
 import {
@@ -1290,7 +1291,7 @@ async function offerCalendarLogin(
     const config = probeGraphConfig(process.env);
     if (!config.msGraphConfigured && !config.googleConfigured) {
         return createActionResultFromError(
-            "No calendar provider configured. Set MSGRAPH_APP_CLIENTID + MSGRAPH_APP_TENANTID or GOOGLE_CALENDAR_CLIENT_ID + GOOGLE_CALENDAR_CLIENT_SECRET in `ts/.env`, then run `@config agent refresh calendar`.",
+            `No calendar provider configured.\n${graphProviderSetupHint("calendar")}`,
         );
     }
     if (!ctx.calendarProvider) {
@@ -1303,7 +1304,7 @@ async function offerCalendarLogin(
     const provider = ctx.calendarProvider;
     if (!provider) {
         return createActionResultFromError(
-            "Calendar env vars are set but the provider could not be created. Check `ts/.env` and restart the agent server.",
+            "Calendar settings are present but the provider could not be created. Check the `msGraph` / `googleCalendar` section of `ts/config.local.yaml` and restart the agent server.",
         );
     }
     if (provider.isAuthenticated()) {

--- a/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
+++ b/ts/packages/agents/calendar/src/calendarActionHandlerV3.ts
@@ -43,7 +43,7 @@ import {
     getAvailableProviders,
     GoogleCalendarClient,
     graphProviderSetupHint,
-    probeGraphConfig,
+    probeCurrentGraphConfig,
 } from "@typeagent/graph-utils";
 import {
     getNWeeksDateRangeISO,
@@ -453,7 +453,7 @@ export class CalendarActionHandlerV3 implements AppAgent {
     public async checkReadiness(
         context: SessionContext<CalendarActionContext>,
     ): Promise<ReadinessReport> {
-        const config = probeGraphConfig(process.env);
+        const config = probeCurrentGraphConfig();
         // Prefer the agentContext's provider when available (already set
         // up by updateAgentContext on enable). Fall back to a fresh
         // provider when the agent was disabled or env vars were set after
@@ -1288,7 +1288,7 @@ async function offerCalendarLogin(
     choiceManager: ChoiceManager,
 ): Promise<ActionResult> {
     const ctx = actionContext.sessionContext.agentContext;
-    const config = probeGraphConfig(process.env);
+    const config = probeCurrentGraphConfig();
     if (!config.msGraphConfigured && !config.googleConfigured) {
         return createActionResultFromError(
             `No calendar provider configured.\n${graphProviderSetupHint("calendar")}`,

--- a/ts/packages/agents/calendar/test/graphReadiness.spec.ts
+++ b/ts/packages/agents/calendar/test/graphReadiness.spec.ts
@@ -70,8 +70,9 @@ describe("evaluateGraphReadiness", () => {
         });
         expect(r.state).toBe("setup-required");
         expect(r.message).toMatch(/no provider configured/i);
-        expect(r.details).toMatch(/MSGRAPH_APP_CLIENTID/);
-        expect(r.details).toMatch(/GOOGLE_CALENDAR_CLIENT_ID/);
+        expect(r.details).toMatch(/config\.local\.yaml/);
+        expect(r.details).toMatch(/msGraph:/);
+        expect(r.details).toMatch(/googleCalendar:/);
         expect(r.details).toMatch(/@config agent refresh calendar/);
     });
 

--- a/ts/packages/agents/calendar/test/graphReadiness.spec.ts
+++ b/ts/packages/agents/calendar/test/graphReadiness.spec.ts
@@ -61,6 +61,23 @@ describe("probeGraphConfig", () => {
 });
 
 describe("evaluateGraphReadiness", () => {
+    test("malformed config cannot be masked by stale ready values", () => {
+        expect(
+            evaluateGraphReadiness("calendar", {
+                msGraphConfigured: true,
+                googleConfigured: false,
+                isAuthenticated: true,
+                providerName: "microsoft",
+                configProblem: "Expected a string at 'msGraph.clientId'",
+            }),
+        ).toEqual(
+            expect.objectContaining({
+                state: "setup-required",
+                message: expect.stringContaining("invalid"),
+            }),
+        );
+    });
+
     test("setup-required when no provider is configured", () => {
         const r = evaluateGraphReadiness("calendar", {
             msGraphConfigured: false,

--- a/ts/packages/agents/discord/package.json
+++ b/ts/packages/agents/discord/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@typeagent/agent-sdk": "workspace:*",
-    "@typeagent/aiclient": "workspace:*"
+    "@typeagent/aiclient": "workspace:*",
+    "@typeagent/config": "workspace:*"
   },
   "devDependencies": {
     "@typeagent/action-grammar-compiler": "workspace:*",

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -16,7 +16,7 @@ import {
     createStructuredResult,
 } from "@typeagent/agent-sdk/helpers/action";
 import { ChatModel, openai } from "@typeagent/aiclient";
-import { configSetupError } from "@typeagent/config";
+import { configSetupError, tryReloadConfigSync } from "@typeagent/config";
 import { DiscordActions } from "./discordSchema.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -152,6 +152,13 @@ async function discordFetch(
 ): Promise<Response> {
     const token = process.env.DISCORD_BOT_TOKEN;
     if (!token) {
+        // Re-read the config files before giving up: this agent runs in a
+        // forked process whose env is a startup snapshot, so a token added
+        // since then is only visible after a reload.
+        tryReloadConfigSync();
+    }
+    const botToken = token ?? process.env.DISCORD_BOT_TOKEN;
+    if (!botToken) {
         throw configSetupError(
             "Discord is not configured.",
             ["DISCORD_BOT_TOKEN"],
@@ -159,7 +166,7 @@ async function discordFetch(
         );
     }
     const headers: Record<string, string> = {
-        Authorization: `Bot ${token}`,
+        Authorization: `Bot ${botToken}`,
         "Content-Type": "application/json",
         ...(options.headers as Record<string, string>),
     };

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -16,7 +16,7 @@ import {
     createStructuredResult,
 } from "@typeagent/agent-sdk/helpers/action";
 import { ChatModel, openai } from "@typeagent/aiclient";
-import { configSetupError, tryReloadConfigSync } from "@typeagent/config";
+import { configSetupError, tryReloadConfigKeysSync } from "@typeagent/config";
 import { DiscordActions } from "./discordSchema.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -150,14 +150,10 @@ async function discordFetch(
     path: string,
     options: RequestInit = {},
 ): Promise<Response> {
-    const token = process.env.DISCORD_BOT_TOKEN;
-    if (!token) {
-        // Re-read the config files before giving up: this agent runs in a
-        // forked process whose env is a startup snapshot, so a token added
-        // since then is only visible after a reload.
-        tryReloadConfigSync();
-    }
-    const botToken = token ?? process.env.DISCORD_BOT_TOKEN;
+    // Re-read this agent's key on every request so changed and removed local
+    // overrides take effect without touching unrelated inherited settings.
+    tryReloadConfigKeysSync(["DISCORD_BOT_TOKEN"]);
+    const botToken = process.env.DISCORD_BOT_TOKEN;
     if (!botToken) {
         throw configSetupError(
             "Discord is not configured.",

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -16,7 +16,7 @@ import {
     createStructuredResult,
 } from "@typeagent/agent-sdk/helpers/action";
 import { ChatModel, openai } from "@typeagent/aiclient";
-import { configSetupHint } from "@typeagent/config";
+import { configSetupError } from "@typeagent/config";
 import { DiscordActions } from "./discordSchema.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -152,11 +152,10 @@ async function discordFetch(
 ): Promise<Response> {
     const token = process.env.DISCORD_BOT_TOKEN;
     if (!token) {
-        throw new Error(
-            `Discord is not configured.\n${configSetupHint(
-                ["DISCORD_BOT_TOKEN"],
-                "The bot token comes from your application's Bot page in the Discord developer portal.",
-            )}`,
+        throw configSetupError(
+            "Discord is not configured.",
+            ["DISCORD_BOT_TOKEN"],
+            "The bot token comes from your application's Bot page in the Discord developer portal.",
         );
     }
     const headers: Record<string, string> = {

--- a/ts/packages/agents/discord/src/discordActionHandler.ts
+++ b/ts/packages/agents/discord/src/discordActionHandler.ts
@@ -16,6 +16,7 @@ import {
     createStructuredResult,
 } from "@typeagent/agent-sdk/helpers/action";
 import { ChatModel, openai } from "@typeagent/aiclient";
+import { configSetupHint } from "@typeagent/config";
 import { DiscordActions } from "./discordSchema.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
@@ -152,7 +153,10 @@ async function discordFetch(
     const token = process.env.DISCORD_BOT_TOKEN;
     if (!token) {
         throw new Error(
-            "DISCORD_BOT_TOKEN is not set. Please add it to ts/.env.",
+            `Discord is not configured.\n${configSetupHint(
+                ["DISCORD_BOT_TOKEN"],
+                "The bot token comes from your application's Bot page in the Discord developer portal.",
+            )}`,
         );
     }
     const headers: Record<string, string> = {

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -12,7 +12,7 @@ import {
     GoogleEmailClient,
     graphProviderSetupHint,
     parseDayRange,
-    probeGraphConfig,
+    probeCurrentGraphConfig,
 } from "@typeagent/graph-utils";
 import chalk from "chalk";
 import {
@@ -392,7 +392,7 @@ function emailTs(): string {
 async function checkEmailReadiness(
     context: SessionContext<EmailActionContext>,
 ): Promise<ReadinessReport> {
-    const config = probeGraphConfig(process.env);
+    const config = probeCurrentGraphConfig();
     let provider = context.agentContext?.emailProvider;
     if (!provider && (config.msGraphConfigured || config.googleConfigured)) {
         provider = createEmailProviderFromConfig();
@@ -411,7 +411,7 @@ async function setupEmail(
     actionContext: ActionContext<EmailActionContext>,
 ): Promise<ActionResult> {
     const ctx = actionContext.sessionContext.agentContext;
-    const config = probeGraphConfig(process.env);
+    const config = probeCurrentGraphConfig();
     if (!config.msGraphConfigured && !config.googleConfigured) {
         return createActionResultFromError(
             `No email provider configured.\n${graphProviderSetupHint("email")}`,

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -10,6 +10,7 @@ import {
     claimSilentRestoreAnnouncement,
     evaluateGraphReadiness,
     GoogleEmailClient,
+    graphProviderSetupHint,
     parseDayRange,
     probeGraphConfig,
 } from "@typeagent/graph-utils";
@@ -413,7 +414,7 @@ async function setupEmail(
     const config = probeGraphConfig(process.env);
     if (!config.msGraphConfigured && !config.googleConfigured) {
         return createActionResultFromError(
-            "No email provider configured. Set MSGRAPH_APP_CLIENTID + MSGRAPH_APP_TENANTID or GOOGLE_CALENDAR_CLIENT_ID + GOOGLE_CALENDAR_CLIENT_SECRET in `ts/.env`, then run `@config agent refresh email`.",
+            `No email provider configured.\n${graphProviderSetupHint("email")}`,
         );
     }
     if (!ctx.emailProvider) {
@@ -426,7 +427,7 @@ async function setupEmail(
     const provider = ctx.emailProvider;
     if (!provider) {
         return createActionResultFromError(
-            "Email env vars are set but the provider could not be created. Check `ts/.env` and restart the agent server.",
+            "Email settings are present but the provider could not be created. Check the `msGraph` / `googleCalendar` section of `ts/config.local.yaml` and restart the agent server.",
         );
     }
     if (provider.isAuthenticated()) {

--- a/ts/packages/agents/email/src/emailActionHandler.ts
+++ b/ts/packages/agents/email/src/emailActionHandler.ts
@@ -10,7 +10,7 @@ import {
     claimSilentRestoreAnnouncement,
     evaluateGraphReadiness,
     GoogleEmailClient,
-    graphProviderSetupHint,
+    graphProviderSetupError,
     parseDayRange,
     probeCurrentGraphConfig,
 } from "@typeagent/graph-utils";
@@ -413,9 +413,10 @@ async function setupEmail(
     const ctx = actionContext.sessionContext.agentContext;
     const config = probeCurrentGraphConfig();
     if (!config.msGraphConfigured && !config.googleConfigured) {
-        return createActionResultFromError(
-            `No email provider configured.\n${graphProviderSetupHint("email")}`,
-        );
+        // Thrown rather than returned: the dispatcher only attaches
+        // `errorDisplayContent` on the throw path, and without it the hint's
+        // markdown renders as literal text.
+        throw graphProviderSetupError("email");
     }
     if (!ctx.emailProvider) {
         ctx.emailProvider = createEmailProviderFromConfig();

--- a/ts/packages/agents/player/README.md
+++ b/ts/packages/agents/player/README.md
@@ -28,7 +28,7 @@ The `player` agent (package name `music`) implements Spotify support. Enable it 
 
 1. Enable the agent: `@config agent player on`
 2. Authenticate: `@player spotify login` — this opens the browser for a one-time authorization. Afterward, the refresh token is stored (DPAPI-encrypted on Windows, Keychain on macOS, libsecret on Linux via `@azure/msal-node-extensions`) at `$(HOME)/.typeagent/profiles/<profile>/player/token`, so subsequent runs mint access tokens without prompting.
-3. (Optional) Load Spotify listening history: `@player spotify load <path-to-history-file>`
+3. (Optional) Load Spotify listening history: `@player spotify load <path>` — `<path>` can be an absolute path to a single extended streaming history `.json` file, or a directory (every `.json` file in it is loaded, and files that aren't streaming history are skipped). Relative paths resolve against the agent's instance storage first, then the current working directory.
 4. To clear the cached token: `@player spotify logout`
 5. To disable the agent entirely: `@config agent player off`
 

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -56,10 +56,12 @@ const loadHandler: CommandHandler = {
 
         const skipped =
             result.skipped.length !== 0
-                ? ` (${result.skipped.length} file(s) skipped)`
+                ? `\n\nSkipped ${result.skipped.length} file(s) that aren't Spotify streaming history: ${result.skipped
+                      .map((f) => f.replace(/^.*[\\/]/, ""))
+                      .join(", ")}.`
                 : "";
         context.actionIO.setDisplay(
-            `Spotify user data loaded: ${result.records} track play(s) from ${result.loaded.length} file(s)${skipped}.`,
+            `Spotify user data loaded: ${result.records} track play(s) from ${result.loaded.length} file(s).${skipped}`,
         );
     },
 };

--- a/ts/packages/agents/player/src/agent/playerCommands.ts
+++ b/ts/packages/agents/player/src/agent/playerCommands.ts
@@ -25,7 +25,8 @@ import {
 const loadHandlerParameters = {
     args: {
         file: {
-            description: "File to load",
+            description:
+                "File or directory to load (a directory loads all Spotify streaming history .json files in it)",
         },
     },
 } as const;
@@ -47,13 +48,19 @@ const loadHandler: CommandHandler = {
         }
         context.actionIO.setDisplay("Loading Spotify user data...");
 
-        await loadHistoryFile(
+        const result = await loadHistoryFile(
             sessionContext.instanceStorage,
             params.args.file,
             agentContext.spotify,
         );
 
-        context.actionIO.setDisplay("Spotify user data loaded.");
+        const skipped =
+            result.skipped.length !== 0
+                ? ` (${result.skipped.length} file(s) skipped)`
+                : "";
+        context.actionIO.setDisplay(
+            `Spotify user data loaded: ${result.records} track play(s) from ${result.loaded.length} file(s)${skipped}.`,
+        );
     },
 };
 const handlers: CommandHandlerTable = {

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -26,7 +26,7 @@ import {
     configPathForEnvVar,
     configSetupHint,
     getConfigProblems,
-    reloadConfigSync,
+    reloadConfigKeysSync,
 } from "@typeagent/config";
 import { searchTracks } from "../client.js";
 import { htmlStatus } from "../playback.js";
@@ -50,6 +50,13 @@ import {
 
 const debugSpotify = registerDebug("typeagent:spotify");
 const debugError = registerDebug("typeagent:spotify:error");
+// Completion results cross the agent RPC boundary on every keystroke.
+const MAX_PLAYER_COMPLETIONS = 100;
+const SPOTIFY_CONFIG_KEYS = [
+    "SPOTIFY_APP_CLI",
+    "SPOTIFY_APP_CLISEC",
+    "SPOTIFY_APP_PORT",
+] as const;
 
 export function instantiate(): AppAgent {
     return {
@@ -82,11 +89,22 @@ export function instantiate(): AppAgent {
 // Exported for unit tests.
 export async function checkPlayerReadiness(): Promise<ReadinessReport> {
     try {
-        reloadConfigSync();
+        reloadConfigKeysSync(SPOTIFY_CONFIG_KEYS);
     } catch (e) {
         // Best-effort: a malformed config file shouldn't turn the probe
         // into a hard failure — fall through and report what's missing.
         debugError(`Failed to reload config during readiness check: ${e}`);
+    }
+    const problem = getConfigProblems().find((p) => p.section === "spotify");
+    if (problem !== undefined) {
+        return {
+            state: "setup-required",
+            message: `Spotify configuration is invalid and was ignored: ${problem.message}`,
+            details: configSetupHint(
+                SPOTIFY_CONFIG_KEYS,
+                "Replace any placeholder with a real value, then run `@config agent refresh player`.",
+            ),
+        };
     }
     const missing: string[] = [];
     if (!process.env.SPOTIFY_APP_CLI) missing.push("SPOTIFY_APP_CLI");
@@ -109,17 +127,6 @@ export async function checkPlayerReadiness(): Promise<ReadinessReport> {
     // section was rejected — a leftover `<value>` placeholder, a port
     // that isn't a number. Say so, otherwise the user is told to add
     // settings they can plainly see in the file.
-    const problem = getConfigProblems().find((p) => p.section === "spotify");
-    if (problem !== undefined) {
-        return {
-            state: "setup-required",
-            message: `Spotify configuration is invalid and was ignored: ${problem.message}`,
-            details: configSetupHint(
-                missing,
-                "Replace any placeholder with a real value — `clientId` and `clientSecret` come from the Spotify developer dashboard for your app, and `port` is the (unquoted, numeric) redirect port you registered there. Then run `@config agent refresh player`.",
-            ),
-        };
-    }
     return {
         state: "setup-required",
         message: `Spotify is not configured. Missing: ${configKeyNames(missing).join(", ")}.`,
@@ -489,7 +496,7 @@ async function getPlayerDynamicDisplay(
     throw new Error(`Invalid displayId ${displayId}`);
 }
 
-async function getPlayerActionCompletion(
+export async function getPlayerActionCompletion(
     context: SessionContext<PlayerActionContext>,
     action: AppAction,
     propertyName: string,
@@ -505,6 +512,7 @@ async function getPlayerActionCompletion(
     if (userData === undefined) {
         return result;
     }
+    const partialValue = getPartialPropertyValue(action, propertyName);
 
     let track = false;
     let artist = false;
@@ -552,7 +560,7 @@ async function getPlayerActionCompletion(
                     const names = userData.data.playlists
                         .map((pl) => pl.name)
                         .sort();
-                    result.push(...names);
+                    result.push(...filterCompletions(names, partialValue));
                 }
             }
             return result;
@@ -561,9 +569,12 @@ async function getPlayerActionCompletion(
                 const devices = await getUserDevices(clientContext.service);
                 if (devices !== undefined) {
                     result.push(
-                        ...devices.devices
-                            .filter((device) => device.id !== null)
-                            .map((device) => device.name),
+                        ...filterCompletions(
+                            devices.devices
+                                .filter((device) => device.id !== null)
+                                .map((device) => device.name),
+                            partialValue,
+                        ),
                     );
                 }
             }
@@ -577,7 +588,37 @@ async function getPlayerActionCompletion(
             artist,
             album,
             playlist,
+            partialValue,
+            MAX_PLAYER_COMPLETIONS,
         ),
     );
     return result;
+}
+
+function filterCompletions(names: string[], partialValue: string): string[] {
+    const query = partialValue.trim().toLocaleLowerCase();
+    return names
+        .filter(
+            (name) =>
+                query.length === 0 || name.toLocaleLowerCase().includes(query),
+        )
+        .slice(0, MAX_PLAYER_COMPLETIONS);
+}
+
+function getPartialPropertyValue(
+    action: AppAction,
+    propertyName: string,
+): string {
+    let value: unknown = action;
+    for (const segment of propertyName.split(".")) {
+        if (
+            typeof value !== "object" ||
+            value === null ||
+            !(segment in value)
+        ) {
+            return "";
+        }
+        value = (value as Record<string, unknown>)[segment];
+    }
+    return typeof value === "string" ? value : "";
 }

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -595,7 +595,13 @@ export async function getPlayerActionCompletion(
     return result;
 }
 
-function filterCompletions(names: string[], partialValue: string): string[] {
+function filterCompletions(
+    names: string[],
+    partialValue: string | undefined,
+): string[] {
+    if (partialValue === undefined) {
+        return names;
+    }
     const query = partialValue.trim().toLocaleLowerCase();
     return names
         .filter(
@@ -608,7 +614,7 @@ function filterCompletions(names: string[], partialValue: string): string[] {
 function getPartialPropertyValue(
     action: AppAction,
     propertyName: string,
-): string {
+): string | undefined {
     let value: unknown = action;
     for (const segment of propertyName.split(".")) {
         if (
@@ -616,9 +622,9 @@ function getPartialPropertyValue(
             value === null ||
             !(segment in value)
         ) {
-            return "";
+            return undefined;
         }
         value = (value as Record<string, unknown>)[segment];
     }
-    return typeof value === "string" ? value : "";
+    return typeof value === "string" ? value : undefined;
 }

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -25,6 +25,8 @@ import {
     configKeyNames,
     configPathForEnvVar,
     configSetupHint,
+    getConfigProblems,
+    reloadConfigSync,
 } from "@typeagent/config";
 import { searchTracks } from "../client.js";
 import { htmlStatus } from "../playback.js";
@@ -47,6 +49,7 @@ import {
 } from "../userData.js";
 
 const debugSpotify = registerDebug("typeagent:spotify");
+const debugError = registerDebug("typeagent:spotify:error");
 
 export function instantiate(): AppAgent {
     return {
@@ -67,12 +70,24 @@ export function instantiate(): AppAgent {
 // config.local.yaml). Spotify integration is impossible without these,
 // so we surface the missing configuration up front instead of letting
 // the user discover it on the first action. No `setup` hook — this is a
-// manual-config case (edit config.local.yaml, restart the agent server);
-// the dispatcher's setup-required error points the user at
-// @config agent refresh once they've fixed it.
+// manual-config case (edit config.local.yaml, then run
+// `@config agent refresh player`).
+//
+// The probe re-reads the config files first. This agent usually runs in
+// a forked child process whose `process.env` was snapshotted when it was
+// spawned, so without the reload every refresh would re-report the state
+// the user just fixed and the only way out would be restarting the
+// server — which is exactly what the setup hint promises it isn't.
 //
 // Exported for unit tests.
 export async function checkPlayerReadiness(): Promise<ReadinessReport> {
+    try {
+        reloadConfigSync();
+    } catch (e) {
+        // Best-effort: a malformed config file shouldn't turn the probe
+        // into a hard failure — fall through and report what's missing.
+        debugError(`Failed to reload config during readiness check: ${e}`);
+    }
     const missing: string[] = [];
     if (!process.env.SPOTIFY_APP_CLI) missing.push("SPOTIFY_APP_CLI");
     if (!process.env.SPOTIFY_APP_CLISEC) missing.push("SPOTIFY_APP_CLISEC");
@@ -90,6 +105,21 @@ export async function checkPlayerReadiness(): Promise<ReadinessReport> {
         };
     }
     if (missing.length === 0) return { state: "ready" };
+    // The settings can also be "missing" because the whole `spotify:`
+    // section was rejected — a leftover `<value>` placeholder, a port
+    // that isn't a number. Say so, otherwise the user is told to add
+    // settings they can plainly see in the file.
+    const problem = getConfigProblems().find((p) => p.section === "spotify");
+    if (problem !== undefined) {
+        return {
+            state: "setup-required",
+            message: `Spotify configuration is invalid and was ignored: ${problem.message}`,
+            details: configSetupHint(
+                missing,
+                "Replace any placeholder with a real value — `clientId` and `clientSecret` come from the Spotify developer dashboard for your app, and `port` is the (unquoted, numeric) redirect port you registered there. Then run `@config agent refresh player`.",
+            ),
+        };
+    }
     return {
         state: "setup-required",
         message: `Spotify is not configured. Missing: ${configKeyNames(missing).join(", ")}.`,

--- a/ts/packages/agents/player/src/agent/playerHandlers.ts
+++ b/ts/packages/agents/player/src/agent/playerHandlers.ts
@@ -21,6 +21,11 @@ import {
     ResolveEntityResult,
 } from "@typeagent/agent-sdk";
 import { createActionResultFromError } from "@typeagent/agent-sdk/helpers/action";
+import {
+    configKeyNames,
+    configPathForEnvVar,
+    configSetupHint,
+} from "@typeagent/config";
 import { searchTracks } from "../client.js";
 import { htmlStatus } from "../playback.js";
 import { getPlayerCommandInterface } from "./playerCommands.js";
@@ -57,12 +62,14 @@ export function instantiate(): AppAgent {
     };
 }
 
-// Cheap probe for the env vars the token provider requires. Spotify
-// integration is impossible without these, so we surface the missing
-// configuration up front instead of letting the user discover it on the
-// first action. No `setup` hook — this is a manual-config case (edit
-// .env, restart the agent server); the dispatcher's setup-required
-// error points the user at @config agent refresh once they've fixed it.
+// Cheap probe for the Spotify settings the token provider requires
+// (read from process.env, which the config loader populates from
+// config.local.yaml). Spotify integration is impossible without these,
+// so we surface the missing configuration up front instead of letting
+// the user discover it on the first action. No `setup` hook — this is a
+// manual-config case (edit config.local.yaml, restart the agent server);
+// the dispatcher's setup-required error points the user at
+// @config agent refresh once they've fixed it.
 //
 // Exported for unit tests.
 export async function checkPlayerReadiness(): Promise<ReadinessReport> {
@@ -75,17 +82,21 @@ export async function checkPlayerReadiness(): Promise<ReadinessReport> {
     } else if (parseInt(port).toString() !== port) {
         return {
             state: "setup-required",
-            message: `SPOTIFY_APP_PORT has invalid port number "${port}".`,
-            details:
-                "Set SPOTIFY_APP_PORT to an integer in ts/.env (the redirect port your Spotify app is registered with).",
+            message: `Spotify ${configPathForEnvVar("SPOTIFY_APP_PORT")} has invalid port number "${port}".`,
+            details: configSetupHint(
+                [{ envVar: "SPOTIFY_APP_PORT", placeholder: "9999" }],
+                "It must be an integer — the redirect port your Spotify app is registered with.",
+            ),
         };
     }
     if (missing.length === 0) return { state: "ready" };
     return {
         state: "setup-required",
-        message: `Spotify env vars not set: ${missing.join(", ")}.`,
-        details:
-            "Set them in ts/.env. SPOTIFY_APP_CLI and SPOTIFY_APP_CLISEC come from the Spotify developer dashboard for your app; SPOTIFY_APP_PORT is the redirect port you registered there.",
+        message: `Spotify is not configured. Missing: ${configKeyNames(missing).join(", ")}.`,
+        details: configSetupHint(
+            missing,
+            "`clientId` and `clientSecret` come from the Spotify developer dashboard for your app; `port` is the redirect port you registered there. Then run `@config agent refresh player`.",
+        ),
     };
 }
 

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -61,6 +61,7 @@ import {
     saveUserData,
     addUserDataStrings,
     UserData,
+    type MusicItemInfo,
     addFullTracks,
     getPlaylistsFromUserData,
     updatePlaylists,
@@ -214,7 +215,9 @@ function getIdPart(uri: string) {
         const parts = uri.split(":");
         return parts[parts.length - 1];
     } else {
-        console.log(`Invalid uri: ${uri}`);
+        // Podcast/video/local-file rows land here on every history load, so
+        // this is debug output, not console noise.
+        debugSpotify(`Skipping row with non-track uri: ${uri}`);
         return "";
     }
 }
@@ -402,7 +405,11 @@ export async function loadHistoryFile(
         for (const record of data) {
             debugSpotify(`${record.master_metadata_track_name}`);
         }
-        const tracks = data.filter((r) => r.spotify_track_uri !== null);
+        const tracks = data.filter(
+            (r) =>
+                r.spotify_track_uri !== null &&
+                getIdPart(r.spotify_track_uri) !== "",
+        );
         mergeUserDataKind(
             context.userData.data.tracks,
             tracks.map((r) => ({
@@ -414,6 +421,20 @@ export async function loadHistoryFile(
                 id: getIdPart(r.spotify_track_uri),
             })),
         );
+        // Streaming history carries the artist and album names alongside the
+        // track, but no ids for them. Without merging these, completion for
+        // `target.artist` / `target.albumName` stays empty no matter how much
+        // history is loaded — only the Spotify API path ever filled those.
+        // Key on the name so a later API update (which has real ids) doesn't
+        // produce a second entry for the same artist.
+        mergeUserDataKind(
+            context.userData.data.artists,
+            namedItems(tracks, (r) => r.master_metadata_album_artist_name),
+        );
+        mergeUserDataKind(
+            context.userData.data.albums,
+            namedItems(tracks, (r) => r.master_metadata_album_album_name),
+        );
         result.loaded.push(source.name);
         result.records += tracks.length;
     }
@@ -424,8 +445,39 @@ export async function loadHistoryFile(
         );
     }
 
+    // The name index is built once and cached; wildcard validation consults
+    // it to decide whether a track/artist the user named is one of theirs.
+    // Leaving the pre-load index in place would make everything just loaded
+    // look unknown until the next restart.
+    delete context.userData.data.nameMap;
+
     await saveUserData(instanceStorage, context.userData.data);
     return result;
+}
+
+// Artist/album entries derived from history rows, deduped by name (history
+// has no ids for them) and skipping rows where the name is absent — podcast
+// and local-file plays leave these null.
+function namedItems(
+    records: SpotifyRecord[],
+    getName: (r: SpotifyRecord) => string | null,
+): MusicItemInfo[] {
+    const byName = new Map<string, MusicItemInfo>();
+    for (const record of records) {
+        const name = getName(record);
+        if (!name) {
+            continue;
+        }
+        const id = `name:${name.toLocaleLowerCase()}`;
+        const existing = byName.get(id);
+        if (existing === undefined) {
+            byName.set(id, { id, name, freq: 1, timestamps: [record.ts] });
+        } else {
+            existing.freq++;
+            existing.timestamps.push(record.ts);
+        }
+    }
+    return Array.from(byName.values());
 }
 
 async function htmlPlaylistNames(

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -63,6 +63,7 @@ import {
     saveUserData,
     addUserDataStrings,
     UserData,
+    type SpotifyUserData,
     type MusicItemInfo,
     type HistorySourceData,
     MAX_ITEM_TIMESTAMPS,
@@ -214,6 +215,11 @@ interface SpotifyRecord {
     spotify_track_uri: string | null;
 }
 
+interface SpotifyTrackRecord extends SpotifyRecord {
+    master_metadata_track_name: string;
+    spotify_track_uri: string;
+}
+
 function getIdPart(uri: string | null) {
     if (uri && uri.startsWith("spotify:track:")) {
         const parts = uri.split(":");
@@ -224,6 +230,17 @@ function getIdPart(uri: string | null) {
         debugSpotify(`Skipping row with non-track uri: ${uri}`);
         return "";
     }
+}
+
+function isSpotifyTrackRecord(
+    record: SpotifyRecord,
+): record is SpotifyTrackRecord {
+    return (
+        typeof record.master_metadata_track_name === "string" &&
+        record.master_metadata_track_name.trim().length > 0 &&
+        typeof record.spotify_track_uri === "string" &&
+        getIdPart(record.spotify_track_uri) !== ""
+    );
 }
 
 // A single streaming history JSON file to load, along with how to read it.
@@ -433,22 +450,22 @@ export async function loadHistoryFile(
             result.loaded.push(source.name);
             continue;
         }
-        const tracks = data.filter(
-            (r) =>
-                typeof r.master_metadata_track_name === "string" &&
-                r.master_metadata_track_name.trim().length > 0 &&
-                getIdPart(r.spotify_track_uri) !== "",
-        );
+        const tracks = data.filter(isSpotifyTrackRecord);
         const sourceData: HistorySourceData = {
             fingerprint,
             tracks: aggregateItems(
                 tracks.map((r) => ({
                     timestamps: [r.ts],
                     freq: 1,
-                    name: r.master_metadata_track_name!,
-                    albumArtist:
-                        r.master_metadata_album_artist_name ?? undefined,
-                    albumName: r.master_metadata_album_album_name ?? undefined,
+                    name: r.master_metadata_track_name,
+                    ...(r.master_metadata_album_artist_name === null
+                        ? {}
+                        : {
+                              albumArtist: r.master_metadata_album_artist_name,
+                          }),
+                    ...(r.master_metadata_album_album_name === null
+                        ? {}
+                        : { albumName: r.master_metadata_album_album_name }),
                     id: getIdPart(r.spotify_track_uri),
                 })),
             ),
@@ -495,16 +512,19 @@ function cloneUserData(userData: SpotifyUserData): SpotifyUserData {
                 { ...item, timestamps: [...item.timestamps] },
             ]),
         );
+    const {
+        historySources,
+        nameMap: _discardedNameMap,
+        ...userDataWithoutDerivedState
+    } = userData;
     return {
-        ...userData,
+        ...userDataWithoutDerivedState,
         tracks: cloneMap(userData.tracks),
         artists: cloneMap(userData.artists),
         albums: cloneMap(userData.albums),
-        historySources:
-            userData.historySources === undefined
-                ? undefined
-                : structuredClone(userData.historySources),
-        nameMap: undefined,
+        ...(historySources === undefined
+            ? {}
+            : { historySources: structuredClone(historySources) }),
     };
 }
 

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -23,6 +23,7 @@ import chalk from "chalk";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { createHash } from "node:crypto";
 import { loadConfigSync } from "@typeagent/config";
 //import * as Filter from "./trackFilter.js";
 import { openai, ChatModelWithStreaming } from "@typeagent/aiclient";
@@ -58,10 +59,13 @@ import { SpotifyService } from "./service.js";
 import {
     initializeUserData,
     mergeUserDataKind,
+    removeUserDataKind,
     saveUserData,
     addUserDataStrings,
     UserData,
     type MusicItemInfo,
+    type HistorySourceData,
+    MAX_ITEM_TIMESTAMPS,
     addFullTracks,
     getPlaylistsFromUserData,
     updatePlaylists,
@@ -204,13 +208,13 @@ async function printTrackNames(
 
 interface SpotifyRecord {
     ts: string;
-    master_metadata_track_name: string;
-    master_metadata_album_artist_name: string;
-    master_metadata_album_album_name: string;
-    spotify_track_uri: string;
+    master_metadata_track_name: string | null;
+    master_metadata_album_artist_name: string | null;
+    master_metadata_album_album_name: string | null;
+    spotify_track_uri: string | null;
 }
 
-function getIdPart(uri: string) {
+function getIdPart(uri: string | null) {
     if (uri && uri.startsWith("spotify:track:")) {
         const parts = uri.split(":");
         return parts[parts.length - 1];
@@ -345,20 +349,37 @@ async function getHistorySources(
     return sources;
 }
 
-function isSpotifyHistoryData(data: any): data is SpotifyRecord[] {
-    if (!Array.isArray(data)) {
+function isSpotifyHistoryData(data: unknown): data is SpotifyRecord[] {
+    if (!Array.isArray(data) || data.length === 0) {
         return false;
     }
-    // Only the shape of the first record is checked; Spotify's extended
-    // streaming history files are homogeneous.
-    const record = data[0];
-    return (
-        record === undefined ||
-        (typeof record === "object" &&
+    return data.every(
+        (record: unknown) =>
+            typeof record === "object" &&
             record !== null &&
-            typeof record.ts === "string" &&
-            "spotify_track_uri" in record)
+            typeof (record as Record<string, unknown>).ts === "string" &&
+            Number.isFinite(
+                Date.parse((record as Record<string, string>).ts),
+            ) &&
+            isNullableString(
+                (record as Record<string, unknown>).master_metadata_track_name,
+            ) &&
+            isNullableString(
+                (record as Record<string, unknown>)
+                    .master_metadata_album_artist_name,
+            ) &&
+            isNullableString(
+                (record as Record<string, unknown>)
+                    .master_metadata_album_album_name,
+            ) &&
+            isNullableString(
+                (record as Record<string, unknown>).spotify_track_uri,
+            ),
     );
+}
+
+function isNullableString(value: unknown): value is string | null {
+    return value === null || typeof value === "string";
 }
 
 export async function loadHistoryFile(
@@ -382,10 +403,14 @@ export async function loadHistoryFile(
         skipped: [],
         records: 0,
     };
+    const original = context.userData.data;
+    const draft = cloneUserData(original);
     for (const source of sources) {
         let data: SpotifyRecord[];
+        let content: string;
         try {
-            const parsed = JSON.parse(await source.read());
+            content = await source.read();
+            const parsed = JSON.parse(content);
             if (!isSpotifyHistoryData(parsed)) {
                 throw new Error("Not a Spotify streaming history file");
             }
@@ -398,43 +423,50 @@ export async function loadHistoryFile(
                 continue;
             }
             throw new Error(
-                `Error reading history file ${source.name}: ${e.message}`,
+                `Error reading history file ${path.basename(source.name)}: ${e.message}`,
             );
         }
 
-        for (const record of data) {
-            debugSpotify(`${record.master_metadata_track_name}`);
+        const fingerprint = createHash("sha256").update(content).digest("hex");
+        const previous = draft.historySources?.[source.name];
+        if (previous?.fingerprint === fingerprint) {
+            result.loaded.push(source.name);
+            continue;
         }
         const tracks = data.filter(
             (r) =>
-                r.spotify_track_uri !== null &&
+                typeof r.master_metadata_track_name === "string" &&
+                r.master_metadata_track_name.trim().length > 0 &&
                 getIdPart(r.spotify_track_uri) !== "",
         );
-        mergeUserDataKind(
-            context.userData.data.tracks,
-            tracks.map((r) => ({
-                timestamps: [r.ts],
-                freq: 1,
-                name: r.master_metadata_track_name,
-                albumArtist: r.master_metadata_album_artist_name,
-                albumName: r.master_metadata_album_album_name,
-                id: getIdPart(r.spotify_track_uri),
-            })),
-        );
-        // Streaming history carries the artist and album names alongside the
-        // track, but no ids for them. Without merging these, completion for
-        // `target.artist` / `target.albumName` stays empty no matter how much
-        // history is loaded — only the Spotify API path ever filled those.
-        // Key on the name so a later API update (which has real ids) doesn't
-        // produce a second entry for the same artist.
-        mergeUserDataKind(
-            context.userData.data.artists,
-            namedItems(tracks, (r) => r.master_metadata_album_artist_name),
-        );
-        mergeUserDataKind(
-            context.userData.data.albums,
-            namedItems(tracks, (r) => r.master_metadata_album_album_name),
-        );
+        const sourceData: HistorySourceData = {
+            fingerprint,
+            tracks: aggregateItems(
+                tracks.map((r) => ({
+                    timestamps: [r.ts],
+                    freq: 1,
+                    name: r.master_metadata_track_name!,
+                    albumArtist:
+                        r.master_metadata_album_artist_name ?? undefined,
+                    albumName: r.master_metadata_album_album_name ?? undefined,
+                    id: getIdPart(r.spotify_track_uri),
+                })),
+            ),
+            artists: namedItems(
+                tracks,
+                (r) => r.master_metadata_album_artist_name,
+            ),
+            albums: namedItems(
+                tracks,
+                (r) => r.master_metadata_album_album_name,
+            ),
+        };
+        if (previous !== undefined) {
+            removeHistorySource(draft, previous);
+        }
+        applyHistorySource(draft, sourceData);
+        draft.historySources ??= {};
+        draft.historySources[source.name] = sourceData;
         result.loaded.push(source.name);
         result.records += tracks.length;
     }
@@ -449,15 +481,72 @@ export async function loadHistoryFile(
     // it to decide whether a track/artist the user named is one of theirs.
     // Leaving the pre-load index in place would make everything just loaded
     // look unknown until the next restart.
-    delete context.userData.data.nameMap;
-
-    await saveUserData(instanceStorage, context.userData.data);
+    delete draft.nameMap;
+    await saveUserData(instanceStorage, draft);
+    context.userData.data = draft;
     return result;
 }
 
-// Artist/album entries derived from history rows, deduped by name (history
-// has no ids for them) and skipping rows where the name is absent — podcast
-// and local-file plays leave these null.
+function cloneUserData(userData: SpotifyUserData): SpotifyUserData {
+    const cloneMap = (items: Map<string, MusicItemInfo>) =>
+        new Map(
+            Array.from(items, ([id, item]) => [
+                id,
+                { ...item, timestamps: [...item.timestamps] },
+            ]),
+        );
+    return {
+        ...userData,
+        tracks: cloneMap(userData.tracks),
+        artists: cloneMap(userData.artists),
+        albums: cloneMap(userData.albums),
+        historySources:
+            userData.historySources === undefined
+                ? undefined
+                : structuredClone(userData.historySources),
+        nameMap: undefined,
+    };
+}
+
+function applyHistorySource(
+    userData: SpotifyUserData,
+    source: HistorySourceData,
+): void {
+    mergeUserDataKind(userData.tracks, source.tracks);
+    mergeUserDataKind(userData.artists, source.artists);
+    mergeUserDataKind(userData.albums, source.albums);
+}
+
+function removeHistorySource(
+    userData: SpotifyUserData,
+    source: HistorySourceData,
+): void {
+    removeUserDataKind(userData.tracks, source.tracks);
+    removeUserDataKind(userData.artists, source.artists);
+    removeUserDataKind(userData.albums, source.albums);
+}
+
+function aggregateItems(items: MusicItemInfo[]): MusicItemInfo[] {
+    const byId = new Map<string, MusicItemInfo>();
+    for (const item of items) {
+        const existing = byId.get(item.id);
+        if (existing === undefined) {
+            byId.set(item.id, { ...item, timestamps: [...item.timestamps] });
+        } else {
+            existing.freq += item.freq;
+            existing.timestamps.push(...item.timestamps);
+        }
+    }
+    for (const item of byId.values()) {
+        item.timestamps.sort();
+        item.timestamps = item.timestamps.slice(-MAX_ITEM_TIMESTAMPS);
+    }
+    return Array.from(byId.values());
+}
+
+// History exports have no artist/album ids, so these synthetic ids identify
+// history-derived entries only. API-derived entries keep their Spotify ids;
+// completion deduplicates their display names.
 function namedItems(
     records: SpotifyRecord[],
     getName: (r: SpotifyRecord) => string | null,
@@ -465,7 +554,7 @@ function namedItems(
     const byName = new Map<string, MusicItemInfo>();
     for (const record of records) {
         const name = getName(record);
-        if (!name) {
+        if (!name || name.trim().length === 0) {
             continue;
         }
         const id = `name:${name.toLocaleLowerCase()}`;
@@ -476,6 +565,10 @@ function namedItems(
             existing.freq++;
             existing.timestamps.push(record.ts);
         }
+    }
+    for (const item of byName.values()) {
+        item.timestamps.sort();
+        item.timestamps = item.timestamps.slice(-MAX_ITEM_TIMESTAMPS);
     }
     return Array.from(byName.values());
 }

--- a/ts/packages/agents/player/src/client.ts
+++ b/ts/packages/agents/player/src/client.ts
@@ -20,6 +20,9 @@ import {
 } from "./agent/playerSchema.js";
 import { createTokenProvider } from "./defaultTokenProvider.js";
 import chalk from "chalk";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { loadConfigSync } from "@typeagent/config";
 //import * as Filter from "./trackFilter.js";
 import { openai, ChatModelWithStreaming } from "@typeagent/aiclient";
@@ -105,7 +108,6 @@ import {
     setMaxVolumeAction,
     setVolumeAction,
 } from "./volume.js";
-import e from "express";
 
 function createWarningActionResult(message: string) {
     debugSpotifyError(message);
@@ -217,27 +219,193 @@ function getIdPart(uri: string) {
     }
 }
 
+// A single streaming history JSON file to load, along with how to read it.
+type HistorySource = {
+    name: string;
+    read: () => Promise<string>;
+};
+
+type HistorySources = {
+    sources: HistorySource[];
+    // True when the user pointed at a directory, in which case files that
+    // aren't Spotify streaming history are silently skipped.
+    isDirectory: boolean;
+};
+
+export type LoadHistoryResult = {
+    loaded: string[];
+    skipped: string[];
+    records: number;
+};
+
+function expandHomeDir(p: string) {
+    return p === "~" || p.startsWith("~/") || p.startsWith("~\\")
+        ? path.join(os.homedir(), p.slice(1))
+        : p;
+}
+
+function isJsonFileName(name: string) {
+    return name.toLowerCase().endsWith(".json");
+}
+
+function createFsSource(filePath: string): HistorySource {
+    return {
+        name: filePath,
+        read: () => fs.promises.readFile(filePath, "utf8"),
+    };
+}
+
+async function getFsHistorySources(
+    fullPath: string,
+): Promise<HistorySources | undefined> {
+    let stats;
+    try {
+        stats = await fs.promises.stat(fullPath);
+    } catch {
+        return undefined;
+    }
+    if (!stats.isDirectory()) {
+        return { sources: [createFsSource(fullPath)], isDirectory: false };
+    }
+    const entries = await fs.promises.readdir(fullPath, {
+        withFileTypes: true,
+    });
+    const sources = entries
+        .filter((entry) => entry.isFile() && isJsonFileName(entry.name))
+        .map((entry) => entry.name)
+        .sort()
+        .map((name) => createFsSource(path.join(fullPath, name)));
+    return { sources, isDirectory: true };
+}
+
+async function getStorageHistorySources(
+    instanceStorage: Storage,
+    historyPath: string,
+): Promise<HistorySources | undefined> {
+    if (!(await instanceStorage.exists(historyPath))) {
+        return undefined;
+    }
+    let names: string[] | undefined;
+    try {
+        // Listing a file (instead of a directory) throws.
+        names = await instanceStorage.list(historyPath);
+    } catch {
+        names = undefined;
+    }
+    if (names === undefined) {
+        return {
+            sources: [
+                {
+                    name: historyPath,
+                    read: () => instanceStorage.read(historyPath, "utf8"),
+                },
+            ],
+            isDirectory: false,
+        };
+    }
+    const sources = names
+        .filter(isJsonFileName)
+        .sort()
+        .map((name) => {
+            const filePath = `${historyPath}/${name}`;
+            return {
+                name: filePath,
+                read: () => instanceStorage.read(filePath, "utf8"),
+            };
+        });
+    return { sources, isDirectory: true };
+}
+
+// Resolve the user supplied path to the set of files to load.  Absolute paths
+// (and paths that exist relative to the current working directory) are read
+// directly from the file system; everything else is resolved against the
+// agent's instance storage.
+async function getHistorySources(
+    instanceStorage: Storage,
+    historyPath: string,
+): Promise<HistorySources> {
+    const expandedPath = expandHomeDir(historyPath);
+    if (path.isAbsolute(expandedPath)) {
+        const sources = await getFsHistorySources(expandedPath);
+        if (sources === undefined) {
+            throw new Error(`History path not found: ${historyPath}`);
+        }
+        return sources;
+    }
+
+    const sources =
+        (await getStorageHistorySources(instanceStorage, expandedPath)) ??
+        (await getFsHistorySources(path.resolve(process.cwd(), expandedPath)));
+    if (sources === undefined) {
+        throw new Error(`History path not found: ${historyPath}`);
+    }
+    return sources;
+}
+
+function isSpotifyHistoryData(data: any): data is SpotifyRecord[] {
+    if (!Array.isArray(data)) {
+        return false;
+    }
+    // Only the shape of the first record is checked; Spotify's extended
+    // streaming history files are homogeneous.
+    const record = data[0];
+    return (
+        record === undefined ||
+        (typeof record === "object" &&
+            record !== null &&
+            typeof record.ts === "string" &&
+            "spotify_track_uri" in record)
+    );
+}
+
 export async function loadHistoryFile(
     instanceStorage: Storage,
     historyPath: string,
     context: IClientContext,
-) {
-    if (!(await instanceStorage.exists(historyPath))) {
-        throw new Error(`History file not found: ${historyPath}`);
-    }
+): Promise<LoadHistoryResult> {
     if (!context.userData) {
         throw new Error("User data not enabled");
     }
-    try {
-        const rawData = await instanceStorage.read(historyPath, "utf8");
-        let data: SpotifyRecord[] = JSON.parse(rawData);
-        for (const record of data) {
-            console.log(`${record.master_metadata_track_name}`);
+    const { sources, isDirectory } = await getHistorySources(
+        instanceStorage,
+        historyPath,
+    );
+    if (isDirectory && sources.length === 0) {
+        throw new Error(`No JSON files found in directory: ${historyPath}`);
+    }
+
+    const result: LoadHistoryResult = {
+        loaded: [],
+        skipped: [],
+        records: 0,
+    };
+    for (const source of sources) {
+        let data: SpotifyRecord[];
+        try {
+            const parsed = JSON.parse(await source.read());
+            if (!isSpotifyHistoryData(parsed)) {
+                throw new Error("Not a Spotify streaming history file");
+            }
+            data = parsed;
+        } catch (e: any) {
+            if (isDirectory) {
+                // Silently skip files that aren't streaming history.
+                debugSpotify(`Skipping ${source.name}: ${e.message}`);
+                result.skipped.push(source.name);
+                continue;
+            }
+            throw new Error(
+                `Error reading history file ${source.name}: ${e.message}`,
+            );
         }
-        data = data.filter((r) => r.spotify_track_uri !== null);
+
+        for (const record of data) {
+            debugSpotify(`${record.master_metadata_track_name}`);
+        }
+        const tracks = data.filter((r) => r.spotify_track_uri !== null);
         mergeUserDataKind(
             context.userData.data.tracks,
-            data.map((r) => ({
+            tracks.map((r) => ({
                 timestamps: [r.ts],
                 freq: 1,
                 name: r.master_metadata_track_name,
@@ -246,10 +414,18 @@ export async function loadHistoryFile(
                 id: getIdPart(r.spotify_track_uri),
             })),
         );
-        await saveUserData(instanceStorage, context.userData.data);
-    } catch (e: any) {
-        throw new Error(`Error reading history file: ${e.message}`);
+        result.loaded.push(source.name);
+        result.records += tracks.length;
     }
+
+    if (result.loaded.length === 0) {
+        throw new Error(
+            `No Spotify streaming history files found in: ${historyPath}`,
+        );
+    }
+
+    await saveUserData(instanceStorage, context.userData.data);
+    return result;
 }
 
 async function htmlPlaylistNames(

--- a/ts/packages/agents/player/src/defaultTokenProvider.ts
+++ b/ts/packages/agents/player/src/defaultTokenProvider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { loadConfigSync } from "@typeagent/config";
+import { loadConfigSync, configSetupHint } from "@typeagent/config";
 import { TokenProvider } from "./tokenProvider.js";
 import { Storage } from "@typeagent/agent-sdk";
 
@@ -28,23 +28,35 @@ const scopes = [
 const baseClientId = process.env.SPOTIFY_APP_CLI;
 const baseClientSecret = process.env.SPOTIFY_APP_CLISEC;
 const defaultPort = process.env.SPOTIFY_APP_PORT;
+const spotifyConfigHint = (missing: string[]) =>
+    configSetupHint(
+        missing,
+        "`clientId` and `clientSecret` come from the Spotify developer dashboard for your app; `port` is the redirect port you registered there.",
+    );
+
 export async function createTokenProvider(storage?: Storage) {
     if (baseClientId === undefined) {
-        throw new Error("SPOTIFY_APP_CLI not set");
+        throw new Error(
+            `Spotify is not configured (missing spotify.clientId).\n${spotifyConfigHint(["SPOTIFY_APP_CLI"])}`,
+        );
     }
 
     if (baseClientSecret === undefined) {
-        throw new Error("SPOTIFY_APP_CLISEC not set");
+        throw new Error(
+            `Spotify is not configured (missing spotify.clientSecret).\n${spotifyConfigHint(["SPOTIFY_APP_CLISEC"])}`,
+        );
     }
 
     if (defaultPort === undefined) {
-        throw new Error("SPOTIFY_APP_PORT not set");
+        throw new Error(
+            `Spotify is not configured (missing spotify.port).\n${spotifyConfigHint(["SPOTIFY_APP_PORT"])}`,
+        );
     }
 
     const port = parseInt(defaultPort);
     if (port.toString() !== defaultPort) {
         throw new Error(
-            `SPOTIFY_APP_PORT has invalid port number ${defaultPort}`,
+            `Spotify spotify.port has invalid port number ${defaultPort}. It must be an integer — the redirect port your Spotify app is registered with.`,
         );
     }
 

--- a/ts/packages/agents/player/src/defaultTokenProvider.ts
+++ b/ts/packages/agents/player/src/defaultTokenProvider.ts
@@ -3,7 +3,7 @@
 
 import {
     loadConfigSync,
-    reloadConfigSync,
+    tryReloadConfigSync,
     configSetupError,
 } from "@typeagent/config";
 import { TokenProvider } from "./tokenProvider.js";
@@ -36,11 +36,7 @@ export async function createTokenProvider(storage?: Storage) {
     // Agent processes are forked with a snapshot of process.env, so re-read
     // the config files here: otherwise settings the user added since startup
     // (and confirmed with `@config agent refresh player`) stay invisible.
-    try {
-        reloadConfigSync();
-    } catch {
-        // Keep whatever was loaded at startup.
-    }
+    tryReloadConfigSync();
 
     const baseClientId = process.env.SPOTIFY_APP_CLI;
     const baseClientSecret = process.env.SPOTIFY_APP_CLISEC;

--- a/ts/packages/agents/player/src/defaultTokenProvider.ts
+++ b/ts/packages/agents/player/src/defaultTokenProvider.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { loadConfigSync, configSetupHint } from "@typeagent/config";
+import {
+    loadConfigSync,
+    reloadConfigSync,
+    configSetupError,
+} from "@typeagent/config";
 import { TokenProvider } from "./tokenProvider.js";
 import { Storage } from "@typeagent/agent-sdk";
 
@@ -25,38 +29,53 @@ const scopes = [
     "ugc-image-upload",
 ];
 
-const baseClientId = process.env.SPOTIFY_APP_CLI;
-const baseClientSecret = process.env.SPOTIFY_APP_CLISEC;
-const defaultPort = process.env.SPOTIFY_APP_PORT;
-const spotifyConfigHint = (missing: string[]) =>
-    configSetupHint(
-        missing,
-        "`clientId` and `clientSecret` come from the Spotify developer dashboard for your app; `port` is the redirect port you registered there.",
-    );
+const CONFIG_NOTE =
+    "`clientId` and `clientSecret` come from the Spotify developer dashboard for your app; `port` is the redirect port you registered there.";
 
 export async function createTokenProvider(storage?: Storage) {
+    // Agent processes are forked with a snapshot of process.env, so re-read
+    // the config files here: otherwise settings the user added since startup
+    // (and confirmed with `@config agent refresh player`) stay invisible.
+    try {
+        reloadConfigSync();
+    } catch {
+        // Keep whatever was loaded at startup.
+    }
+
+    const baseClientId = process.env.SPOTIFY_APP_CLI;
+    const baseClientSecret = process.env.SPOTIFY_APP_CLISEC;
+    const defaultPort = process.env.SPOTIFY_APP_PORT;
+
     if (baseClientId === undefined) {
-        throw new Error(
-            `Spotify is not configured (missing spotify.clientId).\n${spotifyConfigHint(["SPOTIFY_APP_CLI"])}`,
+        throw configSetupError(
+            "Spotify is not configured (missing spotify.clientId).",
+            ["SPOTIFY_APP_CLI"],
+            CONFIG_NOTE,
         );
     }
 
     if (baseClientSecret === undefined) {
-        throw new Error(
-            `Spotify is not configured (missing spotify.clientSecret).\n${spotifyConfigHint(["SPOTIFY_APP_CLISEC"])}`,
+        throw configSetupError(
+            "Spotify is not configured (missing spotify.clientSecret).",
+            ["SPOTIFY_APP_CLISEC"],
+            CONFIG_NOTE,
         );
     }
 
     if (defaultPort === undefined) {
-        throw new Error(
-            `Spotify is not configured (missing spotify.port).\n${spotifyConfigHint(["SPOTIFY_APP_PORT"])}`,
+        throw configSetupError(
+            "Spotify is not configured (missing spotify.port).",
+            ["SPOTIFY_APP_PORT"],
+            CONFIG_NOTE,
         );
     }
 
     const port = parseInt(defaultPort);
     if (port.toString() !== defaultPort) {
-        throw new Error(
-            `Spotify spotify.port has invalid port number ${defaultPort}. It must be an integer — the redirect port your Spotify app is registered with.`,
+        throw configSetupError(
+            `Spotify spotify.port has an invalid port number: ${defaultPort}. It must be an integer.`,
+            ["SPOTIFY_APP_PORT"],
+            CONFIG_NOTE,
         );
     }
 

--- a/ts/packages/agents/player/src/defaultTokenProvider.ts
+++ b/ts/packages/agents/player/src/defaultTokenProvider.ts
@@ -3,7 +3,7 @@
 
 import {
     loadConfigSync,
-    tryReloadConfigSync,
+    tryReloadConfigKeysSync,
     configSetupError,
 } from "@typeagent/config";
 import { TokenProvider } from "./tokenProvider.js";
@@ -31,12 +31,17 @@ const scopes = [
 
 const CONFIG_NOTE =
     "`clientId` and `clientSecret` come from the Spotify developer dashboard for your app; `port` is the redirect port you registered there.";
+const SPOTIFY_CONFIG_KEYS = [
+    "SPOTIFY_APP_CLI",
+    "SPOTIFY_APP_CLISEC",
+    "SPOTIFY_APP_PORT",
+] as const;
 
 export async function createTokenProvider(storage?: Storage) {
     // Agent processes are forked with a snapshot of process.env, so re-read
     // the config files here: otherwise settings the user added since startup
     // (and confirmed with `@config agent refresh player`) stay invisible.
-    tryReloadConfigSync();
+    tryReloadConfigKeysSync(SPOTIFY_CONFIG_KEYS);
 
     const baseClientId = process.env.SPOTIFY_APP_CLI;
     const baseClientSecret = process.env.SPOTIFY_APP_CLISEC;

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -313,7 +313,7 @@ export function getUserDataCompletions(
     artist = false,
     album = false,
     playlist = false,
-    partialValue = "",
+    partialValue?: string,
     limit = 100,
 ): string[] {
     const completions: string[] = [];
@@ -339,8 +339,12 @@ export function getUserDataCompletions(
     // The same artist or album can appear both as a history-derived entry
     // (keyed by name) and as an API-derived one (keyed by its Spotify id),
     // so drop repeats while keeping the established ordering.
+    const uniqueCompletions = dedupe(completions);
+    if (partialValue === undefined) {
+        return uniqueCompletions;
+    }
     const query = partialValue.trim().toLocaleLowerCase();
-    return dedupe(completions)
+    return uniqueCompletions
         .filter(
             (name) =>
                 query.length === 0 || name.toLocaleLowerCase().includes(query),

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -25,12 +25,22 @@ export interface MusicItemInfo {
     albumArtist?: string;
 }
 
+export const MAX_ITEM_TIMESTAMPS = 32;
+
+export interface HistorySourceData {
+    fingerprint: string;
+    tracks: MusicItemInfo[];
+    artists: MusicItemInfo[];
+    albums: MusicItemInfo[];
+}
+
 export interface SpotifyUserData {
     lastUpdated: number;
     playlists?: SpotifyApi.PlaylistObjectSimplified[];
     tracks: Map<string, MusicItemInfo>;
     artists: Map<string, MusicItemInfo>;
     albums: Map<string, MusicItemInfo>;
+    historySources?: Record<string, HistorySourceData>;
     nameMap?: Map<string, MusicItemInfo>;
 }
 
@@ -39,6 +49,7 @@ interface SpotifyUserDataJSON {
     tracks: MusicItemInfo[];
     artists: MusicItemInfo[];
     albums: MusicItemInfo[];
+    historySources?: Record<string, HistorySourceData>;
 }
 
 function getUserDataFilePath() {
@@ -80,11 +91,22 @@ async function loadUserData(
     if (await instanceStorage.exists(userDataPath)) {
         const content = await instanceStorage.read(userDataPath, "utf8");
         const json: SpotifyUserDataJSON = JSON.parse(content);
+        const itemsToMap = (items: MusicItemInfo[]) =>
+            new Map(
+                items.map((item) => [
+                    item.id,
+                    {
+                        ...item,
+                        timestamps: boundedTimestamps([...item.timestamps]),
+                    },
+                ]),
+            );
         return {
             lastUpdated: json.lastUpdated,
-            tracks: new Map(json.tracks.map((t) => [t.id, t])),
-            artists: new Map(json.artists.map((a) => [a.id, a])),
-            albums: new Map(json.albums.map((a) => [a.id, a])),
+            tracks: itemsToMap(json.tracks),
+            artists: itemsToMap(json.artists),
+            albums: itemsToMap(json.albums),
+            historySources: json.historySources,
         };
     }
     return {
@@ -104,6 +126,7 @@ export async function saveUserData(
         tracks: Array.from(userData.tracks.values()),
         artists: Array.from(userData.artists.values()),
         albums: Array.from(userData.albums.values()),
+        historySources: userData.historySources,
     };
     await storage.write(getUserDataFilePath(), JSON.stringify(json, null, 2));
 }
@@ -116,16 +139,54 @@ export function mergeUserDataKind(
     for (const newItem of newItems) {
         const info = existing.get(newItem.id);
         if (!info) {
-            existing.set(newItem.id, newItem);
+            existing.set(newItem.id, {
+                ...newItem,
+                timestamps: boundedTimestamps([...newItem.timestamps]),
+            });
             added++;
         } else {
             // Update the frequency and timestamps
             info.freq += newItem.freq;
-            info.timestamps = info.timestamps.concat(newItem.timestamps).sort();
+            info.timestamps = boundedTimestamps(
+                info.timestamps.concat(newItem.timestamps),
+            );
             info.name = newItem.name;
         }
     }
     return added;
+}
+
+function boundedTimestamps(timestamps: string[]): string[] {
+    timestamps.sort();
+    return timestamps.slice(-MAX_ITEM_TIMESTAMPS);
+}
+
+export function removeUserDataKind(
+    existing: Map<string, MusicItemInfo>,
+    oldItems: MusicItemInfo[],
+): void {
+    for (const oldItem of oldItems) {
+        const info = existing.get(oldItem.id);
+        if (info === undefined) {
+            continue;
+        }
+        info.freq -= oldItem.freq;
+        const removed = new Map<string, number>();
+        for (const timestamp of oldItem.timestamps) {
+            removed.set(timestamp, (removed.get(timestamp) ?? 0) + 1);
+        }
+        info.timestamps = info.timestamps.filter((timestamp) => {
+            const count = removed.get(timestamp) ?? 0;
+            if (count === 0) {
+                return true;
+            }
+            removed.set(timestamp, count - 1);
+            return false;
+        });
+        if (info.freq <= 0) {
+            existing.delete(oldItem.id);
+        }
+    }
 }
 
 function trackToJSON(track: SpotifyApi.TrackObjectSimplified): MusicItemInfo {
@@ -204,8 +265,10 @@ function mergeTracksWithTimestamps(
         } else {
             // Update the frequency and timestamps
             info.freq++;
-            info.timestamps.push(track.played_at);
-            info.timestamps.sort();
+            info.timestamps = boundedTimestamps([
+                ...info.timestamps,
+                track.played_at,
+            ]);
         }
     }
     return [added, 0, 0];
@@ -246,55 +309,23 @@ export function getUserDataCompletions(
     artist = false,
     album = false,
     playlist = false,
+    partialValue = "",
+    limit = 100,
 ): string[] {
     const completions: string[] = [];
     if (track) {
         // return names of tracks, sorted by timestamp
-        const trackNames = Array.from(userData.tracks.values())
-            .sort((a, b) => {
-                const aTime =
-                    a.timestamps.length > 0
-                        ? new Date(
-                              a.timestamps[a.timestamps.length - 1],
-                          ).getTime()
-                        : 0;
-                const bTime =
-                    b.timestamps.length > 0
-                        ? new Date(
-                              b.timestamps[b.timestamps.length - 1],
-                          ).getTime()
-                        : 0;
-                return bTime - aTime;
-            })
-            .map((t) => t.name);
+        const trackNames = rankedItems(userData.tracks).map((t) => t.name);
         completions.push(...trackNames);
     }
     if (artist) {
         // return names of artists, sorted by timestamp
-        const artistNames = Array.from(userData.artists.values())
-            .sort((a, b) => {
-                const aTime =
-                    a.timestamps.length > 0
-                        ? new Date(
-                              a.timestamps[a.timestamps.length - 1],
-                          ).getTime()
-                        : 0;
-                const bTime =
-                    b.timestamps.length > 0
-                        ? new Date(
-                              b.timestamps[b.timestamps.length - 1],
-                          ).getTime()
-                        : 0;
-                return bTime - aTime;
-            })
-            .map((a) => a.name);
+        const artistNames = rankedItems(userData.artists).map((a) => a.name);
         completions.push(...artistNames);
     }
     if (album) {
         // for now just return names no sorting
-        const albumNames = Array.from(userData.albums.values()).map(
-            (a) => a.name,
-        );
+        const albumNames = rankedItems(userData.albums).map((a) => a.name);
         completions.push(...albumNames);
     }
     if (playlist && userData.playlists) {
@@ -304,7 +335,31 @@ export function getUserDataCompletions(
     // The same artist or album can appear both as a history-derived entry
     // (keyed by name) and as an API-derived one (keyed by its Spotify id),
     // so drop repeats while keeping the established ordering.
-    return dedupe(completions);
+    const query = partialValue.trim().toLocaleLowerCase();
+    return dedupe(completions)
+        .filter(
+            (name) =>
+                query.length === 0 || name.toLocaleLowerCase().includes(query),
+        )
+        .slice(0, limit);
+}
+
+function rankedItems(items: Map<string, MusicItemInfo>): MusicItemInfo[] {
+    return Array.from(items.values())
+        .map((item) => ({
+            item,
+            recency:
+                item.timestamps.length === 0
+                    ? 0
+                    : Date.parse(item.timestamps[item.timestamps.length - 1]),
+        }))
+        .sort(
+            (a, b) =>
+                b.recency - a.recency ||
+                b.item.freq - a.item.freq ||
+                a.item.name.localeCompare(b.item.name),
+        )
+        .map(({ item }) => item);
 }
 
 function dedupe(names: string[]): string[] {

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -301,7 +301,25 @@ export function getUserDataCompletions(
         const playlistNames = userData.playlists.map((p) => p.name);
         completions.push(...playlistNames);
     }
-    return completions;
+    // The same artist or album can appear both as a history-derived entry
+    // (keyed by name) and as an API-derived one (keyed by its Spotify id),
+    // so drop repeats while keeping the established ordering.
+    return dedupe(completions);
+}
+
+function dedupe(names: string[]): string[] {
+    const seen = new Set<string>();
+    return names.filter((name) => {
+        if (name === undefined || name === null) {
+            return false;
+        }
+        const key = name.toLocaleLowerCase();
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
 }
 
 export function addFullTracks(

--- a/ts/packages/agents/player/src/userData.ts
+++ b/ts/packages/agents/player/src/userData.ts
@@ -106,7 +106,9 @@ async function loadUserData(
             tracks: itemsToMap(json.tracks),
             artists: itemsToMap(json.artists),
             albums: itemsToMap(json.albums),
-            historySources: json.historySources,
+            ...(json.historySources === undefined
+                ? {}
+                : { historySources: json.historySources }),
         };
     }
     return {
@@ -126,7 +128,9 @@ export async function saveUserData(
         tracks: Array.from(userData.tracks.values()),
         artists: Array.from(userData.artists.values()),
         albums: Array.from(userData.albums.values()),
-        historySources: userData.historySources,
+        ...(userData.historySources === undefined
+            ? {}
+            : { historySources: userData.historySources }),
     };
     await storage.write(getUserDataFilePath(), JSON.stringify(json, null, 2));
 }

--- a/ts/packages/agents/player/test/defaultTokenProvider.spec.ts
+++ b/ts/packages/agents/player/test/defaultTokenProvider.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Tests for createTokenProvider's config handling.
+ *
+ * Agent processes are forked with a snapshot of process.env, so the token
+ * provider has to re-read the config files at call time rather than trust
+ * values captured when the module was first imported — otherwise settings
+ * the user added after startup (and confirmed with `@config agent refresh
+ * player`) stay invisible to `@player spotify login`.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ENV_KEYS = [
+    "SPOTIFY_APP_CLI",
+    "SPOTIFY_APP_CLISEC",
+    "SPOTIFY_APP_PORT",
+] as const;
+
+// Set before the module is imported: importing it loads config, and the
+// developer's real config.local.yaml would otherwise leak into the results.
+const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-token-"));
+const savedConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
+process.env.TYPEAGENT_CONFIG_DIR = configDir;
+const localConfigPath = path.join(configDir, "config.local.yaml");
+
+let createTokenProvider: (storage?: any) => Promise<unknown>;
+
+beforeAll(async () => {
+    ({ createTokenProvider } = await import("../src/defaultTokenProvider.js"));
+});
+
+afterAll(() => {
+    if (savedConfigDir === undefined) delete process.env.TYPEAGENT_CONFIG_DIR;
+    else process.env.TYPEAGENT_CONFIG_DIR = savedConfigDir;
+    fs.rmSync(configDir, { recursive: true, force: true });
+});
+
+describe("createTokenProvider", () => {
+    let saved: Record<string, string | undefined>;
+
+    beforeEach(() => {
+        saved = {};
+        for (const k of ENV_KEYS) {
+            saved[k] = process.env[k];
+            delete process.env[k];
+        }
+        fs.rmSync(localConfigPath, { force: true });
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (saved[k] === undefined) delete process.env[k];
+            else process.env[k] = saved[k];
+        }
+    });
+
+    test("reports missing settings with a pasteable markdown hint", async () => {
+        const e: any = await createTokenProvider().then(
+            () => undefined,
+            (e) => e,
+        );
+        expect(e.message).toContain("spotify.clientId");
+        // The one-line summary stays plain; the snippet lives in markdown.
+        expect(e.message).not.toContain("```");
+        expect(e.markdown).toContain("```yaml");
+        expect(e.markdown).toContain("clientId");
+    });
+
+    test("picks up values added to config.local.yaml since startup", async () => {
+        fs.writeFileSync(
+            localConfigPath,
+            [
+                "spotify:",
+                "  clientId: id",
+                "  clientSecret: secret",
+                "  port: 8080",
+                "",
+            ].join("\n"),
+        );
+        await expect(createTokenProvider()).resolves.toBeDefined();
+    });
+
+    test("explains a non-numeric port instead of failing obscurely", async () => {
+        fs.writeFileSync(
+            localConfigPath,
+            ["spotify:", "  clientId: id", "  clientSecret: secret", ""].join(
+                "\n",
+            ),
+        );
+        process.env.SPOTIFY_APP_PORT = "not-a-port";
+        const e: any = await createTokenProvider().then(
+            () => undefined,
+            (e) => e,
+        );
+        expect(e.message).toContain("invalid port number");
+        expect(e.markdown).toContain("```yaml");
+    });
+});

--- a/ts/packages/agents/player/test/defaultTokenProvider.spec.ts
+++ b/ts/packages/agents/player/test/defaultTokenProvider.spec.ts
@@ -23,10 +23,13 @@ const ENV_KEYS = [
 
 // Set before the module is imported: importing it loads config, and the
 // developer's real config.local.yaml would otherwise leak into the results.
-const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-token-"));
+const importConfigDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "player-token-import-"),
+);
 const savedConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
-process.env.TYPEAGENT_CONFIG_DIR = configDir;
-const localConfigPath = path.join(configDir, "config.local.yaml");
+process.env.TYPEAGENT_CONFIG_DIR = importConfigDir;
+let configDir: string;
+let localConfigPath: string;
 
 let createTokenProvider: (storage?: any) => Promise<unknown>;
 
@@ -37,13 +40,16 @@ beforeAll(async () => {
 afterAll(() => {
     if (savedConfigDir === undefined) delete process.env.TYPEAGENT_CONFIG_DIR;
     else process.env.TYPEAGENT_CONFIG_DIR = savedConfigDir;
-    fs.rmSync(configDir, { recursive: true, force: true });
+    fs.rmSync(importConfigDir, { recursive: true, force: true });
 });
 
 describe("createTokenProvider", () => {
     let saved: Record<string, string | undefined>;
 
     beforeEach(() => {
+        configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-token-"));
+        localConfigPath = path.join(configDir, "config.local.yaml");
+        process.env.TYPEAGENT_CONFIG_DIR = configDir;
         saved = {};
         for (const k of ENV_KEYS) {
             saved[k] = process.env[k];
@@ -57,6 +63,7 @@ describe("createTokenProvider", () => {
             if (saved[k] === undefined) delete process.env[k];
             else process.env[k] = saved[k];
         }
+        fs.rmSync(configDir, { recursive: true, force: true });
     });
 
     test("reports missing settings with a pasteable markdown hint", async () => {

--- a/ts/packages/agents/player/test/loadHistory.spec.ts
+++ b/ts/packages/agents/player/test/loadHistory.spec.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * End-to-end test for `@player spotify load` → action completion.
+ *
+ * Loading streaming history is only useful if the names it brings in then
+ * show up as completions and are accepted by wildcard validation, so this
+ * exercises the whole join: parse the files, merge into the in-memory user
+ * data, and read it back the way getPlayerActionCompletion does.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadHistoryFile } from "../src/client.js";
+import {
+    addUserDataStrings,
+    getUserDataCompletions,
+    type SpotifyUserData,
+} from "../src/userData.js";
+
+function record(
+    trackName: string,
+    artist: string,
+    album: string,
+    id: string,
+    ts = "2024-01-01T00:00:00Z",
+) {
+    return {
+        ts,
+        master_metadata_track_name: trackName,
+        master_metadata_album_artist_name: artist,
+        master_metadata_album_album_name: album,
+        spotify_track_uri: `spotify:track:${id}`,
+    };
+}
+
+// Minimal Storage stand-in: loadHistoryFile only reads the history files
+// through it and writes userdata.json back.
+function fakeStorage(dir: string) {
+    const written = new Map<string, string>();
+    return {
+        written,
+        async exists(p: string) {
+            return fs.existsSync(path.join(dir, p));
+        },
+        async read(p: string) {
+            return fs.readFileSync(path.join(dir, p), "utf8");
+        },
+        async write(p: string, data: string) {
+            written.set(p, data);
+        },
+        async list(p: string) {
+            return fs.readdirSync(path.join(dir, p));
+        },
+        async getFullPath(p: string) {
+            return path.join(dir, p);
+        },
+    } as any;
+}
+
+function emptyUserData(): SpotifyUserData {
+    return {
+        lastUpdated: 0,
+        tracks: new Map(),
+        artists: new Map(),
+        albums: new Map(),
+    };
+}
+
+describe("loadHistoryFile → completions", () => {
+    let dir: string;
+    let context: any;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), "player-history-"));
+        context = {
+            userData: { data: emptyUserData(), instanceStorage: undefined },
+        };
+    });
+
+    afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+    function writeHistory(name: string, records: unknown[]) {
+        fs.writeFileSync(path.join(dir, name), JSON.stringify(records));
+    }
+
+    test("track names from a loaded file become completions", async () => {
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            record("Song B", "Artist B", "Album B", "bbb"),
+        ]);
+        const result = await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        expect(result.records).toBe(2);
+        const tracks = getUserDataCompletions(context.userData.data, true);
+        expect(tracks).toEqual(expect.arrayContaining(["Song A", "Song B"]));
+    });
+
+    test("artist and album names come from history too", async () => {
+        // Only the Spotify API used to populate these, so completion for
+        // `target.artist` / `target.albumName` stayed empty after a load.
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            record("Song B", "Artist A", "Album A", "bbb"),
+        ]);
+        await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        const artists = getUserDataCompletions(
+            context.userData.data,
+            false,
+            true,
+        );
+        expect(artists).toEqual(["Artist A"]); // deduped across both plays
+        const albums = getUserDataCompletions(
+            context.userData.data,
+            false,
+            false,
+            true,
+        );
+        expect(albums).toEqual(["Album A"]);
+    });
+
+    test("invalidates the cached name index so new tracks validate", async () => {
+        // addUserDataStrings caches nameMap; wildcard validation consults it.
+        // Without invalidation everything just loaded looks unknown until
+        // the next restart.
+        addUserDataStrings(context.userData.data);
+        expect(context.userData.data.nameMap!.size).toBe(0);
+
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+        ]);
+        await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        expect(context.userData.data.nameMap).toBeUndefined();
+        expect(
+            addUserDataStrings(context.userData.data).get("song a"),
+        ).toBeDefined();
+    });
+
+    test("drops rows with no track uri instead of collapsing them", async () => {
+        // getIdPart returns "" for podcast/local-file rows; merging them
+        // would make every such row share one map entry.
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            {
+                ts: "2024-01-02T00:00:00Z",
+                master_metadata_track_name: null,
+                master_metadata_album_artist_name: null,
+                master_metadata_album_album_name: null,
+                spotify_track_uri: null,
+            },
+            {
+                ts: "2024-01-03T00:00:00Z",
+                master_metadata_track_name: "Episode",
+                master_metadata_album_artist_name: null,
+                master_metadata_album_album_name: null,
+                spotify_track_uri: "spotify:episode:zzz",
+            },
+        ]);
+        const result = await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        expect(result.records).toBe(1);
+        expect(context.userData.data.tracks.size).toBe(1);
+        expect(context.userData.data.tracks.has("")).toBe(false);
+    });
+
+    test("a directory load reports which files were skipped", async () => {
+        writeHistory("Streaming_History_Audio_2023.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+        ]);
+        fs.writeFileSync(
+            path.join(dir, "SearchQueries.json"),
+            JSON.stringify([{ search: "nope" }]),
+        );
+        const result = await loadHistoryFile(fakeStorage(dir), dir, context);
+        expect(result.loaded.map((f) => path.basename(f))).toEqual([
+            "Streaming_History_Audio_2023.json",
+        ]);
+        expect(result.skipped.map((f) => path.basename(f))).toEqual([
+            "SearchQueries.json",
+        ]);
+    });
+});

--- a/ts/packages/agents/player/test/loadHistory.spec.ts
+++ b/ts/packages/agents/player/test/loadHistory.spec.ts
@@ -179,6 +179,142 @@ describe("loadHistoryFile → completions", () => {
         expect(context.userData.data.tracks.has("")).toBe(false);
     });
 
+    test("rejects a mixed file instead of partially importing it", async () => {
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            { ts: "2024-01-02T00:00:00Z", spotify_track_uri: 42 },
+        ]);
+        await expect(
+            loadHistoryFile(
+                fakeStorage(dir),
+                path.join(dir, "history.json"),
+                context,
+            ),
+        ).rejects.toThrow(/not a spotify streaming history file/i);
+        expect(context.userData.data.tracks.size).toBe(0);
+    });
+
+    test("does not treat an empty array as a history file", async () => {
+        writeHistory("history.json", []);
+        await expect(
+            loadHistoryFile(
+                fakeStorage(dir),
+                path.join(dir, "history.json"),
+                context,
+            ),
+        ).rejects.toThrow(/not a spotify streaming history file/i);
+    });
+
+    test("skips null and empty track names", async () => {
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            {
+                ...record("", "Artist B", "Album B", "bbb"),
+                master_metadata_track_name: "",
+            },
+            {
+                ...record("unused", "Artist C", "Album C", "ccc"),
+                master_metadata_track_name: null,
+            },
+        ]);
+        const result = await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        expect(result.records).toBe(1);
+        expect(context.userData.data.tracks.size).toBe(1);
+        expect(() => addUserDataStrings(context.userData.data)).not.toThrow();
+    });
+
+    test("loading the same source twice is idempotent", async () => {
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+            record("Song A", "Artist A", "Album A", "aaa"),
+        ]);
+        const storage = fakeStorage(dir);
+        await loadHistoryFile(storage, path.join(dir, "history.json"), context);
+        await loadHistoryFile(storage, path.join(dir, "history.json"), context);
+        expect(context.userData.data.tracks.get("aaa")?.freq).toBe(2);
+    });
+
+    test("bounds persisted timestamps without losing frequency", async () => {
+        writeHistory(
+            "history.json",
+            Array.from({ length: 100 }, (_, i) =>
+                record(
+                    "Song A",
+                    "Artist A",
+                    "Album A",
+                    "aaa",
+                    new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString(),
+                ),
+            ),
+        );
+        await loadHistoryFile(
+            fakeStorage(dir),
+            path.join(dir, "history.json"),
+            context,
+        );
+        const track = context.userData.data.tracks.get("aaa");
+        expect(track.freq).toBe(100);
+        expect(track.timestamps).toHaveLength(32);
+        expect(track.timestamps[track.timestamps.length - 1]).toBe(
+            new Date(Date.UTC(2024, 0, 1, 0, 99)).toISOString(),
+        );
+    });
+
+    test("replaces contributions when a source is modified", async () => {
+        const file = path.join(dir, "history.json");
+        writeHistory("history.json", [
+            record("Old Song", "Old Artist", "Old Album", "aaa"),
+        ]);
+        const storage = fakeStorage(dir);
+        await loadHistoryFile(storage, file, context);
+        writeHistory("history.json", [
+            record("New Song", "New Artist", "New Album", "bbb"),
+        ]);
+        await loadHistoryFile(storage, file, context);
+        expect(context.userData.data.tracks.has("aaa")).toBe(false);
+        expect(context.userData.data.tracks.get("bbb")?.freq).toBe(1);
+        expect(context.userData.data.artists.has("name:old artist")).toBe(
+            false,
+        );
+    });
+
+    test("loads a file and directory from instance storage", async () => {
+        writeHistory("single.json", [
+            record("Single", "Artist", "Album", "single"),
+        ]);
+        writeHistory("folder.json", [
+            record("Folder", "Artist", "Album", "folder"),
+        ]);
+        fs.mkdirSync(path.join(dir, "history"));
+        fs.renameSync(
+            path.join(dir, "folder.json"),
+            path.join(dir, "history", "folder.json"),
+        );
+        const storage = fakeStorage(dir);
+        await loadHistoryFile(storage, "single.json", context);
+        await loadHistoryFile(storage, "history", context);
+        expect(context.userData.data.tracks.has("single")).toBe(true);
+        expect(context.userData.data.tracks.has("folder")).toBe(true);
+    });
+
+    test("does not mutate memory when a single-file save fails", async () => {
+        writeHistory("history.json", [
+            record("Song A", "Artist A", "Album A", "aaa"),
+        ]);
+        const storage = fakeStorage(dir);
+        storage.write = async () => {
+            throw new Error("disk full");
+        };
+        await expect(
+            loadHistoryFile(storage, path.join(dir, "history.json"), context),
+        ).rejects.toThrow("disk full");
+        expect(context.userData.data.tracks.size).toBe(0);
+    });
+
     test("a directory load reports which files were skipped", async () => {
         writeHistory("Streaming_History_Audio_2023.json", [
             record("Song A", "Artist A", "Album A", "aaa"),

--- a/ts/packages/agents/player/test/playerReadiness.spec.ts
+++ b/ts/packages/agents/player/test/playerReadiness.spec.ts
@@ -49,8 +49,8 @@ describe("checkPlayerReadiness", () => {
         process.env.SPOTIFY_APP_PORT = "8080";
         const out = await checkPlayerReadiness();
         expect(out.state).toBe("setup-required");
-        expect(out.message).toContain("SPOTIFY_APP_CLI");
-        expect(out.message).not.toContain("SPOTIFY_APP_CLISEC,");
+        expect(out.message).toContain("spotify.clientId");
+        expect(out.message).not.toContain("spotify.clientSecret");
     });
 
     test("setup-required when SPOTIFY_APP_CLISEC is missing", async () => {
@@ -58,7 +58,7 @@ describe("checkPlayerReadiness", () => {
         process.env.SPOTIFY_APP_PORT = "8080";
         const out = await checkPlayerReadiness();
         expect(out.state).toBe("setup-required");
-        expect(out.message).toContain("SPOTIFY_APP_CLISEC");
+        expect(out.message).toContain("spotify.clientSecret");
     });
 
     test("setup-required when SPOTIFY_APP_PORT is missing", async () => {
@@ -66,15 +66,15 @@ describe("checkPlayerReadiness", () => {
         process.env.SPOTIFY_APP_CLISEC = "secret";
         const out = await checkPlayerReadiness();
         expect(out.state).toBe("setup-required");
-        expect(out.message).toContain("SPOTIFY_APP_PORT");
+        expect(out.message).toContain("spotify.port");
     });
 
-    test("lists every missing var when more than one is unset", async () => {
+    test("lists every missing key when more than one is unset", async () => {
         const out = await checkPlayerReadiness();
         expect(out.state).toBe("setup-required");
-        expect(out.message).toContain("SPOTIFY_APP_CLI");
-        expect(out.message).toContain("SPOTIFY_APP_CLISEC");
-        expect(out.message).toContain("SPOTIFY_APP_PORT");
+        expect(out.message).toContain("spotify.clientId");
+        expect(out.message).toContain("spotify.clientSecret");
+        expect(out.message).toContain("spotify.port");
     });
 
     test("setup-required with port-specific message when SPOTIFY_APP_PORT isn't a number", async () => {
@@ -100,6 +100,9 @@ describe("checkPlayerReadiness", () => {
         const out = await checkPlayerReadiness();
         expect(out.state).toBe("setup-required");
         expect(out.details).toBeTruthy();
-        expect(out.details).toMatch(/ts\/\.env/);
+        // Points at the YAML config, not the legacy env vars.
+        expect(out.details).toMatch(/config\.local\.yaml/);
+        expect(out.details).toMatch(/clientId:/);
+        expect(out.details).not.toMatch(/SPOTIFY_APP_/);
     });
 });

--- a/ts/packages/agents/player/test/playerReadiness.spec.ts
+++ b/ts/packages/agents/player/test/playerReadiness.spec.ts
@@ -26,10 +26,13 @@ const ENV_KEYS = [
 // Point the config loader at a scratch dir BEFORE the agent module is
 // imported: importing it loads config, and the developer's real
 // config.local.yaml would otherwise decide the outcome of every case.
-const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-readiness-"));
+const importConfigDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "player-readiness-import-"),
+);
 const savedConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
-process.env.TYPEAGENT_CONFIG_DIR = configDir;
-const localConfigPath = path.join(configDir, "config.local.yaml");
+process.env.TYPEAGENT_CONFIG_DIR = importConfigDir;
+let configDir: string;
+let localConfigPath: string;
 
 let checkPlayerReadiness: () => Promise<ReadinessReport>;
 
@@ -40,13 +43,16 @@ beforeAll(async () => {
 afterAll(() => {
     if (savedConfigDir === undefined) delete process.env.TYPEAGENT_CONFIG_DIR;
     else process.env.TYPEAGENT_CONFIG_DIR = savedConfigDir;
-    fs.rmSync(configDir, { recursive: true, force: true });
+    fs.rmSync(importConfigDir, { recursive: true, force: true });
 });
 
 describe("checkPlayerReadiness", () => {
     let saved: Record<string, string | undefined>;
 
     beforeEach(() => {
+        configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-readiness-"));
+        localConfigPath = path.join(configDir, "config.local.yaml");
+        process.env.TYPEAGENT_CONFIG_DIR = configDir;
         saved = {};
         for (const k of ENV_KEYS) {
             saved[k] = process.env[k];
@@ -60,6 +66,7 @@ describe("checkPlayerReadiness", () => {
             if (saved[k] === undefined) delete process.env[k];
             else process.env[k] = saved[k];
         }
+        fs.rmSync(configDir, { recursive: true, force: true });
     });
 
     test("ready when all three vars are set with a valid port", async () => {

--- a/ts/packages/agents/player/test/playerReadiness.spec.ts
+++ b/ts/packages/agents/player/test/playerReadiness.spec.ts
@@ -4,19 +4,44 @@
 /**
  * Tests for the player agent's checkReadiness env-var probe.
  *
- * The probe reads SPOTIFY_APP_CLI / SPOTIFY_APP_CLISEC / SPOTIFY_APP_PORT
- * from process.env. Each test snapshots and restores the relevant vars so
- * the test harness's actual .env (which may or may not be configured)
- * doesn't bleed across cases.
+ * The probe re-reads the config files (so a `@config agent refresh` after
+ * editing `config.local.yaml` sees the new values) and then reads
+ * SPOTIFY_APP_CLI / SPOTIFY_APP_CLISEC / SPOTIFY_APP_PORT from
+ * process.env. Each test points the config loader at an empty temp dir
+ * and snapshots the relevant vars, so neither the developer's real
+ * config.local.yaml nor a previous case bleeds in.
  */
 
-import { checkPlayerReadiness } from "../src/agent/playerHandlers.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ReadinessReport } from "@typeagent/agent-sdk";
 
 const ENV_KEYS = [
     "SPOTIFY_APP_CLI",
     "SPOTIFY_APP_CLISEC",
     "SPOTIFY_APP_PORT",
 ] as const;
+
+// Point the config loader at a scratch dir BEFORE the agent module is
+// imported: importing it loads config, and the developer's real
+// config.local.yaml would otherwise decide the outcome of every case.
+const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "player-readiness-"));
+const savedConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
+process.env.TYPEAGENT_CONFIG_DIR = configDir;
+const localConfigPath = path.join(configDir, "config.local.yaml");
+
+let checkPlayerReadiness: () => Promise<ReadinessReport>;
+
+beforeAll(async () => {
+    ({ checkPlayerReadiness } = await import("../src/agent/playerHandlers.js"));
+});
+
+afterAll(() => {
+    if (savedConfigDir === undefined) delete process.env.TYPEAGENT_CONFIG_DIR;
+    else process.env.TYPEAGENT_CONFIG_DIR = savedConfigDir;
+    fs.rmSync(configDir, { recursive: true, force: true });
+});
 
 describe("checkPlayerReadiness", () => {
     let saved: Record<string, string | undefined>;
@@ -27,6 +52,7 @@ describe("checkPlayerReadiness", () => {
             saved[k] = process.env[k];
             delete process.env[k];
         }
+        fs.rmSync(localConfigPath, { force: true });
     });
 
     afterEach(() => {
@@ -104,5 +130,46 @@ describe("checkPlayerReadiness", () => {
         expect(out.details).toMatch(/config\.local\.yaml/);
         expect(out.details).toMatch(/clientId:/);
         expect(out.details).not.toMatch(/SPOTIFY_APP_/);
+    });
+
+    test("picks up values added to config.local.yaml since startup", async () => {
+        // The report tells the user to edit config.local.yaml and run
+        // `@config agent refresh player`. That only works if the probe
+        // re-reads the file: the agent typically runs in a forked child
+        // whose process.env was snapshotted before the edit.
+        expect((await checkPlayerReadiness()).state).toBe("setup-required");
+        fs.writeFileSync(
+            localConfigPath,
+            "spotify:\n  clientId: id\n  clientSecret: secret\n  port: 8080\n",
+        );
+        expect((await checkPlayerReadiness()).state).toBe("ready");
+    });
+
+    test("picks up a corrected value, not just newly added ones", async () => {
+        fs.writeFileSync(
+            localConfigPath,
+            "spotify:\n  clientId: id\n  clientSecret: secret\n  port: nope\n",
+        );
+        expect((await checkPlayerReadiness()).state).toBe("setup-required");
+        fs.writeFileSync(
+            localConfigPath,
+            "spotify:\n  clientId: id\n  clientSecret: secret\n  port: 8080\n",
+        );
+        expect((await checkPlayerReadiness()).state).toBe("ready");
+    });
+
+    test("explains an invalid value instead of calling it missing", async () => {
+        // A pasted-but-unedited snippet: `port: <value>` is a string, so
+        // the typed converter rejects the whole `spotify:` section and the
+        // settings look absent. Saying "not configured" sends the user
+        // looking for lines that are right there in the file.
+        fs.writeFileSync(
+            localConfigPath,
+            "spotify:\n  clientId: <value>\n  clientSecret: <value>\n  port: <value>\n",
+        );
+        const out = await checkPlayerReadiness();
+        expect(out.state).toBe("setup-required");
+        expect(out.message).toMatch(/invalid/i);
+        expect(out.message).toContain("spotify.port");
     });
 });

--- a/ts/packages/agents/player/test/userData.spec.ts
+++ b/ts/packages/agents/player/test/userData.spec.ts
@@ -3,9 +3,12 @@
 
 import {
     getUserDataCompletions,
+    MAX_ITEM_TIMESTAMPS,
+    mergeUserDataKind,
     MusicItemInfo,
     SpotifyUserData,
 } from "../src/userData.js";
+import { getPlayerActionCompletion } from "../src/agent/playerHandlers.js";
 
 function makeItem(name: string, lastTimestamp?: string): MusicItemInfo {
     return {
@@ -89,5 +92,84 @@ describe("getUserDataCompletions — tracks sorted by timestamp", () => {
         expect(result[0]).toBe("New Track");
         expect(result[1]).toBe("Mid Track");
         expect(result[2]).toBe("Old Track");
+    });
+
+    describe("mergeUserDataKind", () => {
+        test("bounds timestamps while preserving full frequency", () => {
+            const items = new Map<string, MusicItemInfo>();
+            mergeUserDataKind(items, [
+                {
+                    id: "track",
+                    name: "Track",
+                    freq: 100,
+                    timestamps: Array.from({ length: 100 }, (_, i) =>
+                        String(i).padStart(3, "0"),
+                    ),
+                },
+            ]);
+            expect(items.get("track")?.freq).toBe(100);
+            expect(items.get("track")?.timestamps).toHaveLength(
+                MAX_ITEM_TIMESTAMPS,
+            );
+        });
+    });
+
+    describe("player action completion RPC payload", () => {
+        test("uses the partial property value and caps results", async () => {
+            const data = emptyUserData();
+            for (let i = 0; i < 150; i++) {
+                data.tracks.set(
+                    String(i),
+                    makeItem(
+                        `Needle ${i}`,
+                        new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString(),
+                    ),
+                );
+            }
+            data.tracks.set("other", makeItem("Unrelated"));
+            const result = await getPlayerActionCompletion(
+                {
+                    agentContext: {
+                        spotify: {
+                            userData: { data },
+                        },
+                    },
+                } as any,
+                {
+                    actionName: "playMusic",
+                    parameters: { target: { trackName: "needle" } },
+                } as any,
+                "parameters.target.trackName",
+            );
+            expect(result).toHaveLength(100);
+            expect(result[0]).toBe("Needle 149");
+            expect(result).not.toContain("Unrelated");
+        });
+    });
+
+    test("filters, ranks, and caps large completion sets", () => {
+        const data = emptyUserData();
+        for (let i = 0; i < 250; i++) {
+            data.tracks.set(
+                String(i),
+                makeItem(
+                    `Needle Track ${i}`,
+                    new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString(),
+                ),
+            );
+        }
+        data.tracks.set("other", makeItem("Unrelated", "2030-01-01T00:00:00Z"));
+        const result = getUserDataCompletions(
+            data,
+            true,
+            false,
+            false,
+            false,
+            "needle",
+            100,
+        );
+        expect(result).toHaveLength(100);
+        expect(result[0]).toBe("Needle Track 249");
+        expect(result).not.toContain("Unrelated");
     });
 });

--- a/ts/packages/agents/player/test/userData.spec.ts
+++ b/ts/packages/agents/player/test/userData.spec.ts
@@ -145,6 +145,42 @@ describe("getUserDataCompletions — tracks sorted by timestamp", () => {
             expect(result[0]).toBe("Needle 149");
             expect(result).not.toContain("Unrelated");
         });
+
+        test("returns the full ranked list when the current property is absent", async () => {
+            const data = emptyUserData();
+            for (let i = 0; i < 101; i++) {
+                data.tracks.set(
+                    String(i),
+                    makeItem(
+                        `Recent unrelated track ${i}`,
+                        new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString(),
+                    ),
+                );
+            }
+            data.tracks.set(
+                "bohemian",
+                makeItem("Bohemian Rhapsody", "2000-01-01T00:00:00Z"),
+            );
+
+            const result = await getPlayerActionCompletion(
+                {
+                    agentContext: {
+                        spotify: {
+                            userData: { data },
+                        },
+                    },
+                } as any,
+                {
+                    actionName: "playMusic",
+                    parameters: { target: { kind: "track" } },
+                } as any,
+                "parameters.target.trackName",
+            );
+
+            expect(result).toHaveLength(102);
+            expect(result).toContain("Bohemian Rhapsody");
+            expect(result[0]).toBe("Recent unrelated track 100");
+        });
     });
 
     test("filters, ranks, and caps large completion sets", () => {

--- a/ts/packages/cache/src/cache/cache.ts
+++ b/ts/packages/cache/src/cache/cache.ts
@@ -38,6 +38,16 @@ import {
 } from "./explainWorkQueue.js";
 import { GrammarStoreImpl } from "./grammarStore.js";
 import { GrammarStore, MatchResult } from "./types.js";
+import {
+    getSchemaNamespaceKeys,
+    splitSchemaNamespaceKey,
+} from "./schemaNamespace.js";
+
+export {
+    getSchemaNamespaceKey,
+    getSchemaNamespaceKeys,
+    splitSchemaNamespaceKey,
+} from "./schemaNamespace.js";
 
 export type ProcessRequestActionResult = {
     explanationResult: ProcessExplanationResult;
@@ -68,39 +78,6 @@ function getFailedResult(message: string): ProcessRequestActionResult {
             },
             elapsedMs: 0,
         },
-    };
-}
-
-export function getSchemaNamespaceKey(
-    name: string,
-    activityName: string | undefined,
-    schemaInfoProvider: SchemaInfoProvider | undefined,
-) {
-    return `${name},${schemaInfoProvider?.getActionSchemaFileHash(name) ?? ""},${activityName ?? ""}`;
-}
-
-// Namespace policy. Combines schema name, file hash, and activity name to indicate enabling/disabling of matching.
-export function getSchemaNamespaceKeys(
-    schemaNames: string[],
-    activityName: string | undefined,
-    schemaInfoProvider: SchemaInfoProvider | undefined,
-) {
-    // Current namespace keys policy is just combining schema name its file hash
-    return schemaNames.map((name) =>
-        getSchemaNamespaceKey(name, activityName, schemaInfoProvider),
-    );
-}
-
-export function splitSchemaNamespaceKey(namespaceKey: string): {
-    schemaName: string;
-    hash: string | undefined;
-    activityName: string | undefined;
-} {
-    const [schemaName, hash, activityName] = namespaceKey.split(",");
-    return {
-        schemaName,
-        hash: hash !== "" ? hash : undefined,
-        activityName: activityName !== "" ? activityName : undefined,
     };
 }
 

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -35,7 +35,10 @@ import {
     shouldPreferNewResult,
 } from "../constructions/constructionCache.js";
 import { MatchResult, GrammarStore } from "./types.js";
-import { getSchemaNamespaceKey, splitSchemaNamespaceKey } from "./cache.js";
+import {
+    getSchemaNamespaceKey,
+    splitSchemaNamespaceKey,
+} from "./schemaNamespace.js";
 import { SchemaInfoProvider } from "../explanation/schemaInfoProvider.js";
 import {
     createExecutableAction,

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -10,11 +10,11 @@ import {
     NFA,
     compileGrammarToNFA,
     matchGrammarWithNFA,
-    computeNFACompletions,
+    computeNFACompletionsFromInput,
     DFA,
     compileNFAToDFA,
     matchDFAWithSplitting,
-    getDFACompletions,
+    getDFACompletionsFromInput,
     tokenizeRequest,
 } from "@typeagent/action-grammar";
 
@@ -326,100 +326,66 @@ export class GrammarStoreImpl implements GrammarStore {
             // setUseDFA() prevents in normal use, but isn't impossible
             // to construct directly).
             if (this.useNFA && entry.nfa) {
-                // NFA-based completions: tokenize into complete whole tokens
-                const tokens = input
-                    .trim()
-                    .split(/\s+/)
-                    .filter((t) => t.length > 0);
+                const partial = computeNFACompletionsFromInput(
+                    entry.nfa,
+                    input,
+                    direction,
+                );
+                const partialPrefixLength = partial.matchedPrefixLength ?? 0;
+                if (partialPrefixLength !== matchedPrefixLength) {
+                    const adopt = shouldPreferNewResult(
+                        matchedPrefixLength,
+                        afterWildcard,
+                        partialPrefixLength,
+                        partial.afterWildcard,
+                        input.length,
+                    );
+                    if (!adopt) continue;
 
-                const nfaResult = computeNFACompletions(entry.nfa, tokens);
-                for (const g of nfaResult.groups) {
-                    if (g.completions.length > 0) {
-                        groups.push({
-                            name: "Request Completions",
-                            completions: g.completions,
-                            separatorMode: g.separatorMode,
-                        });
-                    }
+                    matchedPrefixLength = partialPrefixLength;
+                    groups.length = 0;
+                    properties.length = 0;
+                    closedSet = undefined;
+                    directionSensitive = false;
+                    afterWildcard = undefined;
+                    grammarPartials = [];
                 }
-                if (
-                    nfaResult.properties !== undefined &&
-                    nfaResult.properties.length > 0
-                ) {
-                    // NFA schema name is stored in nfa.name, fall back to namespace key
+                if (partialPrefixLength === matchedPrefixLength) {
                     const schemaName =
                         entry.nfa.name ??
                         splitSchemaNamespaceKey(name).schemaName;
-                    for (const p of nfaResult.properties) {
-                        const action: any = p.match;
-                        // Same guard as the DFA branch below: a property can
-                        // come from a plain-object (non-action) grammar and
-                        // carry no match, which createExecutableAction can't
-                        // represent. Throwing here would abort completion for
-                        // the whole request, not just this grammar.
-                        if (action?.actionName === undefined) {
-                            continue;
-                        }
-                        properties.push({
-                            actions: [
-                                createExecutableAction(
-                                    schemaName,
-                                    action.actionName,
-                                    action.parameters,
-                                ),
-                            ],
-                            names: p.propertyNames,
-                            // Property completions represent free-form entity
-                            // slots — the actual values come from agents at
-                            // runtime, so the grammar cannot know the first
-                            // character.  "autoSpacePunctuation" defers
-                            // resolution to the shell, which inspects the
-                            // character pair per item.
-                            separatorMode: "autoSpacePunctuation",
-                        });
-                    }
+                    grammarPartials.push({ partial, schemaName });
                 }
             } else if (this.useDFA && entry.dfa) {
                 // DFA-based completions (recoverable fallback — see comment
                 // above the NFA branch for why NFA is preferred).
-                const tokens = input
-                    .trim()
-                    .split(/\s+/)
-                    .filter((t) => t.length > 0);
+                const partial = getDFACompletionsFromInput(
+                    entry.dfa,
+                    input,
+                    direction,
+                );
+                const partialPrefixLength = partial.matchedPrefixLength ?? 0;
+                if (partialPrefixLength !== matchedPrefixLength) {
+                    const adopt = shouldPreferNewResult(
+                        matchedPrefixLength,
+                        afterWildcard,
+                        partialPrefixLength,
+                        partial.afterWildcard,
+                        input.length,
+                    );
+                    if (!adopt) continue;
 
-                const dfaCompResult = getDFACompletions(entry.dfa, tokens);
-                if (
-                    dfaCompResult.completions &&
-                    dfaCompResult.completions.length > 0
-                ) {
-                    groups.push({
-                        name: "Request Completions",
-                        completions: dfaCompResult.completions,
-                    });
+                    matchedPrefixLength = partialPrefixLength;
+                    groups.length = 0;
+                    properties.length = 0;
+                    closedSet = undefined;
+                    directionSensitive = false;
+                    afterWildcard = undefined;
+                    grammarPartials = [];
                 }
-                if (
-                    dfaCompResult.properties &&
-                    dfaCompResult.properties.length > 0
-                ) {
+                if (partialPrefixLength === matchedPrefixLength) {
                     const { schemaName } = splitSchemaNamespaceKey(name);
-                    for (const p of dfaCompResult.properties) {
-                        // Skip properties with no actionName (plain-object
-                        // grammars).  createExecutableAction needs one; for
-                        // non-action grammars the DFA's property entry isn't
-                        // surfaced as a typed action.
-                        if (p.actionName === undefined) continue;
-                        properties.push({
-                            actions: [
-                                createExecutableAction(
-                                    schemaName,
-                                    p.actionName,
-                                    {},
-                                ),
-                            ],
-                            names: [p.propertyPath],
-                            separatorMode: "autoSpacePunctuation",
-                        });
-                    }
+                    grammarPartials.push({ partial, schemaName });
                 }
             } else {
                 // simple grammar-based completions
@@ -521,6 +487,7 @@ export class GrammarStoreImpl implements GrammarStore {
                         if (action?.actionName === undefined) {
                             continue;
                         }
+                        applyCompletionPartialValue(action, p);
                         properties.push({
                             actions: [
                                 createExecutableAction(
@@ -545,5 +512,38 @@ export class GrammarStoreImpl implements GrammarStore {
             directionSensitive,
             afterWildcard,
         };
+    }
+}
+
+function applyCompletionPartialValue(
+    match: Record<string, any>,
+    property: {
+        propertyNames: string[];
+        partialValue?: string | undefined;
+    },
+): void {
+    if (property.partialValue === undefined) return;
+    for (const propertyName of property.propertyNames) {
+        const parts = propertyName.split(".");
+        let target = match;
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            if (
+                part === "__proto__" ||
+                part === "constructor" ||
+                part === "prototype"
+            ) {
+                throw new Error("Invalid completion property path");
+            }
+            if (i === parts.length - 1) {
+                target[part] = property.partialValue;
+            } else {
+                const current = target[part];
+                target =
+                    current !== null && typeof current === "object"
+                        ? current
+                        : (target[part] = {});
+            }
+        }
     }
 }

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -349,6 +349,14 @@ export class GrammarStoreImpl implements GrammarStore {
                         splitSchemaNamespaceKey(name).schemaName;
                     for (const p of nfaResult.properties) {
                         const action: any = p.match;
+                        // Same guard as the DFA branch below: a property can
+                        // come from a plain-object (non-action) grammar and
+                        // carry no match, which createExecutableAction can't
+                        // represent. Throwing here would abort completion for
+                        // the whole request, not just this grammar.
+                        if (action?.actionName === undefined) {
+                            continue;
+                        }
                         properties.push({
                             actions: [
                                 createExecutableAction(
@@ -504,6 +512,12 @@ export class GrammarStoreImpl implements GrammarStore {
                 ) {
                     for (const p of partial.properties) {
                         const action: any = p.match;
+                        // See the NFA branch above: skip properties with no
+                        // resolved action rather than throwing, which would
+                        // wipe out completions for the entire request.
+                        if (action?.actionName === undefined) {
+                            continue;
+                        }
                         properties.push({
                             actions: [
                                 createExecutableAction(

--- a/ts/packages/cache/src/cache/grammarStore.ts
+++ b/ts/packages/cache/src/cache/grammarStore.ts
@@ -10,11 +10,11 @@ import {
     NFA,
     compileGrammarToNFA,
     matchGrammarWithNFA,
-    computeNFACompletionsFromInput,
+    computeNFACompletions,
     DFA,
     compileNFAToDFA,
     matchDFAWithSplitting,
-    getDFACompletionsFromInput,
+    getDFACompletions,
     tokenizeRequest,
 } from "@typeagent/action-grammar";
 
@@ -326,66 +326,100 @@ export class GrammarStoreImpl implements GrammarStore {
             // setUseDFA() prevents in normal use, but isn't impossible
             // to construct directly).
             if (this.useNFA && entry.nfa) {
-                const partial = computeNFACompletionsFromInput(
-                    entry.nfa,
-                    input,
-                    direction,
-                );
-                const partialPrefixLength = partial.matchedPrefixLength ?? 0;
-                if (partialPrefixLength !== matchedPrefixLength) {
-                    const adopt = shouldPreferNewResult(
-                        matchedPrefixLength,
-                        afterWildcard,
-                        partialPrefixLength,
-                        partial.afterWildcard,
-                        input.length,
-                    );
-                    if (!adopt) continue;
+                // NFA-based completions: tokenize into complete whole tokens
+                const tokens = input
+                    .trim()
+                    .split(/\s+/)
+                    .filter((t) => t.length > 0);
 
-                    matchedPrefixLength = partialPrefixLength;
-                    groups.length = 0;
-                    properties.length = 0;
-                    closedSet = undefined;
-                    directionSensitive = false;
-                    afterWildcard = undefined;
-                    grammarPartials = [];
+                const nfaResult = computeNFACompletions(entry.nfa, tokens);
+                for (const g of nfaResult.groups) {
+                    if (g.completions.length > 0) {
+                        groups.push({
+                            name: "Request Completions",
+                            completions: g.completions,
+                            separatorMode: g.separatorMode,
+                        });
+                    }
                 }
-                if (partialPrefixLength === matchedPrefixLength) {
+                if (
+                    nfaResult.properties !== undefined &&
+                    nfaResult.properties.length > 0
+                ) {
+                    // NFA schema name is stored in nfa.name, fall back to namespace key
                     const schemaName =
                         entry.nfa.name ??
                         splitSchemaNamespaceKey(name).schemaName;
-                    grammarPartials.push({ partial, schemaName });
+                    for (const p of nfaResult.properties) {
+                        const action: any = p.match;
+                        // Same guard as the DFA branch below: a property can
+                        // come from a plain-object (non-action) grammar and
+                        // carry no match, which createExecutableAction can't
+                        // represent. Throwing here would abort completion for
+                        // the whole request, not just this grammar.
+                        if (action?.actionName === undefined) {
+                            continue;
+                        }
+                        properties.push({
+                            actions: [
+                                createExecutableAction(
+                                    schemaName,
+                                    action.actionName,
+                                    action.parameters,
+                                ),
+                            ],
+                            names: p.propertyNames,
+                            // Property completions represent free-form entity
+                            // slots — the actual values come from agents at
+                            // runtime, so the grammar cannot know the first
+                            // character.  "autoSpacePunctuation" defers
+                            // resolution to the shell, which inspects the
+                            // character pair per item.
+                            separatorMode: "autoSpacePunctuation",
+                        });
+                    }
                 }
             } else if (this.useDFA && entry.dfa) {
                 // DFA-based completions (recoverable fallback — see comment
                 // above the NFA branch for why NFA is preferred).
-                const partial = getDFACompletionsFromInput(
-                    entry.dfa,
-                    input,
-                    direction,
-                );
-                const partialPrefixLength = partial.matchedPrefixLength ?? 0;
-                if (partialPrefixLength !== matchedPrefixLength) {
-                    const adopt = shouldPreferNewResult(
-                        matchedPrefixLength,
-                        afterWildcard,
-                        partialPrefixLength,
-                        partial.afterWildcard,
-                        input.length,
-                    );
-                    if (!adopt) continue;
+                const tokens = input
+                    .trim()
+                    .split(/\s+/)
+                    .filter((t) => t.length > 0);
 
-                    matchedPrefixLength = partialPrefixLength;
-                    groups.length = 0;
-                    properties.length = 0;
-                    closedSet = undefined;
-                    directionSensitive = false;
-                    afterWildcard = undefined;
-                    grammarPartials = [];
+                const dfaCompResult = getDFACompletions(entry.dfa, tokens);
+                if (
+                    dfaCompResult.completions &&
+                    dfaCompResult.completions.length > 0
+                ) {
+                    groups.push({
+                        name: "Request Completions",
+                        completions: dfaCompResult.completions,
+                    });
                 }
-                if (partialPrefixLength === matchedPrefixLength) {
+                if (
+                    dfaCompResult.properties &&
+                    dfaCompResult.properties.length > 0
+                ) {
                     const { schemaName } = splitSchemaNamespaceKey(name);
-                    grammarPartials.push({ partial, schemaName });
+                    for (const p of dfaCompResult.properties) {
+                        // Skip properties with no actionName (plain-object
+                        // grammars).  createExecutableAction needs one; for
+                        // non-action grammars the DFA's property entry isn't
+                        // surfaced as a typed action.
+                        if (p.actionName === undefined) continue;
+                        properties.push({
+                            actions: [
+                                createExecutableAction(
+                                    schemaName,
+                                    p.actionName,
+                                    {},
+                                ),
+                            ],
+                            names: [p.propertyPath],
+                            separatorMode: "autoSpacePunctuation",
+                        });
+                    }
                 }
             } else {
                 // simple grammar-based completions
@@ -487,7 +521,6 @@ export class GrammarStoreImpl implements GrammarStore {
                         if (action?.actionName === undefined) {
                             continue;
                         }
-                        applyCompletionPartialValue(action, p);
                         properties.push({
                             actions: [
                                 createExecutableAction(
@@ -512,38 +545,5 @@ export class GrammarStoreImpl implements GrammarStore {
             directionSensitive,
             afterWildcard,
         };
-    }
-}
-
-function applyCompletionPartialValue(
-    match: Record<string, any>,
-    property: {
-        propertyNames: string[];
-        partialValue?: string | undefined;
-    },
-): void {
-    if (property.partialValue === undefined) return;
-    for (const propertyName of property.propertyNames) {
-        const parts = propertyName.split(".");
-        let target = match;
-        for (let i = 0; i < parts.length; i++) {
-            const part = parts[i];
-            if (
-                part === "__proto__" ||
-                part === "constructor" ||
-                part === "prototype"
-            ) {
-                throw new Error("Invalid completion property path");
-            }
-            if (i === parts.length - 1) {
-                target[part] = property.partialValue;
-            } else {
-                const current = target[part];
-                target =
-                    current !== null && typeof current === "object"
-                        ? current
-                        : (target[part] = {});
-            }
-        }
     }
 }

--- a/ts/packages/cache/src/cache/schemaNamespace.ts
+++ b/ts/packages/cache/src/cache/schemaNamespace.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { SchemaInfoProvider } from "../explanation/schemaInfoProvider.js";
+
+export function getSchemaNamespaceKey(
+    name: string,
+    activityName: string | undefined,
+    schemaInfoProvider: SchemaInfoProvider | undefined,
+) {
+    return `${name},${schemaInfoProvider?.getActionSchemaFileHash(name) ?? ""},${activityName ?? ""}`;
+}
+
+// Namespace policy. Combines schema name, file hash, and activity name to indicate enabling/disabling of matching.
+export function getSchemaNamespaceKeys(
+    schemaNames: string[],
+    activityName: string | undefined,
+    schemaInfoProvider: SchemaInfoProvider | undefined,
+) {
+    return schemaNames.map((name) =>
+        getSchemaNamespaceKey(name, activityName, schemaInfoProvider),
+    );
+}
+
+export function splitSchemaNamespaceKey(namespaceKey: string): {
+    schemaName: string;
+    hash: string | undefined;
+    activityName: string | undefined;
+} {
+    const [schemaName, hash, activityName] = namespaceKey.split(",");
+    return {
+        schemaName,
+        hash: hash !== "" ? hash : undefined,
+        activityName: activityName !== "" ? activityName : undefined,
+    };
+}

--- a/ts/packages/cache/src/constructions/importConstructions.ts
+++ b/ts/packages/cache/src/constructions/importConstructions.ts
@@ -21,7 +21,7 @@ import registerDebug from "debug";
 import { ExplainerFactory } from "../cache/factory.js";
 import { printTransformNamespaces } from "../utils/print.js";
 import { ConstructionCache } from "./constructionCache.js";
-import { getSchemaNamespaceKeys } from "../cache/cache.js";
+import { getSchemaNamespaceKeys } from "../cache/schemaNamespace.js";
 
 const debugConstCreate = registerDebug("typeagent:const:create");
 const debugConstMerge = registerDebug("typeagent:const:merge");

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -58,7 +58,7 @@ export { computeActionSchemaFileHash } from "./explanation/schemaInfoProvider.js
 export {
     getSchemaNamespaceKey,
     splitSchemaNamespaceKey,
-} from "./cache/cache.js";
+} from "./cache/schemaNamespace.js";
 export { WildcardMode } from "./constructions/constructions.js";
 
 // Testing

--- a/ts/packages/cache/src/index.ts
+++ b/ts/packages/cache/src/index.ts
@@ -55,6 +55,10 @@ export { AgentCacheFactory, getDefaultExplainerName } from "./cache/factory.js";
 export type { MatchResult, GrammarStore } from "./cache/types.js";
 export { GrammarStoreImpl } from "./cache/grammarStore.js";
 export { computeActionSchemaFileHash } from "./explanation/schemaInfoProvider.js";
+export {
+    getSchemaNamespaceKey,
+    splitSchemaNamespaceKey,
+} from "./cache/cache.js";
 export { WildcardMode } from "./constructions/constructions.js";
 
 // Testing

--- a/ts/packages/cache/src/utils/print.ts
+++ b/ts/packages/cache/src/utils/print.ts
@@ -7,7 +7,7 @@ import {
 } from "@typeagent/common-utils";
 import chalk from "chalk";
 import { ProcessRequestActionResult } from "../cache/cache.js";
-import { ImportConstructionResult } from "../index.js";
+import type { ImportConstructionResult } from "../constructions/importConstructions.js";
 import { Transforms } from "../constructions/transforms.js";
 import { ProcessExplanationResult } from "../cache/explainWorkQueue.js";
 

--- a/ts/packages/chat-ui/src/chatPanel.ts
+++ b/ts/packages/chat-ui/src/chatPanel.ts
@@ -80,6 +80,7 @@ import type {
 } from "./providers.js";
 import { createWebSpeechProvider } from "./webSpeechProvider.js";
 import { openSettingsPopup, openHelpPopup } from "./popups.js";
+import { highlightJson } from "./highlight.js";
 import { TemplateEditor, type TemplateEditServices } from "./templateEditor.js";
 import type { TemplateEditConfig } from "@typeagent/dispatcher-types";
 import {
@@ -287,92 +288,6 @@ function escapeHtml(s: string): string {
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
         .replace(/'/g, "&#39;");
-}
-
-// Lightweight JSON syntax highlighter — returns HTML with span wrappers
-// around tokens. Implemented as a hand-rolled scanner rather than a
-// single tokenizing regex so we have no chance of polynomial backtracking
-// on adversarial input (the JSON comes from action data which can carry
-// arbitrary user content). Also escapes <, >, & in any character that
-// passes through.
-// Avoids pulling in highlight.js / Prism just to colorize the action
-// JSON popup.
-// code-complexity-allow: hand-rolled JSON scanner kept branchy to avoid regex backtracking
-function highlightJson(json: string): string {
-    const escapeChar = (c: string): string =>
-        c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : c;
-    const wrap = (cls: string, text: string): string =>
-        `<span class="${cls}">${text}</span>`;
-
-    let out = "";
-    let i = 0;
-    const n = json.length;
-    while (i < n) {
-        const ch = json[i];
-        if (ch === '"') {
-            // Linear scan to the matching closing quote, honoring `\\`
-            // and `\"` escapes. Each character is consumed at most once,
-            // so this is O(n) worst case.
-            let j = i + 1;
-            let raw = '"';
-            while (j < n) {
-                const cj = json[j];
-                if (cj === "\\" && j + 1 < n) {
-                    raw += "\\" + escapeChar(json[j + 1]);
-                    j += 2;
-                    continue;
-                }
-                raw += escapeChar(cj);
-                j++;
-                if (cj === '"') break;
-            }
-            i = j;
-            // If a colon follows (optionally with whitespace), this is a
-            // JSON object key; otherwise a string value.
-            let k = i;
-            while (k < n && (json[k] === " " || json[k] === "\t")) k++;
-            if (json[k] === ":") {
-                out += wrap("json-key", raw + json.slice(i, k + 1));
-                i = k + 1;
-            } else {
-                out += wrap("json-string", raw);
-            }
-        } else if (
-            (ch >= "0" && ch <= "9") ||
-            (ch === "-" &&
-                i + 1 < n &&
-                json[i + 1] >= "0" &&
-                json[i + 1] <= "9")
-        ) {
-            let j = i + 1;
-            while (
-                j < n &&
-                ((json[j] >= "0" && json[j] <= "9") ||
-                    json[j] === "." ||
-                    json[j] === "e" ||
-                    json[j] === "E" ||
-                    json[j] === "+" ||
-                    json[j] === "-")
-            ) {
-                j++;
-            }
-            out += wrap("json-number", json.slice(i, j));
-            i = j;
-        } else if (json.startsWith("true", i)) {
-            out += wrap("json-bool", "true");
-            i += 4;
-        } else if (json.startsWith("false", i)) {
-            out += wrap("json-bool", "false");
-            i += 5;
-        } else if (json.startsWith("null", i)) {
-            out += wrap("json-null", "null");
-            i += 4;
-        } else {
-            out += escapeChar(ch);
-            i++;
-        }
-    }
-    return out;
 }
 
 // Generates a UUID for tagging user-message bubbles. Falls back to a

--- a/ts/packages/chat-ui/src/chatPanel.ts
+++ b/ts/packages/chat-ui/src/chatPanel.ts
@@ -44,6 +44,7 @@ import {
 } from "./connectionStatus.js";
 import { type StatusNotice, type StatusNoticeLevel } from "./statusNotice.js";
 import { createBellIconSvg } from "./icons.js";
+import { copyTextToClipboard } from "./clipboard.js";
 
 // Restrictive sanitize config used at .innerHTML sinks below. The HTML
 // passed in is built from values that, while in practice come from
@@ -1196,7 +1197,7 @@ export class ChatPanel {
         copyBtn.textContent = "Copy";
         copyBtn.title = "Copy to clipboard";
         copyBtn.addEventListener("click", () => {
-            void navigator.clipboard?.writeText(text);
+            void copyTextToClipboard(text);
         });
         header.appendChild(copyBtn);
 

--- a/ts/packages/chat-ui/src/clipboard.ts
+++ b/ts/packages/chat-ui/src/clipboard.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Clipboard writes that work across the hosts.
+ *
+ * `navigator.clipboard` is missing or rejects in some of the contexts the
+ * chat UI runs in (older webviews, non-secure origins, denied permission),
+ * so every copy affordance goes through here and falls back to the
+ * `execCommand` textarea trick.
+ */
+
+/** Copy `text`, returning whether it made it to the clipboard. */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+    if (!text) {
+        return false;
+    }
+    if (navigator.clipboard?.writeText !== undefined) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return true;
+        } catch {
+            // Fall through to the legacy path.
+        }
+    }
+    return fallbackCopy(text);
+}
+
+function fallbackCopy(text: string): boolean {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    let copied = false;
+    try {
+        copied = document.execCommand("copy");
+    } catch {
+        // Best-effort; nothing more to do.
+    }
+    ta.remove();
+    return copied;
+}

--- a/ts/packages/chat-ui/src/contextMenu.ts
+++ b/ts/packages/chat-ui/src/contextMenu.ts
@@ -10,6 +10,8 @@
  * non-empty.
  */
 
+import { copyTextToClipboard } from "./clipboard.js";
+
 type MenuItemId = "cut" | "copy" | "paste" | "selectAll";
 
 interface MenuItem {
@@ -193,26 +195,7 @@ export class ChatContextMenu {
 
 function copyText(text: string) {
     if (!text) return;
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
-    } else {
-        fallbackCopy(text);
-    }
-}
-
-function fallbackCopy(text: string) {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.style.position = "fixed";
-    ta.style.left = "-9999px";
-    document.body.appendChild(ta);
-    ta.select();
-    try {
-        document.execCommand("copy");
-    } catch {
-        // Best-effort; nothing more to do.
-    }
-    ta.remove();
+    void copyTextToClipboard(text);
 }
 
 // Notify listeners (send-button enable state, completion fetch) that an

--- a/ts/packages/chat-ui/src/fileLink.ts
+++ b/ts/packages/chat-ui/src/fileLink.ts
@@ -8,7 +8,8 @@
  * URL (produced by `@typeagent/config`'s `fileLinkHref`) because `file:`
  * hrefs are sanitized away and are inert in Electron / webview hosts.
  * Hosts get the click through `PlatformAdapter.handleLinkClick` and use
- * this helper to recover the path before handing it to the OS.
+ * this helper to recover a local path. The host must still compare it with
+ * its allowlisted config path before opening it.
  */
 
 /** Scheme used for "open this local file" links in chat content. */
@@ -22,23 +23,41 @@ export function isFileLink(href: string): boolean {
 /**
  * The filesystem path a `typeagent-file:` link points at, or `undefined`
  * for any other href. Mirrors Node's `fileURLToPath` for the cases the
- * link generator can produce (including Windows drive letters and UNC
- * paths), without pulling in a Node dependency.
+ * link generator can produce, without pulling in a Node dependency. UNC paths
+ * are rejected because following a remote SMB path from message content can
+ * trigger network authentication or execute a remote file.
  */
 export function fileLinkToPath(href: string): string | undefined {
     if (!isFileLink(href)) {
         return undefined;
     }
+    const encodedPath = href.slice(FILE_LINK_SCHEME.length);
+    if (
+        /(?:^|[\\/])\.\.(?:[\\/]|$)/.test(encodedPath) ||
+        /%2e%2e(?:%2f|%5c|[\\/]|$)/i.test(encodedPath)
+    ) {
+        return undefined;
+    }
     let url: URL;
     try {
-        url = new URL(`file:${href.slice(FILE_LINK_SCHEME.length)}`);
+        url = new URL(`file:${encodedPath}`);
     } catch {
         return undefined;
     }
-    const pathname = decodeURIComponent(url.pathname);
     if (url.hostname) {
-        // UNC: file://server/share/file -> \\server\share\file
-        return `\\\\${url.hostname}${pathname.replace(/\//g, "\\")}`;
+        return undefined;
+    }
+    let pathname: string;
+    try {
+        pathname = decodeURIComponent(url.pathname);
+    } catch {
+        return undefined;
+    }
+    if (
+        pathname.split(/[\\/]/).some((segment) => segment === "..") ||
+        pathname.includes("\0")
+    ) {
+        return undefined;
     }
     // Windows drive letters arrive as "/C:/dir/file".
     return /^\/[a-zA-Z]:/.test(pathname)

--- a/ts/packages/chat-ui/src/fileLink.ts
+++ b/ts/packages/chat-ui/src/fileLink.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Local-file links in chat content.
+ *
+ * Messages link to files on the user's machine with a `typeagent-file:`
+ * URL (produced by `@typeagent/config`'s `fileLinkHref`) because `file:`
+ * hrefs are sanitized away and are inert in Electron / webview hosts.
+ * Hosts get the click through `PlatformAdapter.handleLinkClick` and use
+ * this helper to recover the path before handing it to the OS.
+ */
+
+/** Scheme used for "open this local file" links in chat content. */
+export const FILE_LINK_SCHEME = "typeagent-file:";
+
+/** True when the href is a local-file link. */
+export function isFileLink(href: string): boolean {
+    return href.startsWith(FILE_LINK_SCHEME);
+}
+
+/**
+ * The filesystem path a `typeagent-file:` link points at, or `undefined`
+ * for any other href. Mirrors Node's `fileURLToPath` for the cases the
+ * link generator can produce (including Windows drive letters and UNC
+ * paths), without pulling in a Node dependency.
+ */
+export function fileLinkToPath(href: string): string | undefined {
+    if (!isFileLink(href)) {
+        return undefined;
+    }
+    let url: URL;
+    try {
+        url = new URL(`file:${href.slice(FILE_LINK_SCHEME.length)}`);
+    } catch {
+        return undefined;
+    }
+    const pathname = decodeURIComponent(url.pathname);
+    if (url.hostname) {
+        // UNC: file://server/share/file -> \\server\share\file
+        return `\\\\${url.hostname}${pathname.replace(/\//g, "\\")}`;
+    }
+    // Windows drive letters arrive as "/C:/dir/file".
+    return /^\/[a-zA-Z]:/.test(pathname)
+        ? pathname.slice(1).replace(/\//g, "\\")
+        : pathname;
+}

--- a/ts/packages/chat-ui/src/highlight.ts
+++ b/ts/packages/chat-ui/src/highlight.ts
@@ -5,9 +5,9 @@
  * Tiny syntax highlighters shared by the chat renderers.
  *
  * Both return HTML with <span class="json-*"> wrappers and escape `<`,
- * `>` and `&` on every character that passes through, so the output is
- * safe to assign to innerHTML. The token class names are shared between
- * the two languages so a single set of CSS rules colors both.
+ * `>` and `&` on every character that passes through. The renderer also
+ * sanitizes this markup into a DOM fragment before insertion. The token
+ * class names are shared so one set of CSS rules colors both languages.
  */
 // Lightweight JSON syntax highlighter — returns HTML with span wrappers
 // around tokens. Implemented as a hand-rolled scanner rather than a
@@ -100,8 +100,7 @@ export function highlightJson(json: string): string {
 // `key: value` pairs and comments, not the full YAML grammar — and it
 // reuses the JSON token classes so one set of CSS colors both.
 //
-// Like highlightJson, it escapes every character it passes through, so
-// the result is safe to assign to innerHTML.
+// Like highlightJson, it escapes every character it passes through.
 export function highlightYaml(yaml: string): string {
     const esc = (s: string): string =>
         s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/ts/packages/chat-ui/src/highlight.ts
+++ b/ts/packages/chat-ui/src/highlight.ts
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Tiny syntax highlighters shared by the chat renderers.
+ *
+ * Both return HTML with <span class="json-*"> wrappers and escape `<`,
+ * `>` and `&` on every character that passes through, so the output is
+ * safe to assign to innerHTML. The token class names are shared between
+ * the two languages so a single set of CSS rules colors both.
+ */
+// Lightweight JSON syntax highlighter — returns HTML with span wrappers
+// around tokens. Implemented as a hand-rolled scanner rather than a
+// single tokenizing regex so we have no chance of polynomial backtracking
+// on adversarial input (the JSON comes from action data which can carry
+// arbitrary user content). Also escapes <, >, & in any character that
+// passes through.
+// Avoids pulling in highlight.js / Prism just to colorize the action
+// JSON popup.
+// code-complexity-allow: hand-rolled JSON scanner kept branchy to avoid regex backtracking
+export function highlightJson(json: string): string {
+    const escapeChar = (c: string): string =>
+        c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : c;
+    const wrap = (cls: string, text: string): string =>
+        `<span class="${cls}">${text}</span>`;
+
+    let out = "";
+    let i = 0;
+    const n = json.length;
+    while (i < n) {
+        const ch = json[i];
+        if (ch === '"') {
+            // Linear scan to the matching closing quote, honoring `\\`
+            // and `\"` escapes. Each character is consumed at most once,
+            // so this is O(n) worst case.
+            let j = i + 1;
+            let raw = '"';
+            while (j < n) {
+                const cj = json[j];
+                if (cj === "\\" && j + 1 < n) {
+                    raw += "\\" + escapeChar(json[j + 1]);
+                    j += 2;
+                    continue;
+                }
+                raw += escapeChar(cj);
+                j++;
+                if (cj === '"') break;
+            }
+            i = j;
+            // If a colon follows (optionally with whitespace), this is a
+            // JSON object key; otherwise a string value.
+            let k = i;
+            while (k < n && (json[k] === " " || json[k] === "\t")) k++;
+            if (json[k] === ":") {
+                out += wrap("json-key", raw + json.slice(i, k + 1));
+                i = k + 1;
+            } else {
+                out += wrap("json-string", raw);
+            }
+        } else if (
+            (ch >= "0" && ch <= "9") ||
+            (ch === "-" &&
+                i + 1 < n &&
+                json[i + 1] >= "0" &&
+                json[i + 1] <= "9")
+        ) {
+            let j = i + 1;
+            while (
+                j < n &&
+                ((json[j] >= "0" && json[j] <= "9") ||
+                    json[j] === "." ||
+                    json[j] === "e" ||
+                    json[j] === "E" ||
+                    json[j] === "+" ||
+                    json[j] === "-")
+            ) {
+                j++;
+            }
+            out += wrap("json-number", json.slice(i, j));
+            i = j;
+        } else if (json.startsWith("true", i)) {
+            out += wrap("json-bool", "true");
+            i += 4;
+        } else if (json.startsWith("false", i)) {
+            out += wrap("json-bool", "false");
+            i += 5;
+        } else if (json.startsWith("null", i)) {
+            out += wrap("json-null", "null");
+            i += 4;
+        } else {
+            out += escapeChar(ch);
+            i++;
+        }
+    }
+    return out;
+}
+
+// Lightweight YAML highlighter for the config snippets agents hand the
+// user. Line-oriented and deliberately minimal — these snippets are
+// `key: value` pairs and comments, not the full YAML grammar — and it
+// reuses the JSON token classes so one set of CSS colors both.
+//
+// Like highlightJson, it escapes every character it passes through, so
+// the result is safe to assign to innerHTML.
+export function highlightYaml(yaml: string): string {
+    const esc = (s: string): string =>
+        s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    const wrap = (cls: string, text: string): string =>
+        `<span class="${cls}">${esc(text)}</span>`;
+
+    return yaml
+        .split("\n")
+        .map((line) => {
+            const trimmed = line.trim();
+            if (trimmed === "") {
+                return esc(line);
+            }
+            if (trimmed.startsWith("#")) {
+                return wrap("json-null", line);
+            }
+            // Split on the first ": " (or a trailing ":"), which is the
+            // key/value boundary for the flat mappings we emit.
+            const m = /^(\s*-?\s*)([^:]+)(:)(\s*)(.*)$/.exec(line);
+            if (m === null) {
+                return esc(line);
+            }
+            const [, indent, key, colon, space, rest] = m;
+            const value =
+                rest === ""
+                    ? ""
+                    : /^-?\d+(\.\d+)?$/.test(rest)
+                      ? wrap("json-number", rest)
+                      : rest === "true" || rest === "false"
+                        ? wrap("json-bool", rest)
+                        : wrap("json-string", rest);
+            return (
+                esc(indent) + wrap("json-key", key + colon) + esc(space) + value
+            );
+        })
+        .join("\n");
+}

--- a/ts/packages/chat-ui/src/index.ts
+++ b/ts/packages/chat-ui/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./platformAdapter.js";
 
 export { setContent, swapContent } from "./setContent.js";
+export { FILE_LINK_SCHEME, fileLinkToPath, isFileLink } from "./fileLink.js";
 
 export {
     PartialCompletion,

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -783,21 +783,28 @@ async function copyInlineCommand(code: HTMLElement): Promise<void> {
 
 // Colorize fenced blocks whose language we can highlight cheaply. The
 // markdown renderer emits `language-<lang>` on the <code>. Guarded by a
-// data flag because `innerHTML +=` re-serializes the container: the spans
-// survive that round-trip and must not be re-scanned as source text.
+// data flag because later container serialization preserves the spans,
+// which must not be re-scanned as source text.
 function highlightCodeBlock(code: HTMLElement): void {
     if (code.dataset.highlighted === "true") {
         return;
     }
     const lang = /(?:^|\s)language-([\w-]+)/.exec(code.className)?.[1];
     const source = code.textContent ?? "";
+    let highlighted: string;
     if (lang === "yaml" || lang === "yml") {
-        code.innerHTML = highlightYaml(source);
+        highlighted = highlightYaml(source);
     } else if (lang === "json") {
-        code.innerHTML = highlightJson(source);
+        highlighted = highlightJson(source);
     } else {
         return;
     }
+    const fragment = DOMPurify.sanitize(highlighted, {
+        ALLOWED_TAGS: ["span"],
+        ALLOWED_ATTR: ["class"],
+        RETURN_DOM_FRAGMENT: true,
+    });
+    code.replaceChildren(fragment);
     code.dataset.highlighted = "true";
 }
 

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -22,6 +22,7 @@ import DOMPurify from "dompurify";
 import MarkdownIt from "markdown-it";
 import { PlatformAdapter, ChatSettingsView } from "./platformAdapter.js";
 import { iconCheck, iconCopy } from "./icons.js";
+import { copyTextToClipboard } from "./clipboard.js";
 
 const ansiUpTextToHtml = new AnsiUp();
 ansiUpTextToHtml.use_classes = true;
@@ -669,10 +670,7 @@ async function copyStatusMessage(
     text: string,
     anchor: HTMLElement,
 ): Promise<void> {
-    try {
-        await navigator.clipboard.writeText(text);
-    } catch (e) {
-        console.warn("clipboard write failed", e);
+    if (!(await copyTextToClipboard(text))) {
         return;
     }
     showCopiedToast(anchor);
@@ -694,14 +692,21 @@ function showCopiedToast(anchor: HTMLElement): void {
 
 // Give every fenced code block a hover-reveal copy button, so snippets an
 // agent hands the user (config YAML, shell commands) can be grabbed in one
-// click instead of hand-selected. Idempotent: re-running over already
-// decorated blocks is a no-op, which matters because the `innerHTML +=`
-// append sink re-walks previously rendered content.
+// click instead of hand-selected.
+//
+// The click is delegated to `root` rather than bound on each button: the
+// `innerHTML +=` append sink re-serializes the container, which recreates
+// the buttons and drops any listener attached directly to them (the link
+// and status-badge handlers below re-bind for the same reason). `root`
+// itself survives, so one listener on it keeps working.
 function attachCodeBlockCopyButtons(root: HTMLElement): void {
     const codes = root.querySelectorAll<HTMLElement>("pre > code");
     codes.forEach((code) => {
         const pre = code.parentElement;
-        if (pre === null || pre.classList.contains("chat-code-block")) {
+        if (
+            pre === null ||
+            pre.querySelector(":scope > button.chat-code-copy") !== null
+        ) {
             return;
         }
         pre.classList.add("chat-code-block");
@@ -711,23 +716,36 @@ function attachCodeBlockCopyButtons(root: HTMLElement): void {
         button.title = "Copy to clipboard";
         button.setAttribute("aria-label", "Copy code to clipboard");
         button.appendChild(iconCopy());
-        button.addEventListener("click", async (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            try {
-                await navigator.clipboard.writeText(code.textContent ?? "");
-            } catch (error) {
-                console.warn("clipboard write failed", error);
-                return;
-            }
-            showCopiedToast(button);
-            // Brief check-mark confirmation on the button itself, so the
-            // feedback survives the toast fading out.
-            button.replaceChildren(iconCheck());
-            setTimeout(() => button.replaceChildren(iconCopy()), 1200);
-        });
         pre.appendChild(button);
     });
+    if (codes.length === 0 || root.dataset.chatCodeCopyBound === "true") {
+        return;
+    }
+    root.dataset.chatCodeCopyBound = "true";
+    root.addEventListener("click", (e) => {
+        const button = (e.target as HTMLElement | null)?.closest<HTMLElement>(
+            "button.chat-code-copy",
+        );
+        if (button === null || button === undefined || !root.contains(button)) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        // The button lives inside the <pre>, so exclude it from the text.
+        const code = button.parentElement?.querySelector("code");
+        void copyCodeBlock(code?.textContent ?? "", button);
+    });
+}
+
+async function copyCodeBlock(text: string, button: HTMLElement): Promise<void> {
+    if (!(await copyTextToClipboard(text))) {
+        return;
+    }
+    showCopiedToast(button);
+    // Brief check-mark confirmation on the button itself, so the feedback
+    // survives the toast fading out.
+    button.replaceChildren(iconCheck());
+    setTimeout(() => button.replaceChildren(iconCopy()), 1200);
 }
 
 /**

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -21,6 +21,7 @@ import {
 import DOMPurify from "dompurify";
 import MarkdownIt from "markdown-it";
 import { PlatformAdapter, ChatSettingsView } from "./platformAdapter.js";
+import { iconCheck, iconCopy } from "./icons.js";
 
 const ansiUpTextToHtml = new AnsiUp();
 ansiUpTextToHtml.use_classes = true;
@@ -562,7 +563,7 @@ function processContent(
                 ADD_DATA_URI_TAGS: ["img"],
                 ADD_URI_SAFE_ATTR: ["src", "href"],
                 ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
             });
         case "markdown": {
             const md = createMarkdownRenderer();
@@ -577,7 +578,7 @@ function processContent(
                 ADD_DATA_URI_TAGS: ["img"],
                 ADD_URI_SAFE_ATTR: ["src", "href", "style"],
                 ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
             });
         }
         case "text":
@@ -689,6 +690,44 @@ function showCopiedToast(anchor: HTMLElement): void {
     toast.style.top = `${rect.top}px`;
     document.body.appendChild(toast);
     setTimeout(() => toast.remove(), 1200);
+}
+
+// Give every fenced code block a hover-reveal copy button, so snippets an
+// agent hands the user (config YAML, shell commands) can be grabbed in one
+// click instead of hand-selected. Idempotent: re-running over already
+// decorated blocks is a no-op, which matters because the `innerHTML +=`
+// append sink re-walks previously rendered content.
+function attachCodeBlockCopyButtons(root: HTMLElement): void {
+    const codes = root.querySelectorAll<HTMLElement>("pre > code");
+    codes.forEach((code) => {
+        const pre = code.parentElement;
+        if (pre === null || pre.classList.contains("chat-code-block")) {
+            return;
+        }
+        pre.classList.add("chat-code-block");
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "chat-code-copy";
+        button.title = "Copy to clipboard";
+        button.setAttribute("aria-label", "Copy code to clipboard");
+        button.appendChild(iconCopy());
+        button.addEventListener("click", async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            try {
+                await navigator.clipboard.writeText(code.textContent ?? "");
+            } catch (error) {
+                console.warn("clipboard write failed", error);
+                return;
+            }
+            showCopiedToast(button);
+            // Brief check-mark confirmation on the button itself, so the
+            // feedback survives the toast fading out.
+            button.replaceChildren(iconCheck());
+            setTimeout(() => button.replaceChildren(iconCopy()), 1200);
+        });
+        pre.appendChild(button);
+    });
 }
 
 /**
@@ -850,7 +889,7 @@ export function setContent(
             ADD_DATA_URI_TAGS: ["img"],
             ADD_URI_SAFE_ATTR: ["src", "href", "style"],
             ALLOWED_URI_REGEXP:
-                /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+                /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
         });
 
         // Plain-text content authors no links of its own, so bare URLs would
@@ -868,6 +907,7 @@ export function setContent(
             if (
                 href &&
                 (href.startsWith("typeagent-browser://") ||
+                    href.startsWith("typeagent-file:") ||
                     href.startsWith("http://") ||
                     href.startsWith("https://"))
             ) {
@@ -881,6 +921,9 @@ export function setContent(
 
         // Phase 4a — wire sort + filter on any sc-table elements just added.
         attachTableInteractivity(contentElm);
+
+        // Fenced code blocks get a hover copy button.
+        attachCodeBlockCopyButtons(contentElm);
 
         // Status badges (agent-status readiness/load indicators and other
         // tooltip-bearing status glyphs) stash their full message in a

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -23,6 +23,7 @@ import MarkdownIt from "markdown-it";
 import { PlatformAdapter, ChatSettingsView } from "./platformAdapter.js";
 import { iconCheck, iconCopy } from "./icons.js";
 import { copyTextToClipboard } from "./clipboard.js";
+import { highlightJson, highlightYaml } from "./highlight.js";
 
 const ansiUpTextToHtml = new AnsiUp();
 ansiUpTextToHtml.use_classes = true;
@@ -710,6 +711,7 @@ function attachCodeBlockCopyButtons(root: HTMLElement): void {
             return;
         }
         pre.classList.add("chat-code-block");
+        highlightCodeBlock(code);
         const button = document.createElement("button");
         button.type = "button";
         button.className = "chat-code-copy";
@@ -718,23 +720,85 @@ function attachCodeBlockCopyButtons(root: HTMLElement): void {
         button.appendChild(iconCopy());
         pre.appendChild(button);
     });
-    if (codes.length === 0 || root.dataset.chatCodeCopyBound === "true") {
+    decorateInlineCommands(root);
+    if (
+        (codes.length === 0 && !root.querySelector("code.chat-inline-copy")) ||
+        root.dataset.chatCodeCopyBound === "true"
+    ) {
         return;
     }
     root.dataset.chatCodeCopyBound = "true";
     root.addEventListener("click", (e) => {
-        const button = (e.target as HTMLElement | null)?.closest<HTMLElement>(
-            "button.chat-code-copy",
-        );
-        if (button === null || button === undefined || !root.contains(button)) {
+        const target = e.target as HTMLElement | null;
+        const button = target?.closest<HTMLElement>("button.chat-code-copy");
+        if (button !== null && button !== undefined && root.contains(button)) {
+            e.preventDefault();
+            e.stopPropagation();
+            // The button lives inside the <pre>, so exclude it from the text.
+            const code = button.parentElement?.querySelector("code");
+            void copyCodeBlock(code?.textContent ?? "", button);
             return;
         }
-        e.preventDefault();
-        e.stopPropagation();
-        // The button lives inside the <pre>, so exclude it from the text.
-        const code = button.parentElement?.querySelector("code");
-        void copyCodeBlock(code?.textContent ?? "", button);
+        const inline = target?.closest<HTMLElement>("code.chat-inline-copy");
+        if (inline !== null && inline !== undefined && root.contains(inline)) {
+            e.preventDefault();
+            e.stopPropagation();
+            void copyInlineCommand(inline);
+        }
     });
+}
+
+// Commands an agent tells the user to run (`@config agent refresh player`)
+// arrive as inline code, not a fenced block, so they miss out on the block
+// copy button — yet they're the thing the user most wants to paste. Make
+// those click-to-copy.
+//
+// Deliberately narrow: only inline code that reads as a command, so an
+// ordinary mention of a setting name like `clientId` doesn't become a
+// mystery click target.
+function decorateInlineCommands(root: HTMLElement): void {
+    root.querySelectorAll<HTMLElement>("code").forEach((code) => {
+        if (code.closest("pre") !== null) {
+            return;
+        }
+        const text = code.textContent?.trim() ?? "";
+        if (!text.startsWith("@") || text.length < 2) {
+            return;
+        }
+        code.classList.add("chat-inline-copy");
+        code.title = "Click to copy";
+    });
+}
+
+async function copyInlineCommand(code: HTMLElement): Promise<void> {
+    if (!(await copyTextToClipboard(code.textContent?.trim() ?? ""))) {
+        return;
+    }
+    showCopiedToast(code);
+    // The element is the affordance here (there's no button to swap an
+    // icon on), so flash it instead.
+    code.classList.add("chat-inline-copied");
+    setTimeout(() => code.classList.remove("chat-inline-copied"), 600);
+}
+
+// Colorize fenced blocks whose language we can highlight cheaply. The
+// markdown renderer emits `language-<lang>` on the <code>. Guarded by a
+// data flag because `innerHTML +=` re-serializes the container: the spans
+// survive that round-trip and must not be re-scanned as source text.
+function highlightCodeBlock(code: HTMLElement): void {
+    if (code.dataset.highlighted === "true") {
+        return;
+    }
+    const lang = /(?:^|\s)language-([\w-]+)/.exec(code.className)?.[1];
+    const source = code.textContent ?? "";
+    if (lang === "yaml" || lang === "yml") {
+        code.innerHTML = highlightYaml(source);
+    } else if (lang === "json") {
+        code.innerHTML = highlightJson(source);
+    } else {
+        return;
+    }
+    code.dataset.highlighted = "true";
 }
 
 async function copyCodeBlock(text: string, button: HTMLElement): Promise<void> {

--- a/ts/packages/chat-ui/styles/chat.css
+++ b/ts/packages/chat-ui/styles/chat.css
@@ -1603,6 +1603,56 @@ pre.chat-code-block:hover .chat-code-copy,
   background: var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.06));
 }
 
+/* Syntax tokens inside chat code blocks, set by highlightCodeBlock().
+   Same palette as the action-JSON popup so highlighted YAML and JSON read
+   identically wherever they appear. `!important` matches the popup rules:
+   the surrounding bubble sets a foreground color that would otherwise
+   inherit down into these spans. */
+pre.chat-code-block code .json-key {
+  color: #9c27b0 !important;
+  font-weight: 600;
+}
+
+pre.chat-code-block code .json-string {
+  color: #0a8043 !important;
+}
+
+pre.chat-code-block code .json-number {
+  color: #1976d2 !important;
+}
+
+pre.chat-code-block code .json-bool {
+  color: #b85c00 !important;
+  font-weight: 600;
+}
+
+pre.chat-code-block code .json-null {
+  color: #888 !important;
+  font-style: italic;
+}
+
+/* Inline commands (`@config agent refresh player`) are click-to-copy.
+   Keep the affordance quiet — a pointer cursor and a hover tint — so the
+   text still reads as prose rather than as a button. */
+code.chat-inline-copy {
+  cursor: pointer;
+  border-radius: 3px;
+  transition:
+    background-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+code.chat-inline-copy:hover {
+  background: var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.08));
+  box-shadow: 0 0 0 2px
+    var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.08));
+}
+
+code.chat-inline-copied {
+  background: rgba(10, 128, 67, 0.18);
+  box-shadow: 0 0 0 2px rgba(10, 128, 67, 0.18);
+}
+
 .sc-code {
   background: var(--vscode-textCodeBlock-background, #f0f0f0);
   border-radius: 4px;

--- a/ts/packages/chat-ui/styles/chat.css
+++ b/ts/packages/chat-ui/styles/chat.css
@@ -1567,6 +1567,40 @@ table.sc-kv-table.sc-card-fields {
 
 /* --- Code blocks --------------------------------------------------------- */
 
+/* Fenced code blocks in agent messages. `position: relative` anchors the
+   hover-reveal copy button added by attachCodeBlockCopyButtons. */
+pre.chat-code-block {
+  position: relative;
+}
+
+.chat-code-copy {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+  background: var(--vscode-editorWidget-background, rgba(255, 255, 255, 0.85));
+  color: var(--vscode-editorWidget-foreground, #333);
+  border: 1px solid var(--vscode-widget-border, rgba(0, 0, 0, 0.15));
+}
+
+pre.chat-code-block:hover .chat-code-copy,
+.chat-code-copy:focus-visible {
+  opacity: 1;
+}
+
+.chat-code-copy:hover {
+  background: var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.06));
+}
+
 .sc-code {
   background: var(--vscode-textCodeBlock-background, #f0f0f0);
   border-radius: 4px;

--- a/ts/packages/chat-ui/styles/chat.css
+++ b/ts/packages/chat-ui/styles/chat.css
@@ -1585,7 +1585,9 @@ pre.chat-code-block {
   padding: 0;
   border-radius: 4px;
   cursor: pointer;
-  opacity: 0;
+  /* Dimmed rather than hidden: the button is the only hint that a snippet
+     can be copied, so it has to be discoverable without hovering. */
+  opacity: 0.5;
   transition: opacity 0.12s ease;
   background: var(--vscode-editorWidget-background, rgba(255, 255, 255, 0.85));
   color: var(--vscode-editorWidget-foreground, #333);

--- a/ts/packages/chat-ui/test/fileLink.spec.ts
+++ b/ts/packages/chat-ui/test/fileLink.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "@jest/globals";
+import { fileLinkToPath, isFileLink } from "../src/fileLink.js";
+
+describe("fileLinkToPath", () => {
+    it("recovers a Windows path", () => {
+        expect(
+            fileLinkToPath("typeagent-file:///D:/Git/TypeAgent/ts/config.yaml"),
+        ).toBe("D:\\Git\\TypeAgent\\ts\\config.yaml");
+    });
+
+    it("decodes escaped characters", () => {
+        expect(
+            fileLinkToPath("typeagent-file:///D:/My%20Docs/config.local.yaml"),
+        ).toBe("D:\\My Docs\\config.local.yaml");
+    });
+
+    it("recovers a POSIX path", () => {
+        expect(fileLinkToPath("typeagent-file:///home/me/ts/config.yaml")).toBe(
+            "/home/me/ts/config.yaml",
+        );
+    });
+
+    it("recovers a UNC path", () => {
+        expect(
+            fileLinkToPath("typeagent-file://server/share/config.yaml"),
+        ).toBe("\\\\server\\share\\config.yaml");
+    });
+
+    it("ignores other schemes", () => {
+        expect(fileLinkToPath("https://example.org/file.yaml")).toBeUndefined();
+        expect(isFileLink("https://example.org")).toBe(false);
+    });
+});

--- a/ts/packages/chat-ui/test/fileLink.spec.ts
+++ b/ts/packages/chat-ui/test/fileLink.spec.ts
@@ -23,10 +23,21 @@ describe("fileLinkToPath", () => {
         );
     });
 
-    it("recovers a UNC path", () => {
+    it("rejects UNC paths", () => {
         expect(
             fileLinkToPath("typeagent-file://server/share/config.yaml"),
-        ).toBe("\\\\server\\share\\config.yaml");
+        ).toBeUndefined();
+    });
+
+    it("rejects encoded traversal and malformed escapes", () => {
+        expect(
+            fileLinkToPath(
+                "typeagent-file:///D:/repo/ts/%2e%2e/other/config.local.yaml",
+            ),
+        ).toBeUndefined();
+        expect(
+            fileLinkToPath("typeagent-file:///D:/repo/%E0%A4%A"),
+        ).toBeUndefined();
     });
 
     it("ignores other schemes", () => {

--- a/ts/packages/chat-ui/test/setContent.spec.ts
+++ b/ts/packages/chat-ui/test/setContent.spec.ts
@@ -116,14 +116,57 @@ describe("setContent local-file links", () => {
 });
 
 describe("setContent code blocks", () => {
+    const yaml = "```yaml\nspotify:\n  clientId: <value>\n```";
+
+    function clickCopy(elm: HTMLElement): void {
+        elm.querySelector<HTMLButtonElement>("button.chat-code-copy")!.click();
+    }
+
     it("adds a copy button to fenced code blocks", () => {
-        const elm = render({
-            type: "markdown",
-            content: "```yaml\nspotify:\n  clientId: <value>\n```",
-        });
+        const elm = render({ type: "markdown", content: yaml });
         const pre = elm.querySelector("pre");
         expect(pre?.classList.contains("chat-code-block")).toBe(true);
         expect(pre?.querySelector("button.chat-code-copy")).not.toBeNull();
+    });
+
+    it("copies the block's text without the button's own markup", async () => {
+        const writeText = jest.fn(async () => {});
+        Object.defineProperty(navigator, "clipboard", {
+            value: { writeText },
+            configurable: true,
+        });
+        const elm = render({ type: "markdown", content: yaml });
+        document.body.appendChild(elm);
+        clickCopy(elm);
+        expect(writeText).toHaveBeenCalledWith(
+            "spotify:\n  clientId: <value>\n",
+        );
+    });
+
+    it("still copies after more content is appended", () => {
+        // setContent appends with `innerHTML +=`, which re-serializes the
+        // container and drops listeners bound to individual elements — the
+        // handler is delegated to the container so it survives.
+        const writeText = jest.fn(async () => {});
+        Object.defineProperty(navigator, "clipboard", {
+            value: { writeText },
+            configurable: true,
+        });
+        const elm = render({ type: "markdown", content: yaml });
+        document.body.appendChild(elm);
+        setContent(
+            elm,
+            { type: "markdown", content: "and then some prose." },
+            defaultChatSettings,
+            "agent",
+            { handleLinkClick() {} },
+            "inline",
+        );
+        expect(elm.querySelectorAll("button.chat-code-copy")).toHaveLength(1);
+        clickCopy(elm);
+        expect(writeText).toHaveBeenCalledWith(
+            "spotify:\n  clientId: <value>\n",
+        );
     });
 
     it("does not add a copy button to inline code", () => {

--- a/ts/packages/chat-ui/test/setContent.spec.ts
+++ b/ts/packages/chat-ui/test/setContent.spec.ts
@@ -193,6 +193,19 @@ describe("setContent code blocks", () => {
         );
     });
 
+    it("keeps highlighted source text inert", () => {
+        const elm = render({
+            type: "markdown",
+            content:
+                '```json\n{"value": "</span><img src=x onerror=alert(1)>"}\n```',
+        });
+        const code = elm.querySelector("pre > code")!;
+        expect(code.querySelector("img")).toBeNull();
+        expect(code.textContent).toContain(
+            "</span><img src=x onerror=alert(1)>",
+        );
+    });
+
     it("leaves blocks in unknown languages alone", () => {
         const elm = render({
             type: "markdown",

--- a/ts/packages/chat-ui/test/setContent.spec.ts
+++ b/ts/packages/chat-ui/test/setContent.spec.ts
@@ -93,6 +93,48 @@ describe("setContent markdown linkification", () => {
     });
 });
 
+describe("setContent local-file links", () => {
+    it("keeps typeagent-file links and routes clicks to the adapter", () => {
+        const handleLinkClick = jest.fn();
+        const href = "typeagent-file:///d:/repo/ts/config.local.yaml";
+        const elm = render(
+            {
+                type: "markdown",
+                content: `Edit [\`config.local.yaml\`](<${href}>)`,
+            },
+            { handleLinkClick },
+        );
+        const link = elm.querySelector<HTMLAnchorElement>("a[href]");
+        // The sanitizer allows the scheme through...
+        expect(link?.getAttribute("href")).toBe(href);
+        link!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+        // ...and the host decides how to open it.
+        expect(handleLinkClick).toHaveBeenCalledWith(href, expect.anything());
+    });
+});
+
+describe("setContent code blocks", () => {
+    it("adds a copy button to fenced code blocks", () => {
+        const elm = render({
+            type: "markdown",
+            content: "```yaml\nspotify:\n  clientId: <value>\n```",
+        });
+        const pre = elm.querySelector("pre");
+        expect(pre?.classList.contains("chat-code-block")).toBe(true);
+        expect(pre?.querySelector("button.chat-code-copy")).not.toBeNull();
+    });
+
+    it("does not add a copy button to inline code", () => {
+        const elm = render({
+            type: "markdown",
+            content: "Run `pnpm build` first.",
+        });
+        expect(elm.querySelector("button.chat-code-copy")).toBeNull();
+    });
+});
+
 describe("setContent plain-text linkification", () => {
     it("turns a bare https URL in text content into a clickable link", () => {
         const elm = render({

--- a/ts/packages/chat-ui/test/setContent.spec.ts
+++ b/ts/packages/chat-ui/test/setContent.spec.ts
@@ -176,6 +176,61 @@ describe("setContent code blocks", () => {
         });
         expect(elm.querySelector("button.chat-code-copy")).toBeNull();
     });
+
+    it("syntax-highlights yaml and json blocks", () => {
+        const elm = render({ type: "markdown", content: yaml });
+        const code = elm.querySelector("pre > code")!;
+        expect(code.querySelector(".json-key")?.textContent).toBe("spotify:");
+        // Highlighting must not disturb the text the copy button grabs.
+        expect(code.textContent).toBe("spotify:\n  clientId: <value>\n");
+
+        const json = render({
+            type: "markdown",
+            content: '```json\n{"port": 8080}\n```',
+        });
+        expect(json.querySelector("pre > code .json-number")?.textContent).toBe(
+            "8080",
+        );
+    });
+
+    it("leaves blocks in unknown languages alone", () => {
+        const elm = render({
+            type: "markdown",
+            content: "```\nplain text\n```",
+        });
+        const code = elm.querySelector("pre > code")!;
+        expect(code.querySelector("span")).toBeNull();
+        expect(code.textContent).toBe("plain text\n");
+    });
+});
+
+describe("setContent inline commands", () => {
+    it("makes an inline command click-to-copy", async () => {
+        const writeText = jest.fn(async () => {});
+        Object.defineProperty(navigator, "clipboard", {
+            value: { writeText },
+            configurable: true,
+        });
+        const elm = render({
+            type: "markdown",
+            content: "Then run `@config agent refresh player`.",
+        });
+        document.body.appendChild(elm);
+        const code = elm.querySelector<HTMLElement>("code.chat-inline-copy")!;
+        expect(code.textContent).toBe("@config agent refresh player");
+        code.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+        expect(writeText).toHaveBeenCalledWith("@config agent refresh player");
+    });
+
+    it("leaves ordinary inline code as prose", () => {
+        const elm = render({
+            type: "markdown",
+            content: "The `clientId` comes from the dashboard.",
+        });
+        expect(elm.querySelector("code.chat-inline-copy")).toBeNull();
+    });
 });
 
 describe("setContent plain-text linkification", () => {

--- a/ts/packages/config/src/fileLink.ts
+++ b/ts/packages/config/src/fileLink.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Links to local files inside chat messages.
+ *
+ * Plain `file:` URLs are stripped by the renderer's sanitizer (and are
+ * inert in Electron / VS Code webviews anyway), so messages use a custom
+ * `typeagent-file:` scheme instead. The chat hosts recognize it, turn it
+ * back into a path and hand it to the OS ("open with the default editor").
+ * The wire format is a `file:` URL with the scheme swapped, so encoding
+ * of spaces, `#`, drive letters, ... is whatever `pathToFileURL` produces.
+ */
+
+import { pathToFileURL } from "node:url";
+
+/** Scheme used for "open this local file" links in chat content. */
+export const FILE_LINK_SCHEME = "typeagent-file:";
+
+/**
+ * The href for a local file link, or `undefined` when there is no path to
+ * link to (callers then fall back to plain text).
+ */
+export function fileLinkHref(filePath: string | undefined): string | undefined {
+    if (filePath === undefined || filePath === "") {
+        return undefined;
+    }
+    return pathToFileURL(filePath).href.replace(/^file:/, FILE_LINK_SCHEME);
+}

--- a/ts/packages/config/src/fileLink.ts
+++ b/ts/packages/config/src/fileLink.ts
@@ -13,6 +13,7 @@
  */
 
 import { pathToFileURL } from "node:url";
+import path from "node:path";
 
 /** Scheme used for "open this local file" links in chat content. */
 export const FILE_LINK_SCHEME = "typeagent-file:";
@@ -26,4 +27,32 @@ export function fileLinkHref(filePath: string | undefined): string | undefined {
         return undefined;
     }
     return pathToFileURL(filePath).href.replace(/^file:/, FILE_LINK_SCHEME);
+}
+
+/**
+ * Validate the only local-file target chat content is allowed to open.
+ *
+ * This check must also run in each host process that opens the file; rendered
+ * message content is untrusted and renderer-side checks are not a security
+ * boundary.
+ */
+export function isAllowedConfigFilePath(
+    candidate: string,
+    expectedConfigPath: string,
+): boolean {
+    if (
+        candidate.length === 0 ||
+        !path.isAbsolute(candidate) ||
+        candidate.startsWith("\\\\") ||
+        candidate.startsWith("//") ||
+        candidate.split(/[\\/]/).some((segment) => segment === "..")
+    ) {
+        return false;
+    }
+    const resolvedCandidate = path.resolve(candidate);
+    const resolvedExpected = path.resolve(expectedConfigPath);
+    return process.platform === "win32"
+        ? resolvedCandidate.toLocaleLowerCase() ===
+              resolvedExpected.toLocaleLowerCase()
+        : resolvedCandidate === resolvedExpected;
 }

--- a/ts/packages/config/src/fileLink.ts
+++ b/ts/packages/config/src/fileLink.ts
@@ -42,6 +42,7 @@ export function isAllowedConfigFilePath(
 ): boolean {
     if (
         candidate.length === 0 ||
+        candidate.includes("\0") ||
         !path.isAbsolute(candidate) ||
         candidate.startsWith("\\\\") ||
         candidate.startsWith("//") ||
@@ -52,7 +53,6 @@ export function isAllowedConfigFilePath(
     const resolvedCandidate = path.resolve(candidate);
     const resolvedExpected = path.resolve(expectedConfigPath);
     return process.platform === "win32"
-        ? resolvedCandidate.toLocaleLowerCase() ===
-              resolvedExpected.toLocaleLowerCase()
+        ? resolvedCandidate.toLowerCase() === resolvedExpected.toLowerCase()
         : resolvedCandidate === resolvedExpected;
 }

--- a/ts/packages/config/src/flatten.ts
+++ b/ts/packages/config/src/flatten.ts
@@ -46,13 +46,26 @@ const VALUE_GROUP_KEYS = new Set(["identity"]);
  * - Arrays are not supported in Phase 1 and produce a descriptive
  *   error pointing the caller at the future structured schema.
  */
-export function flatten(tree: ConfigTree | null | undefined): FlatEnv {
+export function flatten(
+    tree: ConfigTree | null | undefined,
+    options: FlattenOptions = {},
+): FlatEnv {
     if (tree === null || tree === undefined) {
         return {};
     }
     const out: FlatEnv = {};
-    walk(tree, [], out, /*passthrough*/ false);
+    walk(tree, [], out, /*passthrough*/ false, options);
     return out;
+}
+
+export interface FlattenOptions {
+    /**
+     * Called when a top-level section fails to convert (a typo'd value,
+     * a leftover `<value>` placeholder, ...). When supplied, that one
+     * section is skipped and the rest of the file still loads; without
+     * it the error propagates and the whole tree is rejected.
+     */
+    readonly onSectionError?: (section: string, error: Error) => void;
 }
 
 function walk(
@@ -60,6 +73,7 @@ function walk(
     path: string[],
     out: FlatEnv,
     passthrough: boolean,
+    options: FlattenOptions,
 ): void {
     if (node === null || node === undefined) {
         return;
@@ -79,14 +93,18 @@ function walk(
             node as Record<string, unknown>,
         )) {
             if (path.length === 0 && VALUE_GROUP_KEYS.has(rawKey)) {
-                expandValueGroup(rawKey, value, out);
+                tryTopLevel(rawKey, options, () =>
+                    expandValueGroup(rawKey, value, out),
+                );
                 continue;
             }
             if (path.length === 0 && isTypedSectionKey(rawKey)) {
-                const sub = typedSectionToFlat(rawKey, value);
-                for (const [k, v] of Object.entries(sub)) {
-                    out[k] = v;
-                }
+                tryTopLevel(rawKey, options, () => {
+                    const sub = typedSectionToFlat(rawKey, value);
+                    for (const [k, v] of Object.entries(sub)) {
+                        out[k] = v;
+                    }
+                });
                 continue;
             }
             const isPassthroughBoundary =
@@ -96,6 +114,7 @@ function walk(
                 isPassthroughBoundary ? path : [...path, rawKey],
                 out,
                 passthrough || isPassthroughBoundary,
+                options,
             );
         }
         return;
@@ -109,6 +128,29 @@ function walk(
     const stringValue = scalarToString(node);
     if (stringValue !== undefined) {
         out[flatKey] = stringValue;
+    }
+}
+
+// Run a top-level section's conversion. Without an `onSectionError`
+// handler the error propagates (the caller wants all-or-nothing); with
+// one, the section is reported and skipped so one bad entry can't
+// silently take the whole config file down with it.
+function tryTopLevel(
+    section: string,
+    options: FlattenOptions,
+    convert: () => void,
+): void {
+    if (options.onSectionError === undefined) {
+        convert();
+        return;
+    }
+    try {
+        convert();
+    } catch (e: any) {
+        options.onSectionError(
+            section,
+            e instanceof Error ? e : new Error(String(e)),
+        );
     }
 }
 

--- a/ts/packages/config/src/flatten.ts
+++ b/ts/packages/config/src/flatten.ts
@@ -100,7 +100,13 @@ function walk(
             }
             if (path.length === 0 && isTypedSectionKey(rawKey)) {
                 tryTopLevel(rawKey, options, () => {
-                    const sub = typedSectionToFlat(rawKey, value);
+                    const sub = typedSectionToFlat(
+                        rawKey,
+                        value,
+                        options.onSectionError === undefined
+                            ? undefined
+                            : (error) => options.onSectionError!(rawKey, error),
+                    );
                     for (const [k, v] of Object.entries(sub)) {
                         out[k] = v;
                     }

--- a/ts/packages/config/src/hints.ts
+++ b/ts/packages/config/src/hints.ts
@@ -16,9 +16,11 @@
  * away from the real converter in `runtime/tree.ts`.
  */
 
+import { fileLinkHref } from "./fileLink.js";
+import { resolveLocalConfigPath } from "./loader.js";
+
 /** Where users put their own settings. */
 export const CONFIG_LOCAL_FILE = "ts/config.local.yaml";
-
 /** Fully commented example of every supported section. */
 export const CONFIG_SAMPLE_FILE = "ts/config.sample.yaml";
 
@@ -132,13 +134,38 @@ export function configYamlSnippet(vars: ConfigHintVar[]): string {
 }
 
 /**
+ * `resolveLocalConfigPath` walks the filesystem, so treat any failure
+ * (permissions, exotic install layout) as "no link".
+ */
+function tryResolveLocalConfigPath(): string | undefined {
+    try {
+        return resolveLocalConfigPath();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Markdown for the `config.local.yaml` reference. When the file's location
+ * on this machine can be resolved, it becomes a `typeagent-file:` link the
+ * chat hosts open in the user's editor; otherwise it degrades to plain
+ * code text.
+ */
+export function configLocalFileLink(): string {
+    const target = fileLinkHref(tryResolveLocalConfigPath());
+    return target === undefined
+        ? `\`${CONFIG_LOCAL_FILE}\``
+        : `[\`${CONFIG_LOCAL_FILE}\`](<${target}>)`;
+}
+
+/**
  * Full "how to configure this" blurb: the YAML to add, where to add it,
  * and an optional agent-specific note (where to obtain the values, which
  * command to run afterwards, ...).
  */
 export function configSetupHint(vars: ConfigHintVar[], note?: string): string {
     const lines = [
-        `Add to \`${CONFIG_LOCAL_FILE}\` (see \`${CONFIG_SAMPLE_FILE}\` for the full format):`,
+        `Add to ${configLocalFileLink()} (see \`${CONFIG_SAMPLE_FILE}\` for the full format):`,
         "",
         "```yaml",
         configYamlSnippet(vars),

--- a/ts/packages/config/src/hints.ts
+++ b/ts/packages/config/src/hints.ts
@@ -11,56 +11,16 @@
  * translation plus the phrasing of the "here is what to add" message so
  * every agent says the same thing.
  *
- * `hints.spec.ts` verifies each mapping by flattening the YAML path and
- * checking it produces the mapped env var, so the table cannot drift
- * away from the real converter in `runtime/tree.ts`.
  */
 
 import { fileLinkHref } from "./fileLink.js";
 import { resolveLocalConfigPath } from "./loader.js";
+import { simpleConfigMappingForEnvVar } from "./mappings.js";
 
 /** Where users put their own settings. */
 export const CONFIG_LOCAL_FILE = "ts/config.local.yaml";
 /** Fully commented example of every supported section. */
 export const CONFIG_SAMPLE_FILE = "ts/config.sample.yaml";
-
-/**
- * Legacy env var name -> dotted path in the YAML config tree.
- *
- * Only the vars that appear in user-facing setup messages are listed;
- * anything missing falls back to the `env:` passthrough block, which is
- * the correct YAML form for a var the typed schema doesn't model.
- */
-const CONFIG_PATH_BY_ENV_VAR: Readonly<Record<string, string>> = {
-    // Spotify (player agent).
-    SPOTIFY_APP_CLI: "spotify.clientId",
-    SPOTIFY_APP_CLISEC: "spotify.clientSecret",
-    SPOTIFY_APP_PORT: "spotify.port",
-
-    // Microsoft Graph (calendar / email agents).
-    MSGRAPH_APP_CLIENTID: "msGraph.clientId",
-    MSGRAPH_APP_CLIENTSECRET: "msGraph.clientSecret",
-    MSGRAPH_APP_TENANTID: "msGraph.tenantId",
-    MSGRAPH_APP_USERNAME: "msGraph.username",
-    MSGRAPH_APP_PASSWD: "msGraph.password",
-
-    // Google (calendar / email agents).
-    GOOGLE_CALENDAR_CLIENT_ID: "googleCalendar.clientId",
-    GOOGLE_CALENDAR_CLIENT_SECRET: "googleCalendar.clientSecret",
-
-    // Speech (shell voice input).
-    SPEECH_SDK_KEY: "speech.auth",
-    SPEECH_SDK_REGION: "speech.region",
-    SPEECH_SDK_ENDPOINT: "speech.endpoint",
-
-    // Azure Maps.
-    AZURE_MAPS_CLIENTID: "maps.clientId",
-    AZURE_MAPS_ENDPOINT: "maps.endpoint",
-
-    // Telemetry / session storage backends.
-    COSMOSDB_CONNECTION_STRING: "storage.database.cosmosDbConnectionString",
-    MONGODB_CONNECTION_STRING: "storage.database.mongoDbConnectionString",
-};
 
 /**
  * A setting to mention in a hint: either the bare env var name, or the
@@ -73,7 +33,7 @@ export type ConfigHintVar = string | { envVar: string; placeholder?: string };
  * schema doesn't model it (in which case it belongs under `env:`).
  */
 export function configPathForEnvVar(envVar: string): string | undefined {
-    return CONFIG_PATH_BY_ENV_VAR[envVar];
+    return simpleConfigMappingForEnvVar(envVar)?.configPath;
 }
 
 function normalize(v: ConfigHintVar): { envVar: string; placeholder: string } {

--- a/ts/packages/config/src/hints.ts
+++ b/ts/packages/config/src/hints.ts
@@ -77,7 +77,7 @@ function render(node: Node, indent: number, out: string[]): void {
  * `env:` passthrough block (which `flatten()` copies verbatim into the
  * flat env namespace).
  */
-export function configYamlSnippet(vars: ConfigHintVar[]): string {
+export function configYamlSnippet(vars: readonly ConfigHintVar[]): string {
     const root: Node = new Map();
     for (const v of vars) {
         const { envVar, placeholder } = normalize(v);
@@ -123,7 +123,10 @@ export function configLocalFileLink(): string {
  * and an optional agent-specific note (where to obtain the values, which
  * command to run afterwards, ...).
  */
-export function configSetupHint(vars: ConfigHintVar[], note?: string): string {
+export function configSetupHint(
+    vars: readonly ConfigHintVar[],
+    note?: string,
+): string {
     const lines = [
         `Add to ${configLocalFileLink()} (see \`${CONFIG_SAMPLE_FILE}\` for the full format):`,
         "",
@@ -142,7 +145,7 @@ export function configSetupHint(vars: ConfigHintVar[], note?: string): string {
  * message ("missing: spotify.clientId, spotify.clientSecret"). Unmapped
  * vars keep their env var name.
  */
-export function configKeyNames(vars: ConfigHintVar[]): string[] {
+export function configKeyNames(vars: readonly ConfigHintVar[]): string[] {
     return vars.map((v) => {
         const { envVar } = normalize(v);
         return configPathForEnvVar(envVar) ?? envVar;

--- a/ts/packages/config/src/hints.ts
+++ b/ts/packages/config/src/hints.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * User-facing setup hints.
+ *
+ * Configuration now lives in `config.local.yaml`; the flat `KEY=value`
+ * env vars are the legacy (still supported) form that the YAML flattens
+ * into. Code that detects missing configuration therefore knows the env
+ * var name, but the user needs the YAML key. This module owns that
+ * translation plus the phrasing of the "here is what to add" message so
+ * every agent says the same thing.
+ *
+ * `hints.spec.ts` verifies each mapping by flattening the YAML path and
+ * checking it produces the mapped env var, so the table cannot drift
+ * away from the real converter in `runtime/tree.ts`.
+ */
+
+/** Where users put their own settings. */
+export const CONFIG_LOCAL_FILE = "ts/config.local.yaml";
+
+/** Fully commented example of every supported section. */
+export const CONFIG_SAMPLE_FILE = "ts/config.sample.yaml";
+
+/**
+ * Legacy env var name -> dotted path in the YAML config tree.
+ *
+ * Only the vars that appear in user-facing setup messages are listed;
+ * anything missing falls back to the `env:` passthrough block, which is
+ * the correct YAML form for a var the typed schema doesn't model.
+ */
+const CONFIG_PATH_BY_ENV_VAR: Readonly<Record<string, string>> = {
+    // Spotify (player agent).
+    SPOTIFY_APP_CLI: "spotify.clientId",
+    SPOTIFY_APP_CLISEC: "spotify.clientSecret",
+    SPOTIFY_APP_PORT: "spotify.port",
+
+    // Microsoft Graph (calendar / email agents).
+    MSGRAPH_APP_CLIENTID: "msGraph.clientId",
+    MSGRAPH_APP_CLIENTSECRET: "msGraph.clientSecret",
+    MSGRAPH_APP_TENANTID: "msGraph.tenantId",
+    MSGRAPH_APP_USERNAME: "msGraph.username",
+    MSGRAPH_APP_PASSWD: "msGraph.password",
+
+    // Google (calendar / email agents).
+    GOOGLE_CALENDAR_CLIENT_ID: "googleCalendar.clientId",
+    GOOGLE_CALENDAR_CLIENT_SECRET: "googleCalendar.clientSecret",
+
+    // Speech (shell voice input).
+    SPEECH_SDK_KEY: "speech.auth",
+    SPEECH_SDK_REGION: "speech.region",
+    SPEECH_SDK_ENDPOINT: "speech.endpoint",
+
+    // Azure Maps.
+    AZURE_MAPS_CLIENTID: "maps.clientId",
+    AZURE_MAPS_ENDPOINT: "maps.endpoint",
+
+    // Telemetry / session storage backends.
+    COSMOSDB_CONNECTION_STRING: "storage.database.cosmosDbConnectionString",
+    MONGODB_CONNECTION_STRING: "storage.database.mongoDbConnectionString",
+};
+
+/**
+ * A setting to mention in a hint: either the bare env var name, or the
+ * name plus the placeholder to show as its YAML value.
+ */
+export type ConfigHintVar = string | { envVar: string; placeholder?: string };
+
+/**
+ * The YAML key path for a legacy env var, or `undefined` when the typed
+ * schema doesn't model it (in which case it belongs under `env:`).
+ */
+export function configPathForEnvVar(envVar: string): string | undefined {
+    return CONFIG_PATH_BY_ENV_VAR[envVar];
+}
+
+function normalize(v: ConfigHintVar): { envVar: string; placeholder: string } {
+    return typeof v === "string"
+        ? { envVar: v, placeholder: "<value>" }
+        : { envVar: v.envVar, placeholder: v.placeholder ?? "<value>" };
+}
+
+type Node = Map<string, Node | string>;
+
+function insert(root: Node, segments: string[], value: string): void {
+    let node = root;
+    for (const segment of segments.slice(0, -1)) {
+        const existing = node.get(segment);
+        if (existing instanceof Map) {
+            node = existing;
+        } else {
+            const child: Node = new Map();
+            node.set(segment, child);
+            node = child;
+        }
+    }
+    node.set(segments[segments.length - 1], value);
+}
+
+function render(node: Node, indent: number, out: string[]): void {
+    const pad = " ".repeat(indent);
+    for (const [key, value] of node) {
+        if (value instanceof Map) {
+            out.push(`${pad}${key}:`);
+            render(value, indent + 2, out);
+        } else {
+            out.push(`${pad}${key}: ${value}`);
+        }
+    }
+}
+
+/**
+ * Render the YAML the user should add for the given settings. Vars the
+ * typed schema knows go under their section; the rest are grouped in the
+ * `env:` passthrough block (which `flatten()` copies verbatim into the
+ * flat env namespace).
+ */
+export function configYamlSnippet(vars: ConfigHintVar[]): string {
+    const root: Node = new Map();
+    for (const v of vars) {
+        const { envVar, placeholder } = normalize(v);
+        const configPath = configPathForEnvVar(envVar);
+        insert(
+            root,
+            configPath !== undefined ? configPath.split(".") : ["env", envVar],
+            placeholder,
+        );
+    }
+    const out: string[] = [];
+    render(root, 0, out);
+    return out.join("\n");
+}
+
+/**
+ * Full "how to configure this" blurb: the YAML to add, where to add it,
+ * and an optional agent-specific note (where to obtain the values, which
+ * command to run afterwards, ...).
+ */
+export function configSetupHint(vars: ConfigHintVar[], note?: string): string {
+    const lines = [
+        `Add to \`${CONFIG_LOCAL_FILE}\` (see \`${CONFIG_SAMPLE_FILE}\` for the full format):`,
+        "",
+        "```yaml",
+        configYamlSnippet(vars),
+        "```",
+    ];
+    if (note) {
+        lines.push("", note);
+    }
+    return lines.join("\n");
+}
+
+/**
+ * The YAML keys for the given env vars, for inline use in a one-line
+ * message ("missing: spotify.clientId, spotify.clientSecret"). Unmapped
+ * vars keep their env var name.
+ */
+export function configKeyNames(vars: ConfigHintVar[]): string[] {
+    return vars.map((v) => {
+        const { envVar } = normalize(v);
+        return configPathForEnvVar(envVar) ?? envVar;
+    });
+}

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -4,8 +4,8 @@
 export {
     loadConfig,
     loadConfigSync,
-    reloadConfigSync,
-    tryReloadConfigSync,
+    reloadConfigKeysSync,
+    tryReloadConfigKeysSync,
     getConfigProblems,
     computeConfigDrift,
     resolveLocalConfigPath,
@@ -44,7 +44,19 @@ export {
     configYamlSnippet,
     type ConfigHintVar,
 } from "./hints.js";
-export { fileLinkHref, FILE_LINK_SCHEME } from "./fileLink.js";
+export {
+    fileLinkHref,
+    isAllowedConfigFilePath,
+    FILE_LINK_SCHEME,
+} from "./fileLink.js";
+export {
+    SIMPLE_CONFIG_MAPPINGS,
+    SIMPLE_CONFIG_MAPPING_LIST,
+    simpleConfigMappingForEnvVar,
+    simpleConfigMappingsForSection,
+    type SimpleConfigMapping,
+    type SimpleConfigValueKind,
+} from "./mappings.js";
 export {
     ConfigSetupError,
     configSetupError,

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -44,6 +44,11 @@ export {
     type ConfigHintVar,
 } from "./hints.js";
 export { fileLinkHref, FILE_LINK_SCHEME } from "./fileLink.js";
+export {
+    ConfigSetupError,
+    configSetupError,
+    getErrorMarkdown,
+} from "./setupError.js";
 export { validateConfigTree, configTreeSchema } from "./schema.js";
 export {
     ConfigSource,

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -25,6 +25,15 @@ export {
     REDACTED,
 } from "./redact.js";
 export { runCli, type CliIO, type CliArgs } from "./cli.js";
+export {
+    CONFIG_LOCAL_FILE,
+    CONFIG_SAMPLE_FILE,
+    configKeyNames,
+    configPathForEnvVar,
+    configSetupHint,
+    configYamlSnippet,
+    type ConfigHintVar,
+} from "./hints.js";
 export { validateConfigTree, configTreeSchema } from "./schema.js";
 export {
     ConfigSource,

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -4,8 +4,11 @@
 export {
     loadConfig,
     loadConfigSync,
+    reloadConfigSync,
+    getConfigProblems,
     computeConfigDrift,
     resolveLocalConfigPath,
+    type ConfigProblem,
 } from "./loader.js";
 export { flatten, mergeFlat } from "./flatten.js";
 export {

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export { loadConfig, loadConfigSync, computeConfigDrift } from "./loader.js";
+export {
+    loadConfig,
+    loadConfigSync,
+    computeConfigDrift,
+    resolveLocalConfigPath,
+} from "./loader.js";
 export { flatten, mergeFlat } from "./flatten.js";
 export {
     fetchKeyVaultConfig,
@@ -29,11 +34,13 @@ export {
     CONFIG_LOCAL_FILE,
     CONFIG_SAMPLE_FILE,
     configKeyNames,
+    configLocalFileLink,
     configPathForEnvVar,
     configSetupHint,
     configYamlSnippet,
     type ConfigHintVar,
 } from "./hints.js";
+export { fileLinkHref, FILE_LINK_SCHEME } from "./fileLink.js";
 export { validateConfigTree, configTreeSchema } from "./schema.js";
 export {
     ConfigSource,

--- a/ts/packages/config/src/index.ts
+++ b/ts/packages/config/src/index.ts
@@ -5,6 +5,7 @@ export {
     loadConfig,
     loadConfigSync,
     reloadConfigSync,
+    tryReloadConfigSync,
     getConfigProblems,
     computeConfigDrift,
     resolveLocalConfigPath,

--- a/ts/packages/config/src/loader.ts
+++ b/ts/packages/config/src/loader.ts
@@ -9,7 +9,7 @@ import yaml from "js-yaml";
 import dotenv from "dotenv";
 import registerDebug from "debug";
 
-import { flatten, mergeFlat } from "./flatten.js";
+import { flatten, mergeFlat, type FlattenOptions } from "./flatten.js";
 import { fetchKeyVaultConfig } from "./keyVault.js";
 import { validateConfigTree } from "./schema.js";
 import {
@@ -147,6 +147,53 @@ function readDotEnvFile(filePath: string): FlatEnv {
 }
 
 /**
+ * A top-level section of a config file that failed to convert and was
+ * therefore skipped — most often a leftover `<value>` placeholder or a
+ * value of the wrong type. Reported instead of silently dropping the
+ * whole file, which used to leave everything looking "not configured".
+ */
+export interface ConfigProblem {
+    /** Absolute path of the file the section came from. */
+    readonly file: string;
+    /** Top-level key, e.g. `spotify`. */
+    readonly section: string;
+    /** Converter message, e.g. `Expected a number at 'spotify.port'`. */
+    readonly message: string;
+}
+
+let configProblems: ConfigProblem[] = [];
+const warnedProblems = new Set<string>();
+
+/**
+ * Sections skipped by the most recent load. Setup/readiness checks use
+ * this to explain "you configured it, but the value is invalid" rather
+ * than reporting the setting as missing.
+ */
+export function getConfigProblems(): ConfigProblem[] {
+    return configProblems;
+}
+
+function flattenOptions(file: string): FlattenOptions {
+    // Section errors are always non-fatal: one mistyped value shouldn't
+    // take down the whole file (which reads to the user as "nothing is
+    // configured", the exact confusion this reporting exists to avoid).
+    // File-level errors — unreadable file, invalid YAML — still honor
+    // `strict`.
+    return {
+        onSectionError: (section, error) => {
+            configProblems.push({ file, section, message: error.message });
+            const key = `${file}:${section}:${error.message}`;
+            if (!warnedProblems.has(key)) {
+                warnedProblems.add(key);
+                console.warn(
+                    `Warning: skipping '${section}:' in ${file} — ${error.message}`,
+                );
+            }
+        },
+    };
+}
+
+/**
  * Synchronous loader used by tests and any entry point that cannot
  * await. Reads YAML files and the `.env` fallback only — never reaches
  * out to Key Vault.
@@ -161,6 +208,7 @@ export function loadConfigSync(
     const trackSources = options.trackSources ?? false;
     const populateProcessEnv = options.populateProcessEnv ?? true;
     const strict = options.strict ?? true;
+    configProblems = [];
 
     debug(
         "loading config (defaults=%s, local=%s, dotenv=%s)",
@@ -188,7 +236,7 @@ export function loadConfigSync(
         if (tree) {
             layers.push({
                 source: ConfigSource.Defaults,
-                flat: flatten(tree),
+                flat: flatten(tree, flattenOptions(defaultsPath)),
             });
         }
     } catch (err) {
@@ -202,7 +250,7 @@ export function loadConfigSync(
         if (tree) {
             layers.push({
                 source: ConfigSource.Local,
-                flat: flatten(tree),
+                flat: flatten(tree, flattenOptions(localPath)),
             });
         }
     } catch (err) {
@@ -294,6 +342,9 @@ export async function loadConfig(
 
     debug("loading config with key vault (vault=%s)", vaultName);
 
+    // Discard anything the vault-name pre-pass reported; the layers
+    // below are re-read and re-report on their own.
+    configProblems = [];
     const layers: { source: ConfigSource; flat: FlatEnv }[] = [];
 
     // .env
@@ -318,7 +369,7 @@ export async function loadConfig(
         if (tree) {
             layers.push({
                 source: ConfigSource.KeyVault,
-                flat: flatten(tree),
+                flat: flatten(tree, flattenOptions("key vault")),
             });
         }
     } catch (err) {
@@ -367,7 +418,10 @@ function pushYamlLayer(
     try {
         const tree = readYamlFile(filePath);
         if (tree) {
-            layers.push({ source, flat: flatten(tree) });
+            layers.push({
+                source,
+                flat: flatten(tree, flattenOptions(filePath)),
+            });
         }
     } catch (err) {
         if (strict) throw err;
@@ -407,6 +461,37 @@ function finalize(
     );
 
     return sources !== undefined ? { env: merged, sources } : { env: merged };
+}
+
+/**
+ * Re-read the config files and push any changes into `process.env`.
+ *
+ * Normal loading never clobbers `process.env` (a shell export outranks
+ * the files). A reload is different: it happens because the user just
+ * edited `config.local.yaml` and asked for the new values to take
+ * effect — `@config agent refresh`, say — so the files win for the keys
+ * they define. That also matters for agents running in a forked child,
+ * whose entire `process.env` is a snapshot of the parent taken at fork
+ * time and cannot be told apart from a real shell export.
+ *
+ * Returns the keys whose values actually changed.
+ */
+export function reloadConfigSync(options: LoadConfigOptions = {}): string[] {
+    const { env } = loadConfigSync({
+        strict: false,
+        ...options,
+        populateProcessEnv: false,
+    });
+    const changed: string[] = [];
+    for (const [key, value] of Object.entries(env)) {
+        if (process.env[key] === value) {
+            continue;
+        }
+        process.env[key] = value;
+        changed.push(key);
+    }
+    debug("reloaded config, %d key(s) changed", changed.length);
+    return changed;
 }
 
 /**

--- a/ts/packages/config/src/loader.ts
+++ b/ts/packages/config/src/loader.ts
@@ -72,6 +72,18 @@ interface ResolvedConfigPaths {
 }
 
 /**
+ * Absolute path of the `config.local.yaml` this process would load, resolved
+ * with the same precedence as {@link loadConfigSync}. Used by setup hints so
+ * they can point at (and link to) the actual file on this machine rather than
+ * a generic repo-relative path. Returns the path whether or not it exists.
+ */
+export function resolveLocalConfigPath(
+    options: LoadConfigOptions = {},
+): string {
+    return resolveConfigPaths(options).localPath;
+}
+
+/**
  * Resolve the three config file paths. Precedence per file:
  *   explicit option  >  dedicated env var  >  `<configDir>/<filename>`
  * where `configDir` is, in order:

--- a/ts/packages/config/src/loader.ts
+++ b/ts/packages/config/src/loader.ts
@@ -495,6 +495,26 @@ export function reloadConfigSync(options: LoadConfigOptions = {}): string[] {
 }
 
 /**
+ * `reloadConfigSync` for callers that must not fail because of it: a
+ * broken or unreadable config file leaves whatever was loaded at startup
+ * in place rather than turning "your Spotify settings are missing" into
+ * an unrelated parse error. Returns the keys that changed, or none.
+ *
+ * This is what agents should call before reading their settings. An agent
+ * process is forked with a snapshot of `process.env`, so without a reload
+ * it can never observe an edit the user made after startup — which is
+ * exactly what `@config agent refresh <agent>` promises to pick up.
+ */
+export function tryReloadConfigSync(options: LoadConfigOptions = {}): string[] {
+    try {
+        return reloadConfigSync(options);
+    } catch (e: any) {
+        debug("config reload failed: %s", e?.message ?? e);
+        return [];
+    }
+}
+
+/**
  * Merge a flat env map into `process.env`. Existing values in
  * `process.env` are preserved — they sit at higher precedence than
  * any config file (matching how `dotenv.config()` behaved). This

--- a/ts/packages/config/src/loader.ts
+++ b/ts/packages/config/src/loader.ts
@@ -71,6 +71,8 @@ interface ResolvedConfigPaths {
     dotEnvPath: string;
 }
 
+type ConfigLayer = { source: ConfigSource; flat: FlatEnv };
+
 /**
  * Absolute path of the `config.local.yaml` this process would load, resolved
  * with the same precedence as {@link loadConfigSync}. Used by setup hints so
@@ -217,7 +219,7 @@ export function loadConfigSync(
         dotEnvPath,
     );
 
-    const layers: { source: ConfigSource; flat: FlatEnv }[] = [];
+    const layers: ConfigLayer[] = [];
 
     // .env (legacy fallback, lowest precedence)
     try {
@@ -276,6 +278,7 @@ export function loadConfigSync(
     }
 
     if (populateProcessEnv) {
+        rememberReloadState(localPath, layers);
         applyToProcessEnv(merged, sources);
     }
 
@@ -380,7 +383,7 @@ export async function loadConfig(
     // local
     pushYamlLayer(layers, ConfigSource.Local, localPath, strict);
 
-    return finalize(layers, populateProcessEnv, trackSources);
+    return finalize(layers, populateProcessEnv, trackSources, localPath);
 }
 
 /**
@@ -434,9 +437,10 @@ function pushYamlLayer(
  * and (optionally) push the result into `process.env`.
  */
 function finalize(
-    layers: { source: ConfigSource; flat: FlatEnv }[],
+    layers: ConfigLayer[],
     populateProcessEnv: boolean,
     trackSources: boolean,
+    localPath?: string,
 ): LoadConfigResult {
     const merged: FlatEnv = mergeFlat(...layers.map((l) => l.flat));
 
@@ -451,6 +455,9 @@ function finalize(
     }
 
     if (populateProcessEnv) {
+        if (localPath !== undefined) {
+            rememberReloadState(localPath, layers);
+        }
         applyToProcessEnv(merged, sources);
     }
 
@@ -463,31 +470,110 @@ function finalize(
     return sources !== undefined ? { env: merged, sources } : { env: merged };
 }
 
+interface ReloadState {
+    readonly inheritedValue: string | undefined;
+    readonly restoreInheritedValue: boolean;
+}
+
+const reloadState = new Map<string, ReloadState>();
+
+function rememberReloadState(
+    localPath: string,
+    layers: readonly ConfigLayer[],
+): void {
+    const local =
+        layers.find(({ source }) => source === ConfigSource.Local)?.flat ?? {};
+    const lower = mergeFlat(
+        ...layers
+            .filter(({ source }) => source !== ConfigSource.Local)
+            .map(({ flat }) => flat),
+    );
+    const lowerSources: SourceMap = {};
+    for (const layer of layers) {
+        if (layer.source === ConfigSource.Local) {
+            continue;
+        }
+        for (const key of Object.keys(layer.flat)) {
+            lowerSources[key] = layer.source;
+        }
+    }
+    const keys = new Set([...Object.keys(lower), ...Object.keys(local)]);
+    for (const key of keys) {
+        const stateKey = `${localPath}\0${key}`;
+        if (reloadState.has(stateKey)) {
+            continue;
+        }
+        const current = process.env[key];
+        const processValueWins =
+            current !== undefined && current !== local[key];
+        reloadState.set(stateKey, {
+            inheritedValue: processValueWins ? current : lower[key],
+            restoreInheritedValue:
+                processValueWins || lowerSources[key] === ConfigSource.KeyVault,
+        });
+    }
+}
+
 /**
- * Re-read the config files and push any changes into `process.env`.
+ * Re-read only the legacy env keys used by one agent.
  *
- * Normal loading never clobbers `process.env` (a shell export outranks
- * the files). A reload is different: it happens because the user just
- * edited `config.local.yaml` and asked for the new values to take
- * effect — `@config agent refresh`, say — so the files win for the keys
- * they define. That also matters for agents running in a forked child,
- * whose entire `process.env` is a snapshot of the parent taken at fork
- * time and cannot be told apart from a real shell export.
- *
- * Returns the keys whose values actually changed.
+ * Local values override the inherited startup value while present. Removing a
+ * local override restores that inherited value (including a value populated by
+ * Key Vault in the parent process), or deletes the key when no inherited value
+ * existed. Keys outside `keys` are never changed.
  */
-export function reloadConfigSync(options: LoadConfigOptions = {}): string[] {
-    const { env } = loadConfigSync({
-        strict: false,
+export function reloadConfigKeysSync(
+    keys: readonly string[],
+    options: LoadConfigOptions = {},
+): string[] {
+    const paths = resolveConfigPaths(options);
+    loadConfigSync({
         ...options,
+        strict: true,
         populateProcessEnv: false,
     });
+    const localTree = readYamlFile(paths.localPath);
+    const local = localTree
+        ? flatten(localTree, { onSectionError: () => {} })
+        : {};
+    const defaultsTree = readYamlFile(paths.defaultsPath);
+    const lower = mergeFlat(
+        readDotEnvFile(paths.dotEnvPath),
+        defaultsTree
+            ? flatten(defaultsTree, flattenOptions(paths.defaultsPath))
+            : {},
+    );
     const changed: string[] = [];
-    for (const [key, value] of Object.entries(env)) {
+    for (const key of keys) {
+        const stateKey = `${paths.localPath}\0${key}`;
+        let state = reloadState.get(stateKey);
+        if (state === undefined) {
+            const current = process.env[key];
+            const localValue = local[key];
+            const lowerValue = lower[key];
+            state = {
+                inheritedValue:
+                    current !== undefined && current !== localValue
+                        ? current
+                        : lowerValue,
+                restoreInheritedValue:
+                    current !== undefined &&
+                    current !== localValue &&
+                    current !== lowerValue,
+            };
+            reloadState.set(stateKey, state);
+        }
+        const value =
+            local[key] ??
+            (state.restoreInheritedValue ? state.inheritedValue : lower[key]);
         if (process.env[key] === value) {
             continue;
         }
-        process.env[key] = value;
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
         changed.push(key);
     }
     debug("reloaded config, %d key(s) changed", changed.length);
@@ -495,7 +581,7 @@ export function reloadConfigSync(options: LoadConfigOptions = {}): string[] {
 }
 
 /**
- * `reloadConfigSync` for callers that must not fail because of it: a
+ * Scoped reload for callers that must not fail because of it: a
  * broken or unreadable config file leaves whatever was loaded at startup
  * in place rather than turning "your Spotify settings are missing" into
  * an unrelated parse error. Returns the keys that changed, or none.
@@ -505,9 +591,12 @@ export function reloadConfigSync(options: LoadConfigOptions = {}): string[] {
  * it can never observe an edit the user made after startup — which is
  * exactly what `@config agent refresh <agent>` promises to pick up.
  */
-export function tryReloadConfigSync(options: LoadConfigOptions = {}): string[] {
+export function tryReloadConfigKeysSync(
+    keys: readonly string[],
+    options: LoadConfigOptions = {},
+): string[] {
     try {
-        return reloadConfigSync(options);
+        return reloadConfigKeysSync(keys, options);
     } catch (e: any) {
         debug("config reload failed: %s", e?.message ?? e);
         return [];

--- a/ts/packages/config/src/mappings.ts
+++ b/ts/packages/config/src/mappings.ts
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type SimpleConfigValueKind = "string" | "number" | "auth";
+
+export interface SimpleConfigMapping {
+    readonly envVar: string;
+    readonly configPath: string;
+    readonly valueKind: SimpleConfigValueKind;
+    readonly omitEmptyInProjection?: boolean;
+}
+
+/**
+ * Static leaf mappings shared by setup hints and the typed runtime converters.
+ * Complex and pattern-based sections, such as Azure OpenAI deployments, remain
+ * in their procedural converters.
+ */
+export const SIMPLE_CONFIG_MAPPINGS = {
+    spotifyClientId: {
+        envVar: "SPOTIFY_APP_CLI",
+        configPath: "spotify.clientId",
+        valueKind: "string",
+    },
+    spotifyClientSecret: {
+        envVar: "SPOTIFY_APP_CLISEC",
+        configPath: "spotify.clientSecret",
+        valueKind: "string",
+    },
+    spotifyPort: {
+        envVar: "SPOTIFY_APP_PORT",
+        configPath: "spotify.port",
+        valueKind: "number",
+    },
+    msGraphClientId: {
+        envVar: "MSGRAPH_APP_CLIENTID",
+        configPath: "msGraph.clientId",
+        valueKind: "string",
+    },
+    msGraphClientSecret: {
+        envVar: "MSGRAPH_APP_CLIENTSECRET",
+        configPath: "msGraph.clientSecret",
+        valueKind: "string",
+    },
+    msGraphTenantId: {
+        envVar: "MSGRAPH_APP_TENANTID",
+        configPath: "msGraph.tenantId",
+        valueKind: "string",
+    },
+    msGraphUsername: {
+        envVar: "MSGRAPH_APP_USERNAME",
+        configPath: "msGraph.username",
+        valueKind: "string",
+    },
+    msGraphPassword: {
+        envVar: "MSGRAPH_APP_PASSWD",
+        configPath: "msGraph.password",
+        valueKind: "string",
+    },
+    googleCalendarClientId: {
+        envVar: "GOOGLE_CALENDAR_CLIENT_ID",
+        configPath: "googleCalendar.clientId",
+        valueKind: "string",
+    },
+    googleCalendarClientSecret: {
+        envVar: "GOOGLE_CALENDAR_CLIENT_SECRET",
+        configPath: "googleCalendar.clientSecret",
+        valueKind: "string",
+    },
+    speechAuth: {
+        envVar: "SPEECH_SDK_KEY",
+        configPath: "speech.auth",
+        valueKind: "auth",
+    },
+    speechRegion: {
+        envVar: "SPEECH_SDK_REGION",
+        configPath: "speech.region",
+        valueKind: "string",
+    },
+    speechEndpoint: {
+        envVar: "SPEECH_SDK_ENDPOINT",
+        configPath: "speech.endpoint",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    mapsClientId: {
+        envVar: "AZURE_MAPS_CLIENTID",
+        configPath: "maps.clientId",
+        valueKind: "string",
+    },
+    mapsEndpoint: {
+        envVar: "AZURE_MAPS_ENDPOINT",
+        configPath: "maps.endpoint",
+        valueKind: "string",
+    },
+    wikipediaClientId: {
+        envVar: "WIKIPEDIA_CLIENT_ID",
+        configPath: "wikipedia.clientId",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    wikipediaClientSecret: {
+        envVar: "WIKIPEDIA_CLIENT_SECRET",
+        configPath: "wikipedia.clientSecret",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    wikipediaEndpoint: {
+        envVar: "WIKIPEDIA_ENDPOINT",
+        configPath: "wikipedia.endpoint",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    azureStorageAccount: {
+        envVar: "AZURE_STORAGE_ACCOUNT",
+        configPath: "storage.azure.account",
+        valueKind: "string",
+    },
+    azureStorageContainer: {
+        envVar: "AZURE_STORAGE_CONTAINER",
+        configPath: "storage.azure.container",
+        valueKind: "string",
+    },
+    awsStorageBucketName: {
+        envVar: "AWS_S3_BUCKET_NAME",
+        configPath: "storage.aws.bucketName",
+        valueKind: "string",
+    },
+    awsStorageRegion: {
+        envVar: "AWS_S3_REGION",
+        configPath: "storage.aws.region",
+        valueKind: "string",
+    },
+    awsStorageAccessKeyId: {
+        envVar: "AWS_ACCESS_KEY_ID",
+        configPath: "storage.aws.accessKeyId",
+        valueKind: "string",
+    },
+    awsStorageSecretAccessKey: {
+        envVar: "AWS_SECRET_ACCESS_KEY",
+        configPath: "storage.aws.secretAccessKey",
+        valueKind: "string",
+    },
+    cosmosDbConnectionString: {
+        envVar: "COSMOSDB_CONNECTION_STRING",
+        configPath: "storage.database.cosmosDbConnectionString",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    mongoDbConnectionString: {
+        envVar: "MONGODB_CONNECTION_STRING",
+        configPath: "storage.database.mongoDbConnectionString",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+    sharedVault: {
+        envVar: "TYPEAGENT_SHAREDVAULT",
+        configPath: "vault.shared",
+        valueKind: "string",
+        omitEmptyInProjection: true,
+    },
+} as const satisfies Record<string, SimpleConfigMapping>;
+
+export const SIMPLE_CONFIG_MAPPING_LIST: readonly SimpleConfigMapping[] =
+    Object.values(SIMPLE_CONFIG_MAPPINGS);
+
+const CONFIG_MAPPING_BY_ENV_VAR = new Map(
+    SIMPLE_CONFIG_MAPPING_LIST.map((mapping) => [mapping.envVar, mapping]),
+);
+
+export function simpleConfigMappingForEnvVar(
+    envVar: string,
+): SimpleConfigMapping | undefined {
+    return CONFIG_MAPPING_BY_ENV_VAR.get(envVar);
+}
+
+export function simpleConfigMappingsForSection(
+    section: string,
+): readonly SimpleConfigMapping[] {
+    const prefix = `${section}.`;
+    return SIMPLE_CONFIG_MAPPING_LIST.filter((mapping) =>
+        mapping.configPath.startsWith(prefix),
+    );
+}

--- a/ts/packages/config/src/runtime/build.ts
+++ b/ts/packages/config/src/runtime/build.ts
@@ -21,6 +21,7 @@
  */
 
 import type { FlatEnv } from "../types.js";
+import { SIMPLE_CONFIG_MAPPINGS as MAPPING } from "../mappings.js";
 import {
     isRegion,
     regionFromEnvSuffix,
@@ -614,16 +615,17 @@ function buildOpenAIVariant(flat: Map<string, string>, suffix: string) {
 }
 
 function buildSpeech(flat: Map<string, string>) {
-    const keyRaw = popString(flat, "SPEECH_SDK_KEY");
-    const region = popString(flat, "SPEECH_SDK_REGION");
-    const endpoint = popString(flat, "SPEECH_SDK_ENDPOINT");
+    const keyRaw = popString(flat, MAPPING.speechAuth.envVar);
+    const region = popString(flat, MAPPING.speechRegion.envVar);
+    const endpoint = popString(flat, MAPPING.speechEndpoint.envVar);
     if (!region) return undefined;
     if (!isRegion(region)) {
         // Unknown region — leave the keys in `extra` rather than
         // producing a malformed typed object.
-        if (keyRaw !== undefined) flat.set("SPEECH_SDK_KEY", keyRaw);
-        flat.set("SPEECH_SDK_REGION", region);
-        if (endpoint !== undefined) flat.set("SPEECH_SDK_ENDPOINT", endpoint);
+        if (keyRaw !== undefined) flat.set(MAPPING.speechAuth.envVar, keyRaw);
+        flat.set(MAPPING.speechRegion.envVar, region);
+        if (endpoint !== undefined)
+            flat.set(MAPPING.speechEndpoint.envVar, endpoint);
         return undefined;
     }
     return {
@@ -634,22 +636,24 @@ function buildSpeech(flat: Map<string, string>) {
 }
 
 function buildMaps(flat: Map<string, string>) {
-    const clientId = popString(flat, "AZURE_MAPS_CLIENTID");
-    const endpoint = popString(flat, "AZURE_MAPS_ENDPOINT");
+    const clientId = popString(flat, MAPPING.mapsClientId.envVar);
+    const endpoint = popString(flat, MAPPING.mapsEndpoint.envVar);
     if (!clientId || !endpoint) {
-        if (clientId !== undefined) flat.set("AZURE_MAPS_CLIENTID", clientId);
-        if (endpoint !== undefined) flat.set("AZURE_MAPS_ENDPOINT", endpoint);
+        if (clientId !== undefined)
+            flat.set(MAPPING.mapsClientId.envVar, clientId);
+        if (endpoint !== undefined)
+            flat.set(MAPPING.mapsEndpoint.envVar, endpoint);
         return undefined;
     }
     return { clientId, endpoint };
 }
 
 function buildMsGraph(flat: Map<string, string>) {
-    const clientId = popString(flat, "MSGRAPH_APP_CLIENTID");
-    const clientSecret = popString(flat, "MSGRAPH_APP_CLIENTSECRET");
-    const tenantId = popString(flat, "MSGRAPH_APP_TENANTID");
-    const username = popString(flat, "MSGRAPH_APP_USERNAME");
-    const password = popString(flat, "MSGRAPH_APP_PASSWD");
+    const clientId = popString(flat, MAPPING.msGraphClientId.envVar);
+    const clientSecret = popString(flat, MAPPING.msGraphClientSecret.envVar);
+    const tenantId = popString(flat, MAPPING.msGraphTenantId.envVar);
+    const username = popString(flat, MAPPING.msGraphUsername.envVar);
+    const password = popString(flat, MAPPING.msGraphPassword.envVar);
     if (!clientId && !clientSecret && !tenantId) return undefined;
     return {
         clientId: clientId ?? "",
@@ -661,16 +665,19 @@ function buildMsGraph(flat: Map<string, string>) {
 }
 
 function buildGoogleCalendar(flat: Map<string, string>) {
-    const clientId = popString(flat, "GOOGLE_CALENDAR_CLIENT_ID");
-    const clientSecret = popString(flat, "GOOGLE_CALENDAR_CLIENT_SECRET");
+    const clientId = popString(flat, MAPPING.googleCalendarClientId.envVar);
+    const clientSecret = popString(
+        flat,
+        MAPPING.googleCalendarClientSecret.envVar,
+    );
     if (!clientId || !clientSecret) return undefined;
     return { clientId, clientSecret };
 }
 
 function buildSpotify(flat: Map<string, string>) {
-    const clientId = popString(flat, "SPOTIFY_APP_CLI");
-    const clientSecret = popString(flat, "SPOTIFY_APP_CLISEC");
-    const portStr = popString(flat, "SPOTIFY_APP_PORT");
+    const clientId = popString(flat, MAPPING.spotifyClientId.envVar);
+    const clientSecret = popString(flat, MAPPING.spotifyClientSecret.envVar);
+    const portStr = popString(flat, MAPPING.spotifyPort.envVar);
     if (!clientId || !clientSecret) return undefined;
     const port = portStr ? parseInt(portStr, 10) : 9999;
     return {
@@ -681,9 +688,9 @@ function buildSpotify(flat: Map<string, string>) {
 }
 
 function buildWikipedia(flat: Map<string, string>) {
-    const clientId = popString(flat, "WIKIPEDIA_CLIENT_ID");
-    const clientSecret = popString(flat, "WIKIPEDIA_CLIENT_SECRET");
-    const endpoint = popString(flat, "WIKIPEDIA_ENDPOINT");
+    const clientId = popString(flat, MAPPING.wikipediaClientId.envVar);
+    const clientSecret = popString(flat, MAPPING.wikipediaClientSecret.envVar);
+    const endpoint = popString(flat, MAPPING.wikipediaEndpoint.envVar);
     if (!clientId && !clientSecret && !endpoint) return undefined;
     return {
         clientId: clientId ?? "",
@@ -693,20 +700,23 @@ function buildWikipedia(flat: Map<string, string>) {
 }
 
 function buildStorage(flat: Map<string, string>) {
-    const azureAccount = popString(flat, "AZURE_STORAGE_ACCOUNT");
-    const azureContainer = popString(flat, "AZURE_STORAGE_CONTAINER");
+    const azureAccount = popString(flat, MAPPING.azureStorageAccount.envVar);
+    const azureContainer = popString(
+        flat,
+        MAPPING.azureStorageContainer.envVar,
+    );
     const cosmosDbConnectionString = popString(
         flat,
-        "COSMOSDB_CONNECTION_STRING",
+        MAPPING.cosmosDbConnectionString.envVar,
     );
     const mongoDbConnectionString = popString(
         flat,
-        "MONGODB_CONNECTION_STRING",
+        MAPPING.mongoDbConnectionString.envVar,
     );
-    const awsBucket = popString(flat, "AWS_S3_BUCKET_NAME");
-    const awsRegion = popString(flat, "AWS_S3_REGION");
-    const awsAccessKey = popString(flat, "AWS_ACCESS_KEY_ID");
-    const awsSecret = popString(flat, "AWS_SECRET_ACCESS_KEY");
+    const awsBucket = popString(flat, MAPPING.awsStorageBucketName.envVar);
+    const awsRegion = popString(flat, MAPPING.awsStorageRegion.envVar);
+    const awsAccessKey = popString(flat, MAPPING.awsStorageAccessKeyId.envVar);
+    const awsSecret = popString(flat, MAPPING.awsStorageSecretAccessKey.envVar);
 
     const azure =
         azureAccount && azureContainer
@@ -749,7 +759,7 @@ function buildStorage(flat: Map<string, string>) {
 }
 
 function buildVault(flat: Map<string, string>) {
-    const shared = popString(flat, "TYPEAGENT_SHAREDVAULT");
+    const shared = popString(flat, MAPPING.sharedVault.envVar);
     if (!shared) return undefined;
     return { shared };
 }

--- a/ts/packages/config/src/runtime/shim.ts
+++ b/ts/packages/config/src/runtime/shim.ts
@@ -17,6 +17,7 @@
  */
 
 import { regionToEnvSuffix } from "./regions.js";
+import { SIMPLE_CONFIG_MAPPING_LIST } from "../mappings.js";
 import {
     AuthMode,
     Config,
@@ -35,6 +36,33 @@ export type EnvOutput = Record<string, string>;
  */
 function authToString(auth: AuthMode): string {
     return auth.kind === "identity" ? "identity" : auth.value;
+}
+
+function emitSimpleConfigMappings(config: Config, out: EnvOutput): void {
+    for (const mapping of SIMPLE_CONFIG_MAPPING_LIST) {
+        let value: unknown = config;
+        for (const segment of mapping.configPath.split(".")) {
+            if (
+                value === undefined ||
+                value === null ||
+                typeof value !== "object"
+            ) {
+                value = undefined;
+                break;
+            }
+            value = (value as Record<string, unknown>)[segment];
+        }
+        if (
+            value === undefined ||
+            (mapping.omitEmptyInProjection && value === "")
+        ) {
+            continue;
+        }
+        out[mapping.envVar] =
+            mapping.valueKind === "auth"
+                ? authToString(value as AuthMode)
+                : String(value);
+    }
 }
 
 function emitEndpoint(
@@ -147,84 +175,7 @@ export function configToEnv(config: Config): EnvOutput {
         emitDeployment(out, deployment);
     }
 
-    // Speech.
-    if (config.speech) {
-        out.SPEECH_SDK_KEY = authToString(config.speech.auth);
-        out.SPEECH_SDK_REGION = config.speech.region;
-        if (config.speech.endpoint) {
-            out.SPEECH_SDK_ENDPOINT = config.speech.endpoint;
-        }
-    }
-
-    // Maps.
-    if (config.maps) {
-        out.AZURE_MAPS_CLIENTID = config.maps.clientId;
-        out.AZURE_MAPS_ENDPOINT = config.maps.endpoint;
-    }
-
-    // Microsoft Graph.
-    if (config.msGraph) {
-        out.MSGRAPH_APP_CLIENTID = config.msGraph.clientId;
-        out.MSGRAPH_APP_CLIENTSECRET = config.msGraph.clientSecret;
-        out.MSGRAPH_APP_TENANTID = config.msGraph.tenantId;
-        if (config.msGraph.username !== undefined) {
-            out.MSGRAPH_APP_USERNAME = config.msGraph.username;
-        }
-        if (config.msGraph.password !== undefined) {
-            out.MSGRAPH_APP_PASSWD = config.msGraph.password;
-        }
-    }
-
-    // Google Calendar.
-    if (config.googleCalendar) {
-        out.GOOGLE_CALENDAR_CLIENT_ID = config.googleCalendar.clientId;
-        out.GOOGLE_CALENDAR_CLIENT_SECRET = config.googleCalendar.clientSecret;
-    }
-
-    // Spotify.
-    if (config.spotify) {
-        out.SPOTIFY_APP_CLI = config.spotify.clientId;
-        out.SPOTIFY_APP_CLISEC = config.spotify.clientSecret;
-        out.SPOTIFY_APP_PORT = String(config.spotify.port);
-    }
-
-    // Wikipedia.
-    if (config.wikipedia) {
-        if (config.wikipedia.clientId) {
-            out.WIKIPEDIA_CLIENT_ID = config.wikipedia.clientId;
-        }
-        if (config.wikipedia.clientSecret) {
-            out.WIKIPEDIA_CLIENT_SECRET = config.wikipedia.clientSecret;
-        }
-        if (config.wikipedia.endpoint) {
-            out.WIKIPEDIA_ENDPOINT = config.wikipedia.endpoint;
-        }
-    }
-
-    // Storage.
-    if (config.storage.azure) {
-        out.AZURE_STORAGE_ACCOUNT = config.storage.azure.account;
-        out.AZURE_STORAGE_CONTAINER = config.storage.azure.container;
-    }
-    if (config.storage.aws) {
-        out.AWS_S3_BUCKET_NAME = config.storage.aws.bucketName;
-        out.AWS_S3_REGION = config.storage.aws.region;
-        out.AWS_ACCESS_KEY_ID = config.storage.aws.accessKeyId;
-        out.AWS_SECRET_ACCESS_KEY = config.storage.aws.secretAccessKey;
-    }
-    if (config.storage.database?.cosmosDbConnectionString) {
-        out.COSMOSDB_CONNECTION_STRING =
-            config.storage.database.cosmosDbConnectionString;
-    }
-    if (config.storage.database?.mongoDbConnectionString) {
-        out.MONGODB_CONNECTION_STRING =
-            config.storage.database.mongoDbConnectionString;
-    }
-
-    // Vault.
-    if (config.vault?.shared) {
-        out.TYPEAGENT_SHAREDVAULT = config.vault.shared;
-    }
+    emitSimpleConfigMappings(config, out);
 
     // OpenAI (main + named variants like LOCAL).
     if (config.openAI) {

--- a/ts/packages/config/src/runtime/tree.ts
+++ b/ts/packages/config/src/runtime/tree.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ConfigTree, FlatEnv } from "../types.js";
+import { simpleConfigMappingsForSection } from "../mappings.js";
 import { regionFromUrl, regionToEnvSuffix } from "./regions.js";
 import { buildConfig } from "./build.js";
 import {
@@ -877,129 +878,65 @@ function emitOpenAIVariant(
         );
 }
 
-function emitSpeech(node: unknown, out: FlatEnv): void {
-    const s = asObject(node, "speech");
-    if (s.auth !== undefined)
-        out.SPEECH_SDK_KEY = authToYaml(readAuth(s.auth, "speech.auth"));
-    if (s.region !== undefined)
-        out.SPEECH_SDK_REGION = asString(s.region, "speech.region");
-    if (s.endpoint !== undefined)
-        out.SPEECH_SDK_ENDPOINT = asString(s.endpoint, "speech.endpoint");
+function emitSimpleMappedSection(
+    section: string,
+    node: unknown,
+    out: FlatEnv,
+    onLeafError?: (error: Error) => void,
+): void {
+    const sectionNode = asObject(node, section);
+    for (const mapping of simpleConfigMappingsForSection(section)) {
+        const segments = mapping.configPath.split(".").slice(1);
+        let parent = sectionNode;
+        let where = section;
+        let missing = false;
+        for (const segment of segments.slice(0, -1)) {
+            where += `.${segment}`;
+            const child = parent[segment];
+            if (child === undefined) {
+                missing = true;
+                break;
+            }
+            parent = asObject(child, where);
+        }
+        if (missing) continue;
+
+        const value = parent[segments[segments.length - 1]];
+        if (value === undefined) continue;
+        try {
+            switch (mapping.valueKind) {
+                case "auth":
+                    out[mapping.envVar] = authToYaml(
+                        readAuth(value, mapping.configPath),
+                    );
+                    break;
+                case "number":
+                    out[mapping.envVar] = String(
+                        asNumber(value, mapping.configPath),
+                    );
+                    break;
+                case "string":
+                    out[mapping.envVar] = asString(value, mapping.configPath);
+                    break;
+            }
+        } catch (error) {
+            if (onLeafError === undefined) {
+                throw error;
+            }
+            onLeafError(
+                error instanceof Error ? error : new Error(String(error)),
+            );
+        }
+    }
 }
 
-function emitMaps(node: unknown, out: FlatEnv): void {
-    const m = asObject(node, "maps");
-    if (m.clientId !== undefined)
-        out.AZURE_MAPS_CLIENTID = asString(m.clientId, "maps.clientId");
-    if (m.endpoint !== undefined)
-        out.AZURE_MAPS_ENDPOINT = asString(m.endpoint, "maps.endpoint");
-}
-
-function emitMsGraph(node: unknown, out: FlatEnv): void {
-    const m = asObject(node, "msGraph");
-    if (m.clientId !== undefined)
-        out.MSGRAPH_APP_CLIENTID = asString(m.clientId, "msGraph.clientId");
-    if (m.clientSecret !== undefined)
-        out.MSGRAPH_APP_CLIENTSECRET = asString(
-            m.clientSecret,
-            "msGraph.clientSecret",
-        );
-    if (m.tenantId !== undefined)
-        out.MSGRAPH_APP_TENANTID = asString(m.tenantId, "msGraph.tenantId");
-    if (m.username !== undefined)
-        out.MSGRAPH_APP_USERNAME = asString(m.username, "msGraph.username");
-    if (m.password !== undefined)
-        out.MSGRAPH_APP_PASSWD = asString(m.password, "msGraph.password");
-}
-
-function emitGoogleCalendar(node: unknown, out: FlatEnv): void {
-    const g = asObject(node, "googleCalendar");
-    if (g.clientId !== undefined)
-        out.GOOGLE_CALENDAR_CLIENT_ID = asString(
-            g.clientId,
-            "googleCalendar.clientId",
-        );
-    if (g.clientSecret !== undefined)
-        out.GOOGLE_CALENDAR_CLIENT_SECRET = asString(
-            g.clientSecret,
-            "googleCalendar.clientSecret",
-        );
-}
-
-function emitSpotify(node: unknown, out: FlatEnv): void {
-    const s = asObject(node, "spotify");
-    if (s.clientId !== undefined)
-        out.SPOTIFY_APP_CLI = asString(s.clientId, "spotify.clientId");
-    if (s.clientSecret !== undefined)
-        out.SPOTIFY_APP_CLISEC = asString(
-            s.clientSecret,
-            "spotify.clientSecret",
-        );
-    if (s.port !== undefined)
-        out.SPOTIFY_APP_PORT = String(asNumber(s.port, "spotify.port"));
-}
-
-function emitWikipedia(node: unknown, out: FlatEnv): void {
-    const w = asObject(node, "wikipedia");
-    if (w.clientId !== undefined)
-        out.WIKIPEDIA_CLIENT_ID = asString(w.clientId, "wikipedia.clientId");
-    if (w.clientSecret !== undefined)
-        out.WIKIPEDIA_CLIENT_SECRET = asString(
-            w.clientSecret,
-            "wikipedia.clientSecret",
-        );
-    if (w.endpoint !== undefined)
-        out.WIKIPEDIA_ENDPOINT = asString(w.endpoint, "wikipedia.endpoint");
-}
-
-function emitStorage(node: unknown, out: FlatEnv): void {
+function emitStorage(
+    node: unknown,
+    out: FlatEnv,
+    onLeafError?: (error: Error) => void,
+): void {
     const s = asObject(node, "storage");
-    if (s.azure !== undefined) {
-        const a = asObject(s.azure, "storage.azure");
-        if (a.account !== undefined)
-            out.AZURE_STORAGE_ACCOUNT = asString(
-                a.account,
-                "storage.azure.account",
-            );
-        if (a.container !== undefined)
-            out.AZURE_STORAGE_CONTAINER = asString(
-                a.container,
-                "storage.azure.container",
-            );
-    }
-    if (s.aws !== undefined) {
-        const a = asObject(s.aws, "storage.aws");
-        if (a.bucketName !== undefined)
-            out.AWS_S3_BUCKET_NAME = asString(
-                a.bucketName,
-                "storage.aws.bucketName",
-            );
-        if (a.region !== undefined)
-            out.AWS_S3_REGION = asString(a.region, "storage.aws.region");
-        if (a.accessKeyId !== undefined)
-            out.AWS_ACCESS_KEY_ID = asString(
-                a.accessKeyId,
-                "storage.aws.accessKeyId",
-            );
-        if (a.secretAccessKey !== undefined)
-            out.AWS_SECRET_ACCESS_KEY = asString(
-                a.secretAccessKey,
-                "storage.aws.secretAccessKey",
-            );
-    }
-    if (s.database !== undefined) {
-        const d = asObject(s.database, "storage.database");
-        if (d.cosmosDbConnectionString !== undefined)
-            out.COSMOSDB_CONNECTION_STRING = asString(
-                d.cosmosDbConnectionString,
-                "storage.database.cosmosDbConnectionString",
-            );
-        if (d.mongoDbConnectionString !== undefined)
-            out.MONGODB_CONNECTION_STRING = asString(
-                d.mongoDbConnectionString,
-                "storage.database.mongoDbConnectionString",
-            );
-    }
+    emitSimpleMappedSection("storage", node, out, onLeafError);
     if (s.elastic !== undefined) {
         const e = asObject(s.elastic, "storage.elastic");
         if (e.apiKey !== undefined)
@@ -1007,12 +944,6 @@ function emitStorage(node: unknown, out: FlatEnv): void {
         if (e.uri !== undefined)
             out.ELASTIC_URI = asString(e.uri, "storage.elastic.uri");
     }
-}
-
-function emitVault(node: unknown, out: FlatEnv): void {
-    const v = asObject(node, "vault");
-    if (v.shared !== undefined)
-        out.TYPEAGENT_SHAREDVAULT = asString(v.shared, "vault.shared");
 }
 
 function emitAzureFoundry(node: unknown, out: FlatEnv): void {
@@ -1152,7 +1083,11 @@ function emitReasoning(node: unknown, out: FlatEnv): void {
  * `configToEnv` but operating on the YAML object form (no Map types,
  * regions as object keys).
  */
-export function typedSectionToFlat(key: string, node: unknown): FlatEnv {
+export function typedSectionToFlat(
+    key: string,
+    node: unknown,
+    onLeafError?: (error: Error) => void,
+): FlatEnv {
     const out: FlatEnv = {};
     switch (key) {
         case "azureOpenAI":
@@ -1162,28 +1097,28 @@ export function typedSectionToFlat(key: string, node: unknown): FlatEnv {
             emitOpenAI(node, out);
             break;
         case "speech":
-            emitSpeech(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "maps":
-            emitMaps(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "msGraph":
-            emitMsGraph(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "googleCalendar":
-            emitGoogleCalendar(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "spotify":
-            emitSpotify(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "wikipedia":
-            emitWikipedia(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "storage":
-            emitStorage(node, out);
+            emitStorage(node, out, onLeafError);
             break;
         case "vault":
-            emitVault(node, out);
+            emitSimpleMappedSection(key, node, out, onLeafError);
             break;
         case "azureFoundry":
             emitAzureFoundry(node, out);

--- a/ts/packages/config/src/setupError.ts
+++ b/ts/packages/config/src/setupError.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { configSetupHint, type ConfigHintVar } from "./hints.js";
+
+/**
+ * Thrown when an agent can't run because required settings are missing
+ * from the config files.
+ *
+ * `message` is the one-line plain-text summary that logs and non-display
+ * consumers see. `markdown` carries the full actionable version — the file
+ * link and the YAML snippet to paste — which only reads correctly when
+ * rendered as markdown. The chat hosts pick `markdown` up (it survives the
+ * agent-process RPC boundary) and fall back to `message` when they can't
+ * render markdown.
+ */
+export class ConfigSetupError extends Error {
+    public readonly markdown: string;
+    constructor(message: string, markdown: string) {
+        super(message);
+        this.name = "ConfigSetupError";
+        this.markdown = markdown;
+    }
+}
+
+/**
+ * A `ConfigSetupError` whose markdown is the summary followed by the
+ * standard "add this to config.local.yaml" hint for `vars`.
+ */
+export function configSetupError(
+    message: string,
+    vars: ConfigHintVar[],
+    note?: string,
+): ConfigSetupError {
+    return new ConfigSetupError(
+        message,
+        `${message}\n\n${configSetupHint(vars, note)}`,
+    );
+}
+
+/**
+ * The markdown an error wants displayed, or undefined when it carries none
+ * (in which case callers should fall back to the plain message).
+ *
+ * Duck-typed rather than an `instanceof` check: errors are rebuilt on the
+ * far side of the agent RPC boundary, and more than one package defines a
+ * markdown-carrying error.
+ */
+export function getErrorMarkdown(e: unknown): string | undefined {
+    const markdown = (e as { markdown?: unknown } | undefined)?.markdown;
+    return typeof markdown === "string" && markdown.length > 0
+        ? markdown
+        : undefined;
+}

--- a/ts/packages/config/test/fileLink.spec.ts
+++ b/ts/packages/config/test/fileLink.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import path from "node:path";
+import { isAllowedConfigFilePath } from "../src/fileLink.js";
+
+describe("isAllowedConfigFilePath", () => {
+    const allowed = path.resolve("test-config", "config.local.yaml");
+
+    test("allows only the normalized config target", () => {
+        expect(isAllowedConfigFilePath(allowed, allowed)).toBe(true);
+        expect(
+            isAllowedConfigFilePath(
+                path.join(path.dirname(allowed), ".", "config.local.yaml"),
+                allowed,
+            ),
+        ).toBe(true);
+    });
+
+    test("rejects executable and unrelated local paths", () => {
+        expect(
+            isAllowedConfigFilePath(
+                path.join(path.dirname(allowed), "payload.exe"),
+                allowed,
+            ),
+        ).toBe(false);
+        expect(
+            isAllowedConfigFilePath(
+                path.join(path.dirname(allowed), "other.yaml"),
+                allowed,
+            ),
+        ).toBe(false);
+    });
+
+    test("rejects traversal to a same-named file and UNC paths", () => {
+        const traversal =
+            path.join(path.dirname(allowed), "child") +
+            `${path.sep}..${path.sep}config.local.yaml`;
+        expect(isAllowedConfigFilePath(traversal, allowed)).toBe(false);
+        expect(
+            isAllowedConfigFilePath(
+                path.join(path.dirname(allowed), "..", "config.local.yaml"),
+                allowed,
+            ),
+        ).toBe(false);
+        expect(
+            isAllowedConfigFilePath(
+                "\\\\server\\share\\config.local.yaml",
+                allowed,
+            ),
+        ).toBe(false);
+    });
+});

--- a/ts/packages/config/test/fileLink.spec.ts
+++ b/ts/packages/config/test/fileLink.spec.ts
@@ -32,7 +32,11 @@ describe("isAllowedConfigFilePath", () => {
         ).toBe(false);
     });
 
-    test("rejects traversal to a same-named file and UNC paths", () => {
+    test("rejects malformed, traversal, and UNC paths", () => {
+        expect(isAllowedConfigFilePath("", allowed)).toBe(false);
+        expect(isAllowedConfigFilePath(`${allowed}\0ignored`, allowed)).toBe(
+            false,
+        );
         const traversal =
             path.join(path.dirname(allowed), "child") +
             `${path.sep}..${path.sep}config.local.yaml`;

--- a/ts/packages/config/test/hints.spec.ts
+++ b/ts/packages/config/test/hints.spec.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import yaml from "js-yaml";
+import { flatten } from "../src/flatten.js";
+import {
+    CONFIG_LOCAL_FILE,
+    configKeyNames,
+    configPathForEnvVar,
+    configSetupHint,
+    configYamlSnippet,
+} from "../src/hints.js";
+
+// Every env var the hint table claims to know, paired with the YAML path
+// it maps to. The first test flattens each path and asserts it really
+// produces that env var, so the table can't drift from tree.ts.
+const MAPPED_VARS = [
+    "SPOTIFY_APP_CLI",
+    "SPOTIFY_APP_CLISEC",
+    "SPOTIFY_APP_PORT",
+    "MSGRAPH_APP_CLIENTID",
+    "MSGRAPH_APP_CLIENTSECRET",
+    "MSGRAPH_APP_TENANTID",
+    "MSGRAPH_APP_USERNAME",
+    "MSGRAPH_APP_PASSWD",
+    "GOOGLE_CALENDAR_CLIENT_ID",
+    "GOOGLE_CALENDAR_CLIENT_SECRET",
+    "SPEECH_SDK_KEY",
+    "SPEECH_SDK_REGION",
+    "SPEECH_SDK_ENDPOINT",
+    "AZURE_MAPS_CLIENTID",
+    "AZURE_MAPS_ENDPOINT",
+    "COSMOSDB_CONNECTION_STRING",
+    "MONGODB_CONNECTION_STRING",
+];
+
+// spotify.port is typed as a number; everything else is a string.
+function sampleValue(configPath: string): string | number {
+    return configPath === "spotify.port" ? 9999 : "probe-value";
+}
+
+function treeFor(configPath: string): any {
+    const segments = configPath.split(".");
+    let node: any = sampleValue(configPath);
+    for (const segment of segments.reverse()) {
+        node = { [segment]: node };
+    }
+    return node;
+}
+
+describe("configPathForEnvVar", () => {
+    test.each(MAPPED_VARS)(
+        "%s maps to a YAML path that flattens back to it",
+        (envVar) => {
+            const configPath = configPathForEnvVar(envVar);
+            expect(configPath).toBeDefined();
+            const flat = flatten(treeFor(configPath!));
+            expect(Object.keys(flat)).toContain(envVar);
+            expect(flat[envVar]).toBe(String(sampleValue(configPath!)));
+        },
+    );
+
+    test("returns undefined for a var the typed schema doesn't model", () => {
+        expect(configPathForEnvVar("DISCORD_BOT_TOKEN")).toBeUndefined();
+    });
+});
+
+describe("configYamlSnippet", () => {
+    test("groups mapped vars under their section", () => {
+        expect(
+            configYamlSnippet([
+                "SPOTIFY_APP_CLI",
+                "SPOTIFY_APP_CLISEC",
+                "SPOTIFY_APP_PORT",
+            ]),
+        ).toBe(
+            [
+                "spotify:",
+                "  clientId: <value>",
+                "  clientSecret: <value>",
+                "  port: <value>",
+            ].join("\n"),
+        );
+    });
+
+    test("uses per-var placeholders when given", () => {
+        expect(
+            configYamlSnippet([
+                { envVar: "SPOTIFY_APP_PORT", placeholder: "9999" },
+            ]),
+        ).toBe(["spotify:", "  port: 9999"].join("\n"));
+    });
+
+    test("falls back to the env: passthrough block for unmapped vars", () => {
+        expect(configYamlSnippet(["DISCORD_BOT_TOKEN"])).toBe(
+            ["env:", "  DISCORD_BOT_TOKEN: <value>"].join("\n"),
+        );
+    });
+
+    test("emits multiple sections in first-seen order", () => {
+        expect(
+            configYamlSnippet([
+                "MSGRAPH_APP_CLIENTID",
+                "GOOGLE_CALENDAR_CLIENT_ID",
+                "MSGRAPH_APP_TENANTID",
+            ]),
+        ).toBe(
+            [
+                "msGraph:",
+                "  clientId: <value>",
+                "  tenantId: <value>",
+                "googleCalendar:",
+                "  clientId: <value>",
+            ].join("\n"),
+        );
+    });
+
+    test("snippets are valid input for flatten()", () => {
+        // The snippet is what we tell users to paste, so it must round-trip
+        // through the real loader path.
+        const snippet = configYamlSnippet([
+            { envVar: "SPOTIFY_APP_CLI", placeholder: "id" },
+            { envVar: "SPOTIFY_APP_CLISEC", placeholder: "secret" },
+            { envVar: "SPOTIFY_APP_PORT", placeholder: "9999" },
+            { envVar: "DISCORD_BOT_TOKEN", placeholder: "token" },
+        ]);
+        // Parse the snippet the same way the loader parses config.local.yaml.
+        const flat = flatten(yaml.load(snippet) as any);
+        expect(flat.SPOTIFY_APP_CLI).toBe("id");
+        expect(flat.SPOTIFY_APP_CLISEC).toBe("secret");
+        expect(flat.SPOTIFY_APP_PORT).toBe("9999");
+        expect(flat.DISCORD_BOT_TOKEN).toBe("token");
+    });
+});
+
+describe("configSetupHint", () => {
+    test("names the local config file and fences the snippet", () => {
+        const hint = configSetupHint(["SPOTIFY_APP_CLI"], "Then do the thing.");
+        expect(hint).toContain(CONFIG_LOCAL_FILE);
+        expect(hint).toContain("```yaml");
+        expect(hint).toContain("clientId:");
+        expect(hint).toContain("Then do the thing.");
+        // The legacy env-var name shouldn't be the headline instruction.
+        expect(hint).not.toContain("SPOTIFY_APP_CLI");
+    });
+});
+
+describe("configKeyNames", () => {
+    test("maps to YAML keys, keeping unmapped names as-is", () => {
+        expect(
+            configKeyNames(["SPOTIFY_APP_CLI", "DISCORD_BOT_TOKEN"]),
+        ).toEqual(["spotify.clientId", "DISCORD_BOT_TOKEN"]);
+    });
+});

--- a/ts/packages/config/test/hints.spec.ts
+++ b/ts/packages/config/test/hints.spec.ts
@@ -143,6 +143,15 @@ describe("configSetupHint", () => {
         // The legacy env-var name shouldn't be the headline instruction.
         expect(hint).not.toContain("SPOTIFY_APP_CLI");
     });
+
+    test("links the local config file so hosts can open it", () => {
+        const hint = configSetupHint(["SPOTIFY_APP_CLI"]);
+        // Inside the monorepo the path always resolves, so the reference is
+        // a markdown link with the `typeagent-file:` scheme the chat hosts
+        // route to "open this file".
+        expect(hint).toContain(`[\`${CONFIG_LOCAL_FILE}\`](<typeagent-file:`);
+        expect(hint).toContain("config.local.yaml>)");
+    });
 });
 
 describe("configKeyNames", () => {

--- a/ts/packages/config/test/hints.spec.ts
+++ b/ts/packages/config/test/hints.spec.ts
@@ -3,6 +3,9 @@
 
 import yaml from "js-yaml";
 import { flatten } from "../src/flatten.js";
+import { SIMPLE_CONFIG_MAPPING_LIST } from "../src/mappings.js";
+import { buildConfig } from "../src/runtime/build.js";
+import { configToEnv } from "../src/runtime/shim.js";
 import {
     CONFIG_LOCAL_FILE,
     configKeyNames,
@@ -11,32 +14,10 @@ import {
     configYamlSnippet,
 } from "../src/hints.js";
 
-// Every env var the hint table claims to know, paired with the YAML path
-// it maps to. The first test flattens each path and asserts it really
-// produces that env var, so the table can't drift from tree.ts.
-const MAPPED_VARS = [
-    "SPOTIFY_APP_CLI",
-    "SPOTIFY_APP_CLISEC",
-    "SPOTIFY_APP_PORT",
-    "MSGRAPH_APP_CLIENTID",
-    "MSGRAPH_APP_CLIENTSECRET",
-    "MSGRAPH_APP_TENANTID",
-    "MSGRAPH_APP_USERNAME",
-    "MSGRAPH_APP_PASSWD",
-    "GOOGLE_CALENDAR_CLIENT_ID",
-    "GOOGLE_CALENDAR_CLIENT_SECRET",
-    "SPEECH_SDK_KEY",
-    "SPEECH_SDK_REGION",
-    "SPEECH_SDK_ENDPOINT",
-    "AZURE_MAPS_CLIENTID",
-    "AZURE_MAPS_ENDPOINT",
-    "COSMOSDB_CONNECTION_STRING",
-    "MONGODB_CONNECTION_STRING",
-];
-
-// spotify.port is typed as a number; everything else is a string.
 function sampleValue(configPath: string): string | number {
-    return configPath === "spotify.port" ? 9999 : "probe-value";
+    if (configPath === "spotify.port") return 9999;
+    if (configPath === "speech.region") return "eastus";
+    return "probe-value";
 }
 
 function treeFor(configPath: string): any {
@@ -49,16 +30,38 @@ function treeFor(configPath: string): any {
 }
 
 describe("configPathForEnvVar", () => {
-    test.each(MAPPED_VARS)(
-        "%s maps to a YAML path that flattens back to it",
-        (envVar) => {
-            const configPath = configPathForEnvVar(envVar);
-            expect(configPath).toBeDefined();
-            const flat = flatten(treeFor(configPath!));
-            expect(Object.keys(flat)).toContain(envVar);
-            expect(flat[envVar]).toBe(String(sampleValue(configPath!)));
+    test.each(SIMPLE_CONFIG_MAPPING_LIST)(
+        "$envVar maps to a YAML path that flattens back to it",
+        ({ envVar, configPath }) => {
+            expect(configPathForEnvVar(envVar)).toBe(configPath);
+            const flat = flatten(treeFor(configPath));
+            expect(flat[envVar]).toBe(String(sampleValue(configPath)));
         },
     );
+
+    test("registry env vars and config paths are unique", () => {
+        expect(
+            new Set(SIMPLE_CONFIG_MAPPING_LIST.map((entry) => entry.envVar))
+                .size,
+        ).toBe(SIMPLE_CONFIG_MAPPING_LIST.length);
+        expect(
+            new Set(SIMPLE_CONFIG_MAPPING_LIST.map((entry) => entry.configPath))
+                .size,
+        ).toBe(SIMPLE_CONFIG_MAPPING_LIST.length);
+    });
+
+    test("all registry entries round-trip through typed runtime config", () => {
+        const flat = Object.fromEntries(
+            SIMPLE_CONFIG_MAPPING_LIST.map(({ envVar, configPath }) => [
+                envVar,
+                String(sampleValue(configPath)),
+            ]),
+        );
+        const projected = configToEnv(buildConfig(flat));
+        for (const { envVar } of SIMPLE_CONFIG_MAPPING_LIST) {
+            expect(projected[envVar]).toBe(flat[envVar]);
+        }
+    });
 
     test("returns undefined for a var the typed schema doesn't model", () => {
         expect(configPathForEnvVar("DISCORD_BOT_TOKEN")).toBeUndefined();

--- a/ts/packages/config/test/loader.spec.ts
+++ b/ts/packages/config/test/loader.spec.ts
@@ -442,56 +442,52 @@ describe("reloadConfigKeysSync", () => {
             reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
                 workspaceRoot: root,
             });
-
-            test("deletes a startup local value after its override is removed", () => {
-                const root = makeTempWorkspace();
-                try {
-                    const file = path.join(root, "config.local.yaml");
-                    fs.writeFileSync(
-                        file,
-                        "spotify:\n  clientId: startup-local\n",
-                    );
-                    loadConfigSync({ workspaceRoot: root });
-                    expect(process.env.SPOTIFY_APP_CLI).toBe("startup-local");
-                    fs.writeFileSync(file, "{}\n");
-                    reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
-                        workspaceRoot: root,
-                    });
-                    expect(process.env.SPOTIFY_APP_CLI).toBeUndefined();
-                } finally {
-                    fs.rmSync(root, { recursive: true, force: true });
-                }
-            });
-
-            test("restores a Key Vault value hidden by a startup local override", async () => {
-                const root = makeTempWorkspace();
-                try {
-                    const file = path.join(root, "config.local.yaml");
-                    fs.writeFileSync(file, "spotify:\n  clientId: local-id\n");
-                    await loadConfig({
-                        workspaceRoot: root,
-                        keyVault: {
-                            vaultName: "test",
-                            fetcher: async () =>
-                                "spotify:\n  clientId: vault-id\n",
-                        },
-                    });
-                    expect(process.env.SPOTIFY_APP_CLI).toBe("local-id");
-                    fs.writeFileSync(file, "{}\n");
-                    reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
-                        workspaceRoot: root,
-                    });
-                    expect(process.env.SPOTIFY_APP_CLI).toBe("vault-id");
-                } finally {
-                    fs.rmSync(root, { recursive: true, force: true });
-                }
-            });
             expect(process.env.SPOTIFY_APP_CLI).toBe("local");
             fs.writeFileSync(file, "{}\n");
             reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
                 workspaceRoot: root,
             });
             expect(process.env.SPOTIFY_APP_CLI).toBe("vault-like-value");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("deletes a startup local value after its override is removed", () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            fs.writeFileSync(file, "spotify:\n  clientId: startup-local\n");
+            loadConfigSync({ workspaceRoot: root });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("startup-local");
+            fs.writeFileSync(file, "{}\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBeUndefined();
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("restores a Key Vault value hidden by a startup local override", async () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            fs.writeFileSync(file, "spotify:\n  clientId: local-id\n");
+            await loadConfig({
+                workspaceRoot: root,
+                keyVault: {
+                    vaultName: "test",
+                    fetcher: async () => "spotify:\n  clientId: vault-id\n",
+                },
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("local-id");
+            fs.writeFileSync(file, "{}\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("vault-id");
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
         }

--- a/ts/packages/config/test/loader.spec.ts
+++ b/ts/packages/config/test/loader.spec.ts
@@ -4,7 +4,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadConfigSync, loadConfig } from "../src/loader.js";
+import {
+    loadConfigSync,
+    loadConfig,
+    reloadConfigSync,
+    getConfigProblems,
+} from "../src/loader.js";
 
 function makeTempWorkspace(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), "typeagent-config-test-"));
@@ -258,6 +263,66 @@ describe("loadConfig (async)", () => {
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
             delete process.env.OPENAI_API_KEY;
+        }
+    });
+});
+
+describe("invalid sections", () => {
+    const trackedKeys = ["OPENAI_API_KEY", "SPOTIFY_APP_PORT"];
+    afterEach(() => cleanProcessEnv(trackedKeys));
+
+    test("skips only the bad section and reports it as a problem", () => {
+        const root = makeTempWorkspace();
+        try {
+            fs.writeFileSync(
+                path.join(root, "config.local.yaml"),
+                [
+                    "openai:",
+                    "  api_key: good",
+                    "spotify:",
+                    "  port: <value>",
+                ].join("\n"),
+            );
+            cleanProcessEnv(trackedKeys);
+            const warn = console.warn;
+            console.warn = () => {};
+            try {
+                const result = loadConfigSync({
+                    workspaceRoot: root,
+                    strict: true,
+                    populateProcessEnv: false,
+                });
+                expect(result.env.OPENAI_API_KEY).toBe("good");
+                expect(result.env.SPOTIFY_APP_PORT).toBeUndefined();
+            } finally {
+                console.warn = warn;
+            }
+            const problems = getConfigProblems();
+            expect(problems.map((p) => p.section)).toContain("spotify");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("reloadConfigSync", () => {
+    afterEach(() => cleanProcessEnv(["OPENAI_API_KEY"]));
+
+    test("overwrites an existing process.env value and reports the change", () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            fs.writeFileSync(file, "openai:\n  api_key: first\n");
+            cleanProcessEnv(["OPENAI_API_KEY"]);
+            loadConfigSync({ workspaceRoot: root });
+            expect(process.env.OPENAI_API_KEY).toBe("first");
+
+            fs.writeFileSync(file, "openai:\n  api_key: second\n");
+            const changed = reloadConfigSync({ workspaceRoot: root });
+            expect(process.env.OPENAI_API_KEY).toBe("second");
+            expect(changed).toContain("OPENAI_API_KEY");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
         }
     });
 });

--- a/ts/packages/config/test/loader.spec.ts
+++ b/ts/packages/config/test/loader.spec.ts
@@ -8,6 +8,7 @@ import {
     loadConfigSync,
     loadConfig,
     reloadConfigSync,
+    tryReloadConfigSync,
     getConfigProblems,
 } from "../src/loader.js";
 
@@ -307,6 +308,27 @@ describe("invalid sections", () => {
 
 describe("reloadConfigSync", () => {
     afterEach(() => cleanProcessEnv(["OPENAI_API_KEY"]));
+
+    test("tryReloadConfigSync keeps startup values when the reload fails", () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            fs.writeFileSync(file, "openai:\n  api_key: first\n");
+            cleanProcessEnv(["OPENAI_API_KEY"]);
+            loadConfigSync({ workspaceRoot: root });
+            expect(process.env.OPENAI_API_KEY).toBe("first");
+
+            // Unparseable YAML: the reload can't produce anything, and the
+            // caller must not be turned into a hard failure by it.
+            fs.writeFileSync(file, "openai:\n  api_key: [unclosed\n");
+            expect(() =>
+                tryReloadConfigSync({ workspaceRoot: root }),
+            ).not.toThrow();
+            expect(process.env.OPENAI_API_KEY).toBe("first");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
 
     test("overwrites an existing process.env value and reports the change", () => {
         const root = makeTempWorkspace();

--- a/ts/packages/config/test/loader.spec.ts
+++ b/ts/packages/config/test/loader.spec.ts
@@ -7,8 +7,8 @@ import * as path from "node:path";
 import {
     loadConfigSync,
     loadConfig,
-    reloadConfigSync,
-    tryReloadConfigSync,
+    reloadConfigKeysSync,
+    tryReloadConfigKeysSync,
     getConfigProblems,
 } from "../src/loader.js";
 
@@ -294,6 +294,7 @@ describe("invalid sections", () => {
                     populateProcessEnv: false,
                 });
                 expect(result.env.OPENAI_API_KEY).toBe("good");
+                expect(result.env.SPOTIFY_APP_CLI).toBeUndefined();
                 expect(result.env.SPOTIFY_APP_PORT).toBeUndefined();
             } finally {
                 console.warn = warn;
@@ -304,12 +305,53 @@ describe("invalid sections", () => {
             fs.rmSync(root, { recursive: true, force: true });
         }
     });
+
+    test("keeps valid leaves when a sibling contains a placeholder", () => {
+        const root = makeTempWorkspace();
+        const warn = console.warn;
+        console.warn = () => {};
+        try {
+            fs.writeFileSync(
+                path.join(root, "config.local.yaml"),
+                [
+                    "spotify:",
+                    "  clientId: good-id",
+                    "  clientSecret: good-secret",
+                    "  port: <value>",
+                ].join("\n"),
+            );
+            const result = loadConfigSync({
+                workspaceRoot: root,
+                populateProcessEnv: false,
+            });
+            expect(result.env.SPOTIFY_APP_CLI).toBe("good-id");
+            expect(result.env.SPOTIFY_APP_CLISEC).toBe("good-secret");
+            expect(result.env.SPOTIFY_APP_PORT).toBeUndefined();
+            expect(getConfigProblems()).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        section: "spotify",
+                        message: expect.stringContaining("spotify.port"),
+                    }),
+                ]),
+            );
+        } finally {
+            console.warn = warn;
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
 });
 
-describe("reloadConfigSync", () => {
-    afterEach(() => cleanProcessEnv(["OPENAI_API_KEY"]));
+describe("reloadConfigKeysSync", () => {
+    afterEach(() =>
+        cleanProcessEnv([
+            "OPENAI_API_KEY",
+            "SPOTIFY_APP_CLI",
+            "SPOTIFY_APP_CLISEC",
+        ]),
+    );
 
-    test("tryReloadConfigSync keeps startup values when the reload fails", () => {
+    test("tryReloadConfigKeysSync keeps startup values when the reload fails", () => {
         const root = makeTempWorkspace();
         try {
             const file = path.join(root, "config.local.yaml");
@@ -322,7 +364,9 @@ describe("reloadConfigSync", () => {
             // caller must not be turned into a hard failure by it.
             fs.writeFileSync(file, "openai:\n  api_key: [unclosed\n");
             expect(() =>
-                tryReloadConfigSync({ workspaceRoot: root }),
+                tryReloadConfigKeysSync(["OPENAI_API_KEY"], {
+                    workspaceRoot: root,
+                }),
             ).not.toThrow();
             expect(process.env.OPENAI_API_KEY).toBe("first");
         } finally {
@@ -340,9 +384,164 @@ describe("reloadConfigSync", () => {
             expect(process.env.OPENAI_API_KEY).toBe("first");
 
             fs.writeFileSync(file, "openai:\n  api_key: second\n");
-            const changed = reloadConfigSync({ workspaceRoot: root });
+            const changed = reloadConfigKeysSync(["OPENAI_API_KEY"], {
+                workspaceRoot: root,
+            });
             expect(process.env.OPENAI_API_KEY).toBe("second");
             expect(changed).toContain("OPENAI_API_KEY");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("changes only keys in the requested scope", () => {
+        const root = makeTempWorkspace();
+        try {
+            fs.writeFileSync(
+                path.join(root, "config.local.yaml"),
+                "spotify:\n  clientId: local\nopenai:\n  api_key: local-openai\n",
+            );
+            process.env.SPOTIFY_APP_CLI = "inherited-spotify";
+            process.env.OPENAI_API_KEY = "inherited-openai";
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("local");
+            expect(process.env.OPENAI_API_KEY).toBe("inherited-openai");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("applies added and changed local overrides", () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            process.env.SPOTIFY_APP_CLI = "inherited";
+            fs.writeFileSync(file, "spotify:\n  clientId: first\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("first");
+            fs.writeFileSync(file, "spotify:\n  clientId: second\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("second");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("restores an inherited value when a local override is removed", () => {
+        const root = makeTempWorkspace();
+        try {
+            const file = path.join(root, "config.local.yaml");
+            process.env.SPOTIFY_APP_CLI = "vault-like-value";
+            fs.writeFileSync(file, "spotify:\n  clientId: local\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+
+            test("deletes a startup local value after its override is removed", () => {
+                const root = makeTempWorkspace();
+                try {
+                    const file = path.join(root, "config.local.yaml");
+                    fs.writeFileSync(
+                        file,
+                        "spotify:\n  clientId: startup-local\n",
+                    );
+                    loadConfigSync({ workspaceRoot: root });
+                    expect(process.env.SPOTIFY_APP_CLI).toBe("startup-local");
+                    fs.writeFileSync(file, "{}\n");
+                    reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                        workspaceRoot: root,
+                    });
+                    expect(process.env.SPOTIFY_APP_CLI).toBeUndefined();
+                } finally {
+                    fs.rmSync(root, { recursive: true, force: true });
+                }
+            });
+
+            test("restores a Key Vault value hidden by a startup local override", async () => {
+                const root = makeTempWorkspace();
+                try {
+                    const file = path.join(root, "config.local.yaml");
+                    fs.writeFileSync(file, "spotify:\n  clientId: local-id\n");
+                    await loadConfig({
+                        workspaceRoot: root,
+                        keyVault: {
+                            vaultName: "test",
+                            fetcher: async () =>
+                                "spotify:\n  clientId: vault-id\n",
+                        },
+                    });
+                    expect(process.env.SPOTIFY_APP_CLI).toBe("local-id");
+                    fs.writeFileSync(file, "{}\n");
+                    reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                        workspaceRoot: root,
+                    });
+                    expect(process.env.SPOTIFY_APP_CLI).toBe("vault-id");
+                } finally {
+                    fs.rmSync(root, { recursive: true, force: true });
+                }
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("local");
+            fs.writeFileSync(file, "{}\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("vault-like-value");
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("restores a default or deletes a removed override", () => {
+        const root = makeTempWorkspace();
+        try {
+            const local = path.join(root, "config.local.yaml");
+            fs.writeFileSync(
+                path.join(root, "config.defaults.yaml"),
+                "spotify:\n  clientId: default-id\n",
+            );
+            fs.writeFileSync(
+                local,
+                "spotify:\n  clientId: local-id\n  clientSecret: local-secret\n",
+            );
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI", "SPOTIFY_APP_CLISEC"], {
+                workspaceRoot: root,
+            });
+            fs.writeFileSync(local, "{}\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI", "SPOTIFY_APP_CLISEC"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBe("default-id");
+            expect(process.env.SPOTIFY_APP_CLISEC).toBeUndefined();
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test("reports malformed scoped sections without retaining stale values", () => {
+        const root = makeTempWorkspace();
+        try {
+            const local = path.join(root, "config.local.yaml");
+            fs.writeFileSync(
+                local,
+                "spotify:\n  clientId: id\n  clientSecret: secret\n  port: 8080\n",
+            );
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            fs.writeFileSync(local, "spotify:\n  port: <value>\n");
+            reloadConfigKeysSync(["SPOTIFY_APP_CLI"], {
+                workspaceRoot: root,
+            });
+            expect(process.env.SPOTIFY_APP_CLI).toBeUndefined();
+            expect(
+                getConfigProblems().some((p) => p.section === "spotify"),
+            ).toBe(true);
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
         }

--- a/ts/packages/config/test/setupError.spec.ts
+++ b/ts/packages/config/test/setupError.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    ConfigSetupError,
+    configSetupError,
+    getErrorMarkdown,
+} from "../src/setupError.js";
+
+describe("configSetupError", () => {
+    test("keeps the summary plain and puts the hint in markdown", () => {
+        const e = configSetupError("Spotify is not configured.", [
+            "SPOTIFY_APP_CLI",
+        ]);
+        expect(e).toBeInstanceOf(ConfigSetupError);
+        expect(e.message).toBe("Spotify is not configured.");
+        expect(e.message).not.toContain("```");
+        expect(e.markdown).toContain("Spotify is not configured.");
+        expect(e.markdown).toContain("```yaml");
+        expect(e.markdown).toContain("clientId");
+    });
+
+    test("includes the agent-specific note", () => {
+        const e = configSetupError(
+            "Spotify is not configured.",
+            ["SPOTIFY_APP_CLI"],
+            "Values come from the developer dashboard.",
+        );
+        expect(e.markdown).toContain(
+            "Values come from the developer dashboard.",
+        );
+    });
+});
+
+describe("getErrorMarkdown", () => {
+    test("reads markdown off any error-shaped value", () => {
+        expect(
+            getErrorMarkdown(configSetupError("x", ["OPENAI_API_KEY"])),
+        ).toContain("```yaml");
+        // Errors are rebuilt on the far side of the agent RPC boundary, so
+        // the property matters, not the class.
+        const rebuilt: Error & { markdown?: string } = new Error("x");
+        rebuilt.markdown = "**x**";
+        expect(getErrorMarkdown(rebuilt)).toBe("**x**");
+    });
+
+    test("returns undefined without usable markdown", () => {
+        expect(getErrorMarkdown(new Error("plain"))).toBeUndefined();
+        expect(getErrorMarkdown(undefined)).toBeUndefined();
+        expect(getErrorMarkdown({ markdown: "" })).toBeUndefined();
+        expect(getErrorMarkdown({ markdown: 42 })).toBeUndefined();
+    });
+});

--- a/ts/packages/defaultAgentProvider/data/explainer/v5/constructions.json
+++ b/ts/packages/defaultAgentProvider/data/explainer/v5/constructions.json
@@ -145,7 +145,7 @@
   ],
   "constructionNamespaces": [
     {
-      "name": "player,kB4Ogob+UuGl3wZjGe1RRFI7o9aqISNeZoAIiCh0io8=,",
+      "name": "player,q17vir5bvUtULvhlqc2dq3KkOCusaWxekl/G7VobtTY=,",
       "constructions": [
         {
           "parts": [
@@ -227,7 +227,6 @@
             },
             {
               "matchSet": "M:artist name_7",
-              "optional": true,
               "wildcardMode": 2,
               "transformInfos": [
                 {

--- a/ts/packages/defaultAgentProvider/data/explainer/v5/data/player/basic.json
+++ b/ts/packages/defaultAgentProvider/data/explainer/v5/data/player/basic.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "schemaName": "player",
-  "sourceHash": "kB4Ogob+UuGl3wZjGe1RRFI7o9aqISNeZoAIiCh0io8=",
+  "sourceHash": "q17vir5bvUtULvhlqc2dq3KkOCusaWxekl/G7VobtTY=",
   "explainerName": "v5",
   "entries": [
     {

--- a/ts/packages/defaultAgentProvider/test/builtinConstructions.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/builtinConstructions.spec.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Guards the shipped built-in construction cache.
+//
+// Two independent ways this file has silently rotted, both of which disable
+// request completion for the player agent (no song / artist suggestions):
+//
+//  1. An invalid construction (e.g. a part that is both `optional` and
+//     captured) makes the whole file fail to load. `setupBuiltInCache`
+//     swallows that into a `console.warn`, so the only symptom is that
+//     nothing is ever cached.
+//  2. The namespace records the player schema hash at generation time. If the
+//     schema changes without regenerating, the file still loads but none of
+//     its constructions are reachable, because the dispatcher looks them up
+//     under the *current* hash.
+//
+// Both are fixed by `pnpm cli data regenerate -b v5 --constructions --updateHash`.
+
+import { loadConstructionCacheFile } from "@typeagent/agent-cache";
+import {
+    getAllActionConfigProvider,
+    createSchemaInfoProvider,
+} from "agent-dispatcher/internal";
+import { getInstanceDir } from "agent-dispatcher/helpers/data";
+import {
+    getDefaultAppAgentProviders,
+    getDefaultConstructionProvider,
+} from "../src/index.js";
+
+const builtinFile =
+    getDefaultConstructionProvider().getBuiltinConstructionConfig("v5")?.file;
+
+// Throws (taking every construction in the file with it) when any construction
+// violates the ConstructionPart invariants.
+async function loadBuiltinCache() {
+    expect(builtinFile).toBeDefined();
+    const cache = await loadConstructionCacheFile(builtinFile!);
+    expect(cache).toBeDefined();
+    return cache!;
+}
+
+describe("Built-in construction cache", () => {
+    it("loads without error", async () => {
+        const cache = await loadBuiltinCache();
+        expect(cache.count).toBeGreaterThan(0);
+    });
+
+    it("is keyed to the current player schema hash", async () => {
+        const { provider } = await getAllActionConfigProvider(
+            getDefaultAppAgentProviders(getInstanceDir()),
+        );
+        const schemaInfoProvider = createSchemaInfoProvider(provider);
+        const hash = schemaInfoProvider.getActionSchemaFileHash("player");
+
+        const cache = await loadBuiltinCache();
+        const namespaces = cache.getConstructionNamespaces();
+        expect(namespaces.some((n) => n.includes(hash))).toBe(true);
+    });
+
+    it("offers the track name property for completion after 'play '", async () => {
+        const cache = await loadBuiltinCache();
+        const result = cache.completion("play ", {
+            wildcard: true,
+            namespaceKeys: cache.getConstructionNamespaces(),
+        });
+        const names = (result?.properties ?? []).flatMap((p) => p.names);
+        expect(names).toContain("parameters.target.trackName");
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/builtinConstructions.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/builtinConstructions.spec.ts
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Guards the shipped built-in construction cache.
+// Guards every built-in construction cache registered by the production
+// explainer factory. This coupling is intentional: a cache is runtime data
+// keyed by the current action-schema hashes, so changing a schema without
+// regenerating its cache must fail offline tests.
 //
 // Two independent ways this file has silently rotted, both of which disable
-// request completion for the player agent (no song / artist suggestions):
+// request completion:
 //
 //  1. An invalid construction (e.g. a part that is both `optional` and
 //     captured) makes the whole file fail to load. `setupBuiltInCache`
@@ -15,12 +18,17 @@
 //     its constructions are reachable, because the dispatcher looks them up
 //     under the *current* hash.
 //
-// Both are fixed by `pnpm cli data regenerate -b v5 --constructions --updateHash`.
+// The error for each cache includes its exact offline regeneration command.
 
-import { loadConstructionCacheFile } from "@typeagent/agent-cache";
+import {
+    getSchemaNamespaceKey,
+    loadConstructionCacheFile,
+    splitSchemaNamespaceKey,
+} from "@typeagent/agent-cache";
 import {
     getAllActionConfigProvider,
     createSchemaInfoProvider,
+    getCacheFactory,
 } from "agent-dispatcher/internal";
 import { getInstanceDir } from "agent-dispatcher/helpers/data";
 import {
@@ -28,41 +36,100 @@ import {
     getDefaultConstructionProvider,
 } from "../src/index.js";
 
-const builtinFile =
-    getDefaultConstructionProvider().getBuiltinConstructionConfig("v5")?.file;
+const regenerationCommand = (explainerName: string) =>
+    `pnpm cli data regenerate -b ${explainerName} --constructions --updateHash`;
 
-// Throws (taking every construction in the file with it) when any construction
-// violates the ConstructionPart invariants.
-async function loadBuiltinCache() {
-    expect(builtinFile).toBeDefined();
-    const cache = await loadConstructionCacheFile(builtinFile!);
-    expect(cache).toBeDefined();
-    return cache!;
+function getBuiltinConfigs() {
+    const provider = getDefaultConstructionProvider();
+    return getCacheFactory()
+        .getExplainerNames()
+        .flatMap((explainerName) => {
+            const config = provider.getBuiltinConstructionConfig(explainerName);
+            return config === undefined ? [] : [{ explainerName, config }];
+        });
+}
+
+async function loadBuiltinCaches() {
+    const configs = getBuiltinConfigs();
+    expect(configs.length).toBeGreaterThan(0);
+    return Promise.all(
+        configs.map(async ({ explainerName, config }) => {
+            let cache;
+            try {
+                cache = await loadConstructionCacheFile(config.file);
+            } catch (error) {
+                throw new Error(
+                    `Unable to load built-in cache for '${explainerName}': ${
+                        error instanceof Error ? error.message : String(error)
+                    }. Regenerate it offline with: ${regenerationCommand(explainerName)}`,
+                );
+            }
+            if (cache === undefined) {
+                throw new Error(
+                    `Unable to load built-in cache for '${explainerName}'. Regenerate it offline with: ${regenerationCommand(explainerName)}`,
+                );
+            }
+            return { explainerName, cache };
+        }),
+    );
 }
 
 describe("Built-in construction cache", () => {
     it("loads without error", async () => {
-        const cache = await loadBuiltinCache();
-        expect(cache.count).toBeGreaterThan(0);
+        for (const { explainerName, cache } of await loadBuiltinCaches()) {
+            if (cache.count === 0) {
+                throw new Error(
+                    `Built-in cache '${explainerName}' is empty. Regenerate it offline with: ${regenerationCommand(explainerName)}`,
+                );
+            }
+        }
     });
 
-    it("is keyed to the current player schema hash", async () => {
+    it("uses exact current schema namespaces", async () => {
         const { provider } = await getAllActionConfigProvider(
             getDefaultAppAgentProviders(getInstanceDir()),
         );
         const schemaInfoProvider = createSchemaInfoProvider(provider);
-        const hash = schemaInfoProvider.getActionSchemaFileHash("player");
 
-        const cache = await loadBuiltinCache();
-        const namespaces = cache.getConstructionNamespaces();
-        expect(namespaces.some((n) => n.includes(hash))).toBe(true);
+        for (const { explainerName, cache } of await loadBuiltinCaches()) {
+            for (const namespace of cache.getConstructionNamespaces()) {
+                const namespaceKeys = namespace.split("|");
+                const expectedKeys = namespaceKeys.map((namespaceKey) => {
+                    const { schemaName, hash, activityName } =
+                        splitSchemaNamespaceKey(namespaceKey);
+                    const currentHash =
+                        schemaInfoProvider.getActionSchemaFileHash(schemaName);
+                    if (hash !== currentHash) {
+                        throw new Error(
+                            `Built-in cache '${explainerName}' has a stale schema hash for '${schemaName}'. Regenerate it offline with: ${regenerationCommand(explainerName)}`,
+                        );
+                    }
+                    return getSchemaNamespaceKey(
+                        schemaName,
+                        activityName,
+                        schemaInfoProvider,
+                    );
+                });
+                expect(namespace).toBe(expectedKeys.join("|"));
+            }
+        }
     });
 
     it("offers the track name property for completion after 'play '", async () => {
-        const cache = await loadBuiltinCache();
-        const result = cache.completion("play ", {
+        const { provider } = await getAllActionConfigProvider(
+            getDefaultAppAgentProviders(getInstanceDir()),
+        );
+        const schemaInfoProvider = createSchemaInfoProvider(provider);
+        const builtins = await loadBuiltinCaches();
+        const cache = builtins.find(
+            ({ explainerName }) => explainerName === "v5",
+        )?.cache;
+        expect(cache).toBeDefined();
+        const result = cache!.completion("play ", {
             wildcard: true,
-            namespaceKeys: cache.getConstructionNamespaces(),
+            namespaceKeys: [
+                getSchemaNamespaceKey("player", undefined, schemaInfoProvider),
+            ],
         });
         const names = (result?.properties ?? []).flatMap((p) => p.names);
         expect(names).toContain("parameters.target.trackName");

--- a/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
@@ -22,9 +22,6 @@
 // namespaces when each instance is created), hence the dynamic imports.
 
 import type { Dispatcher } from "agent-dispatcher";
-import type { AppAgent } from "@typeagent/agent-sdk";
-import type { AppAgentProvider } from "agent-dispatcher";
-import { getPlayerActionCompletion } from "@typeagent/music/agent/handlers";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -36,25 +33,16 @@ describe("Player request completion", () => {
     let originalWrite: typeof process.stderr.write;
     const originalDebug = process.env.DEBUG;
     const originalConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
-    const originalSpotifyConfig = {
-        clientId: process.env.SPOTIFY_APP_CLI,
-        clientSecret: process.env.SPOTIFY_APP_CLISEC,
-        port: process.env.SPOTIFY_APP_PORT,
-    };
     const configDir = path.join(
         process.cwd(),
         `.player-request-completion-${process.pid}`,
     );
-    const receivedPartialValues: string[] = [];
 
     beforeAll(async () => {
         fs.rmSync(configDir, { recursive: true, force: true });
         fs.mkdirSync(configDir, { recursive: true });
         process.env.TYPEAGENT_CONFIG_DIR = configDir;
         process.env.DEBUG = errorNamespace;
-        process.env.SPOTIFY_APP_CLI = "completion-test-client";
-        process.env.SPOTIFY_APP_CLISEC = "completion-test-secret";
-        process.env.SPOTIFY_APP_PORT = "9999";
         originalWrite = process.stderr.write;
         process.stderr.write = ((chunk: any, ...rest: any[]) => {
             const text = typeof chunk === "string" ? chunk : String(chunk);
@@ -70,59 +58,10 @@ describe("Player request completion", () => {
                 getDefaultAppAgentProviders,
                 getDefaultConstructionProvider,
             } = await import("../src/index.js");
-            const providers = getDefaultAppAgentProviders(undefined);
-            const bundled = providers[0];
-            const wrappedBundled: AppAgentProvider = {
-                getAppAgentNames: () => bundled.getAppAgentNames(),
-                getAppAgentManifest: (name) =>
-                    bundled.getAppAgentManifest(name),
-                async loadAppAgent(name) {
-                    const agent = await bundled.loadAppAgent(name);
-                    if (name !== "player") return agent;
-                    return {
-                        ...agent,
-                        getActionCompletion: async (
-                            _context,
-                            action,
-                            propertyName,
-                            entityType,
-                        ) => {
-                            const partial =
-                                (action as any).parameters?.target?.trackName ??
-                                "";
-                            receivedPartialValues.push(partial);
-                            return getPlayerActionCompletion(
-                                {
-                                    agentContext: {
-                                        spotify: {
-                                            userData: {
-                                                data: createCompletionUserData(),
-                                            },
-                                        },
-                                    },
-                                } as any,
-                                action,
-                                propertyName,
-                                entityType,
-                            );
-                        },
-                    } satisfies AppAgent;
-                },
-                unloadAppAgent: (name) => bundled.unloadAppAgent(name),
-            };
             dispatcher = await createDispatcher("completion-test", {
-                appAgentProviders: [wrappedBundled, ...providers.slice(1)],
+                appAgentProviders: getDefaultAppAgentProviders(undefined),
                 constructionProvider: getDefaultConstructionProvider(),
             });
-            const enabled = await dispatcher.submitCommand(
-                "@config agent player",
-            );
-            if (!enabled.ok) {
-                throw new Error(
-                    `Unable to enable player agent: ${enabled.error}`,
-                );
-            }
-            await enabled.entry.completion;
         } catch (error) {
             process.stderr.write = originalWrite;
             throw error;
@@ -143,12 +82,6 @@ describe("Player request completion", () => {
             } else {
                 process.env.TYPEAGENT_CONFIG_DIR = originalConfigDir;
             }
-            restoreEnv("SPOTIFY_APP_CLI", originalSpotifyConfig.clientId);
-            restoreEnv(
-                "SPOTIFY_APP_CLISEC",
-                originalSpotifyConfig.clientSecret,
-            );
-            restoreEnv("SPOTIFY_APP_PORT", originalSpotifyConfig.port);
             fs.rmSync(configDir, { recursive: true, force: true });
         }
     });
@@ -162,51 +95,4 @@ describe("Player request completion", () => {
         },
         30000,
     );
-
-    it("filters an older multiword track before applying the agent cap", async () => {
-        receivedPartialValues.length = 0;
-
-        const result = await dispatcher.getCommandCompletion(
-            "play Bohemian Rhap",
-            "backward",
-        );
-        const completions = result.completions.flatMap(
-            (group) => group.completions,
-        );
-
-        expect(result.startIndex).toBe("play".length);
-        expect(receivedPartialValues).toContain("Bohemian Rhap");
-        expect(completions).toContain("Bohemian Rhapsody");
-        expect(completions).not.toContain("Recent unrelated track 100");
-    }, 30000);
 });
-
-function createCompletionUserData() {
-    const tracks = new Map<string, any>();
-    tracks.set("bohemian", {
-        id: "bohemian",
-        name: "Bohemian Rhapsody",
-        freq: 1,
-        timestamps: ["2000-01-01T00:00:00.000Z"],
-    });
-    for (let i = 0; i < 101; i++) {
-        tracks.set(`recent-${i}`, {
-            id: `recent-${i}`,
-            name: `Recent unrelated track ${i}`,
-            freq: 1,
-            timestamps: [new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString()],
-        });
-    }
-
-    return {
-        lastUpdated: Date.now(),
-        tracks,
-        artists: new Map(),
-        albums: new Map(),
-    };
-}
-
-function restoreEnv(name: string, value: string | undefined) {
-    if (value === undefined) delete process.env[name];
-    else process.env[name] = value;
-}

--- a/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Guards request completion for the player agent end to end.
+//
+// Song/artist autocompletion has broken in ways that produced no visible
+// error, because every layer swallows failures:
+//
+//  - `GrammarStoreImpl.completion` threw a TypeError on a grammar property
+//    that carries no resolved action. `getCommandCompletion` catches
+//    everything into a debug-only channel, so one bad property silently wiped
+//    out completions for the whole request -- including the ones the
+//    construction cache had already produced correctly.
+//  - The shipped built-in construction cache rotting is covered separately by
+//    builtinConstructions.spec.ts.
+//
+// This drives the real dispatcher and asserts on the debug channel that
+// receives the swallowed exceptions, since a thrown completion is otherwise
+// indistinguishable from a legitimately empty one.
+//
+// `DEBUG` has to be set before agent-dispatcher is loaded (debug resolves
+// namespaces when each instance is created), hence the dynamic imports.
+
+import type { Dispatcher } from "agent-dispatcher";
+
+const errorNamespace = "typeagent:command:completion:error";
+
+describe("Player request completion", () => {
+    let dispatcher: Dispatcher;
+    const errors: string[] = [];
+    let originalWrite: typeof process.stderr.write;
+
+    beforeAll(async () => {
+        process.env.DEBUG = errorNamespace;
+
+        const { createDispatcher } = await import("agent-dispatcher");
+        const { getDefaultAppAgentProviders, getDefaultConstructionProvider } =
+            await import("../src/index.js");
+
+        // debug logs through process.stderr.write on node; capturing there
+        // avoids depending on which copy of the debug module got loaded.
+        originalWrite = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((chunk: any, ...rest: any[]) => {
+            const text = typeof chunk === "string" ? chunk : String(chunk);
+            if (text.includes(errorNamespace)) {
+                errors.push(text);
+            }
+            return (originalWrite as any)(chunk, ...rest);
+        }) as typeof process.stderr.write;
+
+        dispatcher = await createDispatcher("completion-test", {
+            appAgentProviders: getDefaultAppAgentProviders(undefined),
+            constructionProvider: getDefaultConstructionProvider(),
+        });
+    }, 120000);
+
+    afterAll(async () => {
+        if (originalWrite !== undefined) {
+            process.stderr.write = originalWrite;
+        }
+        delete process.env.DEBUG;
+        await dispatcher?.close();
+    });
+
+    it.each(["play ", "play music by ", "listen to "])(
+        "completes '%s' without a swallowed error",
+        async (input) => {
+            errors.length = 0;
+            await dispatcher.getCommandCompletion(input, "forward");
+            expect(errors).toEqual([]);
+        },
+        30000,
+    );
+});

--- a/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
@@ -22,6 +22,8 @@
 // namespaces when each instance is created), hence the dynamic imports.
 
 import type { Dispatcher } from "agent-dispatcher";
+import fs from "node:fs";
+import path from "node:path";
 
 const errorNamespace = "typeagent:command:completion:error";
 
@@ -29,37 +31,59 @@ describe("Player request completion", () => {
     let dispatcher: Dispatcher;
     const errors: string[] = [];
     let originalWrite: typeof process.stderr.write;
+    const originalDebug = process.env.DEBUG;
+    const originalConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
+    const configDir = path.join(
+        process.cwd(),
+        `.player-request-completion-${process.pid}`,
+    );
 
     beforeAll(async () => {
+        fs.rmSync(configDir, { recursive: true, force: true });
+        fs.mkdirSync(configDir, { recursive: true });
+        process.env.TYPEAGENT_CONFIG_DIR = configDir;
         process.env.DEBUG = errorNamespace;
-
-        const { createDispatcher } = await import("agent-dispatcher");
-        const { getDefaultAppAgentProviders, getDefaultConstructionProvider } =
-            await import("../src/index.js");
-
-        // debug logs through process.stderr.write on node; capturing there
-        // avoids depending on which copy of the debug module got loaded.
-        originalWrite = process.stderr.write.bind(process.stderr);
+        originalWrite = process.stderr.write;
         process.stderr.write = ((chunk: any, ...rest: any[]) => {
             const text = typeof chunk === "string" ? chunk : String(chunk);
             if (text.includes(errorNamespace)) {
                 errors.push(text);
             }
-            return (originalWrite as any)(chunk, ...rest);
+            return (originalWrite as any).call(process.stderr, chunk, ...rest);
         }) as typeof process.stderr.write;
 
-        dispatcher = await createDispatcher("completion-test", {
-            appAgentProviders: getDefaultAppAgentProviders(undefined),
-            constructionProvider: getDefaultConstructionProvider(),
-        });
+        try {
+            const { createDispatcher } = await import("agent-dispatcher");
+            const {
+                getDefaultAppAgentProviders,
+                getDefaultConstructionProvider,
+            } = await import("../src/index.js");
+            dispatcher = await createDispatcher("completion-test", {
+                appAgentProviders: getDefaultAppAgentProviders(undefined),
+                constructionProvider: getDefaultConstructionProvider(),
+            });
+        } catch (error) {
+            process.stderr.write = originalWrite;
+            throw error;
+        }
     }, 120000);
 
     afterAll(async () => {
-        if (originalWrite !== undefined) {
-            process.stderr.write = originalWrite;
+        try {
+            await dispatcher?.close();
+        } finally {
+            if (originalWrite !== undefined) {
+                process.stderr.write = originalWrite;
+            }
+            if (originalDebug === undefined) delete process.env.DEBUG;
+            else process.env.DEBUG = originalDebug;
+            if (originalConfigDir === undefined) {
+                delete process.env.TYPEAGENT_CONFIG_DIR;
+            } else {
+                process.env.TYPEAGENT_CONFIG_DIR = originalConfigDir;
+            }
+            fs.rmSync(configDir, { recursive: true, force: true });
         }
-        delete process.env.DEBUG;
-        await dispatcher?.close();
     });
 
     it.each(["play ", "play music by ", "listen to "])(

--- a/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/playerRequestCompletion.spec.ts
@@ -22,6 +22,9 @@
 // namespaces when each instance is created), hence the dynamic imports.
 
 import type { Dispatcher } from "agent-dispatcher";
+import type { AppAgent } from "@typeagent/agent-sdk";
+import type { AppAgentProvider } from "agent-dispatcher";
+import { getPlayerActionCompletion } from "@typeagent/music/agent/handlers";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -33,16 +36,25 @@ describe("Player request completion", () => {
     let originalWrite: typeof process.stderr.write;
     const originalDebug = process.env.DEBUG;
     const originalConfigDir = process.env.TYPEAGENT_CONFIG_DIR;
+    const originalSpotifyConfig = {
+        clientId: process.env.SPOTIFY_APP_CLI,
+        clientSecret: process.env.SPOTIFY_APP_CLISEC,
+        port: process.env.SPOTIFY_APP_PORT,
+    };
     const configDir = path.join(
         process.cwd(),
         `.player-request-completion-${process.pid}`,
     );
+    const receivedPartialValues: string[] = [];
 
     beforeAll(async () => {
         fs.rmSync(configDir, { recursive: true, force: true });
         fs.mkdirSync(configDir, { recursive: true });
         process.env.TYPEAGENT_CONFIG_DIR = configDir;
         process.env.DEBUG = errorNamespace;
+        process.env.SPOTIFY_APP_CLI = "completion-test-client";
+        process.env.SPOTIFY_APP_CLISEC = "completion-test-secret";
+        process.env.SPOTIFY_APP_PORT = "9999";
         originalWrite = process.stderr.write;
         process.stderr.write = ((chunk: any, ...rest: any[]) => {
             const text = typeof chunk === "string" ? chunk : String(chunk);
@@ -58,10 +70,59 @@ describe("Player request completion", () => {
                 getDefaultAppAgentProviders,
                 getDefaultConstructionProvider,
             } = await import("../src/index.js");
+            const providers = getDefaultAppAgentProviders(undefined);
+            const bundled = providers[0];
+            const wrappedBundled: AppAgentProvider = {
+                getAppAgentNames: () => bundled.getAppAgentNames(),
+                getAppAgentManifest: (name) =>
+                    bundled.getAppAgentManifest(name),
+                async loadAppAgent(name) {
+                    const agent = await bundled.loadAppAgent(name);
+                    if (name !== "player") return agent;
+                    return {
+                        ...agent,
+                        getActionCompletion: async (
+                            _context,
+                            action,
+                            propertyName,
+                            entityType,
+                        ) => {
+                            const partial =
+                                (action as any).parameters?.target?.trackName ??
+                                "";
+                            receivedPartialValues.push(partial);
+                            return getPlayerActionCompletion(
+                                {
+                                    agentContext: {
+                                        spotify: {
+                                            userData: {
+                                                data: createCompletionUserData(),
+                                            },
+                                        },
+                                    },
+                                } as any,
+                                action,
+                                propertyName,
+                                entityType,
+                            );
+                        },
+                    } satisfies AppAgent;
+                },
+                unloadAppAgent: (name) => bundled.unloadAppAgent(name),
+            };
             dispatcher = await createDispatcher("completion-test", {
-                appAgentProviders: getDefaultAppAgentProviders(undefined),
+                appAgentProviders: [wrappedBundled, ...providers.slice(1)],
                 constructionProvider: getDefaultConstructionProvider(),
             });
+            const enabled = await dispatcher.submitCommand(
+                "@config agent player",
+            );
+            if (!enabled.ok) {
+                throw new Error(
+                    `Unable to enable player agent: ${enabled.error}`,
+                );
+            }
+            await enabled.entry.completion;
         } catch (error) {
             process.stderr.write = originalWrite;
             throw error;
@@ -82,6 +143,12 @@ describe("Player request completion", () => {
             } else {
                 process.env.TYPEAGENT_CONFIG_DIR = originalConfigDir;
             }
+            restoreEnv("SPOTIFY_APP_CLI", originalSpotifyConfig.clientId);
+            restoreEnv(
+                "SPOTIFY_APP_CLISEC",
+                originalSpotifyConfig.clientSecret,
+            );
+            restoreEnv("SPOTIFY_APP_PORT", originalSpotifyConfig.port);
             fs.rmSync(configDir, { recursive: true, force: true });
         }
     });
@@ -95,4 +162,51 @@ describe("Player request completion", () => {
         },
         30000,
     );
+
+    it("filters an older multiword track before applying the agent cap", async () => {
+        receivedPartialValues.length = 0;
+
+        const result = await dispatcher.getCommandCompletion(
+            "play Bohemian Rhap",
+            "backward",
+        );
+        const completions = result.completions.flatMap(
+            (group) => group.completions,
+        );
+
+        expect(result.startIndex).toBe("play".length);
+        expect(receivedPartialValues).toContain("Bohemian Rhap");
+        expect(completions).toContain("Bohemian Rhapsody");
+        expect(completions).not.toContain("Recent unrelated track 100");
+    }, 30000);
 });
+
+function createCompletionUserData() {
+    const tracks = new Map<string, any>();
+    tracks.set("bohemian", {
+        id: "bohemian",
+        name: "Bohemian Rhapsody",
+        freq: 1,
+        timestamps: ["2000-01-01T00:00:00.000Z"],
+    });
+    for (let i = 0; i < 101; i++) {
+        tracks.set(`recent-${i}`, {
+            id: `recent-${i}`,
+            name: `Recent unrelated track ${i}`,
+            freq: 1,
+            timestamps: [new Date(Date.UTC(2024, 0, 1, 0, i)).toISOString()],
+        });
+    }
+
+    return {
+        lastUpdated: Date.now(),
+        tracks,
+        artists: new Map(),
+        albums: new Map(),
+    };
+}
+
+function restoreEnv(name: string, value: string | undefined) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+}

--- a/ts/packages/dispatcher/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/command.ts
@@ -18,6 +18,7 @@ import {
     CommandDescriptorTable,
 } from "@typeagent/agent-sdk";
 import { executeCommand } from "../execute/actionHandlers.js";
+import { getErrorDisplayContent } from "../execute/agentNotReadyError.js";
 import { isCommandDescriptorTable } from "@typeagent/agent-sdk/helpers/command";
 import { parseParams } from "./parameters.js";
 import { getHandlerTableUsage, getUsage } from "./commandHelp.js";
@@ -358,7 +359,7 @@ export async function processCommandNoLock(
         context.clientIO.appendDisplay(
             makeClientIOMessage(
                 context,
-                {
+                getErrorDisplayContent(e) ?? {
                     type: "text",
                     content: `ERROR: ${e.message}`,
                     kind: "error",

--- a/ts/packages/dispatcher/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/completion.ts
@@ -33,24 +33,64 @@ import { CommandCompletionResult } from "@typeagent/dispatcher-types";
 const debug = registerDebug("typeagent:command:completion");
 const debugError = registerDebug("typeagent:command:completion:error");
 
-// Completion must never break typing, so getCommandCompletion swallows
-// everything and returns an empty result.  That made a plain TypeError in the
-// grammar store indistinguishable from "no suggestions available", and it went
-// unnoticed until someone thought to turn on the debug channel.  Bugs in our
-// own code get one console.error per distinct message so they're at least
-// visible without silently spamming a typing user.
-const reportedProgrammingErrors = new Set<string>();
-function reportProgrammingError(e: any) {
-    if (!(e instanceof TypeError) && !(e instanceof ReferenceError)) {
+export type ProgrammingErrorReportingState = {
+    readonly reported: Set<string>;
+    readonly capacity: number;
+};
+
+export function createProgrammingErrorReportingState(
+    capacity = 100,
+): ProgrammingErrorReportingState {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+        throw new RangeError(
+            "Programming error reporting capacity must be positive",
+        );
+    }
+    return { reported: new Set(), capacity };
+}
+
+const programmingErrorReportingState = createProgrammingErrorReportingState();
+
+export function resetProgrammingErrorReportingState() {
+    programmingErrorReportingState.reported.clear();
+}
+
+function isProgrammingError(e: unknown): e is Error {
+    if (e instanceof TypeError || e instanceof ReferenceError) {
+        return true;
+    }
+    if (typeof e !== "object" || e === null) {
+        return false;
+    }
+    const name = (e as { name?: unknown }).name;
+    return name === "TypeError" || name === "ReferenceError";
+}
+
+export function reportProgrammingError(
+    e: unknown,
+    state: ProgrammingErrorReportingState = programmingErrorReportingState,
+    write: (message: string) => void = console.error,
+) {
+    if (!isProgrammingError(e)) {
         return;
     }
-    const key = `${e.name}: ${e.message}`;
-    if (reportedProgrammingErrors.has(key)) {
+    const error = e as { name: string; message?: unknown; stack?: unknown };
+    const message =
+        typeof error.message === "string"
+            ? error.message
+            : String(error.message);
+    const key = `${error.name}: ${message}`;
+    if (state.reported.has(key)) {
         return;
     }
-    reportedProgrammingErrors.add(key);
-    console.error(
-        `Command completion failed with an internal error (suggestions will be missing): ${e.stack ?? key}`,
+    state.reported.add(key);
+    if (state.reported.size > state.capacity) {
+        state.reported.delete(state.reported.values().next().value!);
+    }
+    write(
+        `Command completion failed with an internal error (suggestions will be missing): ${
+            typeof error.stack === "string" ? error.stack : key
+        }`,
     );
 }
 

--- a/ts/packages/dispatcher/dispatcher/src/command/completion.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/completion.ts
@@ -33,6 +33,27 @@ import { CommandCompletionResult } from "@typeagent/dispatcher-types";
 const debug = registerDebug("typeagent:command:completion");
 const debugError = registerDebug("typeagent:command:completion:error");
 
+// Completion must never break typing, so getCommandCompletion swallows
+// everything and returns an empty result.  That made a plain TypeError in the
+// grammar store indistinguishable from "no suggestions available", and it went
+// unnoticed until someone thought to turn on the debug channel.  Bugs in our
+// own code get one console.error per distinct message so they're at least
+// visible without silently spamming a typing user.
+const reportedProgrammingErrors = new Set<string>();
+function reportProgrammingError(e: any) {
+    if (!(e instanceof TypeError) && !(e instanceof ReferenceError)) {
+        return;
+    }
+    const key = `${e.name}: ${e.message}`;
+    if (reportedProgrammingErrors.has(key)) {
+        return;
+    }
+    reportedProgrammingErrors.add(key);
+    console.error(
+        `Command completion failed with an internal error (suggestions will be missing): ${e.stack ?? key}`,
+    );
+}
+
 // Detect whether the last parsed token is a recognized flag name
 // awaiting a value.  Pure: returns metadata only, no side effects.
 //
@@ -806,6 +827,7 @@ export async function getCommandCompletion(
         return completionResult;
     } catch (e: any) {
         debugError(`Command completion error: ${e}\n${e.stack}`);
+        reportProgrammingError(e);
         // On error, return a safe default — don't claim closedSet
         // since we don't know what went wrong.
         return {

--- a/ts/packages/dispatcher/dispatcher/src/context/session.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/session.ts
@@ -990,7 +990,12 @@ export async function setupBuiltInCache(
             builtInConstructions,
         );
     } catch (e: any) {
-        console.warn(`WARNING: Unable to load built-in cache: ${e.message}`);
+        // A corrupt or stale built-in cache disables request completions
+        // entirely, so make the failure loud rather than a passing mention.
+        console.warn(
+            `WARNING: Unable to load built-in cache '${builtInConstructions}': ${e.message}\n` +
+                `WARNING: Request completions will be unavailable. Regenerate it with 'pnpm cli data regenerate -b ${session.explainerName} --constructions --updateHash'.`,
+        );
     }
 }
 

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -37,6 +37,7 @@ import {
     PartialParsedCommandParams,
     ReadinessReport,
     SessionContext,
+    DisplayContent,
 } from "@typeagent/agent-sdk";
 import {
     CommandHandler,
@@ -635,6 +636,26 @@ function getAgentReadinessOrThrow(
     return systemContext.agents.getReadiness(name);
 }
 
+export function getManualAgentSetupDisplay(
+    name: string,
+    report: ReadinessReport,
+): DisplayContent {
+    const lines = [
+        `Agent '${name}' needs configuration before it can be used.`,
+    ];
+    if (report.message) lines.push("", report.message);
+    if (report.details) lines.push("", report.details);
+    lines.push(
+        "",
+        `This agent does not have an in-chat setup flow. After fixing the underlying issue, run \`@config agent refresh ${name}\` to re-check.`,
+    );
+    return {
+        type: "markdown",
+        content: lines.join("\n"),
+        kind: "warning",
+    };
+}
+
 class AgentSetupCommandHandler implements CommandHandler {
     public readonly description =
         "Run setup for an agent that needs configuration before use";
@@ -728,21 +749,10 @@ class AgentSetupCommandHandler implements CommandHandler {
             closeActionContext();
         }
         if (result === undefined) {
-            // Agent reports setup-required but doesn't implement a setup
-            // hook — typically a manual-config case (env vars, files
-            // outside the agent's reach). Show the readiness message as
-            // the primary content and point at @config agent refresh so
-            // the user can re-check after fixing the underlying issue.
-            const lines = [
-                `Agent '${name}' needs configuration before it can be used.`,
-            ];
-            if (report.message) lines.push("", report.message);
-            if (report.details) lines.push("", report.details);
-            lines.push(
-                "",
-                `This agent does not have an in-chat setup flow. After fixing the underlying issue, run \`@config agent refresh ${name}\` to re-check.`,
+            context.actionIO.appendDisplay(
+                getManualAgentSetupDisplay(name, report),
+                "block",
             );
-            displayWarn(lines.join("\n"), context);
             return;
         }
         // emitActionResult above already rendered the display content and

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -17,6 +17,7 @@ import registerDebug from "debug";
 import { getAppAgentName } from "../translation/agentTranslators.js";
 import {
     ActionResult,
+    ActionResultError,
     ActionContext,
     ParsedCommandParams,
     ParameterDefinitions,
@@ -383,6 +384,20 @@ function projectActionResultForDiagnostics(result: ActionResult): unknown {
     }
 }
 
+function displayActionResultError(
+    result: ActionResultError,
+    actionContext: ActionContext<unknown>,
+): void {
+    if (result.errorDisplayContent !== undefined) {
+        actionContext.actionIO.appendDisplay(
+            result.errorDisplayContent,
+            "block",
+        );
+    } else {
+        displayError(result.error, actionContext);
+    }
+}
+
 export function emitActionResult(
     result: ActionResult,
     actionContext: ActionContext<unknown>,
@@ -410,14 +425,7 @@ export function emitActionResult(
     }
     if (result.error !== undefined) {
         if (!("fallbackToReasoning" in result) || !result.fallbackToReasoning) {
-            if (result.errorDisplayContent !== undefined) {
-                actionContext.actionIO.appendDisplay(
-                    result.errorDisplayContent,
-                    "block",
-                );
-            } else {
-                displayError(result.error, actionContext);
-            }
+            displayActionResultError(result, actionContext);
         }
         return;
     }

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -54,6 +54,10 @@ import {
 } from "./pendingActions.js";
 import { getActionContext } from "./actionContext.js";
 import {
+    AgentNotReadyError,
+    getErrorDisplayContent,
+} from "./agentNotReadyError.js";
+import {
     addActionResultToMemory,
     addResultToMemory,
 } from "../context/memory.js";
@@ -102,9 +106,16 @@ export async function checkAgentReady(
         return undefined;
     }
     const reason = report.message ?? "Agent is not ready.";
+    // `details` carries the actionable part (which file to edit, the YAML to
+    // paste). It's markdown, so it travels as rich display content rather
+    // than being folded into the plain-text Error message, which clients
+    // render without formatting (collapsing the snippet's indentation).
+    const details = report.details;
     if (report.state === "unsupported") {
-        throw new Error(
-            `Agent '${appAgentName}' is not supported in this environment: ${reason}`,
+        const message = `Agent '${appAgentName}' is not supported in this environment: ${reason}`;
+        throw new AgentNotReadyError(
+            message,
+            details ? `${message}\n\n${details}` : undefined,
         );
     }
     // setup-required
@@ -125,8 +136,10 @@ export async function checkAgentReady(
     const hint = systemContext.agents.hasSetup(appAgentName)
         ? `Run \`@config agent setup ${appAgentName}\` to configure it.`
         : `After fixing the underlying issue, run \`@config agent refresh ${appAgentName}\` to re-check.`;
-    throw new Error(
-        `Agent '${appAgentName}' needs configuration before it can be used: ${reason} ${hint}`,
+    const headline = `Agent '${appAgentName}' needs configuration before it can be used: ${reason}`;
+    throw new AgentNotReadyError(
+        `${headline} ${hint}`,
+        details ? `${headline}\n\n${details}\n\n${hint}` : undefined,
     );
 }
 
@@ -286,6 +299,12 @@ export async function executeAction(
         }
         const details = serializeError(e);
         result = createActionResultFromError(details.message, details);
+        // Readiness failures carry markdown setup instructions; show those
+        // instead of the flattened one-line message.
+        const errorDisplay = getErrorDisplayContent(e);
+        if (errorDisplay !== undefined) {
+            result = { ...result, errorDisplayContent: errorDisplay };
+        }
     }
     // If the agent ran to completion but a cancel arrived while it was executing,
     // discard the result and treat this as a cancellation.
@@ -381,7 +400,14 @@ export function emitActionResult(
     }
     if (result.error !== undefined) {
         if (!("fallbackToReasoning" in result) || !result.fallbackToReasoning) {
-            displayError(result.error, actionContext);
+            if (result.errorDisplayContent !== undefined) {
+                actionContext.actionIO.appendDisplay(
+                    result.errorDisplayContent,
+                    "block",
+                );
+            } else {
+                displayError(result.error, actionContext);
+            }
         }
         return;
     }

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -938,7 +938,12 @@ export async function executeCommand(
                     "AbortError",
                 );
             }
-            displayError(`ERROR: ${e.message}`, actionContext);
+            const errorDisplay = getErrorDisplayContent(e);
+            if (errorDisplay !== undefined) {
+                actionContext.actionIO.appendDisplay(errorDisplay, "block");
+            } else {
+                displayError(`ERROR: ${e.message}`, actionContext);
+            }
             debugCommandExecError(e.stack);
         }
     } finally {

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -133,14 +133,24 @@ export async function checkAgentReady(
     // Different hint depending on whether the agent can be configured
     // from chat. Without a hook (manual config case), `@config agent
     // setup` would just bounce the user; point at `refresh` instead.
-    const hint = systemContext.agents.hasSetup(appAgentName)
-        ? `Run \`@config agent setup ${appAgentName}\` to configure it.`
-        : `After fixing the underlying issue, run \`@config agent refresh ${appAgentName}\` to re-check.`;
+    const hasSetup = systemContext.agents.hasSetup(appAgentName);
+    const command = hasSetup
+        ? `@config agent setup ${appAgentName}`
+        : `@config agent refresh ${appAgentName}`;
+    const hint = hasSetup
+        ? `Run \`${command}\` to configure it.`
+        : `After fixing the underlying issue, run \`${command}\` to re-check.`;
     const headline = `Agent '${appAgentName}' needs configuration before it can be used: ${reason}`;
-    throw new AgentNotReadyError(
-        `${headline} ${hint}`,
-        details ? `${headline}\n\n${details}\n\n${hint}` : undefined,
-    );
+    // Agents commonly close their own `details` by telling the user to run
+    // the very same command; appending the hint on top of that just says it
+    // twice. Only add it when the details didn't already.
+    const detailsDisplay =
+        details === undefined
+            ? undefined
+            : details.includes(command)
+              ? `${headline}\n\n${details}`
+              : `${headline}\n\n${details}\n\n${hint}`;
+    throw new AgentNotReadyError(`${headline} ${hint}`, detailsDisplay);
 }
 
 function getStreamingActionContext(

--- a/ts/packages/dispatcher/dispatcher/src/execute/agentNotReadyError.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/agentNotReadyError.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DisplayContent } from "@typeagent/agent-sdk";
+
+/**
+ * Thrown by the readiness pre-flight gate when an agent can't run yet.
+ *
+ * `message` stays a single plain-text line (what non-display consumers and
+ * logs see). `markdown` optionally carries the actionable setup instructions
+ * — which file to edit and the config snippet to paste — which only render
+ * correctly as markdown, since plain-text display collapses indentation.
+ */
+export class AgentNotReadyError extends Error {
+    public readonly markdown: string | undefined;
+    constructor(message: string, markdown?: string) {
+        super(message);
+        this.name = "AgentNotReadyError";
+        this.markdown = markdown;
+    }
+}
+
+/**
+ * The rich error display for a thrown value, or undefined when it carries
+ * none (in which case callers should fall back to the plain message).
+ */
+export function getErrorDisplayContent(e: unknown): DisplayContent | undefined {
+    const markdown =
+        e instanceof AgentNotReadyError ? e.markdown : (undefined as undefined);
+    return markdown === undefined
+        ? undefined
+        : { type: "markdown", content: markdown, kind: "error" };
+}

--- a/ts/packages/dispatcher/dispatcher/src/execute/agentNotReadyError.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/agentNotReadyError.ts
@@ -23,11 +23,15 @@ export class AgentNotReadyError extends Error {
 /**
  * The rich error display for a thrown value, or undefined when it carries
  * none (in which case callers should fall back to the plain message).
+ *
+ * Duck-typed on a `markdown` property rather than an `instanceof` check:
+ * errors thrown inside an agent process are rebuilt from the RPC envelope
+ * on this side, and agents raise their own markdown-carrying errors
+ * (`ConfigSetupError`) that this package doesn't own.
  */
 export function getErrorDisplayContent(e: unknown): DisplayContent | undefined {
-    const markdown =
-        e instanceof AgentNotReadyError ? e.markdown : (undefined as undefined);
-    return markdown === undefined
-        ? undefined
-        : { type: "markdown", content: markdown, kind: "error" };
+    const markdown = (e as { markdown?: unknown } | undefined)?.markdown;
+    return typeof markdown === "string" && markdown.length > 0
+        ? { type: "markdown", content: markdown, kind: "error" }
+        : undefined;
 }

--- a/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
@@ -488,6 +488,32 @@ describe("checkAgentReady (pre-flight gate)", () => {
         expect(display.content).toContain("@config agent refresh agentH");
     });
 
+    test("does not repeat the refresh command the details already gave", async () => {
+        const sys = fakeSystemContext({
+            readiness: new Map([
+                [
+                    "agentJ",
+                    {
+                        state: "setup-required",
+                        message: "Spotify is not configured.",
+                        details:
+                            "Add the values, then run `@config agent refresh agentJ`.",
+                    },
+                ],
+            ]),
+            hasSetup: () => false,
+        });
+        const error = await checkAgentReady(
+            "agentJ",
+            sys,
+            fakeActionContext(),
+        ).catch((e) => e);
+        const display = getErrorDisplayContent(error) as any;
+        const occurrences =
+            display.content.split("@config agent refresh agentJ").length - 1;
+        expect(occurrences).toBe(1);
+    });
+
     test("has no rich display when the report has no details", async () => {
         const sys = fakeSystemContext({
             readiness: new Map([

--- a/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
@@ -15,6 +15,7 @@
 import { AppAgentManager } from "../src/context/appAgentManager.js";
 import { PortRegistrar } from "../src/context/portRegistrar.js";
 import { checkAgentReady } from "../src/execute/actionHandlers.js";
+import { getErrorDisplayContent } from "../src/execute/agentNotReadyError.js";
 import type {
     ActionContext,
     ActionResult,
@@ -454,5 +455,51 @@ describe("checkAgentReady (pre-flight gate)", () => {
         await expect(
             checkAgentReady("agentG", sys, fakeActionContext()),
         ).rejects.toThrow(/needs configuration/);
+    });
+
+    test("carries the report's markdown details for rich display", async () => {
+        const sys = fakeSystemContext({
+            readiness: new Map([
+                [
+                    "agentH",
+                    {
+                        state: "setup-required",
+                        message: "Spotify is not configured.",
+                        details:
+                            "Add to `ts/config.local.yaml`:\n\n```yaml\nspotify:\n  clientId: <value>\n```",
+                    },
+                ],
+            ]),
+            hasSetup: () => false,
+        });
+        const error = await checkAgentReady(
+            "agentH",
+            sys,
+            fakeActionContext(),
+        ).catch((e) => e);
+        // The plain message stays a single line for logs / non-display clients.
+        expect(error.message).not.toContain("```");
+        expect(error.message).toContain("Spotify is not configured.");
+        const display = getErrorDisplayContent(error) as any;
+        expect(display.type).toBe("markdown");
+        expect(display.kind).toBe("error");
+        expect(display.content).toContain("ts/config.local.yaml");
+        expect(display.content).toContain("clientId: <value>");
+        expect(display.content).toContain("@config agent refresh agentH");
+    });
+
+    test("has no rich display when the report has no details", async () => {
+        const sys = fakeSystemContext({
+            readiness: new Map([
+                ["agentI", { state: "setup-required", message: "nope" }],
+            ]),
+            hasSetup: () => false,
+        });
+        const error = await checkAgentReady(
+            "agentI",
+            sys,
+            fakeActionContext(),
+        ).catch((e) => e);
+        expect(getErrorDisplayContent(error)).toBeUndefined();
     });
 });

--- a/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
@@ -392,6 +392,15 @@ describe("checkAgentReady (pre-flight gate)", () => {
                 kind: "warning",
                 content: expect.stringContaining("```yaml"),
             });
+            if (
+                typeof display !== "object" ||
+                display === null ||
+                Array.isArray(display) ||
+                !("type" in display) ||
+                display.type !== "markdown"
+            ) {
+                throw new Error("Expected markdown setup display");
+            }
             expect(display.content).toContain("@config agent refresh player");
         });
     });

--- a/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/agentReadiness.spec.ts
@@ -16,6 +16,7 @@ import { AppAgentManager } from "../src/context/appAgentManager.js";
 import { PortRegistrar } from "../src/context/portRegistrar.js";
 import { checkAgentReady } from "../src/execute/actionHandlers.js";
 import { getErrorDisplayContent } from "../src/execute/agentNotReadyError.js";
+import { getManualAgentSetupDisplay } from "../src/context/system/handlers/configCommandHandlers.js";
 import type {
     ActionContext,
     ActionResult,
@@ -375,6 +376,24 @@ describe("checkAgentReady (pre-flight gate)", () => {
         const sys = fakeSystemContext({ readiness: new Map() });
         const out = await checkAgentReady("agentA", sys, fakeActionContext());
         expect(out).toBeUndefined();
+    });
+
+    describe("@config agent setup manual instructions", () => {
+        test("renders setup details as markdown", () => {
+            const display = getManualAgentSetupDisplay("player", {
+                state: "setup-required",
+                message: "Spotify is not configured.",
+                details:
+                    "Add to `ts/config.local.yaml`:\n\n```yaml\nspotify:\n  clientId: <value>\n```",
+            });
+
+            expect(display).toEqual({
+                type: "markdown",
+                kind: "warning",
+                content: expect.stringContaining("```yaml"),
+            });
+            expect(display.content).toContain("@config agent refresh player");
+        });
     });
 
     test("throws with a setup hint when state is setup-required and the agent has setup", async () => {

--- a/ts/packages/dispatcher/dispatcher/test/completion.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/completion.spec.ts
@@ -13,7 +13,13 @@ import {
     initializeCommandHandlerContext,
 } from "../src/context/commandHandlerContext.js";
 import { getCommandInterface } from "@typeagent/agent-sdk/helpers/command";
-import { getCommandCompletion } from "../src/command/completion.js";
+import {
+    createProgrammingErrorReportingState,
+    getCommandCompletion,
+    reportProgrammingError,
+    resetProgrammingErrorReportingState,
+} from "../src/command/completion.js";
+import vm from "node:vm";
 
 // ---------------------------------------------------------------------------
 // Test agent with parameters for completion testing
@@ -739,6 +745,68 @@ describe("Command Completion - startIndex", () => {
             explainer: { enabled: false },
             cache: { enabled: false },
             appAgentProviders: [testCompletionAgentProviderMulti],
+        });
+    });
+
+    describe("completion programming error reporting", () => {
+        test.each(["TypeError", "ReferenceError"])(
+            "detects %s from another realm",
+            (errorName) => {
+                const error = vm.runInNewContext(
+                    `new ${errorName}("cross-realm failure")`,
+                );
+                const messages: string[] = [];
+
+                reportProgrammingError(
+                    error,
+                    createProgrammingErrorReportingState(),
+                    (message) => messages.push(message),
+                );
+
+                expect(messages).toHaveLength(1);
+                expect(messages[0]).toContain(
+                    `${errorName}: cross-realm failure`,
+                );
+            },
+        );
+
+        test("bounds injected dedupe state and evicts the oldest entry", () => {
+            const state = createProgrammingErrorReportingState(2);
+            const messages: string[] = [];
+            const write = (message: string) => messages.push(message);
+
+            reportProgrammingError(new TypeError("first"), state, write);
+            reportProgrammingError(new TypeError("second"), state, write);
+            reportProgrammingError(new TypeError("third"), state, write);
+            reportProgrammingError(new TypeError("first"), state, write);
+
+            expect(state.reported.size).toBe(2);
+            expect(messages).toHaveLength(4);
+        });
+
+        test("default dedupe state can be reset", () => {
+            const messages: string[] = [];
+            const write = (message: string) => messages.push(message);
+            const error = new ReferenceError("resettable");
+
+            resetProgrammingErrorReportingState();
+            reportProgrammingError(error, undefined, write);
+            reportProgrammingError(error, undefined, write);
+            resetProgrammingErrorReportingState();
+            reportProgrammingError(error, undefined, write);
+
+            expect(messages).toHaveLength(2);
+            resetProgrammingErrorReportingState();
+        });
+
+        test("does not match programming error name substrings", () => {
+            const messages: string[] = [];
+            reportProgrammingError(
+                { name: "NotATypeError", message: "no" },
+                createProgrammingErrorReportingState(),
+                (message) => messages.push(message),
+            );
+            expect(messages).toEqual([]);
         });
     });
     afterAll(async () => {

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -29,6 +29,10 @@ import {
     fatal,
 } from "./instance.js";
 import { AGENT_SERVER_DEFAULT_PORT } from "@typeagent/agent-server-client";
+import {
+    isAllowedConfigFilePath,
+    resolveLocalConfigPath,
+} from "@typeagent/config";
 
 import {
     debugShell,
@@ -310,6 +314,17 @@ async function initialize() {
         const shellWindow = getShellWindowForChatViewIpcEvent(event);
         if (!shellWindow) return;
         shell.openPath(path);
+    });
+
+    ipcMain.on("open-config-file", async (event, candidate: string) => {
+        const shellWindow = getShellWindowForChatViewIpcEvent(event);
+        if (!shellWindow) return;
+        const expected = resolveLocalConfigPath();
+        if (!isAllowedConfigFilePath(candidate, expected)) {
+            debugShellError("Rejected non-config local-file link");
+            return;
+        }
+        await shell.openPath(candidate);
     });
 
     ipcMain.on("open-url-in-browser-tab", async (event, url: string) => {

--- a/ts/packages/shell/src/main/speech.ts
+++ b/ts/packages/shell/src/main/speech.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { dialog, globalShortcut, ipcMain } from "electron";
+import { CONFIG_LOCAL_FILE } from "@typeagent/config";
 import { AzureSpeech } from "./azureSpeech.js";
 import { isLocalWhisperEnabled } from "./localWhisperCommandHandler.js";
 
@@ -27,7 +28,7 @@ async function getSpeechToken(silent: boolean) {
         if (!silent) {
             dialog.showErrorBox(
                 "Azure Speech Service: Missing configuration",
-                "Environment variable SPEECH_SDK_KEY or SPEECH_SDK_REGION is missing.  Switch to local whisper or provide the configuration and restart.",
+                `The \`speech\` section of \`${CONFIG_LOCAL_FILE}\` is missing \`auth\` or \`region\`. Switch to local whisper or provide the configuration and restart.`,
             );
         }
         return undefined;

--- a/ts/packages/shell/src/preload/chatView.ts
+++ b/ts/packages/shell/src/preload/chatView.ts
@@ -198,6 +198,9 @@ const api: ClientAPI = {
     openFolder: (path: string) => {
         ipcRenderer.send("open-folder", path);
     },
+    openConfigFile: (path: string) => {
+        ipcRenderer.send("open-config-file", path);
+    },
     openUrlInBrowserTab: (url: string) => {
         ipcRenderer.send("open-url-in-browser-tab", url);
     },

--- a/ts/packages/shell/src/preload/electronTypes.ts
+++ b/ts/packages/shell/src/preload/electronTypes.ts
@@ -70,6 +70,7 @@ export interface ClientAPI {
     saveSettings: (settings: ShellUserSettings) => void;
     openImageFile: () => void;
     openFolder: (path: string) => void;
+    openConfigFile: (path: string) => void;
     openUrlInBrowserTab: (url: string) => void;
     openUrlExternal: (url: string) => void;
 

--- a/ts/packages/shell/src/renderer/src/chatPanelBridge.ts
+++ b/ts/packages/shell/src/renderer/src/chatPanelBridge.ts
@@ -660,7 +660,7 @@ export function createChatPanelClient(
                 // handles files as well as directories.
                 const filePath = fileLinkToPath(href);
                 if (filePath !== undefined) {
-                    getClientAPI().openFolder(filePath);
+                    getClientAPI().openConfigFile(filePath);
                     return;
                 }
                 getClientAPI().openUrlExternal(href);

--- a/ts/packages/shell/src/renderer/src/chatPanelBridge.ts
+++ b/ts/packages/shell/src/renderer/src/chatPanelBridge.ts
@@ -26,6 +26,7 @@ import {
     parseStatusNotice,
     type TemplateEditServices,
     type ConnectionStatus,
+    fileLinkToPath,
 } from "@typeagent/chat-ui";
 import { AppAgentEvent } from "@typeagent/agent-sdk";
 import {
@@ -654,6 +655,14 @@ export function createChatPanelClient(
     const chatPanel = new ChatPanel(rootElement, {
         platformAdapter: {
             handleLinkClick: (href: string) => {
+                // Local-file links open in the OS default editor; the
+                // `openFolder` channel is just `shell.openPath`, which
+                // handles files as well as directories.
+                const filePath = fileLinkToPath(href);
+                if (filePath !== undefined) {
+                    getClientAPI().openFolder(filePath);
+                    return;
+                }
                 getClientAPI().openUrlExternal(href);
             },
         },

--- a/ts/packages/shell/src/renderer/src/webSocketAPI.ts
+++ b/ts/packages/shell/src/renderer/src/webSocketAPI.ts
@@ -56,6 +56,9 @@ export const webapi: ClientAPI = {
     openFolder: () => {
         // not supported on mobile
     },
+    openConfigFile: () => {
+        // not supported on mobile
+    },
     openUrlInBrowserTab: () => {
         // not supported on mobile
     },

--- a/ts/packages/telemetry/src/logger/cosmosDBLoggerSink.ts
+++ b/ts/packages/telemetry/src/logger/cosmosDBLoggerSink.ts
@@ -155,7 +155,7 @@ export function createCosmosDBLoggerSink(
     const endpoint = process.env["COSMOSDB_CONNECTION_STRING"] ?? "";
     if (endpoint === "") {
         throw new Error(
-            "COSMOSDB_CONNECTION_STRING environment variable not set",
+            "Cosmos DB is not configured. Set `storage.database.cosmosDbConnectionString` in `ts/config.local.yaml`.",
         );
     }
     return new CosmosDBLoggerSink(

--- a/ts/packages/telemetry/src/logger/databaseLoggerSink.ts
+++ b/ts/packages/telemetry/src/logger/databaseLoggerSink.ts
@@ -96,6 +96,6 @@ export function createDatabaseLoggerSink(
 
     // No connection string found
     throw new Error(
-        "No database connection string found. Set either COSMOSDB_CONNECTION_STRING or MONGODB_CONNECTION_STRING environment variable.",
+        "No database connection string found. Set `storage.database.cosmosDbConnectionString` or `storage.database.mongoDbConnectionString` in `ts/config.local.yaml`.",
     );
 }

--- a/ts/packages/telemetry/src/logger/mongoLoggerSink.ts
+++ b/ts/packages/telemetry/src/logger/mongoLoggerSink.ts
@@ -113,7 +113,7 @@ export function createMongoDBLoggerSink(
     const dbUrl = process.env["MONGODB_CONNECTION_STRING"] ?? null;
     if (dbUrl === null || dbUrl === "") {
         throw new Error(
-            "MONGODB_CONNECTION_STRING environment variable not set",
+            "MongoDB is not configured. Set `storage.database.mongoDbConnectionString` in `ts/config.local.yaml`.",
         );
     }
     return new MongoDBLoggerSink(

--- a/ts/packages/vscode-shell/src/agentServerBridge.ts
+++ b/ts/packages/vscode-shell/src/agentServerBridge.ts
@@ -28,6 +28,8 @@ import type { ClientIO } from "@typeagent/dispatcher-rpc/types";
 
 function isAllowedConfigPath(candidate: string): boolean {
     if (
+        candidate.length === 0 ||
+        candidate.includes("\0") ||
         !path.isAbsolute(candidate) ||
         candidate.startsWith("\\\\") ||
         candidate.startsWith("//") ||
@@ -37,9 +39,7 @@ function isAllowedConfigPath(candidate: string): boolean {
     }
     const normalize = (value: string) => {
         const resolved = path.resolve(value);
-        return process.platform === "win32"
-            ? resolved.toLocaleLowerCase()
-            : resolved;
+        return process.platform === "win32" ? resolved.toLowerCase() : resolved;
     };
     const allowed = new Set<string>();
     const add = (value: string | undefined) => {

--- a/ts/packages/vscode-shell/src/agentServerBridge.ts
+++ b/ts/packages/vscode-shell/src/agentServerBridge.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 import * as os from "os";
+import * as path from "node:path";
 import {
     connectAgentServer,
     type AgentServerConnection,
@@ -24,6 +25,45 @@ import {
     type Backoff,
 } from "@typeagent/websocket-utils/backoff";
 import type { ClientIO } from "@typeagent/dispatcher-rpc/types";
+
+function isAllowedConfigPath(candidate: string): boolean {
+    if (
+        !path.isAbsolute(candidate) ||
+        candidate.startsWith("\\\\") ||
+        candidate.startsWith("//") ||
+        candidate.split(/[\\/]/).some((segment) => segment === "..")
+    ) {
+        return false;
+    }
+    const normalize = (value: string) => {
+        const resolved = path.resolve(value);
+        return process.platform === "win32"
+            ? resolved.toLocaleLowerCase()
+            : resolved;
+    };
+    const allowed = new Set<string>();
+    const add = (value: string | undefined) => {
+        if (value !== undefined) {
+            allowed.add(normalize(value));
+        }
+    };
+    add(process.env.TYPEAGENT_CONFIG_LOCAL);
+    if (process.env.TYPEAGENT_CONFIG_DIR !== undefined) {
+        add(path.join(process.env.TYPEAGENT_CONFIG_DIR, "config.local.yaml"));
+    }
+    add(
+        path.join(
+            process.env.TYPEAGENT_USER_DATA_DIR ??
+                path.join(os.homedir(), ".typeagent"),
+            "config.local.yaml",
+        ),
+    );
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+        add(path.join(folder.uri.fsPath, "config.local.yaml"));
+        add(path.join(folder.uri.fsPath, "ts", "config.local.yaml"));
+    }
+    return allowed.has(normalize(candidate));
+}
 
 import {
     wrapLegacy,
@@ -1495,7 +1535,7 @@ export class AgentServerBridge {
             case "openFile":
                 // `typeagent-file:` link — show it in an editor tab rather
                 // than handing it to the OS; the user is already in VS Code.
-                if (msg.path) {
+                if (msg.path && isAllowedConfigPath(msg.path)) {
                     void vscode.window.showTextDocument(
                         vscode.Uri.file(msg.path),
                     );

--- a/ts/packages/vscode-shell/src/agentServerBridge.ts
+++ b/ts/packages/vscode-shell/src/agentServerBridge.ts
@@ -1492,6 +1492,15 @@ export class AgentServerBridge {
                     void vscode.env.openExternal(vscode.Uri.parse(msg.href));
                 }
                 break;
+            case "openFile":
+                // `typeagent-file:` link — show it in an editor tab rather
+                // than handing it to the OS; the user is already in VS Code.
+                if (msg.path) {
+                    void vscode.window.showTextDocument(
+                        vscode.Uri.file(msg.path),
+                    );
+                }
+                break;
             case "openMessageWindow":
                 // Open the message content in a new editor panel (a movable
                 // window). The extension owns the panel.

--- a/ts/packages/vscode-shell/src/bridge/messages.ts
+++ b/ts/packages/vscode-shell/src/bridge/messages.ts
@@ -331,6 +331,8 @@ export type BridgeFromWebviewMessage =
     // Double-Esc gesture: cancel every queued + running entry on the session.
     | { type: "cancelAllQueuedAndRunning" }
     | { type: "openExternal"; href: string }
+    // Open a local file in an editor tab (from a `typeagent-file:` link).
+    | { type: "openFile"; path: string }
     // Open a message's content in a new editor panel (a movable window).
     | { type: "openMessageWindow"; html: string; title?: string }
     // Request a fresh Azure Speech authorization token from the server

--- a/ts/packages/vscode-shell/src/webview/main.ts
+++ b/ts/packages/vscode-shell/src/webview/main.ts
@@ -15,6 +15,7 @@ import {
     handleClipboardShortcut,
     STATUS_NOTICE_EVENT,
     parseStatusNotice,
+    fileLinkToPath,
     type ConnectionStatus,
 } from "@typeagent/chat-ui";
 import type {
@@ -183,6 +184,11 @@ const chatPanel = new ChatPanel(rootEl, {
         // Open links via the extension host — webviews can't call window.open
         // for arbitrary URLs in a useful way.
         handleLinkClick: (href: string, _target: string | null) => {
+            const filePath = fileLinkToPath(href);
+            if (filePath !== undefined) {
+                vscode.postMessage({ type: "openFile", path: filePath });
+                return;
+            }
             vscode.postMessage({ type: "openExternal", href });
         },
         // Open the message in a new VS Code editor panel (movable / snappable)

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1836,6 +1836,9 @@ importers:
       '@typeagent/common-utils':
         specifier: workspace:*
         version: link:../../../utils/commonUtils
+      '@typeagent/config':
+        specifier: workspace:*
+        version: link:../../../config
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -2544,6 +2547,9 @@ importers:
       '@typeagent/aiclient':
         specifier: workspace:*
         version: link:../../aiclient
+      '@typeagent/config':
+        specifier: workspace:*
+        version: link:../../config
     devDependencies:
       '@typeagent/action-grammar-compiler':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Accept absolute paths and directories in `@player spotify load`.
- Validate, deduplicate, and atomically persist Spotify streaming history so tracks, artists, and albums feed completion reliably.
- Update configuration errors across the application to reference `config.local.yaml` instead of legacy `.env` variables.
- Centralize env-var-to-YAML mappings and reload only the requested agent settings while preserving lower-precedence values.
- Render setup guidance as markdown with syntax highlighting, copy buttons, and securely allowlisted configuration-file links.
- Restore player song and artist completion, validate built-in construction-cache namespaces against current schema hashes, and bound completion results.

## Spotify history loading

- Resolve absolute paths, paths relative to the current working directory, and paths in agent storage.
- Accept a directory, loading every `.json` file that contains Spotify streaming history and skipping unrelated JSON files.
- Validate records, ignore entries without usable track names or IDs, and omit null optional metadata.
- Track source fingerprints so reloading unchanged exports is idempotent, replace imported history atomically, and bound retained timestamps.
- Merge tracks, artists, and albums into `userData`, then invalidate the cached name index so completion sees newly loaded data immediately.

## Configuration errors and refresh

TypeAgent has moved from `.env` settings to `config.local.yaml`, but several errors still named legacy environment variables. Update those messages for player, email, calendar, graph, Discord, speech, and telemetry/database configuration so they point to the actual YAML keys.

- Generate ready-to-paste configuration snippets and links to `config.local.yaml`.
- Use a shared config-leaf registry for hints and applicable runtime conversion paths, with uniqueness and round-trip coverage to prevent mapping drift.
- Preserve markdown setup guidance across agent RPC and dispatcher error boundaries.
- Re-read only the requested legacy keys when `@config agent refresh <agent>` runs.
- Restore inherited process, Key Vault, or default values when a local override is removed.
- Reject malformed configuration sections independently instead of discarding the entire file.

## Rendering and file-link security

- Render setup markdown with JSON/YAML highlighting and copy controls.
- Allow hosts to open only exact known `config.local.yaml` targets, rejecting unrelated files, executables, traversal, UNC, empty, and NUL-containing paths.
- Sanitize highlighted markup through an allowlisted DOM fragment before insertion so source text cannot be reinterpreted as active HTML.

## Autocompletion and construction cache

- Regenerate the built-in construction cache, removing a part that was both optional and captured.
- Refresh the stale player schema hash and validate shipped namespaces generically against active production schemas.
- Guard `p.match` in the NFA and grammar-partials completion branches, matching the existing DFA guard.
- Filter invalid history values and rank and cap player completion results.
- Report bounded, distinct completion errors instead of hiding them in a debug-only channel.

## Changed files by purpose

| Purpose | Files |
| --- | --- |
| Spotify loading, validation, and persistence | `docs/content/help/commandReference.md`, `ts/docs/overview/command-reference.md`, `ts/packages/agents/player/README.md`, `playerCommands.ts`, `client.ts`, `userData.ts`, `loadHistory.spec.ts`, `userData.spec.ts` |
| Player readiness and completion | `playerHandlers.ts`, `defaultTokenProvider.ts`, `playerReadiness.spec.ts`, `defaultTokenProvider.spec.ts`, player completion tests |
| Shared configuration registry and reload | `ts/packages/config/src/{mappings,flatten,hints,index,loader,setupError}.ts` and corresponding config tests |
| `config.local.yaml` error-message migration | `graphUtils`, calendar, email, Discord, `shell/src/main/speech.ts`, telemetry database logger sinks, and their readiness tests |
| Markdown error propagation | `agentSdk/src/action.ts`, `agentRpc/src/rpc.ts`, dispatcher command/action execution files, `agentNotReadyError.ts`, and related tests |
| Markdown rendering and secure file links | `chat-ui`, config file-link validation, browser extension chat panel, shell renderer bridge, and VS Code shell bridge/webview files |
| Built-in construction-cache validation | `defaultAgentProvider/data/explainer/v5/{constructions.json,data/player/basic.json}`, `builtinConstructions.spec.ts`, dispatcher cache setup |
| Grammar and player completion handling | `cache/src/cache/grammarStore.ts`, dispatcher `completion.ts`, `playerRequestCompletion.spec.ts`, player completion sources |

## Tests

- `builtinConstructions.spec.ts` verifies exact production namespaces, current schema hashes, and player completion integration.
- Spotify tests cover file and directory loading, malformed and nullable records, idempotent source replacement, timestamp bounds, storage behavior, and completion data.
- Configuration tests cover mapping uniqueness and round trips, scoped reload precedence and removal, malformed-section isolation, and secure file-link validation.
- Readiness, RPC, dispatcher, and chat rendering tests cover markdown setup guidance and configuration refresh behavior.
- Chat UI regression coverage verifies malicious highlighted source remains inert text.
