### PR TITLE
Tighten browser action-discovery utterance cues

### DIFF
--- a/ts/packages/benchmarks/src/translationBench/synthesizer/utteranceDisambiguation.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/utteranceDisambiguation.ts
@@ -79,6 +79,36 @@ const KNOWN_CONFUSABLE_PAIRS: ReadonlyArray<
         { schemaName: "browser.actionDiscovery", actionName: "inferActions" },
         "flows vs inferred actions",
     ],
+    [
+        {
+            schemaName: "browser.actionDiscovery",
+            actionName: "registerPageDynamicAgent",
+        },
+        {
+            schemaName: "browser.actionDiscovery",
+            actionName: "detectPageActions",
+        },
+        "register page agent vs detect page actions (registerAgent:true)",
+    ],
+    [
+        {
+            schemaName: "browser.actionDiscovery",
+            actionName: "getWebFlowsForDomain",
+        },
+        {
+            schemaName: "browser.actionDiscovery",
+            actionName: "detectPageActions",
+        },
+        "domain web-flows lookup vs inspect/detect page actions",
+    ],
+    [
+        {
+            schemaName: "browser.actionDiscovery",
+            actionName: "getWebFlowsForDomain",
+        },
+        { schemaName: "browser", actionName: "openWebPage" },
+        "list flows for domain hostname vs navigate to that hostname",
+    ],
 ];
 
 /**
@@ -163,11 +193,27 @@ const ACTION_DISAMBIGUATION_CUES: Readonly<Record<string, readonly string[]>> =
             "close tab",
         ],
         "browser.actionDiscovery.getAllWebFlows": [
-            "web flow",
-            "web flows",
+            // Avoid bare "web flow(s)" — those also fit getWebFlowsForDomain.
+            "all web flows",
+            "every web flow",
             "flows on this page",
-            "available flows",
-            "list flows",
+            "available flows across",
+            "list all flows",
+            "every saved flow",
+            "all saved web flows",
+        ],
+        "browser.actionDiscovery.getWebFlowsForDomain": [
+            "web flows for",
+            "web flow for",
+            "flows for the domain",
+            "flows for domain",
+            "flows for this domain",
+            "list web flows for",
+            "get web flows for",
+            "web flows on the domain",
+            "domain web flows",
+            "web flows registered for",
+            "saved web flows for",
         ],
         "browser.actionDiscovery.detectPageActions": [
             "detect",
@@ -181,6 +227,15 @@ const ACTION_DISAMBIGUATION_CUES: Readonly<Record<string, readonly string[]>> =
             "inspect",
             "lets me do",
             "what this page",
+            "detect and register",
+            "scan and register",
+            "register agent and find",
+        ],
+        "browser.actionDiscovery.registerPageDynamicAgent": [
+            "register page dynamic agent",
+            "register site schema only",
+            "dynamic agent without scanning",
+            "just register the page agent",
         ],
         "browser.actionDiscovery.inferActions": [
             "infer actions",

--- a/ts/packages/benchmarks/test/translationBench.utteranceDisambiguation.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.utteranceDisambiguation.spec.ts
@@ -166,6 +166,98 @@ describe("translation bench utterance disambiguation", () => {
         expect(result.targetCuesMatched.length).toBeGreaterThan(0);
     });
 
+    it("rejects getWebFlowsForDomain gold that reads as detectPageActions", () => {
+        // gen1k case generated-000920: "Inspect github.com to discover which
+        // browser actions are supported for that domain" — terra/luna both
+        // chose detectPageActions; utterance never says web flows.
+        const discoveryCatalog: TranslationBenchBenchmarkSchema[] = [
+            {
+                schemaName: "browser.actionDiscovery",
+                description: "discovery",
+                tools: [
+                    {
+                        type: "function",
+                        function: {
+                            name: "getWebFlowsForDomain",
+                            description: "List web flows for a domain",
+                            parameters: {
+                                type: "object",
+                                properties: {
+                                    domain: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        type: "function",
+                        function: {
+                            name: "detectPageActions",
+                            description: "Detect page actions",
+                            parameters: { type: "object", properties: {} },
+                        },
+                    },
+                ],
+                typeAgent: {
+                    sourceHash: `discovery-${HASH}`,
+                    schemaType: "DiscoveryAction",
+                    parsedActionSchema: toJSONParsedActionSchema(
+                        parseToolsJsonSchema([
+                            {
+                                name: "getWebFlowsForDomain",
+                                description: "List web flows for a domain",
+                                inputSchema: {
+                                    type: "object",
+                                    properties: {
+                                        domain: { type: "string" },
+                                    },
+                                    additionalProperties: false,
+                                },
+                            },
+                            {
+                                name: "detectPageActions",
+                                description: "Detect page actions",
+                                inputSchema: {
+                                    type: "object",
+                                    properties: {},
+                                    additionalProperties: false,
+                                },
+                            },
+                        ]),
+                    ),
+                },
+            },
+            ...catalog,
+        ];
+        const target = {
+            schemaName: "browser.actionDiscovery",
+            actionName: "getWebFlowsForDomain",
+        } as const;
+        const siblings = findTranslationBenchConfusableSiblings(
+            target,
+            discoveryCatalog,
+        );
+        expect(siblings.map((s) => s.actionName)).toEqual(
+            expect.arrayContaining(["detectPageActions", "openWebPage"]),
+        );
+        const ambiguous = checkTranslationBenchUtteranceDisambiguation(
+            "Inspect github.com to discover which browser actions are supported for that domain.",
+            target,
+            siblings,
+            "$.seed.utterance",
+        );
+        expect(ambiguous.ok).toBe(false);
+        expect(ambiguous.message).toMatch(/disambiguat|confusable|cue/i);
+
+        const clear = checkTranslationBenchUtteranceDisambiguation(
+            "List the saved web flows for the domain github.com",
+            target,
+            siblings,
+            "$.seed.utterance",
+        );
+        expect(clear.ok).toBe(true);
+        expect(clear.targetCuesMatched.length).toBeGreaterThan(0);
+    });
+
     it("skips negatives in candidate check", () => {
         const issues = checkTranslationBenchCandidateDisambiguation(
             {


### PR DESCRIPTION
Add confusable-pair cues so action-discovery gold does not collide with detect, register, or navigate.