### PR TITLE
Strip default parameter from action contract

### DIFF
--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=061d858ff1fcd55b7186fc0c7e045457dfdd6672b6dc543e8edf026408cecd33 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=04ffc6fa34cfbe0d06383b4e35423fc5a203f9c3bd8b8f07c91c20b2cef9903c -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/types.ts](./src/core/types.ts)
 - [./src/translationBench/action-parameters-grader.generated.json](./src/translationBench/action-parameters-grader.generated.json)
 - [./src/translationBench/catalog.generated.json](./src/translationBench/catalog.generated.json)
-- _…and 28 more under `./src/`._
+- _…and 29 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `37bd3c767b07c054e8a98db3ff433118405c9648` on `2026-08-07T23:03:45.815Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `54efea2e226011740764eddb4beee99edc562313` on `2026-08-08T00:27:51.771Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
+++ b/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
@@ -75,11 +75,7 @@
                             "optional": false,
                             "spec": {
                               "kind": "string",
-                              "enum": [
-                                "string",
-                                "number",
-                                "boolean"
-                              ]
+                              "enum": ["string", "number", "boolean"]
                             }
                           },
                           "required": {
@@ -168,11 +164,7 @@
                           "optional": false,
                           "spec": {
                             "kind": "string",
-                            "enum": [
-                              "string",
-                              "number",
-                              "boolean"
-                            ]
+                            "enum": ["string", "number", "boolean"]
                           }
                         },
                         "required": {
@@ -1394,11 +1386,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "domain",
-                "pageType",
-                "source"
-              ]
+              "enum": ["domain", "pageType", "source"]
             }
           },
           "limit": {
@@ -1415,11 +1403,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "domain",
-              "pageType",
-              "source"
-            ]
+            "enum": ["domain", "pageType", "source"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1675,11 +1659,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "new",
-                "current",
-                "existing"
-              ]
+              "enum": ["new", "current", "existing"]
             }
           }
         }
@@ -1701,11 +1681,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "new",
-              "current",
-              "existing"
-            ]
+            "enum": ["new", "current", "existing"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1985,10 +1961,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "site",
-                "global"
-              ]
+              "enum": ["site", "global"]
             }
           },
           "domains": {
@@ -2019,10 +1992,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "site",
-              "global"
-            ]
+            "enum": ["site", "global"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2194,11 +2164,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "site",
-                "global",
-                "all"
-              ]
+              "enum": ["site", "global", "all"]
             }
           }
         }
@@ -2209,11 +2175,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "site",
-              "global",
-              "all"
-            ]
+            "enum": ["site", "global", "all"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2983,11 +2945,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "single",
-                "double",
-                "three"
-              ]
+              "enum": ["single", "double", "three"]
             }
           }
         }
@@ -2998,11 +2956,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "single",
-              "double",
-              "three"
-            ]
+            "enum": ["single", "double", "three"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -3265,11 +3219,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "into",
-                "out",
-                "over"
-              ]
+              "enum": ["into", "out", "over"]
             }
           }
         }
@@ -3280,11 +3230,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "into",
-              "out",
-              "over"
-            ]
+            "enum": ["into", "out", "over"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -5893,12 +5839,7 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": [
-                      "first",
-                      "next",
-                      "cursor",
-                      "indexInFile"
-                    ]
+                    "enum": ["first", "next", "cursor", "indexInFile"]
                   }
                 },
                 "position": {
@@ -6355,12 +6296,7 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": [
-                    "first",
-                    "next",
-                    "cursor",
-                    "indexInFile"
-                  ]
+                  "enum": ["first", "next", "cursor", "indexInFile"]
                 }
               },
               "position": {
@@ -7272,13 +7208,7 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": [
-                        "prefix",
-                        "suffix",
-                        "file",
-                        "doc",
-                        "comment"
-                      ]
+                      "enum": ["prefix", "suffix", "file", "doc", "comment"]
                     }
                   },
                   "content": {
@@ -7776,13 +7706,7 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": [
-                      "prefix",
-                      "suffix",
-                      "file",
-                      "doc",
-                      "comment"
-                    ]
+                    "enum": ["prefix", "suffix", "file", "doc", "comment"]
                   }
                 },
                 "content": {
@@ -7882,10 +7806,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "line",
-                "block"
-              ]
+              "enum": ["line", "block"]
             }
           },
           "position": {
@@ -8331,10 +8252,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "line",
-              "block"
-            ]
+            "enum": ["line", "block"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -8793,10 +8711,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "insert",
-                "delete"
-              ]
+              "enum": ["insert", "delete"]
             }
           },
           "count": {
@@ -9258,10 +9173,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "insert",
-              "delete"
-            ]
+            "enum": ["insert", "delete"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -9768,10 +9680,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "agent",
-                "ask"
-              ]
+              "enum": ["agent", "ask"]
             }
           },
           "isPartialQuery": {
@@ -9805,11 +9714,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "view",
-                "editor",
-                "window"
-              ]
+              "enum": ["view", "editor", "window"]
             }
           }
         }
@@ -9831,10 +9736,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "agent",
-              "ask"
-            ]
+            "enum": ["agent", "ask"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -9899,11 +9801,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "view",
-              "editor",
-              "window"
-            ]
+            "enum": ["view", "editor", "window"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11382,11 +11280,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "file",
-                "line",
-                "symbol"
-              ]
+              "enum": ["file", "line", "symbol"]
             }
           },
           "ref": {
@@ -11403,11 +11297,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "file",
-              "line",
-              "symbol"
-            ]
+            "enum": ["file", "line", "symbol"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11499,11 +11389,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "low",
-                "medium",
-                "high"
-              ]
+              "enum": ["low", "medium", "high"]
             }
           },
           "reuseExistingTerminal": {
@@ -11542,11 +11428,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11586,11 +11468,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "build",
-                "rebuild",
-                "clean"
-              ]
+              "enum": ["build", "rebuild", "clean"]
             }
           },
           "folderName": {
@@ -11613,11 +11491,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "build",
-              "rebuild",
-              "clean"
-            ]
+            "enum": ["build", "rebuild", "clean"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11679,11 +11553,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "inferFromName",
-                "workspaceRoot",
-                "activeSelection"
-              ]
+              "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
             }
           }
         }
@@ -11716,11 +11586,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "inferFromName",
-              "workspaceRoot",
-              "activeSelection"
-            ]
+            "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11754,10 +11620,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "exact",
-                "fuzzy"
-              ]
+              "enum": ["exact", "fuzzy"]
             }
           },
           "extensions": {
@@ -11794,10 +11657,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "exact",
-              "fuzzy"
-            ]
+            "enum": ["exact", "fuzzy"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12082,33 +11942,21 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "copilot",
-                "claude",
-                "gpt",
-                "generic"
-              ]
+              "enum": ["copilot", "claude", "gpt", "generic"]
             }
           },
           "newSessionLocation": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "window",
-                "editor",
-                "view"
-              ]
+              "enum": ["window", "editor", "view"]
             }
           },
           "mode": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "agent",
-                "ask"
-              ]
+              "enum": ["agent", "ask"]
             }
           },
           "isPartialQuery": {
@@ -12151,12 +11999,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "copilot",
-              "claude",
-              "gpt",
-              "generic"
-            ]
+            "enum": ["copilot", "claude", "gpt", "generic"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12168,11 +12011,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "window",
-              "editor",
-              "view"
-            ]
+            "enum": ["window", "editor", "view"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12184,10 +12023,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "agent",
-              "ask"
-            ]
+            "enum": ["agent", "ask"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12261,11 +12097,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "last",
-                "folder",
-                "workspace"
-              ]
+              "enum": ["last", "folder", "workspace"]
             }
           },
           "path": {
@@ -12282,11 +12114,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "last",
-              "folder",
-              "workspace"
-            ]
+            "enum": ["last", "folder", "workspace"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12531,12 +12359,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "right",
-                "left",
-                "up",
-                "down"
-              ]
+              "enum": ["right", "left", "up", "down"]
             }
           },
           "editorPosition": {
@@ -12559,12 +12382,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "right",
-              "left",
-              "up",
-              "down"
-            ]
+            "enum": ["right", "left", "up", "down"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12614,10 +12432,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "increase",
-                "decrease"
-              ]
+              "enum": ["increase", "decrease"]
             }
           }
         }
@@ -12628,10 +12443,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "increase",
-              "decrease"
-            ]
+            "enum": ["increase", "decrease"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12657,10 +12469,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "up",
-                "down"
-              ]
+              "enum": ["up", "down"]
             }
           },
           "amount": {
@@ -12677,10 +12486,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "up",
-              "down"
-            ]
+            "enum": ["up", "down"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13294,10 +13100,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "name",
-                "description"
-              ]
+              "enum": ["name", "description"]
             }
           },
           "elevate": {
@@ -13325,10 +13128,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "name",
-              "description"
-            ]
+            "enum": ["name", "description"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13487,11 +13287,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "light",
-                "dark",
-                "toggle"
-              ]
+              "enum": ["light", "dark", "toggle"]
             }
           }
         }
@@ -13502,11 +13298,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "light",
-              "dark",
-              "toggle"
-            ]
+            "enum": ["light", "dark", "toggle"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -13813,10 +13605,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "reduce",
-                "increase"
-              ]
+              "enum": ["reduce", "increase"]
             }
           }
         }
@@ -13827,10 +13616,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "reduce",
-              "increase"
-            ]
+            "enum": ["reduce", "increase"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13856,10 +13642,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "portrait",
-                "landscape"
-              ]
+              "enum": ["portrait", "landscape"]
             }
           }
         }
@@ -13870,10 +13653,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "portrait",
-              "landscape"
-            ]
+            "enum": ["portrait", "landscape"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14050,10 +13830,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "increase",
-                "decrease"
-              ]
+              "enum": ["increase", "decrease"]
             }
           }
         }
@@ -14064,10 +13841,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "increase",
-              "decrease"
-            ]
+            "enum": ["increase", "decrease"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14357,10 +14131,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "left",
-                "right"
-              ]
+              "enum": ["left", "right"]
             }
           }
         }
@@ -14371,10 +14142,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "left",
-              "right"
-            ]
+            "enum": ["left", "right"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14554,10 +14322,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "light",
-                "dark"
-              ]
+              "enum": ["light", "dark"]
             }
           }
         }
@@ -14568,10 +14333,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "light",
-              "dark"
-            ]
+            "enum": ["light", "dark"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -14667,11 +14429,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "bestPerformance",
-                "balanced",
-                "bestPowerEfficiency"
-              ]
+              "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
             }
           }
         }
@@ -14682,11 +14440,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "bestPerformance",
-              "balanced",
-              "bestPowerEfficiency"
-            ]
+            "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14712,10 +14466,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "allow",
-                "deny"
-              ]
+              "enum": ["allow", "deny"]
             }
           }
         }
@@ -14726,10 +14477,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "allow",
-              "deny"
-            ]
+            "enum": ["allow", "deny"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14755,10 +14503,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "allow",
-                "deny"
-              ]
+              "enum": ["allow", "deny"]
             }
           }
         }
@@ -14769,10 +14514,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "allow",
-              "deny"
-            ]
+            "enum": ["allow", "deny"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14798,10 +14540,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "allow",
-                "deny"
-              ]
+              "enum": ["allow", "deny"]
             }
           }
         }
@@ -14812,10 +14551,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "allow",
-              "deny"
-            ]
+            "enum": ["allow", "deny"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15521,10 +15257,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "left",
-                "center"
-              ]
+              "enum": ["left", "center"]
             }
           }
         }
@@ -15535,10 +15268,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "left",
-              "center"
-            ]
+            "enum": ["left", "center"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15564,10 +15294,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "show",
-                "hide"
-              ]
+              "enum": ["show", "hide"]
             }
           }
         }
@@ -15578,10 +15305,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "show",
-              "hide"
-            ]
+            "enum": ["show", "hide"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -19272,10 +18996,7 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": [
-                      "conversation",
-                      "internet"
-                    ]
+                    "enum": ["conversation", "internet"]
                   }
                 },
                 "site": {
@@ -19303,10 +19024,7 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": [
-                    "conversation",
-                    "internet"
-                  ]
+                  "enum": ["conversation", "internet"]
                 }
               },
               "site": {
@@ -24710,11 +24428,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "off",
-                "one",
-                "all"
-              ]
+              "enum": ["off", "one", "all"]
             }
           }
         }
@@ -24725,11 +24439,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "off",
-              "one",
-              "all"
-            ]
+            "enum": ["off", "one", "all"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -25071,12 +24781,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "continue",
-                "diagram",
-                "augment",
-                "research"
-              ]
+              "enum": ["continue", "diagram", "augment", "research"]
             }
           }
         }
@@ -25153,12 +24858,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "continue",
-              "diagram",
-              "augment",
-              "research"
-            ]
+            "enum": ["continue", "diagram", "augment", "research"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25774,11 +25474,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "selected",
-                "inverse",
-                "all"
-              ]
+              "enum": ["selected", "inverse", "all"]
             }
           },
           "files": {
@@ -25849,11 +25545,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "selected",
-              "inverse",
-              "all"
-            ]
+            "enum": ["selected", "inverse", "all"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -26028,10 +25720,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "grid",
-                "filmstrip"
-              ]
+              "enum": ["grid", "filmstrip"]
             }
           }
         }
@@ -26042,10 +25731,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "grid",
-              "filmstrip"
-            ]
+            "enum": ["grid", "filmstrip"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -26208,10 +25894,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "in-progress",
-                "complete"
-              ]
+              "enum": ["in-progress", "complete"]
             }
           }
         }
@@ -26222,10 +25905,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "in-progress",
-              "complete"
-            ]
+            "enum": ["in-progress", "complete"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27540,10 +27220,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "passing",
-                "failing"
-              ]
+              "enum": ["passing", "failing"]
             }
           }
         }
@@ -27565,10 +27242,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "passing",
-              "failing"
-            ]
+            "enum": ["passing", "failing"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27826,13 +27500,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "rest",
-                "graphql",
-                "websocket",
-                "ipc",
-                "sdk"
-              ]
+              "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
             }
           }
         }
@@ -27865,13 +27533,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "rest",
-              "graphql",
-              "websocket",
-              "ipc",
-              "sdk"
-            ]
+            "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -29280,12 +28942,7 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": [
-                        "string",
-                        "number",
-                        "boolean",
-                        "path"
-                      ]
+                      "enum": ["string", "number", "boolean", "path"]
                     }
                   },
                   "required": {
@@ -29416,12 +29073,7 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "path"
-                    ]
+                    "enum": ["string", "number", "boolean", "path"]
                   }
                 },
                 "required": {
@@ -31082,10 +30734,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "all",
-                "unread"
-              ]
+              "enum": ["all", "unread"]
             }
           }
         }
@@ -31096,10 +30745,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "all",
-              "unread"
-            ]
+            "enum": ["all", "unread"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -31375,11 +31021,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "bubble",
-                "toast",
-                "inline"
-              ]
+              "enum": ["bubble", "toast", "inline"]
             }
           },
           "count": {
@@ -31418,11 +31060,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "bubble",
-              "toast",
-              "inline"
-            ]
+            "enum": ["bubble", "toast", "inline"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31474,11 +31112,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "bubble",
-                "toast",
-                "inline"
-              ]
+              "enum": ["bubble", "toast", "inline"]
             }
           }
         }
@@ -31511,11 +31145,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "bubble",
-              "toast",
-              "inline"
-            ]
+            "enum": ["bubble", "toast", "inline"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31936,11 +31566,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "4",
-                "8",
-                "12"
-              ]
+              "enum": ["4", "8", "12"]
             }
           }
         }
@@ -31993,11 +31619,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "4",
-              "8",
-              "12"
-            ]
+            "enum": ["4", "8", "12"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32498,12 +32120,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "text",
-                "code",
-                "designer",
-                "debug"
-              ]
+              "enum": ["text", "code", "designer", "debug"]
             }
           }
         }
@@ -32525,12 +32142,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "text",
-              "code",
-              "designer",
-              "debug"
-            ]
+            "enum": ["text", "code", "designer", "debug"]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32781,10 +32393,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "celsius",
-                "fahrenheit"
-              ]
+              "enum": ["celsius", "fahrenheit"]
             }
           }
         }
@@ -32806,10 +32415,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "celsius",
-              "fahrenheit"
-            ]
+            "enum": ["celsius", "fahrenheit"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -32848,10 +32454,7 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": [
-                "celsius",
-                "fahrenheit"
-              ]
+              "enum": ["celsius", "fahrenheit"]
             }
           }
         }
@@ -32884,10 +32487,7 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": [
-              "celsius",
-              "fahrenheit"
-            ]
+            "enum": ["celsius", "fahrenheit"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -33263,10 +32863,7 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": [
-                "compact",
-                "full"
-              ]
+              "enum": ["compact", "full"]
             }
           }
         }
@@ -33277,10 +32874,7 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": [
-              "compact",
-              "full"
-            ]
+            "enum": ["compact", "full"]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",

--- a/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
+++ b/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
@@ -2,8 +2,8 @@
   "version": 1,
   "description": "Create+verify policies per action parameter. sourceFingerprint is paramSpec-only (stable across policy edits). rulesFingerprint is catalog-level; when it drifts, all actions reclassify. Incremental: only added/updated actions are reclassified; unchanged fingerprints are kept. Regex first, LLM prior reuse (not regex priors), LLM+verifier fallback. Open strings without a name heuristic use structural free_text/nonempty. `create` guides the synthesizer; `verify` / `parameterScore` drive runner soft matching. `llmAsAJudge` marks code/script params that need semantic LLM scoring. Object containers with only soft leaves use nonempty; mixed objects stay exact (no nested dotted paths yet).",
   "catalogVersion": "2026-08-06",
-  "generatedAt": "2026-08-07T23:29:18.858Z",
-  "rulesFingerprint": "32c014c7072f2860",
+  "generatedAt": "2026-08-07T23:34:55.817Z",
+  "rulesFingerprint": "9e5cc2fe1703d258",
   "modes": {
     "exact": "Chosen value must deep-equal expected",
     "exists": "Key must be present; value ignored (hand-authored seeds; not emitted by regex gen)",
@@ -1617,8 +1617,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-free-text-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "openInNewTab": {
@@ -1638,7 +1638,7 @@
         "fields": {
           "position": "exact",
           "title": "nonempty",
-          "url": "nonempty",
+          "url": "ignore",
           "openInNewTab": "exact"
         }
       }
@@ -3196,8 +3196,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -3205,7 +3205,7 @@
         "defaultMode": "exact",
         "fields": {
           "configurationName": "exact",
-          "noDebug": "exact"
+          "noDebug": "ignore"
         }
       }
     },
@@ -9751,8 +9751,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "attachScreenshot": {
@@ -9776,8 +9776,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -9815,9 +9815,9 @@
         "fields": {
           "query": "nonempty",
           "mode": "ignore",
-          "isPartialQuery": "exact",
+          "isPartialQuery": "ignore",
           "attachScreenshot": "exact",
-          "attachFiles": "nonempty",
+          "attachFiles": "ignore",
           "newSession": "exact",
           "newSessionLocation": "exact"
         }
@@ -10783,8 +10783,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "excludeUntitled": {
@@ -10813,7 +10813,7 @@
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "onlyDirty": "exact",
+          "onlyDirty": "ignore",
           "excludeUntitled": "exact",
           "logResult": "exact"
         }
@@ -10854,8 +10854,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "onlyDirty": {
@@ -10876,17 +10876,17 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "showErrorIfNoActiveEditor": "exact",
+          "showErrorIfNoActiveEditor": "ignore",
           "onlyDirty": "exact",
-          "excludeUntitled": "exact"
+          "excludeUntitled": "ignore"
         }
       }
     },
@@ -11443,8 +11443,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -11454,7 +11454,7 @@
           "folderName": "exact",
           "commandToExecute": "llmAsAJudge",
           "commandRiskLevel": "exact",
-          "reuseExistingTerminal": "exact"
+          "reuseExistingTerminal": "ignore"
         }
       }
     },
@@ -11590,8 +11590,8 @@
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
-          "verify": "exact",
-          "rule": "string-enum-exact",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -11600,7 +11600,7 @@
         "fields": {
           "folderName": "exact",
           "relativeTo": "nonempty",
-          "resolutionHint": "exact"
+          "resolutionHint": "ignore"
         }
       }
     },
@@ -11661,8 +11661,8 @@
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
-          "verify": "exact",
-          "rule": "string-enum-exact",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "extensions": {
@@ -11675,8 +11675,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -11692,8 +11692,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -11701,9 +11701,9 @@
         "defaultMode": "exact",
         "fields": {
           "fileName": "exact",
-          "matchStrategy": "exact",
-          "extensions": "nonempty",
-          "includeGenerated": "exact"
+          "matchStrategy": "ignore",
+          "extensions": "ignore",
+          "includeGenerated": "ignore"
         }
       }
     },
@@ -12038,8 +12038,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "attachScreenshot": {
@@ -12063,8 +12063,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -12081,9 +12081,9 @@
           "provider": "exact",
           "newSessionLocation": "exact",
           "mode": "ignore",
-          "isPartialQuery": "exact",
+          "isPartialQuery": "ignore",
           "attachScreenshot": "exact",
-          "attachFiles": "nonempty"
+          "attachFiles": "ignore"
         }
       }
     },
@@ -12554,8 +12554,8 @@
           },
           "typeKind": "string",
           "create": "identifier",
-          "verify": "exact",
-          "rule": "string-identifier-exact",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -12563,7 +12563,7 @@
         "defaultMode": "exact",
         "fields": {
           "filePath": "exact",
-          "themeName": "exact"
+          "themeName": "ignore"
         }
       }
     },
@@ -13143,8 +13143,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -13153,7 +13153,7 @@
         "fields": {
           "service": "exact",
           "matchBy": "exact",
-          "elevate": "exact"
+          "elevate": "ignore"
         }
       }
     },
@@ -14020,8 +14020,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -14029,7 +14029,7 @@
         "defaultMode": "exact",
         "fields": {
           "speedLevel": "exact",
-          "reduceSpeed": "exact"
+          "reduceSpeed": "ignore"
         }
       }
     },
@@ -15520,8 +15520,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "max_uses": {
@@ -15563,7 +15563,7 @@
         "fields": {
           "channel_id": "exact",
           "max_age": "exact",
-          "never_expires": "exact",
+          "never_expires": "ignore",
           "max_uses": "exact",
           "temporary": "exact",
           "unique": "exact"
@@ -15804,8 +15804,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-open-soft-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "tts": {
@@ -15815,8 +15815,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -15825,8 +15825,8 @@
         "fields": {
           "channel_id": "exact",
           "content": "nonempty",
-          "nonce": "nonempty",
-          "tts": "exact"
+          "nonce": "ignore",
+          "tts": "ignore"
         }
       }
     },
@@ -16607,8 +16607,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-open-soft-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "after": {
@@ -16618,8 +16618,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-open-soft-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "limit": {
@@ -16648,8 +16648,8 @@
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "before": "nonempty",
-          "after": "nonempty",
+          "before": "ignore",
+          "after": "ignore",
           "limit": "exact",
           "with_counts": "exact"
         }
@@ -17994,8 +17994,8 @@
           },
           "typeKind": "number",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-number",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -18005,7 +18005,7 @@
           "channel_id": "exact",
           "name": "exact",
           "auto_archive_duration": "exact",
-          "type": "exact"
+          "type": "ignore"
         }
       }
     },
@@ -20282,8 +20282,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-open-soft-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -20291,7 +20291,7 @@
         "defaultMode": "exact",
         "fields": {
           "artifact": "nonempty",
-          "type": "nonempty"
+          "type": "ignore"
         }
       }
     },
@@ -20352,8 +20352,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-open-soft-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -20362,7 +20362,7 @@
         "fields": {
           "hostname": "nonempty",
           "web": "exact",
-          "token": "nonempty"
+          "token": "ignore"
         }
       }
     },
@@ -22825,8 +22825,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -22836,7 +22836,7 @@
           "name": "exact",
           "description": "nonempty",
           "public": "exact",
-          "private": "exact"
+          "private": "ignore"
         }
       }
     },
@@ -23214,8 +23214,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -23223,7 +23223,7 @@
         "defaultMode": "exact",
         "fields": {
           "repo": "exact",
-          "unstar": "exact"
+          "unstar": "ignore"
         }
       }
     },
@@ -24926,8 +24926,8 @@
           },
           "typeKind": "number",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-number",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "context": {
@@ -24937,8 +24937,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-free-text-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -24946,8 +24946,8 @@
         "defaultMode": "exact",
         "fields": {
           "originalRequest": "nonempty",
-          "cursorPosition": "exact",
-          "context": "nonempty"
+          "cursorPosition": "ignore",
+          "context": "ignore"
         }
       }
     },
@@ -25026,8 +25026,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -25042,7 +25042,7 @@
         "fields": {
           "title": "nonempty",
           "files": "nonempty",
-          "search_filters": "nonempty"
+          "search_filters": "ignore"
         }
       }
     },
@@ -25531,8 +25531,8 @@
           },
           "typeKind": "array<number>",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "array-items:type-number",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "typed_literal",
@@ -25563,8 +25563,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -25579,9 +25579,9 @@
         "fields": {
           "title": "nonempty",
           "search_filters": "nonempty",
-          "indices": "exact",
+          "indices": "ignore",
           "selected": "exact",
-          "files": "nonempty"
+          "files": "ignore"
         }
       }
     },
@@ -28215,8 +28215,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         },
         "quantity": {
@@ -28235,7 +28235,7 @@
         "defaultMode": "exact",
         "fields": {
           "target": "exact",
-          "play": "exact",
+          "play": "ignore",
           "quantity": "exact"
         }
       }
@@ -30090,16 +30090,16 @@
             "kind": "string"
           },
           "typeKind": "string",
-          "create": "identifier",
-          "verify": "exact",
-          "rule": "string-identifier-exact",
+          "create": "free_text",
+          "verify": "nonempty",
+          "rule": "string-free-text-nonempty",
           "source": "regex"
         }
       },
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "name": "exact"
+          "name": "nonempty"
         }
       }
     },
@@ -30139,16 +30139,16 @@
             "kind": "string"
           },
           "typeKind": "string",
-          "create": "identifier",
-          "verify": "exact",
-          "rule": "string-identifier-exact",
+          "create": "free_text",
+          "verify": "nonempty",
+          "rule": "string-free-text-nonempty",
           "source": "regex"
         }
       },
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "name": "exact"
+          "name": "nonempty"
         }
       }
     },
@@ -30304,16 +30304,16 @@
             "kind": "string"
           },
           "typeKind": "string",
-          "create": "identifier",
-          "verify": "exact",
-          "rule": "string-identifier-exact",
+          "create": "free_text",
+          "verify": "nonempty",
+          "rule": "string-free-text-nonempty",
           "source": "regex"
         }
       },
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "name": "exact"
+          "name": "nonempty"
         }
       }
     },
@@ -30620,8 +30620,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "exact",
-          "rule": "type-boolean",
+          "verify": "ignore",
+          "rule": "hardcoded-ungrounded-ignore",
           "source": "regex"
         }
       },
@@ -30629,7 +30629,7 @@
         "defaultMode": "exact",
         "fields": {
           "agentName": "exact",
-          "all": "exact"
+          "all": "ignore"
         }
       }
     },

--- a/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
+++ b/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
@@ -2,8 +2,8 @@
   "version": 1,
   "description": "Create+verify policies per action parameter. sourceFingerprint is paramSpec-only (stable across policy edits). rulesFingerprint is catalog-level; when it drifts, all actions reclassify. Incremental: only added/updated actions are reclassified; unchanged fingerprints are kept. Regex first, LLM prior reuse (not regex priors), LLM+verifier fallback. Open strings without a name heuristic use structural free_text/nonempty. `create` guides the synthesizer; `verify` / `parameterScore` drive runner soft matching. `llmAsAJudge` marks code/script params that need semantic LLM scoring. Object containers with only soft leaves use nonempty; mixed objects stay exact (no nested dotted paths yet).",
   "catalogVersion": "2026-08-06",
-  "generatedAt": "2026-08-07T23:34:55.817Z",
-  "rulesFingerprint": "9e5cc2fe1703d258",
+  "generatedAt": "2026-08-08T00:16:23.592Z",
+  "rulesFingerprint": "94e6a3cd9d4836a3",
   "modes": {
     "exact": "Chosen value must deep-equal expected",
     "exists": "Key must be present; value ignored (hand-authored seeds; not emitted by regex gen)",
@@ -75,7 +75,11 @@
                             "optional": false,
                             "spec": {
                               "kind": "string",
-                              "enum": ["string", "number", "boolean"]
+                              "enum": [
+                                "string",
+                                "number",
+                                "boolean"
+                              ]
                             }
                           },
                           "required": {
@@ -164,7 +168,11 @@
                           "optional": false,
                           "spec": {
                             "kind": "string",
-                            "enum": ["string", "number", "boolean"]
+                            "enum": [
+                              "string",
+                              "number",
+                              "boolean"
+                            ]
                           }
                         },
                         "required": {
@@ -1386,7 +1394,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["domain", "pageType", "source"]
+              "enum": [
+                "domain",
+                "pageType",
+                "source"
+              ]
             }
           },
           "limit": {
@@ -1403,7 +1415,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["domain", "pageType", "source"]
+            "enum": [
+              "domain",
+              "pageType",
+              "source"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1617,8 +1633,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-free-text-nonempty",
           "source": "regex"
         },
         "openInNewTab": {
@@ -1638,7 +1654,7 @@
         "fields": {
           "position": "exact",
           "title": "nonempty",
-          "url": "ignore",
+          "url": "nonempty",
           "openInNewTab": "exact"
         }
       }
@@ -1659,7 +1675,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["new", "current", "existing"]
+              "enum": [
+                "new",
+                "current",
+                "existing"
+              ]
             }
           }
         }
@@ -1681,7 +1701,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["new", "current", "existing"]
+            "enum": [
+              "new",
+              "current",
+              "existing"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1961,7 +1985,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["site", "global"]
+              "enum": [
+                "site",
+                "global"
+              ]
             }
           },
           "domains": {
@@ -1992,7 +2019,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["site", "global"]
+            "enum": [
+              "site",
+              "global"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2164,7 +2194,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["site", "global", "all"]
+              "enum": [
+                "site",
+                "global",
+                "all"
+              ]
             }
           }
         }
@@ -2175,7 +2209,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["site", "global", "all"]
+            "enum": [
+              "site",
+              "global",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2945,7 +2983,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["single", "double", "three"]
+              "enum": [
+                "single",
+                "double",
+                "three"
+              ]
             }
           }
         }
@@ -2956,7 +2998,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["single", "double", "three"]
+            "enum": [
+              "single",
+              "double",
+              "three"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -3196,8 +3242,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -3205,7 +3251,7 @@
         "defaultMode": "exact",
         "fields": {
           "configurationName": "exact",
-          "noDebug": "ignore"
+          "noDebug": "exact"
         }
       }
     },
@@ -3219,7 +3265,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["into", "out", "over"]
+              "enum": [
+                "into",
+                "out",
+                "over"
+              ]
             }
           }
         }
@@ -3230,7 +3280,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["into", "out", "over"]
+            "enum": [
+              "into",
+              "out",
+              "over"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -5839,7 +5893,12 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["first", "next", "cursor", "indexInFile"]
+                    "enum": [
+                      "first",
+                      "next",
+                      "cursor",
+                      "indexInFile"
+                    ]
                   }
                 },
                 "position": {
@@ -6296,7 +6355,12 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": ["first", "next", "cursor", "indexInFile"]
+                  "enum": [
+                    "first",
+                    "next",
+                    "cursor",
+                    "indexInFile"
+                  ]
                 }
               },
               "position": {
@@ -7208,7 +7272,13 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": ["prefix", "suffix", "file", "doc", "comment"]
+                      "enum": [
+                        "prefix",
+                        "suffix",
+                        "file",
+                        "doc",
+                        "comment"
+                      ]
                     }
                   },
                   "content": {
@@ -7706,7 +7776,13 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["prefix", "suffix", "file", "doc", "comment"]
+                    "enum": [
+                      "prefix",
+                      "suffix",
+                      "file",
+                      "doc",
+                      "comment"
+                    ]
                   }
                 },
                 "content": {
@@ -7806,7 +7882,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["line", "block"]
+              "enum": [
+                "line",
+                "block"
+              ]
             }
           },
           "position": {
@@ -8252,7 +8331,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["line", "block"]
+            "enum": [
+              "line",
+              "block"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -8711,7 +8793,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["insert", "delete"]
+              "enum": [
+                "insert",
+                "delete"
+              ]
             }
           },
           "count": {
@@ -9173,7 +9258,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["insert", "delete"]
+            "enum": [
+              "insert",
+              "delete"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -9680,7 +9768,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["agent", "ask"]
+              "enum": [
+                "agent",
+                "ask"
+              ]
             }
           },
           "isPartialQuery": {
@@ -9714,7 +9805,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["view", "editor", "window"]
+              "enum": [
+                "view",
+                "editor",
+                "window"
+              ]
             }
           }
         }
@@ -9736,7 +9831,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["agent", "ask"]
+            "enum": [
+              "agent",
+              "ask"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -9751,8 +9849,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "attachScreenshot": {
@@ -9776,8 +9874,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "array-items:string-collection-element-nonempty",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -9801,7 +9899,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["view", "editor", "window"]
+            "enum": [
+              "view",
+              "editor",
+              "window"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -9815,9 +9917,9 @@
         "fields": {
           "query": "nonempty",
           "mode": "ignore",
-          "isPartialQuery": "ignore",
+          "isPartialQuery": "exact",
           "attachScreenshot": "exact",
-          "attachFiles": "ignore",
+          "attachFiles": "nonempty",
           "newSession": "exact",
           "newSessionLocation": "exact"
         }
@@ -10783,8 +10885,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "excludeUntitled": {
@@ -10813,7 +10915,7 @@
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "onlyDirty": "ignore",
+          "onlyDirty": "exact",
           "excludeUntitled": "exact",
           "logResult": "exact"
         }
@@ -10854,8 +10956,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "onlyDirty": {
@@ -10876,17 +10978,17 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "showErrorIfNoActiveEditor": "ignore",
+          "showErrorIfNoActiveEditor": "exact",
           "onlyDirty": "exact",
-          "excludeUntitled": "ignore"
+          "excludeUntitled": "exact"
         }
       }
     },
@@ -11280,7 +11382,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["file", "line", "symbol"]
+              "enum": [
+                "file",
+                "line",
+                "symbol"
+              ]
             }
           },
           "ref": {
@@ -11297,7 +11403,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["file", "line", "symbol"]
+            "enum": [
+              "file",
+              "line",
+              "symbol"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11389,7 +11499,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["low", "medium", "high"]
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
             }
           },
           "reuseExistingTerminal": {
@@ -11428,7 +11542,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11443,8 +11561,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -11454,7 +11572,7 @@
           "folderName": "exact",
           "commandToExecute": "llmAsAJudge",
           "commandRiskLevel": "exact",
-          "reuseExistingTerminal": "ignore"
+          "reuseExistingTerminal": "exact"
         }
       }
     },
@@ -11468,7 +11586,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["build", "rebuild", "clean"]
+              "enum": [
+                "build",
+                "rebuild",
+                "clean"
+              ]
             }
           },
           "folderName": {
@@ -11491,7 +11613,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["build", "rebuild", "clean"]
+            "enum": [
+              "build",
+              "rebuild",
+              "clean"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11553,7 +11679,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
+              "enum": [
+                "inferFromName",
+                "workspaceRoot",
+                "activeSelection"
+              ]
             }
           }
         }
@@ -11586,12 +11716,16 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
+            "enum": [
+              "inferFromName",
+              "workspaceRoot",
+              "activeSelection"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "string-enum-exact",
           "source": "regex"
         }
       },
@@ -11600,7 +11734,7 @@
         "fields": {
           "folderName": "exact",
           "relativeTo": "nonempty",
-          "resolutionHint": "ignore"
+          "resolutionHint": "exact"
         }
       }
     },
@@ -11620,7 +11754,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["exact", "fuzzy"]
+              "enum": [
+                "exact",
+                "fuzzy"
+              ]
             }
           },
           "extensions": {
@@ -11657,12 +11794,15 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["exact", "fuzzy"]
+            "enum": [
+              "exact",
+              "fuzzy"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "string-enum-exact",
           "source": "regex"
         },
         "extensions": {
@@ -11675,8 +11815,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "array-items:string-collection-element-nonempty",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -11692,8 +11832,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -11701,9 +11841,9 @@
         "defaultMode": "exact",
         "fields": {
           "fileName": "exact",
-          "matchStrategy": "ignore",
-          "extensions": "ignore",
-          "includeGenerated": "ignore"
+          "matchStrategy": "exact",
+          "extensions": "nonempty",
+          "includeGenerated": "exact"
         }
       }
     },
@@ -11942,21 +12082,33 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["copilot", "claude", "gpt", "generic"]
+              "enum": [
+                "copilot",
+                "claude",
+                "gpt",
+                "generic"
+              ]
             }
           },
           "newSessionLocation": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["window", "editor", "view"]
+              "enum": [
+                "window",
+                "editor",
+                "view"
+              ]
             }
           },
           "mode": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["agent", "ask"]
+              "enum": [
+                "agent",
+                "ask"
+              ]
             }
           },
           "isPartialQuery": {
@@ -11999,7 +12151,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["copilot", "claude", "gpt", "generic"]
+            "enum": [
+              "copilot",
+              "claude",
+              "gpt",
+              "generic"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12011,7 +12168,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["window", "editor", "view"]
+            "enum": [
+              "window",
+              "editor",
+              "view"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12023,7 +12184,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["agent", "ask"]
+            "enum": [
+              "agent",
+              "ask"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12038,8 +12202,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "attachScreenshot": {
@@ -12063,8 +12227,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "array-items:string-collection-element-nonempty",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -12081,9 +12245,9 @@
           "provider": "exact",
           "newSessionLocation": "exact",
           "mode": "ignore",
-          "isPartialQuery": "ignore",
+          "isPartialQuery": "exact",
           "attachScreenshot": "exact",
-          "attachFiles": "ignore"
+          "attachFiles": "nonempty"
         }
       }
     },
@@ -12097,7 +12261,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["last", "folder", "workspace"]
+              "enum": [
+                "last",
+                "folder",
+                "workspace"
+              ]
             }
           },
           "path": {
@@ -12114,7 +12282,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["last", "folder", "workspace"]
+            "enum": [
+              "last",
+              "folder",
+              "workspace"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12359,7 +12531,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["right", "left", "up", "down"]
+              "enum": [
+                "right",
+                "left",
+                "up",
+                "down"
+              ]
             }
           },
           "editorPosition": {
@@ -12382,7 +12559,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["right", "left", "up", "down"]
+            "enum": [
+              "right",
+              "left",
+              "up",
+              "down"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12432,7 +12614,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["increase", "decrease"]
+              "enum": [
+                "increase",
+                "decrease"
+              ]
             }
           }
         }
@@ -12443,7 +12628,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["increase", "decrease"]
+            "enum": [
+              "increase",
+              "decrease"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12469,7 +12657,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["up", "down"]
+              "enum": [
+                "up",
+                "down"
+              ]
             }
           },
           "amount": {
@@ -12486,7 +12677,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["up", "down"]
+            "enum": [
+              "up",
+              "down"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12554,8 +12748,8 @@
           },
           "typeKind": "string",
           "create": "identifier",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "string-identifier-exact",
           "source": "regex"
         }
       },
@@ -12563,7 +12757,7 @@
         "defaultMode": "exact",
         "fields": {
           "filePath": "exact",
-          "themeName": "ignore"
+          "themeName": "exact"
         }
       }
     },
@@ -13100,7 +13294,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["name", "description"]
+              "enum": [
+                "name",
+                "description"
+              ]
             }
           },
           "elevate": {
@@ -13128,7 +13325,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["name", "description"]
+            "enum": [
+              "name",
+              "description"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13143,8 +13343,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -13153,7 +13353,7 @@
         "fields": {
           "service": "exact",
           "matchBy": "exact",
-          "elevate": "ignore"
+          "elevate": "exact"
         }
       }
     },
@@ -13287,7 +13487,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["light", "dark", "toggle"]
+              "enum": [
+                "light",
+                "dark",
+                "toggle"
+              ]
             }
           }
         }
@@ -13298,7 +13502,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["light", "dark", "toggle"]
+            "enum": [
+              "light",
+              "dark",
+              "toggle"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -13605,7 +13813,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["reduce", "increase"]
+              "enum": [
+                "reduce",
+                "increase"
+              ]
             }
           }
         }
@@ -13616,7 +13827,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["reduce", "increase"]
+            "enum": [
+              "reduce",
+              "increase"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13642,7 +13856,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["portrait", "landscape"]
+              "enum": [
+                "portrait",
+                "landscape"
+              ]
             }
           }
         }
@@ -13653,7 +13870,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["portrait", "landscape"]
+            "enum": [
+              "portrait",
+              "landscape"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13830,7 +14050,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["increase", "decrease"]
+              "enum": [
+                "increase",
+                "decrease"
+              ]
             }
           }
         }
@@ -13841,7 +14064,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["increase", "decrease"]
+            "enum": [
+              "increase",
+              "decrease"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14020,8 +14246,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -14029,7 +14255,7 @@
         "defaultMode": "exact",
         "fields": {
           "speedLevel": "exact",
-          "reduceSpeed": "ignore"
+          "reduceSpeed": "exact"
         }
       }
     },
@@ -14131,7 +14357,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["left", "right"]
+              "enum": [
+                "left",
+                "right"
+              ]
             }
           }
         }
@@ -14142,7 +14371,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["left", "right"]
+            "enum": [
+              "left",
+              "right"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14322,7 +14554,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["light", "dark"]
+              "enum": [
+                "light",
+                "dark"
+              ]
             }
           }
         }
@@ -14333,7 +14568,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["light", "dark"]
+            "enum": [
+              "light",
+              "dark"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -14429,7 +14667,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
+              "enum": [
+                "bestPerformance",
+                "balanced",
+                "bestPowerEfficiency"
+              ]
             }
           }
         }
@@ -14440,7 +14682,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
+            "enum": [
+              "bestPerformance",
+              "balanced",
+              "bestPowerEfficiency"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14466,7 +14712,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14477,7 +14726,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14503,7 +14755,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14514,7 +14769,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14540,7 +14798,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14551,7 +14812,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15257,7 +15521,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["left", "center"]
+              "enum": [
+                "left",
+                "center"
+              ]
             }
           }
         }
@@ -15268,7 +15535,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["left", "center"]
+            "enum": [
+              "left",
+              "center"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15294,7 +15564,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["show", "hide"]
+              "enum": [
+                "show",
+                "hide"
+              ]
             }
           }
         }
@@ -15305,7 +15578,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["show", "hide"]
+            "enum": [
+              "show",
+              "hide"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15520,8 +15796,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "max_uses": {
@@ -15563,7 +15839,7 @@
         "fields": {
           "channel_id": "exact",
           "max_age": "exact",
-          "never_expires": "ignore",
+          "never_expires": "exact",
           "max_uses": "exact",
           "temporary": "exact",
           "unique": "exact"
@@ -15804,8 +16080,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-open-soft-nonempty",
           "source": "regex"
         },
         "tts": {
@@ -15815,8 +16091,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -15825,8 +16101,8 @@
         "fields": {
           "channel_id": "exact",
           "content": "nonempty",
-          "nonce": "ignore",
-          "tts": "ignore"
+          "nonce": "nonempty",
+          "tts": "exact"
         }
       }
     },
@@ -16607,8 +16883,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-open-soft-nonempty",
           "source": "regex"
         },
         "after": {
@@ -16618,8 +16894,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-open-soft-nonempty",
           "source": "regex"
         },
         "limit": {
@@ -16648,8 +16924,8 @@
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "before": "ignore",
-          "after": "ignore",
+          "before": "nonempty",
+          "after": "nonempty",
           "limit": "exact",
           "with_counts": "exact"
         }
@@ -17994,8 +18270,8 @@
           },
           "typeKind": "number",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-number",
           "source": "regex"
         }
       },
@@ -18005,7 +18281,7 @@
           "channel_id": "exact",
           "name": "exact",
           "auto_archive_duration": "exact",
-          "type": "ignore"
+          "type": "exact"
         }
       }
     },
@@ -18996,7 +19272,10 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["conversation", "internet"]
+                    "enum": [
+                      "conversation",
+                      "internet"
+                    ]
                   }
                 },
                 "site": {
@@ -19024,7 +19303,10 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": ["conversation", "internet"]
+                  "enum": [
+                    "conversation",
+                    "internet"
+                  ]
                 }
               },
               "site": {
@@ -20282,8 +20564,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-open-soft-nonempty",
           "source": "regex"
         }
       },
@@ -20291,7 +20573,7 @@
         "defaultMode": "exact",
         "fields": {
           "artifact": "nonempty",
-          "type": "ignore"
+          "type": "nonempty"
         }
       }
     },
@@ -20352,8 +20634,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-open-soft-nonempty",
           "source": "regex"
         }
       },
@@ -20362,7 +20644,7 @@
         "fields": {
           "hostname": "nonempty",
           "web": "exact",
-          "token": "ignore"
+          "token": "nonempty"
         }
       }
     },
@@ -22825,8 +23107,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -22836,7 +23118,7 @@
           "name": "exact",
           "description": "nonempty",
           "public": "exact",
-          "private": "ignore"
+          "private": "exact"
         }
       }
     },
@@ -23214,8 +23496,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -23223,7 +23505,7 @@
         "defaultMode": "exact",
         "fields": {
           "repo": "exact",
-          "unstar": "ignore"
+          "unstar": "exact"
         }
       }
     },
@@ -24428,7 +24710,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["off", "one", "all"]
+              "enum": [
+                "off",
+                "one",
+                "all"
+              ]
             }
           }
         }
@@ -24439,7 +24725,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["off", "one", "all"]
+            "enum": [
+              "off",
+              "one",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -24781,7 +25071,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["continue", "diagram", "augment", "research"]
+              "enum": [
+                "continue",
+                "diagram",
+                "augment",
+                "research"
+              ]
             }
           }
         }
@@ -24858,7 +25153,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["continue", "diagram", "augment", "research"]
+            "enum": [
+              "continue",
+              "diagram",
+              "augment",
+              "research"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -24926,8 +25226,8 @@
           },
           "typeKind": "number",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-number",
           "source": "regex"
         },
         "context": {
@@ -24937,8 +25237,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "string-free-text-nonempty",
           "source": "regex"
         }
       },
@@ -24946,8 +25246,8 @@
         "defaultMode": "exact",
         "fields": {
           "originalRequest": "nonempty",
-          "cursorPosition": "ignore",
-          "context": "ignore"
+          "cursorPosition": "exact",
+          "context": "nonempty"
         }
       }
     },
@@ -25026,8 +25326,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "array-items:string-collection-element-nonempty",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -25042,7 +25342,7 @@
         "fields": {
           "title": "nonempty",
           "files": "nonempty",
-          "search_filters": "ignore"
+          "search_filters": "nonempty"
         }
       }
     },
@@ -25474,7 +25774,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["selected", "inverse", "all"]
+              "enum": [
+                "selected",
+                "inverse",
+                "all"
+              ]
             }
           },
           "files": {
@@ -25531,8 +25835,8 @@
           },
           "typeKind": "array<number>",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "array-items:type-number",
           "source": "regex",
           "item": {
             "create": "typed_literal",
@@ -25545,7 +25849,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["selected", "inverse", "all"]
+            "enum": [
+              "selected",
+              "inverse",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25563,8 +25871,8 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "nonempty",
+          "rule": "array-items:string-collection-element-nonempty",
           "source": "regex",
           "item": {
             "create": "free_text",
@@ -25579,9 +25887,9 @@
         "fields": {
           "title": "nonempty",
           "search_filters": "nonempty",
-          "indices": "ignore",
+          "indices": "exact",
           "selected": "exact",
-          "files": "ignore"
+          "files": "nonempty"
         }
       }
     },
@@ -25720,7 +26028,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["grid", "filmstrip"]
+              "enum": [
+                "grid",
+                "filmstrip"
+              ]
             }
           }
         }
@@ -25731,7 +26042,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["grid", "filmstrip"]
+            "enum": [
+              "grid",
+              "filmstrip"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25894,7 +26208,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["in-progress", "complete"]
+              "enum": [
+                "in-progress",
+                "complete"
+              ]
             }
           }
         }
@@ -25905,7 +26222,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["in-progress", "complete"]
+            "enum": [
+              "in-progress",
+              "complete"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27220,7 +27540,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["passing", "failing"]
+              "enum": [
+                "passing",
+                "failing"
+              ]
             }
           }
         }
@@ -27242,7 +27565,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["passing", "failing"]
+            "enum": [
+              "passing",
+              "failing"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27500,7 +27826,13 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
+              "enum": [
+                "rest",
+                "graphql",
+                "websocket",
+                "ipc",
+                "sdk"
+              ]
             }
           }
         }
@@ -27533,7 +27865,13 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
+            "enum": [
+              "rest",
+              "graphql",
+              "websocket",
+              "ipc",
+              "sdk"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -28215,8 +28553,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         },
         "quantity": {
@@ -28235,7 +28573,7 @@
         "defaultMode": "exact",
         "fields": {
           "target": "exact",
-          "play": "ignore",
+          "play": "exact",
           "quantity": "exact"
         }
       }
@@ -28942,7 +29280,12 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": ["string", "number", "boolean", "path"]
+                      "enum": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "path"
+                      ]
                     }
                   },
                   "required": {
@@ -29073,7 +29416,12 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["string", "number", "boolean", "path"]
+                    "enum": [
+                      "string",
+                      "number",
+                      "boolean",
+                      "path"
+                    ]
                   }
                 },
                 "required": {
@@ -30620,8 +30968,8 @@
           },
           "typeKind": "boolean",
           "create": "typed_literal",
-          "verify": "ignore",
-          "rule": "hardcoded-ungrounded-ignore",
+          "verify": "exact",
+          "rule": "type-boolean",
           "source": "regex"
         }
       },
@@ -30629,7 +30977,7 @@
         "defaultMode": "exact",
         "fields": {
           "agentName": "exact",
-          "all": "ignore"
+          "all": "exact"
         }
       }
     },
@@ -30734,7 +31082,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["all", "unread"]
+              "enum": [
+                "all",
+                "unread"
+              ]
             }
           }
         }
@@ -30745,7 +31096,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["all", "unread"]
+            "enum": [
+              "all",
+              "unread"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -31021,7 +31375,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["bubble", "toast", "inline"]
+              "enum": [
+                "bubble",
+                "toast",
+                "inline"
+              ]
             }
           },
           "count": {
@@ -31060,7 +31418,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["bubble", "toast", "inline"]
+            "enum": [
+              "bubble",
+              "toast",
+              "inline"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31112,7 +31474,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["bubble", "toast", "inline"]
+              "enum": [
+                "bubble",
+                "toast",
+                "inline"
+              ]
             }
           }
         }
@@ -31145,7 +31511,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["bubble", "toast", "inline"]
+            "enum": [
+              "bubble",
+              "toast",
+              "inline"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31566,7 +31936,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["4", "8", "12"]
+              "enum": [
+                "4",
+                "8",
+                "12"
+              ]
             }
           }
         }
@@ -31619,7 +31993,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["4", "8", "12"]
+            "enum": [
+              "4",
+              "8",
+              "12"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32120,7 +32498,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["text", "code", "designer", "debug"]
+              "enum": [
+                "text",
+                "code",
+                "designer",
+                "debug"
+              ]
             }
           }
         }
@@ -32142,7 +32525,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["text", "code", "designer", "debug"]
+            "enum": [
+              "text",
+              "code",
+              "designer",
+              "debug"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32393,7 +32781,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["celsius", "fahrenheit"]
+              "enum": [
+                "celsius",
+                "fahrenheit"
+              ]
             }
           }
         }
@@ -32415,7 +32806,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["celsius", "fahrenheit"]
+            "enum": [
+              "celsius",
+              "fahrenheit"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -32454,7 +32848,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["celsius", "fahrenheit"]
+              "enum": [
+                "celsius",
+                "fahrenheit"
+              ]
             }
           }
         }
@@ -32487,7 +32884,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["celsius", "fahrenheit"]
+            "enum": [
+              "celsius",
+              "fahrenheit"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -32863,7 +33263,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["compact", "full"]
+              "enum": [
+                "compact",
+                "full"
+              ]
             }
           }
         }
@@ -32874,7 +33277,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["compact", "full"]
+            "enum": [
+              "compact",
+              "full"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",

--- a/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
+++ b/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
@@ -2,8 +2,8 @@
   "version": 1,
   "description": "Create+verify policies per action parameter. sourceFingerprint is paramSpec-only (stable across policy edits). rulesFingerprint is catalog-level; when it drifts, all actions reclassify. Incremental: only added/updated actions are reclassified; unchanged fingerprints are kept. Regex first, LLM prior reuse (not regex priors), LLM+verifier fallback. Open strings without a name heuristic use structural free_text/nonempty. `create` guides the synthesizer; `verify` / `parameterScore` drive runner soft matching. `llmAsAJudge` marks code/script params that need semantic LLM scoring. Object containers with only soft leaves use nonempty; mixed objects stay exact (no nested dotted paths yet).",
   "catalogVersion": "2026-08-06",
-  "generatedAt": "2026-08-07T08:27:53.038Z",
-  "rulesFingerprint": "5ddc230063bee47e",
+  "generatedAt": "2026-08-07T23:29:18.858Z",
+  "rulesFingerprint": "32c014c7072f2860",
   "modes": {
     "exact": "Chosen value must deep-equal expected",
     "exists": "Key must be present; value ignored (hand-authored seeds; not emitted by regex gen)",
@@ -75,7 +75,11 @@
                             "optional": false,
                             "spec": {
                               "kind": "string",
-                              "enum": ["string", "number", "boolean"]
+                              "enum": [
+                                "string",
+                                "number",
+                                "boolean"
+                              ]
                             }
                           },
                           "required": {
@@ -164,7 +168,11 @@
                           "optional": false,
                           "spec": {
                             "kind": "string",
-                            "enum": ["string", "number", "boolean"]
+                            "enum": [
+                              "string",
+                              "number",
+                              "boolean"
+                            ]
                           }
                         },
                         "required": {
@@ -1386,7 +1394,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["domain", "pageType", "source"]
+              "enum": [
+                "domain",
+                "pageType",
+                "source"
+              ]
             }
           },
           "limit": {
@@ -1403,7 +1415,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["domain", "pageType", "source"]
+            "enum": [
+              "domain",
+              "pageType",
+              "source"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1500,8 +1516,8 @@
           },
           "typeKind": "string",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "string-free-text-nonempty",
+          "verify": "llmAsAJudge",
+          "rule": "string-llm-as-a-judge",
           "source": "regex"
         },
         "internetLookups": {
@@ -1514,13 +1530,13 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "llmAsAJudge",
+          "rule": "array-items:string-llm-as-a-judge",
           "source": "regex",
           "item": {
             "create": "free_text",
-            "verify": "nonempty",
-            "rule": "string-collection-element-nonempty",
+            "verify": "llmAsAJudge",
+            "rule": "string-llm-as-a-judge",
             "source": "regex"
           }
         },
@@ -1534,13 +1550,13 @@
           },
           "typeKind": "array<string>",
           "create": "free_text",
-          "verify": "nonempty",
-          "rule": "array-items:string-collection-element-nonempty",
+          "verify": "llmAsAJudge",
+          "rule": "array-items:string-llm-as-a-judge",
           "source": "regex",
           "item": {
             "create": "free_text",
-            "verify": "nonempty",
-            "rule": "string-collection-element-nonempty",
+            "verify": "llmAsAJudge",
+            "rule": "string-llm-as-a-judge",
             "source": "regex"
           }
         }
@@ -1548,9 +1564,9 @@
       "parameterScore": {
         "defaultMode": "exact",
         "fields": {
-          "originalRequest": "nonempty",
-          "internetLookups": "nonempty",
-          "sites": "nonempty"
+          "originalRequest": "llmAsAJudge",
+          "internetLookups": "llmAsAJudge",
+          "sites": "llmAsAJudge"
         }
       }
     },
@@ -1659,7 +1675,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["new", "current", "existing"]
+              "enum": [
+                "new",
+                "current",
+                "existing"
+              ]
             }
           }
         }
@@ -1681,7 +1701,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["new", "current", "existing"]
+            "enum": [
+              "new",
+              "current",
+              "existing"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -1961,7 +1985,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["site", "global"]
+              "enum": [
+                "site",
+                "global"
+              ]
             }
           },
           "domains": {
@@ -1992,7 +2019,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["site", "global"]
+            "enum": [
+              "site",
+              "global"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2164,7 +2194,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["site", "global", "all"]
+              "enum": [
+                "site",
+                "global",
+                "all"
+              ]
             }
           }
         }
@@ -2175,7 +2209,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["site", "global", "all"]
+            "enum": [
+              "site",
+              "global",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -2945,7 +2983,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["single", "double", "three"]
+              "enum": [
+                "single",
+                "double",
+                "three"
+              ]
             }
           }
         }
@@ -2956,7 +2998,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["single", "double", "three"]
+            "enum": [
+              "single",
+              "double",
+              "three"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -3219,7 +3265,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["into", "out", "over"]
+              "enum": [
+                "into",
+                "out",
+                "over"
+              ]
             }
           }
         }
@@ -3230,7 +3280,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["into", "out", "over"]
+            "enum": [
+              "into",
+              "out",
+              "over"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -5839,7 +5893,12 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["first", "next", "cursor", "indexInFile"]
+                    "enum": [
+                      "first",
+                      "next",
+                      "cursor",
+                      "indexInFile"
+                    ]
                   }
                 },
                 "position": {
@@ -6296,7 +6355,12 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": ["first", "next", "cursor", "indexInFile"]
+                  "enum": [
+                    "first",
+                    "next",
+                    "cursor",
+                    "indexInFile"
+                  ]
                 }
               },
               "position": {
@@ -7208,7 +7272,13 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": ["prefix", "suffix", "file", "doc", "comment"]
+                      "enum": [
+                        "prefix",
+                        "suffix",
+                        "file",
+                        "doc",
+                        "comment"
+                      ]
                     }
                   },
                   "content": {
@@ -7706,7 +7776,13 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["prefix", "suffix", "file", "doc", "comment"]
+                    "enum": [
+                      "prefix",
+                      "suffix",
+                      "file",
+                      "doc",
+                      "comment"
+                    ]
                   }
                 },
                 "content": {
@@ -7806,7 +7882,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["line", "block"]
+              "enum": [
+                "line",
+                "block"
+              ]
             }
           },
           "position": {
@@ -8252,7 +8331,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["line", "block"]
+            "enum": [
+              "line",
+              "block"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -8711,7 +8793,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["insert", "delete"]
+              "enum": [
+                "insert",
+                "delete"
+              ]
             }
           },
           "count": {
@@ -9173,7 +9258,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["insert", "delete"]
+            "enum": [
+              "insert",
+              "delete"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -9680,7 +9768,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["agent", "ask"]
+              "enum": [
+                "agent",
+                "ask"
+              ]
             }
           },
           "isPartialQuery": {
@@ -9714,7 +9805,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["view", "editor", "window"]
+              "enum": [
+                "view",
+                "editor",
+                "window"
+              ]
             }
           }
         }
@@ -9736,7 +9831,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["agent", "ask"]
+            "enum": [
+              "agent",
+              "ask"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -9801,7 +9899,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["view", "editor", "window"]
+            "enum": [
+              "view",
+              "editor",
+              "window"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11280,7 +11382,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["file", "line", "symbol"]
+              "enum": [
+                "file",
+                "line",
+                "symbol"
+              ]
             }
           },
           "ref": {
@@ -11297,7 +11403,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["file", "line", "symbol"]
+            "enum": [
+              "file",
+              "line",
+              "symbol"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11389,7 +11499,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["low", "medium", "high"]
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ]
             }
           },
           "reuseExistingTerminal": {
@@ -11428,7 +11542,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11468,7 +11586,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["build", "rebuild", "clean"]
+              "enum": [
+                "build",
+                "rebuild",
+                "clean"
+              ]
             }
           },
           "folderName": {
@@ -11491,7 +11613,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["build", "rebuild", "clean"]
+            "enum": [
+              "build",
+              "rebuild",
+              "clean"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11553,7 +11679,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
+              "enum": [
+                "inferFromName",
+                "workspaceRoot",
+                "activeSelection"
+              ]
             }
           }
         }
@@ -11586,7 +11716,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["inferFromName", "workspaceRoot", "activeSelection"]
+            "enum": [
+              "inferFromName",
+              "workspaceRoot",
+              "activeSelection"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11620,7 +11754,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["exact", "fuzzy"]
+              "enum": [
+                "exact",
+                "fuzzy"
+              ]
             }
           },
           "extensions": {
@@ -11657,7 +11794,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["exact", "fuzzy"]
+            "enum": [
+              "exact",
+              "fuzzy"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -11942,21 +12082,33 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["copilot", "claude", "gpt", "generic"]
+              "enum": [
+                "copilot",
+                "claude",
+                "gpt",
+                "generic"
+              ]
             }
           },
           "newSessionLocation": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["window", "editor", "view"]
+              "enum": [
+                "window",
+                "editor",
+                "view"
+              ]
             }
           },
           "mode": {
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["agent", "ask"]
+              "enum": [
+                "agent",
+                "ask"
+              ]
             }
           },
           "isPartialQuery": {
@@ -11999,7 +12151,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["copilot", "claude", "gpt", "generic"]
+            "enum": [
+              "copilot",
+              "claude",
+              "gpt",
+              "generic"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12011,7 +12168,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["window", "editor", "view"]
+            "enum": [
+              "window",
+              "editor",
+              "view"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12023,7 +12184,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["agent", "ask"]
+            "enum": [
+              "agent",
+              "ask"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12097,7 +12261,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["last", "folder", "workspace"]
+              "enum": [
+                "last",
+                "folder",
+                "workspace"
+              ]
             }
           },
           "path": {
@@ -12114,7 +12282,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["last", "folder", "workspace"]
+            "enum": [
+              "last",
+              "folder",
+              "workspace"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -12359,7 +12531,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["right", "left", "up", "down"]
+              "enum": [
+                "right",
+                "left",
+                "up",
+                "down"
+              ]
             }
           },
           "editorPosition": {
@@ -12382,7 +12559,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["right", "left", "up", "down"]
+            "enum": [
+              "right",
+              "left",
+              "up",
+              "down"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12432,7 +12614,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["increase", "decrease"]
+              "enum": [
+                "increase",
+                "decrease"
+              ]
             }
           }
         }
@@ -12443,7 +12628,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["increase", "decrease"]
+            "enum": [
+              "increase",
+              "decrease"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -12469,7 +12657,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["up", "down"]
+              "enum": [
+                "up",
+                "down"
+              ]
             }
           },
           "amount": {
@@ -12486,7 +12677,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["up", "down"]
+            "enum": [
+              "up",
+              "down"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13100,7 +13294,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["name", "description"]
+              "enum": [
+                "name",
+                "description"
+              ]
             }
           },
           "elevate": {
@@ -13128,7 +13325,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["name", "description"]
+            "enum": [
+              "name",
+              "description"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13287,7 +13487,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["light", "dark", "toggle"]
+              "enum": [
+                "light",
+                "dark",
+                "toggle"
+              ]
             }
           }
         }
@@ -13298,7 +13502,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["light", "dark", "toggle"]
+            "enum": [
+              "light",
+              "dark",
+              "toggle"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -13605,7 +13813,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["reduce", "increase"]
+              "enum": [
+                "reduce",
+                "increase"
+              ]
             }
           }
         }
@@ -13616,7 +13827,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["reduce", "increase"]
+            "enum": [
+              "reduce",
+              "increase"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13642,7 +13856,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["portrait", "landscape"]
+              "enum": [
+                "portrait",
+                "landscape"
+              ]
             }
           }
         }
@@ -13653,7 +13870,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["portrait", "landscape"]
+            "enum": [
+              "portrait",
+              "landscape"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -13830,7 +14050,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["increase", "decrease"]
+              "enum": [
+                "increase",
+                "decrease"
+              ]
             }
           }
         }
@@ -13841,7 +14064,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["increase", "decrease"]
+            "enum": [
+              "increase",
+              "decrease"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14131,7 +14357,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["left", "right"]
+              "enum": [
+                "left",
+                "right"
+              ]
             }
           }
         }
@@ -14142,7 +14371,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["left", "right"]
+            "enum": [
+              "left",
+              "right"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14322,7 +14554,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["light", "dark"]
+              "enum": [
+                "light",
+                "dark"
+              ]
             }
           }
         }
@@ -14333,7 +14568,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["light", "dark"]
+            "enum": [
+              "light",
+              "dark"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -14429,7 +14667,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
+              "enum": [
+                "bestPerformance",
+                "balanced",
+                "bestPowerEfficiency"
+              ]
             }
           }
         }
@@ -14440,7 +14682,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["bestPerformance", "balanced", "bestPowerEfficiency"]
+            "enum": [
+              "bestPerformance",
+              "balanced",
+              "bestPowerEfficiency"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14466,7 +14712,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14477,7 +14726,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14503,7 +14755,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14514,7 +14769,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -14540,7 +14798,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["allow", "deny"]
+              "enum": [
+                "allow",
+                "deny"
+              ]
             }
           }
         }
@@ -14551,7 +14812,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["allow", "deny"]
+            "enum": [
+              "allow",
+              "deny"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15257,7 +15521,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["left", "center"]
+              "enum": [
+                "left",
+                "center"
+              ]
             }
           }
         }
@@ -15268,7 +15535,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["left", "center"]
+            "enum": [
+              "left",
+              "center"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -15294,7 +15564,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["show", "hide"]
+              "enum": [
+                "show",
+                "hide"
+              ]
             }
           }
         }
@@ -15305,7 +15578,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["show", "hide"]
+            "enum": [
+              "show",
+              "hide"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -18996,7 +19272,10 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["conversation", "internet"]
+                    "enum": [
+                      "conversation",
+                      "internet"
+                    ]
                   }
                 },
                 "site": {
@@ -19024,7 +19303,10 @@
                 "optional": false,
                 "spec": {
                   "kind": "string",
-                  "enum": ["conversation", "internet"]
+                  "enum": [
+                    "conversation",
+                    "internet"
+                  ]
                 }
               },
               "site": {
@@ -24428,7 +24710,11 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["off", "one", "all"]
+              "enum": [
+                "off",
+                "one",
+                "all"
+              ]
             }
           }
         }
@@ -24439,7 +24725,11 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["off", "one", "all"]
+            "enum": [
+              "off",
+              "one",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -24781,7 +25071,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["continue", "diagram", "augment", "research"]
+              "enum": [
+                "continue",
+                "diagram",
+                "augment",
+                "research"
+              ]
             }
           }
         }
@@ -24858,7 +25153,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["continue", "diagram", "augment", "research"]
+            "enum": [
+              "continue",
+              "diagram",
+              "augment",
+              "research"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25474,7 +25774,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["selected", "inverse", "all"]
+              "enum": [
+                "selected",
+                "inverse",
+                "all"
+              ]
             }
           },
           "files": {
@@ -25545,7 +25849,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["selected", "inverse", "all"]
+            "enum": [
+              "selected",
+              "inverse",
+              "all"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25720,7 +26028,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["grid", "filmstrip"]
+              "enum": [
+                "grid",
+                "filmstrip"
+              ]
             }
           }
         }
@@ -25731,7 +26042,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["grid", "filmstrip"]
+            "enum": [
+              "grid",
+              "filmstrip"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -25894,7 +26208,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["in-progress", "complete"]
+              "enum": [
+                "in-progress",
+                "complete"
+              ]
             }
           }
         }
@@ -25905,7 +26222,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["in-progress", "complete"]
+            "enum": [
+              "in-progress",
+              "complete"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27220,7 +27540,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["passing", "failing"]
+              "enum": [
+                "passing",
+                "failing"
+              ]
             }
           }
         }
@@ -27242,7 +27565,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["passing", "failing"]
+            "enum": [
+              "passing",
+              "failing"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -27500,7 +27826,13 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
+              "enum": [
+                "rest",
+                "graphql",
+                "websocket",
+                "ipc",
+                "sdk"
+              ]
             }
           }
         }
@@ -27533,7 +27865,13 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["rest", "graphql", "websocket", "ipc", "sdk"]
+            "enum": [
+              "rest",
+              "graphql",
+              "websocket",
+              "ipc",
+              "sdk"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -28942,7 +29280,12 @@
                     "optional": false,
                     "spec": {
                       "kind": "string",
-                      "enum": ["string", "number", "boolean", "path"]
+                      "enum": [
+                        "string",
+                        "number",
+                        "boolean",
+                        "path"
+                      ]
                     }
                   },
                   "required": {
@@ -29073,7 +29416,12 @@
                   "optional": false,
                   "spec": {
                     "kind": "string",
-                    "enum": ["string", "number", "boolean", "path"]
+                    "enum": [
+                      "string",
+                      "number",
+                      "boolean",
+                      "path"
+                    ]
                   }
                 },
                 "required": {
@@ -30734,7 +31082,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["all", "unread"]
+              "enum": [
+                "all",
+                "unread"
+              ]
             }
           }
         }
@@ -30745,7 +31096,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["all", "unread"]
+            "enum": [
+              "all",
+              "unread"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -31021,7 +31375,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["bubble", "toast", "inline"]
+              "enum": [
+                "bubble",
+                "toast",
+                "inline"
+              ]
             }
           },
           "count": {
@@ -31060,7 +31418,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["bubble", "toast", "inline"]
+            "enum": [
+              "bubble",
+              "toast",
+              "inline"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31112,7 +31474,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["bubble", "toast", "inline"]
+              "enum": [
+                "bubble",
+                "toast",
+                "inline"
+              ]
             }
           }
         }
@@ -31145,7 +31511,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["bubble", "toast", "inline"]
+            "enum": [
+              "bubble",
+              "toast",
+              "inline"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -31566,7 +31936,11 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["4", "8", "12"]
+              "enum": [
+                "4",
+                "8",
+                "12"
+              ]
             }
           }
         }
@@ -31619,7 +31993,11 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["4", "8", "12"]
+            "enum": [
+              "4",
+              "8",
+              "12"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32120,7 +32498,12 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["text", "code", "designer", "debug"]
+              "enum": [
+                "text",
+                "code",
+                "designer",
+                "debug"
+              ]
             }
           }
         }
@@ -32142,7 +32525,12 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["text", "code", "designer", "debug"]
+            "enum": [
+              "text",
+              "code",
+              "designer",
+              "debug"
+            ]
           },
           "typeKind": "string-enum",
           "create": "enum_literal",
@@ -32393,7 +32781,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["celsius", "fahrenheit"]
+              "enum": [
+                "celsius",
+                "fahrenheit"
+              ]
             }
           }
         }
@@ -32415,7 +32806,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["celsius", "fahrenheit"]
+            "enum": [
+              "celsius",
+              "fahrenheit"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -32454,7 +32848,10 @@
             "optional": true,
             "spec": {
               "kind": "string",
-              "enum": ["celsius", "fahrenheit"]
+              "enum": [
+                "celsius",
+                "fahrenheit"
+              ]
             }
           }
         }
@@ -32487,7 +32884,10 @@
           "optional": true,
           "type": {
             "kind": "string",
-            "enum": ["celsius", "fahrenheit"]
+            "enum": [
+              "celsius",
+              "fahrenheit"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",
@@ -32863,7 +33263,10 @@
             "optional": false,
             "spec": {
               "kind": "string",
-              "enum": ["compact", "full"]
+              "enum": [
+                "compact",
+                "full"
+              ]
             }
           }
         }
@@ -32874,7 +33277,10 @@
           "optional": false,
           "type": {
             "kind": "string",
-            "enum": ["compact", "full"]
+            "enum": [
+              "compact",
+              "full"
+            ]
           },
           "typeKind": "string-enum",
           "create": "unit_or_mode",

--- a/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
+++ b/ts/packages/benchmarks/src/translationBench/action-parameters-grader.generated.json
@@ -3,7 +3,7 @@
   "description": "Create+verify policies per action parameter. sourceFingerprint is paramSpec-only (stable across policy edits). rulesFingerprint is catalog-level; when it drifts, all actions reclassify. Incremental: only added/updated actions are reclassified; unchanged fingerprints are kept. Regex first, LLM prior reuse (not regex priors), LLM+verifier fallback. Open strings without a name heuristic use structural free_text/nonempty. `create` guides the synthesizer; `verify` / `parameterScore` drive runner soft matching. `llmAsAJudge` marks code/script params that need semantic LLM scoring. Object containers with only soft leaves use nonempty; mixed objects stay exact (no nested dotted paths yet).",
   "catalogVersion": "2026-08-06",
   "generatedAt": "2026-08-07T08:27:53.038Z",
-  "rulesFingerprint": "ed8397a82fd660ef",
+  "rulesFingerprint": "5ddc230063bee47e",
   "modes": {
     "exact": "Chosen value must deep-equal expected",
     "exists": "Key must be present; value ignored (hand-authored seeds; not emitted by regex gen)",

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -199,10 +199,6 @@ const LLM_JUDGE_PARAMETER_SET = new Set<string>(LLM_JUDGE_PARAMETERS);
 /** Literal stored strings that must deep-equal (not soft / not llm judge). */
 const EXACT_PARAMETERS = new Set<string>(["github-cli.aliasSet.command"]);
 
-/**
- * Conversation topic titles are freeform NL (paraphrase-OK), not resource ids.
- * Action-scoped so webflow/playlist `name` stays identifier/exact.
- */
 export const NONEMPTY_PARAMETERS = [
     "system.conversation.indexConversation.name",
     "system.conversation.newConversation.name",
@@ -1085,7 +1081,6 @@ export async function buildActionParametersGraderEntry(
                     source: judged.source,
                 };
             } else if (NONEMPTY_PARAMETER_SET.has(fullName)) {
-                // Topic titles: presence matters, exact wording does not.
                 judged = {
                     create: "free_text",
                     verify: "nonempty",

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -196,11 +196,26 @@ const LLM_JUDGE_PARAMETER_SET = new Set<string>(LLM_JUDGE_PARAMETERS);
 /** Literal stored strings that must deep-equal (not soft / not llm judge). */
 const EXACT_PARAMETERS = new Set<string>(["github-cli.aliasSet.command"]);
 
+/**
+ * Hardcoded action.parameter pairs that always verify as nonempty.
+ * Internet lookup query lists / freeform request strings have many valid
+ * surface forms; exact string match is an unfair param-score fail.
+ */
+export const NONEMPTY_PARAMETERS = [
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.originalRequest",
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.internetLookups",
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.sites",
+] as const;
+
+const NONEMPTY_PARAMETER_SET = new Set<string>(NONEMPTY_PARAMETERS);
+
 export const HEURISTIC_SOURCE_HASH: string = createHash("sha256")
     .update(
         JSON.stringify({
             rules: [...REGEX_RULE_IDS].sort(),
             llmJudge: [...LLM_JUDGE_PARAMETERS],
+            nonempty: [...NONEMPTY_PARAMETERS],
+            exact: [...EXACT_PARAMETERS].sort(),
         }),
     )
     .digest("hex")
@@ -1065,6 +1080,27 @@ export async function buildActionParametersGraderEntry(
                     verify: "exact",
                     rule: "string-identifier-exact",
                     source: judged.source,
+                };
+            } else if (NONEMPTY_PARAMETER_SET.has(`${id}.${name}`)) {
+                // Force soft nonempty even if a prior/LLM decision said exact.
+                const isArray = field.spec.kind === "array";
+                judged = {
+                    create: "free_text",
+                    verify: "nonempty",
+                    rule: isArray
+                        ? "array-items:string-collection-element-nonempty"
+                        : "string-free-text-nonempty",
+                    source: judged.source,
+                    ...(isArray && field.spec.kind === "array"
+                        ? {
+                              item: {
+                                  create: "free_text" as const,
+                                  verify: "nonempty" as const,
+                                  rule: "string-collection-element-nonempty",
+                                  source: judged.source,
+                              },
+                          }
+                        : {}),
                 };
             }
             fields[name] = fieldGraderFromDecision(

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -199,11 +199,69 @@ const LLM_JUDGE_PARAMETER_SET = new Set<string>(LLM_JUDGE_PARAMETERS);
 /** Literal stored strings that must deep-equal (not soft / not llm judge). */
 const EXACT_PARAMETERS = new Set<string>(["github-cli.aliasSet.command"]);
 
+/**
+ * Optional params that gold often mints as ungrounded defaults / empties /
+ * dual fields / runtime context. Missing key must not fail paramScore —
+ * only `ignore` (not nonempty) treats omit as pass.
+ */
+export const IGNORE_PARAMETERS = [
+    "browser.openSearchResult.url",
+    "code.code-debug.startDebugging.noDebug",
+    "code.code-editor.launchCopilotChat.attachFiles",
+    "code.code-editor.launchCopilotChat.isPartialQuery",
+    "code.code-editor.saveAllFiles.onlyDirty",
+    "code.code-editor.saveCurrentFile.excludeUntitled",
+    "code.code-editor.saveCurrentFile.showErrorIfNoActiveEditor",
+    "code.code-workbench.openInIntegratedTerminal.reuseExistingTerminal",
+    "code.code-workbench.workbenchCreateFolderFromExplorer.resolutionHint",
+    "code.code-workbench.workbenchOpenFile.extensions",
+    "code.code-workbench.workbenchOpenFile.includeGenerated",
+    "code.code-workbench.workbenchOpenFile.matchStrategy",
+    "code.launchCopilotChat.attachFiles",
+    "code.launchCopilotChat.isPartialQuery",
+    "desktop.ApplyTheme.themeName",
+    "desktop.RestartService.elevate",
+    "desktop.desktop-input.MouseCursorSpeed.reduceSpeed",
+    "discord.createChannelInvite.never_expires",
+    "discord.createMessage.nonce",
+    "discord.createMessage.tts",
+    "discord.getCurrentUserGuilds.after",
+    "discord.getCurrentUserGuilds.before",
+    "discord.startThreadWithoutMessage.type",
+    "github-cli.attestationCreate.type",
+    "github-cli.authLogin.token",
+    "github-cli.repoCreate.private",
+    "github-cli.starRepo.unstar",
+    "markdown.updateDocument.context",
+    "markdown.updateDocument.cursorPosition",
+    "montage.addPhotos.search_filters",
+    "montage.removePhotos.files",
+    "montage.removePhotos.indices",
+    "player.findMusic.play",
+    "system.help.describeAgent.all",
+] as const;
+
+const IGNORE_PARAMETER_SET = new Set<string>(IGNORE_PARAMETERS);
+
+/**
+ * Conversation topic titles are freeform NL (paraphrase-OK), not resource ids.
+ * Action-scoped so webflow/playlist `name` stays identifier/exact.
+ */
+export const NONEMPTY_PARAMETERS = [
+    "system.conversation.indexConversation.name",
+    "system.conversation.newConversation.name",
+    "system.conversation.summarizeConversation.name",
+] as const;
+
+const NONEMPTY_PARAMETER_SET = new Set<string>(NONEMPTY_PARAMETERS);
+
 export const HEURISTIC_SOURCE_HASH: string = createHash("sha256")
     .update(
         JSON.stringify({
             rules: [...REGEX_RULE_IDS].sort(),
             llmJudge: [...LLM_JUDGE_PARAMETERS],
+            ignore: [...IGNORE_PARAMETERS],
+            nonempty: [...NONEMPTY_PARAMETERS],
             exact: [...EXACT_PARAMETERS].sort(),
         }),
     )
@@ -1063,11 +1121,27 @@ export async function buildActionParametersGraderEntry(
                 actionId: id,
                 siblingFieldNames: Object.keys(paramSpec.fields),
             });
-            if (EXACT_PARAMETERS.has(`${id}.${name}`)) {
+            const fullName = `${id}.${name}`;
+            if (EXACT_PARAMETERS.has(fullName)) {
                 judged = {
                     create: "identifier",
                     verify: "exact",
                     rule: "string-identifier-exact",
+                    source: judged.source,
+                };
+            } else if (IGNORE_PARAMETER_SET.has(fullName)) {
+                // Omit-OK optionals: keep create, drop from paramScore.
+                judged = {
+                    ...judged,
+                    verify: "ignore",
+                    rule: "hardcoded-ungrounded-ignore",
+                };
+            } else if (NONEMPTY_PARAMETER_SET.has(fullName)) {
+                // Topic titles: presence matters, exact wording does not.
+                judged = {
+                    create: "free_text",
+                    verify: "nonempty",
+                    rule: "string-free-text-nonempty",
                     source: judged.source,
                 };
             }

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -200,50 +200,6 @@ const LLM_JUDGE_PARAMETER_SET = new Set<string>(LLM_JUDGE_PARAMETERS);
 const EXACT_PARAMETERS = new Set<string>(["github-cli.aliasSet.command"]);
 
 /**
- * Optional params that gold often mints as ungrounded defaults / empties /
- * dual fields / runtime context. Missing key must not fail paramScore —
- * only `ignore` (not nonempty) treats omit as pass.
- */
-export const IGNORE_PARAMETERS = [
-    "browser.openSearchResult.url",
-    "code.code-debug.startDebugging.noDebug",
-    "code.code-editor.launchCopilotChat.attachFiles",
-    "code.code-editor.launchCopilotChat.isPartialQuery",
-    "code.code-editor.saveAllFiles.onlyDirty",
-    "code.code-editor.saveCurrentFile.excludeUntitled",
-    "code.code-editor.saveCurrentFile.showErrorIfNoActiveEditor",
-    "code.code-workbench.openInIntegratedTerminal.reuseExistingTerminal",
-    "code.code-workbench.workbenchCreateFolderFromExplorer.resolutionHint",
-    "code.code-workbench.workbenchOpenFile.extensions",
-    "code.code-workbench.workbenchOpenFile.includeGenerated",
-    "code.code-workbench.workbenchOpenFile.matchStrategy",
-    "code.launchCopilotChat.attachFiles",
-    "code.launchCopilotChat.isPartialQuery",
-    "desktop.ApplyTheme.themeName",
-    "desktop.RestartService.elevate",
-    "desktop.desktop-input.MouseCursorSpeed.reduceSpeed",
-    "discord.createChannelInvite.never_expires",
-    "discord.createMessage.nonce",
-    "discord.createMessage.tts",
-    "discord.getCurrentUserGuilds.after",
-    "discord.getCurrentUserGuilds.before",
-    "discord.startThreadWithoutMessage.type",
-    "github-cli.attestationCreate.type",
-    "github-cli.authLogin.token",
-    "github-cli.repoCreate.private",
-    "github-cli.starRepo.unstar",
-    "markdown.updateDocument.context",
-    "markdown.updateDocument.cursorPosition",
-    "montage.addPhotos.search_filters",
-    "montage.removePhotos.files",
-    "montage.removePhotos.indices",
-    "player.findMusic.play",
-    "system.help.describeAgent.all",
-] as const;
-
-const IGNORE_PARAMETER_SET = new Set<string>(IGNORE_PARAMETERS);
-
-/**
  * Conversation topic titles are freeform NL (paraphrase-OK), not resource ids.
  * Action-scoped so webflow/playlist `name` stays identifier/exact.
  */
@@ -255,65 +211,11 @@ export const NONEMPTY_PARAMETERS = [
 
 const NONEMPTY_PARAMETER_SET = new Set<string>(NONEMPTY_PARAMETERS);
 
-/** True when action.parameter is on the ungrounded-optional ignore list. */
-export function isIgnoredGoldParameter(
-    schemaName: string,
-    actionName: string,
-    fieldName: string,
-): boolean {
-    return IGNORE_PARAMETER_SET.has(`${schemaName}.${actionName}.${fieldName}`);
-}
-
-/** Field names on IGNORE_PARAMETERS for one action (empty when none). */
-export function ignoredGoldParameterNames(
-    schemaName: string,
-    actionName: string,
-): string[] {
-    const prefix = `${schemaName}.${actionName}.`;
-    return IGNORE_PARAMETERS.filter((full) => full.startsWith(prefix)).map(
-        (full) => full.slice(prefix.length),
-    );
-}
-
-/**
- * Drop IGNORE_PARAMETERS keys from gold parameters.
- * Returns a new object; omits `parameters` entirely when nothing remains.
- */
-export function stripIgnoredGoldParameters(
-    schemaName: string,
-    actionName: string,
-    parameters: Record<string, unknown> | undefined,
-): {
-    parameters: Record<string, unknown> | undefined;
-    removed: string[];
-} {
-    if (parameters === undefined) {
-        return { parameters: undefined, removed: [] };
-    }
-    const removed: string[] = [];
-    const next: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(parameters)) {
-        if (isIgnoredGoldParameter(schemaName, actionName, key)) {
-            removed.push(key);
-            continue;
-        }
-        next[key] = value;
-    }
-    if (removed.length === 0) {
-        return { parameters, removed };
-    }
-    return {
-        parameters: Object.keys(next).length > 0 ? next : undefined,
-        removed,
-    };
-}
-
 export const HEURISTIC_SOURCE_HASH: string = createHash("sha256")
     .update(
         JSON.stringify({
             rules: [...REGEX_RULE_IDS].sort(),
             llmJudge: [...LLM_JUDGE_PARAMETERS],
-            ignore: [...IGNORE_PARAMETERS],
             nonempty: [...NONEMPTY_PARAMETERS],
             exact: [...EXACT_PARAMETERS].sort(),
         }),
@@ -1181,13 +1083,6 @@ export async function buildActionParametersGraderEntry(
                     verify: "exact",
                     rule: "string-identifier-exact",
                     source: judged.source,
-                };
-            } else if (IGNORE_PARAMETER_SET.has(fullName)) {
-                // Omit-OK optionals: keep create, drop from paramScore.
-                judged = {
-                    ...judged,
-                    verify: "ignore",
-                    rule: "hardcoded-ungrounded-ignore",
                 };
             } else if (NONEMPTY_PARAMETER_SET.has(fullName)) {
                 // Topic titles: presence matters, exact wording does not.

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -261,9 +261,7 @@ export function isIgnoredGoldParameter(
     actionName: string,
     fieldName: string,
 ): boolean {
-    return IGNORE_PARAMETER_SET.has(
-        `${schemaName}.${actionName}.${fieldName}`,
-    );
+    return IGNORE_PARAMETER_SET.has(`${schemaName}.${actionName}.${fieldName}`);
 }
 
 /** Field names on IGNORE_PARAMETERS for one action (empty when none). */

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -255,6 +255,61 @@ export const NONEMPTY_PARAMETERS = [
 
 const NONEMPTY_PARAMETER_SET = new Set<string>(NONEMPTY_PARAMETERS);
 
+/** True when action.parameter is on the ungrounded-optional ignore list. */
+export function isIgnoredGoldParameter(
+    schemaName: string,
+    actionName: string,
+    fieldName: string,
+): boolean {
+    return IGNORE_PARAMETER_SET.has(
+        `${schemaName}.${actionName}.${fieldName}`,
+    );
+}
+
+/** Field names on IGNORE_PARAMETERS for one action (empty when none). */
+export function ignoredGoldParameterNames(
+    schemaName: string,
+    actionName: string,
+): string[] {
+    const prefix = `${schemaName}.${actionName}.`;
+    return IGNORE_PARAMETERS.filter((full) => full.startsWith(prefix)).map(
+        (full) => full.slice(prefix.length),
+    );
+}
+
+/**
+ * Drop IGNORE_PARAMETERS keys from gold parameters.
+ * Returns a new object; omits `parameters` entirely when nothing remains.
+ */
+export function stripIgnoredGoldParameters(
+    schemaName: string,
+    actionName: string,
+    parameters: Record<string, unknown> | undefined,
+): {
+    parameters: Record<string, unknown> | undefined;
+    removed: string[];
+} {
+    if (parameters === undefined) {
+        return { parameters: undefined, removed: [] };
+    }
+    const removed: string[] = [];
+    const next: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parameters)) {
+        if (isIgnoredGoldParameter(schemaName, actionName, key)) {
+            removed.push(key);
+            continue;
+        }
+        next[key] = value;
+    }
+    if (removed.length === 0) {
+        return { parameters, removed };
+    }
+    return {
+        parameters: Object.keys(next).length > 0 ? next : undefined,
+        removed,
+    };
+}
+
 export const HEURISTIC_SOURCE_HASH: string = createHash("sha256")
     .update(
         JSON.stringify({

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/catalogGenerator/actionParametersGrader.ts
@@ -175,6 +175,9 @@ export interface FieldGraderDecision {
 export const LLM_JUDGE_PARAMETERS = [
     "browser.actionDiscovery.createWebFlowFromRecording.recordedSteps",
     "browser.executeAdHocScript.script",
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.internetLookups",
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.originalRequest",
+    "browser.lookupAndAnswer.lookupAndAnswerInternet.sites",
     "browser.webFlows.editWebFlow.script",
     "code.code-editor.createCodeBlock.body",
     "code.code-editor.createCodeBlock.codeSnippet",
@@ -196,25 +199,11 @@ const LLM_JUDGE_PARAMETER_SET = new Set<string>(LLM_JUDGE_PARAMETERS);
 /** Literal stored strings that must deep-equal (not soft / not llm judge). */
 const EXACT_PARAMETERS = new Set<string>(["github-cli.aliasSet.command"]);
 
-/**
- * Hardcoded action.parameter pairs that always verify as nonempty.
- * Internet lookup query lists / freeform request strings have many valid
- * surface forms; exact string match is an unfair param-score fail.
- */
-export const NONEMPTY_PARAMETERS = [
-    "browser.lookupAndAnswer.lookupAndAnswerInternet.originalRequest",
-    "browser.lookupAndAnswer.lookupAndAnswerInternet.internetLookups",
-    "browser.lookupAndAnswer.lookupAndAnswerInternet.sites",
-] as const;
-
-const NONEMPTY_PARAMETER_SET = new Set<string>(NONEMPTY_PARAMETERS);
-
 export const HEURISTIC_SOURCE_HASH: string = createHash("sha256")
     .update(
         JSON.stringify({
             rules: [...REGEX_RULE_IDS].sort(),
             llmJudge: [...LLM_JUDGE_PARAMETERS],
-            nonempty: [...NONEMPTY_PARAMETERS],
             exact: [...EXACT_PARAMETERS].sort(),
         }),
     )
@@ -1080,27 +1069,6 @@ export async function buildActionParametersGraderEntry(
                     verify: "exact",
                     rule: "string-identifier-exact",
                     source: judged.source,
-                };
-            } else if (NONEMPTY_PARAMETER_SET.has(`${id}.${name}`)) {
-                // Force soft nonempty even if a prior/LLM decision said exact.
-                const isArray = field.spec.kind === "array";
-                judged = {
-                    create: "free_text",
-                    verify: "nonempty",
-                    rule: isArray
-                        ? "array-items:string-collection-element-nonempty"
-                        : "string-free-text-nonempty",
-                    source: judged.source,
-                    ...(isArray && field.spec.kind === "array"
-                        ? {
-                              item: {
-                                  create: "free_text" as const,
-                                  verify: "nonempty" as const,
-                                  rule: "string-collection-element-nonempty",
-                                  source: judged.source,
-                              },
-                          }
-                        : {}),
                 };
             }
             fields[name] = fieldGraderFromDecision(

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
@@ -54,6 +54,7 @@ import {
     runTranslationBenchDataQualityVerifier,
     runTranslationBenchFormatChecker,
 } from "./dataQualityVerifier.js";
+import { ignoredGoldParameterNames } from "./catalogGenerator/actionParametersGrader.js";
 import {
     loadTranslationBenchQualityVerifierPromptPack,
     loadTranslationBenchSynthesizerPromptPack,
@@ -500,10 +501,18 @@ function formatSynthesizerPrompt(
         (tool) => tool.function.name === options.targetAction.actionName,
     )!;
     const parameterField = targetParameterField(options);
+    const omitParams = ignoredGoldParameterNames(
+        options.targetAction.schemaName,
+        options.targetAction.actionName,
+    );
+    const omitClause =
+        omitParams.length === 0
+            ? ""
+            : ` omitUngroundedParameters=${JSON.stringify(omitParams)} — these optional keys must be ABSENT from gold parameters (do not mint defaults, empty values, or dual fields).`;
     const actionContract =
         parameterField === undefined
             ? `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}"}; omit parameters entirely for this parameterless action. Never use name/arguments or a qualified-name string.`
-            : `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}","parameters":{...}} with schema-valid parameters${parameterField.optional ? " when parameters are present" : ""}. Never use name/arguments or a qualified-name string.`;
+            : `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}","parameters":{...}} with schema-valid parameters${parameterField.optional ? " when parameters are present" : ""}. Never use name/arguments or a qualified-name string.${omitClause}`;
     const positiveCount = options.genCaseCount / 2;
     const previousRejectedBlock =
         previousRejectedCandidate === undefined

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
@@ -54,7 +54,7 @@ import {
     runTranslationBenchDataQualityVerifier,
     runTranslationBenchFormatChecker,
 } from "./dataQualityVerifier.js";
-import { ignoredGoldParameterNames } from "./catalogGenerator/actionParametersGrader.js";
+import { omittedGoldParameterNames } from "./goldParameterHygiene.js";
 import {
     loadTranslationBenchQualityVerifierPromptPack,
     loadTranslationBenchSynthesizerPromptPack,
@@ -501,14 +501,14 @@ function formatSynthesizerPrompt(
         (tool) => tool.function.name === options.targetAction.actionName,
     )!;
     const parameterField = targetParameterField(options);
-    const omitParams = ignoredGoldParameterNames(
+    const omitParams = omittedGoldParameterNames(
         options.targetAction.schemaName,
         options.targetAction.actionName,
     );
     const omitClause =
         omitParams.length === 0
             ? ""
-            : ` omitUngroundedParameters=${JSON.stringify(omitParams)} — these optional keys must be ABSENT from gold parameters (do not mint defaults, empty values, or dual fields).`;
+            : ` omitFromGoldParameters=${JSON.stringify(omitParams)} — these optional keys must be ABSENT from gold parameters (do not mint defaults, empty values, or dual fields).`;
     const actionContract =
         parameterField === undefined
             ? `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}"}; omit parameters entirely for this parameterless action. Never use name/arguments or a qualified-name string.`

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/datasetGenerator.ts
@@ -54,7 +54,6 @@ import {
     runTranslationBenchDataQualityVerifier,
     runTranslationBenchFormatChecker,
 } from "./dataQualityVerifier.js";
-import { omittedGoldParameterNames } from "./goldParameterHygiene.js";
 import {
     loadTranslationBenchQualityVerifierPromptPack,
     loadTranslationBenchSynthesizerPromptPack,
@@ -501,18 +500,10 @@ function formatSynthesizerPrompt(
         (tool) => tool.function.name === options.targetAction.actionName,
     )!;
     const parameterField = targetParameterField(options);
-    const omitParams = omittedGoldParameterNames(
-        options.targetAction.schemaName,
-        options.targetAction.actionName,
-    );
-    const omitClause =
-        omitParams.length === 0
-            ? ""
-            : ` omitFromGoldParameters=${JSON.stringify(omitParams)} — these optional keys must be ABSENT from gold parameters (do not mint defaults, empty values, or dual fields).`;
     const actionContract =
         parameterField === undefined
             ? `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}"}; omit parameters entirely for this parameterless action. Never use name/arguments or a qualified-name string.`
-            : `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}","parameters":{...}} with schema-valid parameters${parameterField.optional ? " when parameters are present" : ""}. Never use name/arguments or a qualified-name string.${omitClause}`;
+            : `Every expected action must use exactly {"schemaName":"${options.targetAction.schemaName}","actionName":"${options.targetAction.actionName}","parameters":{...}} with schema-valid parameters${parameterField.optional ? " when parameters are present" : ""}. Never use name/arguments or a qualified-name string. Only include parameters clearly supported by the utterance (or allowed history); omit optional defaults, empty strings/arrays, dual fields, and invented runtime context.`;
     const positiveCount = options.genCaseCount / 2;
     const previousRejectedBlock =
         previousRejectedCandidate === undefined

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
@@ -22,7 +22,7 @@ import {
     normalizeTranslationBenchActionShapePolicy,
     type TranslationBenchActionShapePolicy,
 } from "./actionShape.js";
-import { stripOmittedGoldParameters } from "./goldParameterHygiene.js";
+import { stripEmptyGoldPlaceholders } from "./goldParameterHygiene.js";
 
 export interface TranslationBenchGeneratedCase {
     id: string;
@@ -281,19 +281,15 @@ export function parseTranslationBenchGeneratedCandidate(
             `Generated candidate requires ${expectedPerRole} positive and ${expectedPerRole} negative gen cases`,
         );
     }
-    // Gold hygiene: never keep ungrounded optional defaults on labeled actions.
-    return stripOmittedGoldParametersFromCandidate(structuredClone(parsed));
+    // Gold hygiene: drop empty "" / [] / null placeholders from labeled params.
+    return stripEmptyGoldPlaceholdersFromCandidate(structuredClone(parsed));
 }
 
-function stripOmittedGoldParametersFromActions(
+function stripEmptyGoldPlaceholdersFromActions(
     actions: TranslationBenchBenchmarkAction[],
 ): TranslationBenchBenchmarkAction[] {
     return actions.map((action) => {
-        const { parameters } = stripOmittedGoldParameters(
-            action.schemaName,
-            action.actionName,
-            action.parameters,
-        );
+        const { parameters } = stripEmptyGoldPlaceholders(action.parameters);
         if (parameters === action.parameters) {
             return action;
         }
@@ -306,14 +302,14 @@ function stripOmittedGoldParametersFromActions(
 }
 
 /** Deterministic gold cleanup shared by parse + format checker. */
-export function stripOmittedGoldParametersFromCandidate(
+export function stripEmptyGoldPlaceholdersFromCandidate(
     candidate: TranslationBenchGeneratedCandidate,
 ): TranslationBenchGeneratedCandidate {
     return {
         ...candidate,
         seed: {
             ...candidate.seed,
-            expectedActions: stripOmittedGoldParametersFromActions(
+            expectedActions: stripEmptyGoldPlaceholdersFromActions(
                 candidate.seed.expectedActions,
             ),
         },
@@ -323,7 +319,7 @@ export function stripOmittedGoldParametersFromCandidate(
             }
             return {
                 ...probe,
-                expectedActions: stripOmittedGoldParametersFromActions(
+                expectedActions: stripEmptyGoldPlaceholdersFromActions(
                     probe.expectedActions,
                 ),
             };

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
@@ -22,6 +22,7 @@ import {
     normalizeTranslationBenchActionShapePolicy,
     type TranslationBenchActionShapePolicy,
 } from "./actionShape.js";
+import { stripIgnoredGoldParameters } from "./catalogGenerator/actionParametersGrader.js";
 
 export interface TranslationBenchGeneratedCase {
     id: string;
@@ -280,7 +281,54 @@ export function parseTranslationBenchGeneratedCandidate(
             `Generated candidate requires ${expectedPerRole} positive and ${expectedPerRole} negative gen cases`,
         );
     }
-    return structuredClone(parsed);
+    // Gold hygiene: never keep ungrounded optional defaults on labeled actions.
+    return stripIgnoredGoldParametersFromCandidate(structuredClone(parsed));
+}
+
+function stripIgnoredGoldParametersFromActions(
+    actions: TranslationBenchBenchmarkAction[],
+): TranslationBenchBenchmarkAction[] {
+    return actions.map((action) => {
+        const { parameters } = stripIgnoredGoldParameters(
+            action.schemaName,
+            action.actionName,
+            action.parameters,
+        );
+        if (parameters === action.parameters) {
+            return action;
+        }
+        if (parameters === undefined) {
+            const { parameters: _drop, ...rest } = action;
+            return rest;
+        }
+        return { ...action, parameters };
+    });
+}
+
+/** Deterministic gold cleanup shared by parse + format checker. */
+export function stripIgnoredGoldParametersFromCandidate(
+    candidate: TranslationBenchGeneratedCandidate,
+): TranslationBenchGeneratedCandidate {
+    return {
+        ...candidate,
+        seed: {
+            ...candidate.seed,
+            expectedActions: stripIgnoredGoldParametersFromActions(
+                candidate.seed.expectedActions,
+            ),
+        },
+        genCases: candidate.genCases.map((probe) => {
+            if (probe.role !== "positive") {
+                return probe;
+            }
+            return {
+                ...probe,
+                expectedActions: stripIgnoredGoldParametersFromActions(
+                    probe.expectedActions,
+                ),
+            };
+        }),
+    };
 }
 
 export function parseTranslationBenchReviewerDecision(

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
@@ -22,7 +22,7 @@ import {
     normalizeTranslationBenchActionShapePolicy,
     type TranslationBenchActionShapePolicy,
 } from "./actionShape.js";
-import { stripIgnoredGoldParameters } from "./catalogGenerator/actionParametersGrader.js";
+import { stripOmittedGoldParameters } from "./goldParameterHygiene.js";
 
 export interface TranslationBenchGeneratedCase {
     id: string;
@@ -282,14 +282,14 @@ export function parseTranslationBenchGeneratedCandidate(
         );
     }
     // Gold hygiene: never keep ungrounded optional defaults on labeled actions.
-    return stripIgnoredGoldParametersFromCandidate(structuredClone(parsed));
+    return stripOmittedGoldParametersFromCandidate(structuredClone(parsed));
 }
 
-function stripIgnoredGoldParametersFromActions(
+function stripOmittedGoldParametersFromActions(
     actions: TranslationBenchBenchmarkAction[],
 ): TranslationBenchBenchmarkAction[] {
     return actions.map((action) => {
-        const { parameters } = stripIgnoredGoldParameters(
+        const { parameters } = stripOmittedGoldParameters(
             action.schemaName,
             action.actionName,
             action.parameters,
@@ -306,14 +306,14 @@ function stripIgnoredGoldParametersFromActions(
 }
 
 /** Deterministic gold cleanup shared by parse + format checker. */
-export function stripIgnoredGoldParametersFromCandidate(
+export function stripOmittedGoldParametersFromCandidate(
     candidate: TranslationBenchGeneratedCandidate,
 ): TranslationBenchGeneratedCandidate {
     return {
         ...candidate,
         seed: {
             ...candidate.seed,
-            expectedActions: stripIgnoredGoldParametersFromActions(
+            expectedActions: stripOmittedGoldParametersFromActions(
                 candidate.seed.expectedActions,
             ),
         },
@@ -323,7 +323,7 @@ export function stripIgnoredGoldParametersFromCandidate(
             }
             return {
                 ...probe,
-                expectedActions: stripIgnoredGoldParametersFromActions(
+                expectedActions: stripOmittedGoldParametersFromActions(
                     probe.expectedActions,
                 ),
             };

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/generationCandidate.ts
@@ -198,6 +198,9 @@ export function parseTranslationBenchGeneratedCandidate(
             `Generated candidate requires exactly ${context.genCaseCount} gen cases`,
         );
     }
+    const candidate = stripEmptyGoldPlaceholdersFromCandidate(
+        structuredClone(parsed),
+    );
     const definition = fromJSONParsedActionSchema(
         structuredClone(context.schema.typeAgent!.parsedActionSchema),
     ).actionSchemas.get(context.targetAction.actionName);
@@ -236,9 +239,9 @@ export function parseTranslationBenchGeneratedCandidate(
         }
         validateHistory(probe.history, path);
     };
-    validatePositive(parsed.seed, "seed", "seed");
+    validatePositive(candidate.seed, "seed", "seed");
     const ids = new Set<string>();
-    const seedUtterance = normalizedUtterance(parsed.seed.utterance);
+    const seedUtterance = normalizedUtterance(candidate.seed.utterance);
     if (context.forbiddenUtterances?.has(seedUtterance)) {
         throw new Error(
             "seed duplicates an utterance from another generated row",
@@ -247,7 +250,7 @@ export function parseTranslationBenchGeneratedCandidate(
     const utterances = new Set([seedUtterance]);
     let positives = 0;
     let negatives = 0;
-    parsed.genCases.forEach((probe, index) => {
+    candidate.genCases.forEach((probe, index) => {
         const path = `genCases[${index}]`;
         if (ids.has(probe.id)) throw new Error(`${path} has a duplicate id`);
         ids.add(probe.id);
@@ -281,8 +284,7 @@ export function parseTranslationBenchGeneratedCandidate(
             `Generated candidate requires ${expectedPerRole} positive and ${expectedPerRole} negative gen cases`,
         );
     }
-    // Gold hygiene: drop empty "" / [] / null placeholders from labeled params.
-    return stripEmptyGoldPlaceholdersFromCandidate(structuredClone(parsed));
+    return candidate;
 }
 
 function stripEmptyGoldPlaceholdersFromActions(
@@ -301,7 +303,6 @@ function stripEmptyGoldPlaceholdersFromActions(
     });
 }
 
-/** Deterministic gold cleanup shared by parse + format checker. */
 export function stripEmptyGoldPlaceholdersFromCandidate(
     candidate: TranslationBenchGeneratedCandidate,
 ): TranslationBenchGeneratedCandidate {

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/generationSupport.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/generationSupport.ts
@@ -177,7 +177,12 @@ export function translationBenchResumeKey(
 ): string {
     const normalized = parseWithZod(
         workIdentitySchema,
-        identity,
+        {
+            phase: identity.phase,
+            model: identity.model,
+            scenario: identity.scenario,
+            caseId: identity.caseId,
+        },
         "work identity",
     );
     return JSON.stringify([

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
@@ -2,81 +2,32 @@
 // Licensed under the MIT License.
 
 /**
- * Gold-parameter hygiene for the translation-bench synthesizer harness.
+ * Deterministic gold-parameter hygiene for the translation-bench synthesizer.
  *
- * These keys must not appear in labeled expectedActions parameters: they are
- * optional defaults, empty placeholders, dual fields, or runtime context that
- * gold should omit rather than mint. This is dataset quality — not paramScore
- * verify=ignore.
+ * No per-action hardcodes. Gold should not store "unset" placeholders:
+ * empty strings, empty arrays, null. Prefer omit. Non-empty values (including
+ * boolean false / 0) are left alone — utterance grounding is the labeler's job.
  */
 
-export const OMIT_FROM_GOLD_PARAMETERS = [
-    "browser.openSearchResult.url",
-    "code.code-debug.startDebugging.noDebug",
-    "code.code-editor.launchCopilotChat.attachFiles",
-    "code.code-editor.launchCopilotChat.isPartialQuery",
-    "code.code-editor.saveAllFiles.onlyDirty",
-    "code.code-editor.saveCurrentFile.excludeUntitled",
-    "code.code-editor.saveCurrentFile.showErrorIfNoActiveEditor",
-    "code.code-workbench.openInIntegratedTerminal.reuseExistingTerminal",
-    "code.code-workbench.workbenchCreateFolderFromExplorer.resolutionHint",
-    "code.code-workbench.workbenchOpenFile.extensions",
-    "code.code-workbench.workbenchOpenFile.includeGenerated",
-    "code.code-workbench.workbenchOpenFile.matchStrategy",
-    "code.launchCopilotChat.attachFiles",
-    "code.launchCopilotChat.isPartialQuery",
-    "desktop.ApplyTheme.themeName",
-    "desktop.RestartService.elevate",
-    "desktop.desktop-input.MouseCursorSpeed.reduceSpeed",
-    "discord.createChannelInvite.never_expires",
-    "discord.createMessage.nonce",
-    "discord.createMessage.tts",
-    "discord.getCurrentUserGuilds.after",
-    "discord.getCurrentUserGuilds.before",
-    "discord.startThreadWithoutMessage.type",
-    "github-cli.attestationCreate.type",
-    "github-cli.authLogin.token",
-    "github-cli.repoCreate.private",
-    "github-cli.starRepo.unstar",
-    "markdown.updateDocument.context",
-    "markdown.updateDocument.cursorPosition",
-    "montage.addPhotos.search_filters",
-    "montage.removePhotos.files",
-    "montage.removePhotos.indices",
-    "player.findMusic.play",
-    "system.help.describeAgent.all",
-] as const;
-
-const OMIT_FROM_GOLD_PARAMETER_SET = new Set<string>(OMIT_FROM_GOLD_PARAMETERS);
-
-export function isOmittedFromGoldParameter(
-    schemaName: string,
-    actionName: string,
-    fieldName: string,
-): boolean {
-    return OMIT_FROM_GOLD_PARAMETER_SET.has(
-        `${schemaName}.${actionName}.${fieldName}`,
-    );
-}
-
-/** Field names to omit from gold for one action (empty when none). */
-export function omittedGoldParameterNames(
-    schemaName: string,
-    actionName: string,
-): string[] {
-    const prefix = `${schemaName}.${actionName}.`;
-    return OMIT_FROM_GOLD_PARAMETERS.filter((full) =>
-        full.startsWith(prefix),
-    ).map((full) => full.slice(prefix.length));
+export function isEmptyGoldPlaceholder(value: unknown): boolean {
+    if (value === null || value === undefined) {
+        return true;
+    }
+    if (typeof value === "string" && value.trim() === "") {
+        return true;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+        return true;
+    }
+    return false;
 }
 
 /**
- * Drop OMIT_FROM_GOLD_PARAMETERS keys from gold parameters.
- * Returns a new object; omits `parameters` entirely when nothing remains.
+ * Drop empty placeholder values from gold parameters.
+ * Returns the same object reference when nothing changes; omits `parameters`
+ * entirely when nothing remains.
  */
-export function stripOmittedGoldParameters(
-    schemaName: string,
-    actionName: string,
+export function stripEmptyGoldPlaceholders(
     parameters: Record<string, unknown> | undefined,
 ): {
     parameters: Record<string, unknown> | undefined;
@@ -88,7 +39,7 @@ export function stripOmittedGoldParameters(
     const removed: string[] = [];
     const next: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(parameters)) {
-        if (isOmittedFromGoldParameter(schemaName, actionName, key)) {
+        if (isEmptyGoldPlaceholder(value)) {
             removed.push(key);
             continue;
         }

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+type StripResult = { kept: true; value: unknown } | { kept: false };
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -21,58 +23,87 @@ export function isEmptyGoldPlaceholder(value: unknown): boolean {
     return false;
 }
 
+function childPath(path: string, key: string | number): string {
+    if (typeof key === "number") {
+        return `${path}[${key}]`;
+    }
+    return path === "" ? key : `${path}.${key}`;
+}
+
+function stripArray(
+    value: unknown[],
+    path: string,
+    removed: string[],
+): StripResult {
+    const next: unknown[] = [];
+    let changed = false;
+    for (let i = 0; i < value.length; i += 1) {
+        const child = stripEmptyGoldValue(
+            value[i],
+            childPath(path, i),
+            removed,
+        );
+        if (!child.kept) {
+            changed = true;
+            continue;
+        }
+        if (child.value !== value[i]) {
+            changed = true;
+        }
+        next.push(child.value);
+    }
+    if (next.length === 0) {
+        removed.push(path);
+        return { kept: false };
+    }
+    return { kept: true, value: changed ? next : value };
+}
+
+function stripObject(
+    value: Record<string, unknown>,
+    path: string,
+    removed: string[],
+): StripResult {
+    const next: Record<string, unknown> = {};
+    let changed = false;
+    for (const [key, childValue] of Object.entries(value)) {
+        const child = stripEmptyGoldValue(
+            childValue,
+            childPath(path, key),
+            removed,
+        );
+        if (!child.kept) {
+            changed = true;
+            continue;
+        }
+        if (child.value !== childValue) {
+            changed = true;
+        }
+        next[key] = child.value;
+    }
+    if (Object.keys(next).length === 0) {
+        if (path !== "") {
+            removed.push(path);
+        }
+        return { kept: false };
+    }
+    return { kept: true, value: changed ? next : value };
+}
+
 function stripEmptyGoldValue(
     value: unknown,
     path: string,
     removed: string[],
-): { kept: true; value: unknown } | { kept: false } {
+): StripResult {
     if (isEmptyGoldPlaceholder(value)) {
         removed.push(path);
         return { kept: false };
     }
     if (Array.isArray(value)) {
-        const next: unknown[] = [];
-        let changed = false;
-        for (let i = 0; i < value.length; i += 1) {
-            const childPath = `${path}[${i}]`;
-            const child = stripEmptyGoldValue(value[i], childPath, removed);
-            if (!child.kept) {
-                changed = true;
-                continue;
-            }
-            if (child.value !== value[i]) {
-                changed = true;
-            }
-            next.push(child.value);
-        }
-        if (next.length === 0) {
-            removed.push(path);
-            return { kept: false };
-        }
-        return { kept: true, value: changed ? next : value };
+        return stripArray(value, path, removed);
     }
     if (isPlainObject(value)) {
-        const next: Record<string, unknown> = {};
-        let changed = false;
-        for (const [key, childValue] of Object.entries(value)) {
-            const childPath = path === "" ? key : `${path}.${key}`;
-            const child = stripEmptyGoldValue(childValue, childPath, removed);
-            if (!child.kept) {
-                changed = true;
-                continue;
-            }
-            if (child.value !== childValue) {
-                changed = true;
-            }
-            next[key] = child.value;
-        }
-        if (Object.keys(next).length === 0) {
-            if (path !== "") {
-                removed.push(path);
-            }
-            return { kept: false };
-        }
-        return { kept: true, value: changed ? next : value };
+        return stripObject(value, path, removed);
     }
     return { kept: true, value };
 }

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Gold-parameter hygiene for the translation-bench synthesizer harness.
+ *
+ * These keys must not appear in labeled expectedActions parameters: they are
+ * optional defaults, empty placeholders, dual fields, or runtime context that
+ * gold should omit rather than mint. This is dataset quality — not paramScore
+ * verify=ignore.
+ */
+
+export const OMIT_FROM_GOLD_PARAMETERS = [
+    "browser.openSearchResult.url",
+    "code.code-debug.startDebugging.noDebug",
+    "code.code-editor.launchCopilotChat.attachFiles",
+    "code.code-editor.launchCopilotChat.isPartialQuery",
+    "code.code-editor.saveAllFiles.onlyDirty",
+    "code.code-editor.saveCurrentFile.excludeUntitled",
+    "code.code-editor.saveCurrentFile.showErrorIfNoActiveEditor",
+    "code.code-workbench.openInIntegratedTerminal.reuseExistingTerminal",
+    "code.code-workbench.workbenchCreateFolderFromExplorer.resolutionHint",
+    "code.code-workbench.workbenchOpenFile.extensions",
+    "code.code-workbench.workbenchOpenFile.includeGenerated",
+    "code.code-workbench.workbenchOpenFile.matchStrategy",
+    "code.launchCopilotChat.attachFiles",
+    "code.launchCopilotChat.isPartialQuery",
+    "desktop.ApplyTheme.themeName",
+    "desktop.RestartService.elevate",
+    "desktop.desktop-input.MouseCursorSpeed.reduceSpeed",
+    "discord.createChannelInvite.never_expires",
+    "discord.createMessage.nonce",
+    "discord.createMessage.tts",
+    "discord.getCurrentUserGuilds.after",
+    "discord.getCurrentUserGuilds.before",
+    "discord.startThreadWithoutMessage.type",
+    "github-cli.attestationCreate.type",
+    "github-cli.authLogin.token",
+    "github-cli.repoCreate.private",
+    "github-cli.starRepo.unstar",
+    "markdown.updateDocument.context",
+    "markdown.updateDocument.cursorPosition",
+    "montage.addPhotos.search_filters",
+    "montage.removePhotos.files",
+    "montage.removePhotos.indices",
+    "player.findMusic.play",
+    "system.help.describeAgent.all",
+] as const;
+
+const OMIT_FROM_GOLD_PARAMETER_SET = new Set<string>(OMIT_FROM_GOLD_PARAMETERS);
+
+export function isOmittedFromGoldParameter(
+    schemaName: string,
+    actionName: string,
+    fieldName: string,
+): boolean {
+    return OMIT_FROM_GOLD_PARAMETER_SET.has(
+        `${schemaName}.${actionName}.${fieldName}`,
+    );
+}
+
+/** Field names to omit from gold for one action (empty when none). */
+export function omittedGoldParameterNames(
+    schemaName: string,
+    actionName: string,
+): string[] {
+    const prefix = `${schemaName}.${actionName}.`;
+    return OMIT_FROM_GOLD_PARAMETERS.filter((full) =>
+        full.startsWith(prefix),
+    ).map((full) => full.slice(prefix.length));
+}
+
+/**
+ * Drop OMIT_FROM_GOLD_PARAMETERS keys from gold parameters.
+ * Returns a new object; omits `parameters` entirely when nothing remains.
+ */
+export function stripOmittedGoldParameters(
+    schemaName: string,
+    actionName: string,
+    parameters: Record<string, unknown> | undefined,
+): {
+    parameters: Record<string, unknown> | undefined;
+    removed: string[];
+} {
+    if (parameters === undefined) {
+        return { parameters: undefined, removed: [] };
+    }
+    const removed: string[] = [];
+    const next: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(parameters)) {
+        if (isOmittedFromGoldParameter(schemaName, actionName, key)) {
+            removed.push(key);
+            continue;
+        }
+        next[key] = value;
+    }
+    if (removed.length === 0) {
+        return { parameters, removed };
+    }
+    return {
+        parameters: Object.keys(next).length > 0 ? next : undefined,
+        removed,
+    };
+}

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/goldParameterHygiene.ts
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/**
- * Deterministic gold-parameter hygiene for the translation-bench synthesizer.
- *
- * No per-action hardcodes. Gold should not store "unset" placeholders:
- * empty strings, empty arrays, null. Prefer omit. Non-empty values (including
- * boolean false / 0) are left alone — utterance grounding is the labeler's job.
- */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 export function isEmptyGoldPlaceholder(value: unknown): boolean {
     if (value === null || value === undefined) {
@@ -19,14 +15,68 @@ export function isEmptyGoldPlaceholder(value: unknown): boolean {
     if (Array.isArray(value) && value.length === 0) {
         return true;
     }
+    if (isPlainObject(value) && Object.keys(value).length === 0) {
+        return true;
+    }
     return false;
 }
 
-/**
- * Drop empty placeholder values from gold parameters.
- * Returns the same object reference when nothing changes; omits `parameters`
- * entirely when nothing remains.
- */
+function stripEmptyGoldValue(
+    value: unknown,
+    path: string,
+    removed: string[],
+): { kept: true; value: unknown } | { kept: false } {
+    if (isEmptyGoldPlaceholder(value)) {
+        removed.push(path);
+        return { kept: false };
+    }
+    if (Array.isArray(value)) {
+        const next: unknown[] = [];
+        let changed = false;
+        for (let i = 0; i < value.length; i += 1) {
+            const childPath = `${path}[${i}]`;
+            const child = stripEmptyGoldValue(value[i], childPath, removed);
+            if (!child.kept) {
+                changed = true;
+                continue;
+            }
+            if (child.value !== value[i]) {
+                changed = true;
+            }
+            next.push(child.value);
+        }
+        if (next.length === 0) {
+            removed.push(path);
+            return { kept: false };
+        }
+        return { kept: true, value: changed ? next : value };
+    }
+    if (isPlainObject(value)) {
+        const next: Record<string, unknown> = {};
+        let changed = false;
+        for (const [key, childValue] of Object.entries(value)) {
+            const childPath = path === "" ? key : `${path}.${key}`;
+            const child = stripEmptyGoldValue(childValue, childPath, removed);
+            if (!child.kept) {
+                changed = true;
+                continue;
+            }
+            if (child.value !== childValue) {
+                changed = true;
+            }
+            next[key] = child.value;
+        }
+        if (Object.keys(next).length === 0) {
+            if (path !== "") {
+                removed.push(path);
+            }
+            return { kept: false };
+        }
+        return { kept: true, value: changed ? next : value };
+    }
+    return { kept: true, value };
+}
+
 export function stripEmptyGoldPlaceholders(
     parameters: Record<string, unknown> | undefined,
 ): {
@@ -37,19 +87,15 @@ export function stripEmptyGoldPlaceholders(
         return { parameters: undefined, removed: [] };
     }
     const removed: string[] = [];
-    const next: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(parameters)) {
-        if (isEmptyGoldPlaceholder(value)) {
-            removed.push(key);
-            continue;
-        }
-        next[key] = value;
+    const stripped = stripEmptyGoldValue(parameters, "", removed);
+    if (!stripped.kept) {
+        return { parameters: undefined, removed };
     }
-    if (removed.length === 0) {
-        return { parameters, removed };
+    if (stripped.value === parameters) {
+        return { parameters, removed: [] };
     }
     return {
-        parameters: Object.keys(next).length > 0 ? next : undefined,
+        parameters: stripped.value as Record<string, unknown>,
         removed,
     };
 }

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/index.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/index.ts
@@ -15,3 +15,4 @@ export * from "./synthesizerPrompts.js";
 export * from "./utteranceDisambiguation.js";
 export * from "./catalogGenerator/index.js";
 export { seedQaJsonlAdapter } from "./adapters/seedQaJsonlAdapter.js";
+export * from "./goldParameterHygiene.js";

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
@@ -18,6 +18,8 @@ format_checker:
   description: |-
     Structural validation against the target tool schema and generation contract.
     Fail-closed: any violation rejects the candidate without calling the LLM.
+    Before schema validation, empty gold placeholders ("" / [] / null / {}) are
+    stripped recursively; required fields missing after strip fail closed.
   checks:
     - required_json_shape
     - seed_and_gen_case_counts
@@ -29,7 +31,6 @@ format_checker:
     - history_shape_when_present
     - active_schema_membership
     - utterance_action_disambiguation
-    - strip_empty_gold_placeholders
 
 # Stage 2 — semantic / quality judge (LLM)
 semantic_checker:

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
@@ -29,7 +29,7 @@ format_checker:
     - history_shape_when_present
     - active_schema_membership
     - utterance_action_disambiguation
-    - strip_omit_from_gold_parameters
+    - strip_empty_gold_placeholders
 
 # Stage 2 — semantic / quality judge (LLM)
 semantic_checker:
@@ -82,6 +82,18 @@ semantic_checker:
       openWebPage or followLinkByText without link/URL-specific wording.
     - Negatives that intentionally use adjacent intents are fine when
       expectedActions is empty.
+
+    Gold parameters (groundTruthCorrectness / INVALID_PARAMETERS):
+    - Every expectedActions[].parameters key on seed/positives must be clearly
+      supported by that case's utterance (or allowed history). Prefer omit.
+    - Reject optional default polarity flags the user did not ask for
+      (e.g. unstar:false on "star the repo", noDebug:false when debugging).
+    - Reject empty placeholders ("" / []) — format checker strips these, but
+      leftover empties still fail quality.
+    - Reject invented runtime context not in the utterance (full URLs the user
+      never said, editor cursor/context JSON, nonces, attestation types).
+    - Reject dual/redundant fields that restate each other (public:true with
+      private:false; filePath with an equivalent themeName) — keep one.
 
     Issue codes (use only these): {{issue_codes}}
 

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
@@ -29,7 +29,7 @@ format_checker:
     - history_shape_when_present
     - active_schema_membership
     - utterance_action_disambiguation
-    - strip_ungrounded_optional_gold_parameters
+    - strip_omit_from_gold_parameters
 
 # Stage 2 — semantic / quality judge (LLM)
 semantic_checker:

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/quality-verifier.prompt.yaml
@@ -29,6 +29,7 @@ format_checker:
     - history_shape_when_present
     - active_schema_membership
     - utterance_action_disambiguation
+    - strip_ungrounded_optional_gold_parameters
 
 # Stage 2 — semantic / quality judge (LLM)
 semantic_checker:

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
@@ -83,6 +83,15 @@ template: |-
   - Vary difficulty from beginner to advanced phrasing
   - Match parameter types and ranges in the function description
 
+  Gold parameters (hard requirement for seed + every positive):
+  - Only include parameters the utterance (or allowed history) clearly supports.
+  - NEVER mint schema defaults, polarity flags set to the no-op value, empty
+    strings, empty arrays, invented URLs/nonces/editor state, or dual fields
+    that restate another parameter (e.g. private:false with public:true).
+  - When omitUngroundedParameters is listed for the target action, those keys
+    must be ABSENT from every expectedActions[].parameters object. Prefer omit
+    over false / "" / [].
+
   Attempt: {{attempt}}
 
   Immutable context (YAML):

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
@@ -85,13 +85,12 @@ template: |-
 
   Gold parameters (hard requirement for seed + every positive):
   - Only include parameters the utterance (or allowed history) clearly supports.
-  - NEVER mint schema defaults, polarity flags set to the no-op value, empty
-    strings, empty arrays, invented URLs/nonces/editor state, or dual fields
-    that restate another parameter (e.g. private:false with public:true).
-  - Prefer omit over false / "" / [] when the user did not request that field.
-  - When omitFromGoldParameters is listed for the target action, those keys
-    must be ABSENT from every expectedActions[].parameters object. The format
-    checker strips them deterministically if they still appear.
+  - Prefer omit over writing a value when the user did not ask for that field.
+  - NEVER mint: schema default polarity flags (e.g. unstar:false on "star"),
+    empty strings, empty arrays, invented URLs/nonces/cursor/editor context,
+    or dual fields that restate another parameter (public:true + private:false).
+  - Empty "" / [] / null placeholders are stripped by the format checker; do not
+    rely on that — omit those keys in the label you emit.
 
   Attempt: {{attempt}}
 

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
@@ -88,9 +88,10 @@ template: |-
   - NEVER mint schema defaults, polarity flags set to the no-op value, empty
     strings, empty arrays, invented URLs/nonces/editor state, or dual fields
     that restate another parameter (e.g. private:false with public:true).
-  - When omitUngroundedParameters is listed for the target action, those keys
-    must be ABSENT from every expectedActions[].parameters object. Prefer omit
-    over false / "" / [].
+  - Prefer omit over false / "" / [] when the user did not request that field.
+  - When omitFromGoldParameters is listed for the target action, those keys
+    must be ABSENT from every expectedActions[].parameters object. The format
+    checker strips them deterministically if they still appear.
 
   Attempt: {{attempt}}
 

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/synthesizer.prompt.yaml
@@ -89,8 +89,8 @@ template: |-
   - NEVER mint: schema default polarity flags (e.g. unstar:false on "star"),
     empty strings, empty arrays, invented URLs/nonces/cursor/editor context,
     or dual fields that restate another parameter (public:true + private:false).
-  - Empty "" / [] / null placeholders are stripped by the format checker; do not
-    rely on that — omit those keys in the label you emit.
+  - Empty "" / [] / null / {} placeholders are stripped before schema validation;
+    do not rely on that — omit those keys in the label you emit.
 
   Attempt: {{attempt}}
 

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1429,6 +1429,52 @@ describe("eligible action coverage counting", () => {
     });
 });
 
+describe("hardcoded nonempty verify mode", () => {
+    it("forces lookupAndAnswerInternet freeform params to nonempty", async () => {
+        const catalog = {
+            catalogVersion: "test",
+            generatedAt: "2026-01-01T00:00:00.000Z",
+            actions: [
+                {
+                    schemaName: "browser.lookupAndAnswer",
+                    actionName: "lookupAndAnswerInternet",
+                    paramSpec: objectSpec({
+                        originalRequest: {
+                            optional: false,
+                            spec: { kind: "string" },
+                        },
+                        internetLookups: {
+                            optional: false,
+                            spec: {
+                                kind: "array",
+                                item: { kind: "string" },
+                            },
+                        },
+                        sites: {
+                            optional: true,
+                            spec: {
+                                kind: "array",
+                                item: { kind: "string" },
+                            },
+                        },
+                    }),
+                },
+            ],
+        };
+        const grader = await buildActionParametersGraderCatalog(catalog);
+        const entry =
+            grader.byAction["browser.lookupAndAnswer.lookupAndAnswerInternet"]!;
+        expect(entry.parameterScore.fields).toEqual({
+            originalRequest: "nonempty",
+            internetLookups: "nonempty",
+            sites: "nonempty",
+        });
+        expect(entry.fields.internetLookups.verify).toBe("nonempty");
+        expect(entry.fields.originalRequest.verify).toBe("nonempty");
+        expect(entry.fields.sites.verify).toBe("nonempty");
+    });
+});
+
 describe("llmAsAJudge verify mode", () => {
     it("uses hardcoded action.parameter pairs; LLM may still emit llmAsAJudge", () => {
         expect(

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1456,7 +1456,6 @@ describe("hardcoded nonempty for conversation topic titles", () => {
                     }),
                 },
                 {
-                    // identity name must stay exact (not in NONEMPTY list)
                     schemaName: "list",
                     actionName: "removeItems",
                     paramSpec: objectSpec({

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1429,6 +1429,143 @@ describe("eligible action coverage counting", () => {
     });
 });
 
+describe("hardcoded ignore for ungrounded optionals", () => {
+    it("forces default-polarity and invented-context params to ignore", async () => {
+        const catalog = {
+            catalogVersion: "test",
+            generatedAt: "2026-01-01T00:00:00.000Z",
+            actions: [
+                {
+                    schemaName: "github-cli",
+                    actionName: "starRepo",
+                    paramSpec: objectSpec({
+                        owner: {
+                            optional: false,
+                            spec: { kind: "string" },
+                        },
+                        repo: {
+                            optional: false,
+                            spec: { kind: "string" },
+                        },
+                        unstar: {
+                            optional: true,
+                            spec: { kind: "boolean" },
+                        },
+                    }),
+                },
+                {
+                    schemaName: "browser",
+                    actionName: "openSearchResult",
+                    paramSpec: objectSpec({
+                        position: {
+                            optional: false,
+                            spec: { kind: "number" },
+                        },
+                        url: {
+                            optional: true,
+                            spec: { kind: "string" },
+                        },
+                    }),
+                },
+                {
+                    schemaName: "code",
+                    actionName: "launchCopilotChat",
+                    paramSpec: objectSpec({
+                        attachFiles: {
+                            optional: true,
+                            spec: {
+                                kind: "array",
+                                item: { kind: "string" },
+                            },
+                        },
+                        isPartialQuery: {
+                            optional: true,
+                            spec: { kind: "boolean" },
+                        },
+                    }),
+                },
+            ],
+        };
+        const grader = await buildActionParametersGraderCatalog(catalog);
+        expect(
+            grader.byAction["github-cli.starRepo"]!.parameterScore.fields
+                .unstar,
+        ).toBe("ignore");
+        expect(
+            grader.byAction["browser.openSearchResult"]!.parameterScore.fields
+                .url,
+        ).toBe("ignore");
+        expect(
+            grader.byAction["code.launchCopilotChat"]!.parameterScore.fields
+                .attachFiles,
+        ).toBe("ignore");
+        expect(
+            grader.byAction["code.launchCopilotChat"]!.parameterScore.fields
+                .isPartialQuery,
+        ).toBe("ignore");
+        // non-listed fields stay scored
+        expect(
+            grader.byAction["github-cli.starRepo"]!.parameterScore.fields
+                .owner,
+        ).not.toBe("ignore");
+    });
+});
+
+describe("hardcoded nonempty for conversation topic titles", () => {
+    it("soft-scores conversation name params without loosening identity names", async () => {
+        const catalog = {
+            catalogVersion: "test",
+            generatedAt: "2026-01-01T00:00:00.000Z",
+            actions: [
+                {
+                    schemaName: "system.conversation",
+                    actionName: "summarizeConversation",
+                    paramSpec: objectSpec({
+                        name: {
+                            optional: true,
+                            spec: { kind: "string" },
+                        },
+                    }),
+                },
+                {
+                    schemaName: "system.conversation",
+                    actionName: "indexConversation",
+                    paramSpec: objectSpec({
+                        name: {
+                            optional: true,
+                            spec: { kind: "string" },
+                        },
+                    }),
+                },
+                {
+                    // identity name must stay exact (not in NONEMPTY list)
+                    schemaName: "list",
+                    actionName: "removeItems",
+                    paramSpec: objectSpec({
+                        listName: {
+                            optional: false,
+                            spec: { kind: "string" },
+                        },
+                    }),
+                },
+            ],
+        };
+        const grader = await buildActionParametersGraderCatalog(catalog);
+        expect(
+            grader.byAction["system.conversation.summarizeConversation"]!
+                .parameterScore.fields.name,
+        ).toBe("nonempty");
+        expect(
+            grader.byAction["system.conversation.indexConversation"]!
+                .parameterScore.fields.name,
+        ).toBe("nonempty");
+        expect(
+            grader.byAction["list.removeItems"]!.parameterScore.fields
+                .listName,
+        ).toBe("exact");
+    });
+});
+
 describe("hardcoded llmAsAJudge for internet lookup params", () => {
     it("forces lookupAndAnswerInternet freeform params to llmAsAJudge", async () => {
         const catalog = {

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1429,8 +1429,8 @@ describe("eligible action coverage counting", () => {
     });
 });
 
-describe("hardcoded nonempty verify mode", () => {
-    it("forces lookupAndAnswerInternet freeform params to nonempty", async () => {
+describe("hardcoded llmAsAJudge for internet lookup params", () => {
+    it("forces lookupAndAnswerInternet freeform params to llmAsAJudge", async () => {
         const catalog = {
             catalogVersion: "test",
             generatedAt: "2026-01-01T00:00:00.000Z",
@@ -1465,13 +1465,19 @@ describe("hardcoded nonempty verify mode", () => {
         const entry =
             grader.byAction["browser.lookupAndAnswer.lookupAndAnswerInternet"]!;
         expect(entry.parameterScore.fields).toEqual({
-            originalRequest: "nonempty",
-            internetLookups: "nonempty",
-            sites: "nonempty",
+            originalRequest: "llmAsAJudge",
+            internetLookups: "llmAsAJudge",
+            sites: "llmAsAJudge",
         });
-        expect(entry.fields.internetLookups.verify).toBe("nonempty");
-        expect(entry.fields.originalRequest.verify).toBe("nonempty");
-        expect(entry.fields.sites.verify).toBe("nonempty");
+        expect(entry.fields.internetLookups.verify).toBe("llmAsAJudge");
+        expect(entry.fields.originalRequest.verify).toBe("llmAsAJudge");
+        expect(entry.fields.sites.verify).toBe("llmAsAJudge");
+        expect(
+            parameterRequiresLlmJudge("originalRequest", {
+                create: "free_text",
+                actionId: "browser.lookupAndAnswer.lookupAndAnswerInternet",
+            }),
+        ).toBe(true);
     });
 });
 

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1434,17 +1434,16 @@ describe("eligible action coverage counting", () => {
 
 describe("stripIgnoredGoldParameters", () => {
     it("removes ignore-listed keys and drops empty parameter objects", () => {
-        expect(
-            isIgnoredGoldParameter("github-cli", "starRepo", "unstar"),
-        ).toBe(true);
-        expect(
-            ignoredGoldParameterNames("github-cli", "starRepo"),
-        ).toEqual(["unstar"]);
-        const stripped = stripIgnoredGoldParameters(
-            "github-cli",
-            "starRepo",
-            { repo: "microsoft/TypeScript", unstar: false },
+        expect(isIgnoredGoldParameter("github-cli", "starRepo", "unstar")).toBe(
+            true,
         );
+        expect(ignoredGoldParameterNames("github-cli", "starRepo")).toEqual([
+            "unstar",
+        ]);
+        const stripped = stripIgnoredGoldParameters("github-cli", "starRepo", {
+            repo: "microsoft/TypeScript",
+            unstar: false,
+        });
         expect(stripped.removed).toEqual(["unstar"]);
         expect(stripped.parameters).toEqual({ repo: "microsoft/TypeScript" });
         const onlyDefault = stripIgnoredGoldParameters(
@@ -1454,11 +1453,9 @@ describe("stripIgnoredGoldParameters", () => {
         );
         expect(onlyDefault.removed).toEqual(["unstar"]);
         expect(onlyDefault.parameters).toBeUndefined();
-        const untouched = stripIgnoredGoldParameters(
-            "list",
-            "removeItems",
-            { listName: "groceries" },
-        );
+        const untouched = stripIgnoredGoldParameters("list", "removeItems", {
+            listName: "groceries",
+        });
         expect(untouched.removed).toEqual([]);
         expect(untouched.parameters).toEqual({ listName: "groceries" });
     });

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -21,9 +21,6 @@ import {
     loadActionParametersGraderCatalogFile,
     mergeUnionParamSpecs,
     parameterRequiresLlmJudge,
-    ignoredGoldParameterNames,
-    isIgnoredGoldParameter,
-    stripIgnoredGoldParameters,
     REGEX_RULE_IDS,
     renderSchemaType,
     schemaTypeToParamSpec,
@@ -1429,116 +1426,6 @@ describe("eligible action coverage counting", () => {
         expect(countEligibleTranslationBenchActions(schemas, new Set())).toBe(
             3,
         );
-    });
-});
-
-describe("stripIgnoredGoldParameters", () => {
-    it("removes ignore-listed keys and drops empty parameter objects", () => {
-        expect(isIgnoredGoldParameter("github-cli", "starRepo", "unstar")).toBe(
-            true,
-        );
-        expect(ignoredGoldParameterNames("github-cli", "starRepo")).toEqual([
-            "unstar",
-        ]);
-        const stripped = stripIgnoredGoldParameters("github-cli", "starRepo", {
-            repo: "microsoft/TypeScript",
-            unstar: false,
-        });
-        expect(stripped.removed).toEqual(["unstar"]);
-        expect(stripped.parameters).toEqual({ repo: "microsoft/TypeScript" });
-        const onlyDefault = stripIgnoredGoldParameters(
-            "github-cli",
-            "starRepo",
-            { unstar: false },
-        );
-        expect(onlyDefault.removed).toEqual(["unstar"]);
-        expect(onlyDefault.parameters).toBeUndefined();
-        const untouched = stripIgnoredGoldParameters("list", "removeItems", {
-            listName: "groceries",
-        });
-        expect(untouched.removed).toEqual([]);
-        expect(untouched.parameters).toEqual({ listName: "groceries" });
-    });
-});
-
-describe("hardcoded ignore for ungrounded optionals", () => {
-    it("forces default-polarity and invented-context params to ignore", async () => {
-        const catalog = {
-            catalogVersion: "test",
-            generatedAt: "2026-01-01T00:00:00.000Z",
-            actions: [
-                {
-                    schemaName: "github-cli",
-                    actionName: "starRepo",
-                    paramSpec: objectSpec({
-                        owner: {
-                            optional: false,
-                            spec: { kind: "string" },
-                        },
-                        repo: {
-                            optional: false,
-                            spec: { kind: "string" },
-                        },
-                        unstar: {
-                            optional: true,
-                            spec: { kind: "boolean" },
-                        },
-                    }),
-                },
-                {
-                    schemaName: "browser",
-                    actionName: "openSearchResult",
-                    paramSpec: objectSpec({
-                        position: {
-                            optional: false,
-                            spec: { kind: "number" },
-                        },
-                        url: {
-                            optional: true,
-                            spec: { kind: "string" },
-                        },
-                    }),
-                },
-                {
-                    schemaName: "code",
-                    actionName: "launchCopilotChat",
-                    paramSpec: objectSpec({
-                        attachFiles: {
-                            optional: true,
-                            spec: {
-                                kind: "array",
-                                item: { kind: "string" },
-                            },
-                        },
-                        isPartialQuery: {
-                            optional: true,
-                            spec: { kind: "boolean" },
-                        },
-                    }),
-                },
-            ],
-        };
-        const grader = await buildActionParametersGraderCatalog(catalog);
-        expect(
-            grader.byAction["github-cli.starRepo"]!.parameterScore.fields
-                .unstar,
-        ).toBe("ignore");
-        expect(
-            grader.byAction["browser.openSearchResult"]!.parameterScore.fields
-                .url,
-        ).toBe("ignore");
-        expect(
-            grader.byAction["code.launchCopilotChat"]!.parameterScore.fields
-                .attachFiles,
-        ).toBe("ignore");
-        expect(
-            grader.byAction["code.launchCopilotChat"]!.parameterScore.fields
-                .isPartialQuery,
-        ).toBe("ignore");
-        // non-listed fields stay scored
-        expect(
-            grader.byAction["github-cli.starRepo"]!.parameterScore.fields.owner,
-        ).not.toBe("ignore");
     });
 });
 

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -1505,8 +1505,7 @@ describe("hardcoded ignore for ungrounded optionals", () => {
         ).toBe("ignore");
         // non-listed fields stay scored
         expect(
-            grader.byAction["github-cli.starRepo"]!.parameterScore.fields
-                .owner,
+            grader.byAction["github-cli.starRepo"]!.parameterScore.fields.owner,
         ).not.toBe("ignore");
     });
 });
@@ -1560,8 +1559,7 @@ describe("hardcoded nonempty for conversation topic titles", () => {
                 .parameterScore.fields.name,
         ).toBe("nonempty");
         expect(
-            grader.byAction["list.removeItems"]!.parameterScore.fields
-                .listName,
+            grader.byAction["list.removeItems"]!.parameterScore.fields.listName,
         ).toBe("exact");
     });
 });

--- a/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.catalogGenerator.spec.ts
@@ -21,6 +21,9 @@ import {
     loadActionParametersGraderCatalogFile,
     mergeUnionParamSpecs,
     parameterRequiresLlmJudge,
+    ignoredGoldParameterNames,
+    isIgnoredGoldParameter,
+    stripIgnoredGoldParameters,
     REGEX_RULE_IDS,
     renderSchemaType,
     schemaTypeToParamSpec,
@@ -1426,6 +1429,38 @@ describe("eligible action coverage counting", () => {
         expect(countEligibleTranslationBenchActions(schemas, new Set())).toBe(
             3,
         );
+    });
+});
+
+describe("stripIgnoredGoldParameters", () => {
+    it("removes ignore-listed keys and drops empty parameter objects", () => {
+        expect(
+            isIgnoredGoldParameter("github-cli", "starRepo", "unstar"),
+        ).toBe(true);
+        expect(
+            ignoredGoldParameterNames("github-cli", "starRepo"),
+        ).toEqual(["unstar"]);
+        const stripped = stripIgnoredGoldParameters(
+            "github-cli",
+            "starRepo",
+            { repo: "microsoft/TypeScript", unstar: false },
+        );
+        expect(stripped.removed).toEqual(["unstar"]);
+        expect(stripped.parameters).toEqual({ repo: "microsoft/TypeScript" });
+        const onlyDefault = stripIgnoredGoldParameters(
+            "github-cli",
+            "starRepo",
+            { unstar: false },
+        );
+        expect(onlyDefault.removed).toEqual(["unstar"]);
+        expect(onlyDefault.parameters).toBeUndefined();
+        const untouched = stripIgnoredGoldParameters(
+            "list",
+            "removeItems",
+            { listName: "groceries" },
+        );
+        expect(untouched.removed).toEqual([]);
+        expect(untouched.parameters).toEqual({ listName: "groceries" });
     });
 });
 

--- a/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
@@ -613,18 +613,19 @@ describe("translation bench generation quality loop", () => {
         );
     });
 
-    it("strips omit-from-gold defaults from labeled params and prompts omit list", async () => {
+    it("strips empty gold placeholders and prompts grounded-param rules", async () => {
         const parsed = parseToolsJsonSchema([
             {
-                name: "starRepo",
-                description: "Star a GitHub repository",
+                name: "authLogin",
+                description: "Log in to GitHub CLI",
                 inputSchema: {
                     type: "object",
                     properties: {
-                        repo: { type: "string" },
-                        unstar: { type: "boolean" },
+                        hostname: { type: "string" },
+                        token: { type: "string" },
+                        web: { type: "boolean" },
                     },
-                    required: ["repo"],
+                    required: ["hostname"],
                     additionalProperties: false,
                 },
             },
@@ -652,29 +653,21 @@ describe("translation bench generation quality loop", () => {
                 parsedActionSchema: toJSONParsedActionSchema(parsed),
             },
         };
-        const target = targetAction("github-cli", "starRepo");
+        const target = targetAction("github-cli", "authLogin");
         const dirty = generatedCandidate(target, 2);
-        // Mint ungrounded default the format checker must strip.
-        dirty.seed.expectedActions = [
-            {
-                ...target,
-                parameters: { query: "seed", unstar: false, repo: "a/b" },
-            },
-        ];
-        // generatedCandidate uses {query} but schema wants repo — fix all positives
         for (const probe of [dirty.seed, ...dirty.genCases]) {
             if (probe.expectedActions.length === 0) continue;
             probe.expectedActions = [
                 {
                     ...target,
                     parameters: {
-                        repo: "microsoft/TypeScript",
-                        unstar: false,
+                        hostname: "github.acme.example",
+                        web: true,
+                        token: "",
                     },
                 },
             ];
         }
-        // seed utterance uniqueness with gen cases - generatedCandidate already unique
         let generatorPrompt = "";
         const result = await runTranslationBenchGenerationQualityLoop({
             targetAction: target,
@@ -702,18 +695,21 @@ describe("translation bench generation quality loop", () => {
                 },
             },
         });
-        expect(generatorPrompt).toContain("omitFromGoldParameters");
-        expect(generatorPrompt).toContain("unstar");
+        expect(generatorPrompt).toContain(
+            "Only include parameters clearly supported by the utterance",
+        );
         expect(result.candidate.seed.expectedActions[0]!.parameters).toEqual({
-            repo: "microsoft/TypeScript",
+            hostname: "github.acme.example",
+            web: true,
         });
         for (const probe of result.candidate.genCases) {
             if (probe.role !== "positive") continue;
             expect(probe.expectedActions[0]!.parameters).toEqual({
-                repo: "microsoft/TypeScript",
+                hostname: "github.acme.example",
+                web: true,
             });
             expect(probe.expectedActions[0]!.parameters).not.toHaveProperty(
-                "unstar",
+                "token",
             );
         }
     });

--- a/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
@@ -398,6 +398,23 @@ describe("generated translation bench candidate validation", () => {
         ).toThrow(/target|lookup|action/i);
     });
 
+    it("rejects after strip when a required parameter was only an empty placeholder", () => {
+        const emptyRequired = generatedCandidate();
+        for (const probe of [emptyRequired.seed, ...emptyRequired.genCases]) {
+            if (probe.expectedActions.length === 0) continue;
+            probe.expectedActions = [
+                {
+                    schemaName: "tools",
+                    actionName: "lookup",
+                    parameters: { query: "" },
+                },
+            ];
+        }
+        expect(() =>
+            parseTranslationBenchGeneratedCandidate(emptyRequired, context),
+        ).toThrow(/required|query|missing/i);
+    });
+
     it("canonicalizes generated payload hashes across checkpoint key sorting", () => {
         const schemas = [catalogSchema("tools", ["lookup"])] as const;
         const canonicalHash = computeTranslationBenchCanonicalPayloadHash as (

--- a/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
@@ -613,6 +613,111 @@ describe("translation bench generation quality loop", () => {
         );
     });
 
+    it("strips ignore-listed defaults from gold and prompts omit list", async () => {
+        const parsed = parseToolsJsonSchema([
+            {
+                name: "starRepo",
+                description: "Star a GitHub repository",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        repo: { type: "string" },
+                        unstar: { type: "boolean" },
+                    },
+                    required: ["repo"],
+                    additionalProperties: false,
+                },
+            },
+        ]);
+        const tools = generateActionActionFunctionJsonSchemas({
+            entry: parsed.entry.action!,
+            actionSchemas: parsed.actionSchemas,
+        }).map((tool) => ({
+            type: "function" as const,
+            function: {
+                name: tool.function.name,
+                ...(tool.function.description !== undefined
+                    ? { description: tool.function.description }
+                    : {}),
+                parameters: tool.function.parameters as Record<string, unknown>,
+            },
+        }));
+        const schema: TranslationBenchBenchmarkSchema = {
+            schemaName: "github-cli",
+            description: "github-cli actions",
+            tools,
+            typeAgent: {
+                sourceHash: `github-cli-${HASH}`,
+                schemaType: "GithubCliAction",
+                parsedActionSchema: toJSONParsedActionSchema(parsed),
+            },
+        };
+        const target = targetAction("github-cli", "starRepo");
+        const dirty = generatedCandidate(target, 2);
+        // Mint ungrounded default the format checker must strip.
+        dirty.seed.expectedActions = [
+            {
+                ...target,
+                parameters: { query: "seed", unstar: false, repo: "a/b" },
+            },
+        ];
+        // generatedCandidate uses {query} but schema wants repo — fix all positives
+        for (const probe of [dirty.seed, ...dirty.genCases]) {
+            if (probe.expectedActions.length === 0) continue;
+            probe.expectedActions = [
+                {
+                    ...target,
+                    parameters: {
+                        repo: "microsoft/TypeScript",
+                        unstar: false,
+                    },
+                },
+            ];
+        }
+        // seed utterance uniqueness with gen cases - generatedCandidate already unique
+        let generatorPrompt = "";
+        const result = await runTranslationBenchGenerationQualityLoop({
+            targetAction: target,
+            schema,
+            anchor: sourceAnchor(),
+            activeSchemas: [schema.schemaName],
+            genCaseCount: 2,
+            maxAttempts: 5,
+            generator: {
+                model: "generator-model",
+                async complete(prompt) {
+                    generatorPrompt = prompt;
+                    return JSON.stringify(dirty);
+                },
+            },
+            reviewer: {
+                model: "reviewer-model",
+                async complete(prompt) {
+                    return JSON.stringify(
+                        reviewerDecision(
+                            candidateHashFromPrompt(prompt),
+                            "approve",
+                        ),
+                    );
+                },
+            },
+        });
+        expect(generatorPrompt).toContain("omitUngroundedParameters");
+        expect(generatorPrompt).toContain("unstar");
+        expect(result.candidate.seed.expectedActions[0]!.parameters).toEqual({
+            repo: "microsoft/TypeScript",
+        });
+        for (const probe of result.candidate.genCases) {
+            if (probe.role !== "positive") continue;
+            expect(probe.expectedActions[0]!.parameters).toEqual({
+                repo: "microsoft/TypeScript",
+            });
+            expect(probe.expectedActions[0]!.parameters).not.toHaveProperty(
+                "unstar",
+            );
+        }
+    });
+
     it("uses separate generator and reviewer passes", async () => {
         const generatorPrompts: string[] = [];
         const reviewerPrompts: string[] = [];

--- a/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.datasetGenerator.spec.ts
@@ -613,7 +613,7 @@ describe("translation bench generation quality loop", () => {
         );
     });
 
-    it("strips ignore-listed defaults from gold and prompts omit list", async () => {
+    it("strips omit-from-gold defaults from labeled params and prompts omit list", async () => {
         const parsed = parseToolsJsonSchema([
             {
                 name: "starRepo",
@@ -702,7 +702,7 @@ describe("translation bench generation quality loop", () => {
                 },
             },
         });
-        expect(generatorPrompt).toContain("omitUngroundedParameters");
+        expect(generatorPrompt).toContain("omitFromGoldParameters");
         expect(generatorPrompt).toContain("unstar");
         expect(result.candidate.seed.expectedActions[0]!.parameters).toEqual({
             repo: "microsoft/TypeScript",

--- a/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
@@ -4,35 +4,41 @@
 import { describe, expect, it } from "@jest/globals";
 
 import {
-    isOmittedFromGoldParameter,
-    omittedGoldParameterNames,
-    stripOmittedGoldParameters,
+    isEmptyGoldPlaceholder,
+    stripEmptyGoldPlaceholders,
 } from "../src/translationBench/synthesizer/goldParameterHygiene.js";
 
 describe("gold parameter hygiene", () => {
-    it("lists and strips omit-from-gold keys without touching other fields", () => {
-        expect(
-            isOmittedFromGoldParameter("github-cli", "starRepo", "unstar"),
-        ).toBe(true);
-        expect(omittedGoldParameterNames("github-cli", "starRepo")).toEqual([
-            "unstar",
-        ]);
-        const stripped = stripOmittedGoldParameters("github-cli", "starRepo", {
+    it("detects empty placeholders without treating false/0 as empty", () => {
+        expect(isEmptyGoldPlaceholder("")).toBe(true);
+        expect(isEmptyGoldPlaceholder("   ")).toBe(true);
+        expect(isEmptyGoldPlaceholder([])).toBe(true);
+        expect(isEmptyGoldPlaceholder(null)).toBe(true);
+        expect(isEmptyGoldPlaceholder(undefined)).toBe(true);
+        expect(isEmptyGoldPlaceholder(false)).toBe(false);
+        expect(isEmptyGoldPlaceholder(0)).toBe(false);
+        expect(isEmptyGoldPlaceholder("x")).toBe(false);
+        expect(isEmptyGoldPlaceholder(["a"])).toBe(false);
+    });
+
+    it("strips empty placeholders and keeps real values", () => {
+        const stripped = stripEmptyGoldPlaceholders({
+            repo: "microsoft/TypeScript",
+            token: "",
+            attachFiles: [],
+            unstar: false,
+            count: 0,
+        });
+        expect(stripped.removed.sort()).toEqual(["attachFiles", "token"]);
+        expect(stripped.parameters).toEqual({
             repo: "microsoft/TypeScript",
             unstar: false,
+            count: 0,
         });
-        expect(stripped.removed).toEqual(["unstar"]);
-        expect(stripped.parameters).toEqual({ repo: "microsoft/TypeScript" });
-        const onlyDefault = stripOmittedGoldParameters(
-            "github-cli",
-            "starRepo",
-            { unstar: false },
-        );
-        expect(onlyDefault.removed).toEqual(["unstar"]);
-        expect(onlyDefault.parameters).toBeUndefined();
-        const untouched = stripOmittedGoldParameters("list", "removeItems", {
-            listName: "groceries",
-        });
+        const onlyEmpty = stripEmptyGoldPlaceholders({ token: "", files: [] });
+        expect(onlyEmpty.removed.sort()).toEqual(["files", "token"]);
+        expect(onlyEmpty.parameters).toBeUndefined();
+        const untouched = stripEmptyGoldPlaceholders({ listName: "groceries" });
         expect(untouched.removed).toEqual([]);
         expect(untouched.parameters).toEqual({ listName: "groceries" });
     });

--- a/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
@@ -13,12 +13,14 @@ describe("gold parameter hygiene", () => {
         expect(isEmptyGoldPlaceholder("")).toBe(true);
         expect(isEmptyGoldPlaceholder("   ")).toBe(true);
         expect(isEmptyGoldPlaceholder([])).toBe(true);
+        expect(isEmptyGoldPlaceholder({})).toBe(true);
         expect(isEmptyGoldPlaceholder(null)).toBe(true);
         expect(isEmptyGoldPlaceholder(undefined)).toBe(true);
         expect(isEmptyGoldPlaceholder(false)).toBe(false);
         expect(isEmptyGoldPlaceholder(0)).toBe(false);
         expect(isEmptyGoldPlaceholder("x")).toBe(false);
         expect(isEmptyGoldPlaceholder(["a"])).toBe(false);
+        expect(isEmptyGoldPlaceholder({ a: 1 })).toBe(false);
     });
 
     it("strips empty placeholders and keeps real values", () => {
@@ -26,10 +28,15 @@ describe("gold parameter hygiene", () => {
             repo: "microsoft/TypeScript",
             token: "",
             attachFiles: [],
+            extra: {},
             unstar: false,
             count: 0,
         });
-        expect(stripped.removed.sort()).toEqual(["attachFiles", "token"]);
+        expect(stripped.removed.sort()).toEqual([
+            "attachFiles",
+            "extra",
+            "token",
+        ]);
         expect(stripped.parameters).toEqual({
             repo: "microsoft/TypeScript",
             unstar: false,
@@ -41,5 +48,30 @@ describe("gold parameter hygiene", () => {
         const untouched = stripEmptyGoldPlaceholders({ listName: "groceries" });
         expect(untouched.removed).toEqual([]);
         expect(untouched.parameters).toEqual({ listName: "groceries" });
+    });
+
+    it("strips nested empty placeholders and empty arrays of empties", () => {
+        const stripped = stripEmptyGoldPlaceholders({
+            repo: "microsoft/TypeScript",
+            nested: { token: "", meta: {} },
+            tags: ["", "keep", []],
+            deep: [{ a: "" }, { b: "ok" }],
+        });
+        expect(stripped.parameters).toEqual({
+            repo: "microsoft/TypeScript",
+            tags: ["keep"],
+            deep: [{ b: "ok" }],
+        });
+        expect(stripped.removed).toEqual(
+            expect.arrayContaining([
+                "nested.token",
+                "nested.meta",
+                "nested",
+                "tags[0]",
+                "tags[2]",
+                "deep[0].a",
+                "deep[0]",
+            ]),
+        );
     });
 });

--- a/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.goldParameterHygiene.spec.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "@jest/globals";
+
+import {
+    isOmittedFromGoldParameter,
+    omittedGoldParameterNames,
+    stripOmittedGoldParameters,
+} from "../src/translationBench/synthesizer/goldParameterHygiene.js";
+
+describe("gold parameter hygiene", () => {
+    it("lists and strips omit-from-gold keys without touching other fields", () => {
+        expect(
+            isOmittedFromGoldParameter("github-cli", "starRepo", "unstar"),
+        ).toBe(true);
+        expect(omittedGoldParameterNames("github-cli", "starRepo")).toEqual([
+            "unstar",
+        ]);
+        const stripped = stripOmittedGoldParameters("github-cli", "starRepo", {
+            repo: "microsoft/TypeScript",
+            unstar: false,
+        });
+        expect(stripped.removed).toEqual(["unstar"]);
+        expect(stripped.parameters).toEqual({ repo: "microsoft/TypeScript" });
+        const onlyDefault = stripOmittedGoldParameters(
+            "github-cli",
+            "starRepo",
+            { unstar: false },
+        );
+        expect(onlyDefault.removed).toEqual(["unstar"]);
+        expect(onlyDefault.parameters).toBeUndefined();
+        const untouched = stripOmittedGoldParameters("list", "removeItems", {
+            listName: "groceries",
+        });
+        expect(untouched.removed).toEqual([]);
+        expect(untouched.parameters).toEqual({ listName: "groceries" });
+    });
+});


### PR DESCRIPTION
Param-score fairness and gold hygiene from 1k fail audits.

**Scoring (grader)**
- `llmAsAJudge`: lookupAndAnswerInternet freeform fields
- `nonempty`: conversation topic titles only

**Gold hygiene (no per-action hardcode lists)**
- Labeler prompt + action contract: only utterance-grounded params; no defaults, empties, duals, invented context
- Deterministic format/parse strip of empty `""` / `[]` / `null` placeholders
- Semantic quality verifier rejects ungrounded defaults / empties / duals / invented runtime context