### PR TITLE
Dev/jebransyed/android register

### DIFF
--- a/android/samples/mobile-2/README.md
+++ b/android/samples/mobile-2/README.md
@@ -8,6 +8,8 @@ An Android Jetpack Compose chat client that connects to a TypeAgent agent-server
 - OkHttp WebSocket usage on Android
 - TypeAgent agent-server RPC protocol:
   - `joinConversation` / `submitCommand`
+  - `registerClientAgent` with an inline action schema
+  - Client-hosted `executeAction` callbacks
   - Inbound `appendDisplay`, `setDisplay`, `setDisplayInfo`, and command completion events
   - Inbound `takeAction` client actions
 - Incremental assistant response streaming into a single bubble per `requestId`, honouring
@@ -16,11 +18,15 @@ An Android Jetpack Compose chat client that connects to a TypeAgent agent-server
 - DevTunnel authentication via `X-Tunnel-Authorization` header
 - Build-time configuration via environment variables and `BuildConfig`
 
-## Device actions
+## Client-hosted Android agent
 
-The app implements the `takeAction` client actions emitted by the `androidMobile`
-agent. Unknown actions are logged and ignored, so the app stays compatible with
-servers that emit actions this sample does not support.
+After joining a conversation, the app registers `androidDevice` as a
+client-hosted agent. Its alarm and timer schema is packaged in the APK and sent
+inline to TypeAgent. TypeAgent translates or directly invokes the typed action,
+then calls `executeAction` on the app over the existing WebSocket connection.
+
+The app also retains its existing `takeAction` handlers for compatibility with
+the static `androidMobile` agent.
 
 | Client action | Android intent | Notes |
 |---|---|---|
@@ -35,8 +41,16 @@ Both require the `com.android.alarm.permission.SET_ALARM` permission (declared i
 the manifest, install-time only) and matching `<queries>` entries so
 `resolveActivity` works under Android 11+ package visibility rules.
 
-> `set-timer` requires the server-side `androidMobile` `setTimer` action. Install
-> the agent with `@package install androidMobile` in the TypeAgent CLI/shell.
+The registered client agent does not require installing the server-side
+`androidMobile` package. Use `@action` for a deterministic registration test:
+
+```text
+@action --parameters {"originalRequest":"timer","durationInSeconds":30} androidDevice setTimer
+```
+
+```text
+@action --parameters {"originalRequest":"alarm","time":"12:00"} androidDevice setAlarm
+```
 
 ## Prerequisites
 
@@ -83,4 +97,3 @@ The app connects automatically on launch. Tap **Retry** in the status bar if the
 
 [devtunnel]: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/
 [devtunnel-cli]: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-

--- a/android/samples/mobile-2/app/src/main/assets/typeagent/androidDeviceSchema.ts
+++ b/android/samples/mobile-2/app/src/main/assets/typeagent/androidDeviceSchema.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type AndroidDeviceAction = SetAlarmAction | SetTimerAction;
+
+export type SetAlarmAction = {
+    actionName: "setAlarm";
+    parameters: {
+        // The original user request, used as the alarm label.
+        originalRequest: string;
+        // Local time of day in HH:mm format. The device schedules the next occurrence.
+        time: string;
+    };
+};
+
+export type SetTimerAction = {
+    actionName: "setTimer";
+    parameters: {
+        // The original user request, used as the timer label.
+        originalRequest: string;
+        // Positive timer duration in seconds.
+        durationInSeconds: number;
+    };
+};

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AlarmActionParser.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AlarmActionParser.kt
@@ -8,7 +8,8 @@ internal data class SetAlarmAction(
     val minute: Int
 )
 
-private val alarmTimeRegex = Regex("""^\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2})(?::\d{2})?$""")
+private val alarmTimeRegex =
+    Regex("""^(?:\d{4}-\d{2}-\d{2}T)?(\d{2}):(\d{2})(?::\d{2})?$""")
 
 internal fun parseSetAlarmActionPayload(data: Any?): SetAlarmAction? {
     val payload = data as? JSONObject ?: return null

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AndroidDeviceAgent.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AndroidDeviceAgent.kt
@@ -1,0 +1,106 @@
+package com.example.typeagentchat
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal object AndroidDeviceAgent {
+    const val NAME = "androidDevice"
+    const val CHANNEL_NAME = "agent:$NAME"
+    const val SCHEMA_ASSET = "typeagent/androidDeviceSchema.ts"
+
+    fun createRegistrationParams(
+        conversationId: String,
+        schemaContent: String
+    ): JSONObject {
+        val schemaFile = JSONObject()
+            .put("format", "ts")
+            .put("content", schemaContent)
+        val schema = JSONObject()
+            .put("description", "Sets alarms and countdown timers on this Android device.")
+            .put("schemaType", "AndroidDeviceAction")
+            .put("schemaFile", schemaFile)
+        val manifest = JSONObject()
+            .put("emojiChar", "\u23F0")
+            .put("description", "Sets alarms and countdown timers on this Android device.")
+            .put("defaultEnabled", true)
+            .put("schemaDefaultEnabled", true)
+            .put("actionDefaultEnabled", true)
+            .put("schema", schema)
+
+        return JSONObject()
+            .put("name", NAME)
+            .put("conversationId", conversationId)
+            .put("manifest", manifest)
+            .put("agentInterface", JSONArray().put("executeAction"))
+    }
+
+    fun parseExecuteAction(args: JSONArray): AndroidDeviceActionParseResult {
+        val invocation = args.optJSONObject(0)
+            ?: return AndroidDeviceActionParseResult.ProtocolError(
+                "executeAction requires an invocation object."
+            )
+        val action = invocation.optJSONObject("action")
+            ?: return AndroidDeviceActionParseResult.ProtocolError(
+                "executeAction invocation is missing action."
+            )
+        val actionName = action.optString("actionName").trim()
+        if (actionName.isEmpty()) {
+            return AndroidDeviceActionParseResult.ProtocolError(
+                "executeAction action is missing actionName."
+            )
+        }
+        val parameters = action.optJSONObject("parameters")
+            ?: return AndroidDeviceActionParseResult.ActionError(
+                "Action '$actionName' is missing parameters."
+            )
+
+        return when (actionName) {
+            "setAlarm" -> {
+                val parsed = parseSetAlarmActionPayload(parameters)
+                    ?: return AndroidDeviceActionParseResult.ActionError(
+                        "Invalid setAlarm parameters."
+                    )
+                AndroidDeviceActionParseResult.Success(AndroidDeviceAction.Alarm(parsed))
+            }
+
+            "setTimer" -> {
+                val parsed = parseSetTimerActionPayload(parameters)
+                    ?: return AndroidDeviceActionParseResult.ActionError(
+                        "Invalid setTimer parameters."
+                    )
+                AndroidDeviceActionParseResult.Success(AndroidDeviceAction.Timer(parsed))
+            }
+
+            else -> AndroidDeviceActionParseResult.ActionError(
+                "Unsupported Android agent action: $actionName"
+            )
+        }
+    }
+
+    fun createSuccessResult(message: String): JSONObject {
+        return JSONObject()
+            .put("historyText", message)
+            .put("displayContent", message)
+            .put("entities", JSONArray())
+    }
+
+    fun createErrorResult(message: String): JSONObject {
+        return JSONObject().put("error", message)
+    }
+}
+
+internal sealed interface AndroidDeviceAction {
+    data class Alarm(val action: SetAlarmAction) : AndroidDeviceAction
+    data class Timer(val action: SetTimerAction) : AndroidDeviceAction
+}
+
+internal sealed interface AndroidDeviceActionParseResult {
+    data class Success(val action: AndroidDeviceAction) : AndroidDeviceActionParseResult
+    data class ActionError(val message: String) : AndroidDeviceActionParseResult
+    data class ProtocolError(val message: String) : AndroidDeviceActionParseResult
+}
+
+internal sealed interface AndroidDeviceExecutionResult {
+    data class Success(val message: String) : AndroidDeviceExecutionResult
+    data class Failure(val message: String) : AndroidDeviceExecutionResult
+}

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/MainActivity.kt
@@ -75,17 +75,28 @@ class MainActivity : ComponentActivity() {
     private val webSocketManager = WebSocketManager()
     private val tunnelUrl = BuildConfig.TYPEAGENT_SERVER_URL.trim()
     private val tunnelToken = BuildConfig.TYPEAGENT_TUNNEL_TOKEN.trim().ifBlank { null }
+    private val agentSchemaContent by lazy {
+        assets.open(AndroidDeviceAgent.SCHEMA_ASSET)
+            .bufferedReader()
+            .use { it.readText() }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         webSocketManager.setClientActionHandler(object : WebSocketManager.ClientActionHandler {
-            override fun onSetAlarm(action: SetAlarmAction) {
-                runOnUiThread { launchSetAlarmIntent(action) }
+            override fun onSetAlarm(
+                action: SetAlarmAction,
+                completion: (AndroidDeviceExecutionResult) -> Unit
+            ) {
+                runOnUiThread { launchSetAlarmIntent(action, completion) }
             }
 
-            override fun onSetTimer(action: SetTimerAction) {
-                runOnUiThread { launchSetTimerIntent(action) }
+            override fun onSetTimer(
+                action: SetTimerAction,
+                completion: (AndroidDeviceExecutionResult) -> Unit
+            ) {
+                runOnUiThread { launchSetTimerIntent(action, completion) }
             }
 
             override fun onSearchNearby(action: SearchNearbyAction) {
@@ -94,7 +105,8 @@ class MainActivity : ComponentActivity() {
         })
         webSocketManager.connect(
             url = tunnelUrl,
-            tunnelToken = tunnelToken
+            tunnelToken = tunnelToken,
+            schemaContent = agentSchemaContent
         )
 
         setContent {
@@ -114,7 +126,10 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private fun launchSetAlarmIntent(action: SetAlarmAction) {
+    private fun launchSetAlarmIntent(
+        action: SetAlarmAction,
+        completion: (AndroidDeviceExecutionResult) -> Unit
+    ) {
         val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
             putExtra(AlarmClock.EXTRA_HOUR, action.hour)
             putExtra(AlarmClock.EXTRA_MINUTES, action.minute)
@@ -127,10 +142,14 @@ class MainActivity : ComponentActivity() {
             intent = intent,
             actionName = "set-alarm",
             detail = "hour=${action.hour} minute=${action.minute}",
-            successMessage = "Alarm set for %02d:%02d".format(action.hour, action.minute),
+            successMessage = "Alarm request sent for %02d:%02d".format(
+                action.hour,
+                action.minute
+            ),
             missingAppMessage = "No alarm app is available on this device.",
             deniedMessage = "This app is not allowed to set alarms.",
-            backgroundMessage = "Could not set the alarm while the app was in the background."
+            backgroundMessage = "Could not set the alarm while the app was in the background.",
+            completion = completion
         )
     }
 
@@ -145,7 +164,10 @@ class MainActivity : ComponentActivity() {
      * the only in-app feedback, so it is not optional - and it must not claim
      * success when the launch was refused. See [launchExternalIntent].
      */
-    private fun launchSetTimerIntent(action: SetTimerAction) {
+    private fun launchSetTimerIntent(
+        action: SetTimerAction,
+        completion: (AndroidDeviceExecutionResult) -> Unit
+    ) {
         val intent = Intent(AlarmClock.ACTION_SET_TIMER).apply {
             putExtra(AlarmClock.EXTRA_LENGTH, action.durationInSeconds)
             putExtra(AlarmClock.EXTRA_SKIP_UI, true)
@@ -157,10 +179,12 @@ class MainActivity : ComponentActivity() {
             intent = intent,
             actionName = "set-timer",
             detail = "durationInSeconds=${action.durationInSeconds}",
-            successMessage = "Timer set for ${formatTimerDuration(action.durationInSeconds)}",
+            successMessage =
+                "Timer request sent for ${formatTimerDuration(action.durationInSeconds)}",
             missingAppMessage = "No timer app is available on this device.",
             deniedMessage = "This app is not allowed to set timers.",
-            backgroundMessage = "Could not set the timer while the app was in the background."
+            backgroundMessage = "Could not set the timer while the app was in the background.",
+            completion = completion
         )
     }
 
@@ -208,7 +232,8 @@ class MainActivity : ComponentActivity() {
         successMessage: String,
         missingAppMessage: String,
         deniedMessage: String,
-        backgroundMessage: String
+        backgroundMessage: String,
+        completion: (AndroidDeviceExecutionResult) -> Unit = {}
     ) {
         val target = intent.resolveActivity(packageManager)
         Log.d(
@@ -218,6 +243,7 @@ class MainActivity : ComponentActivity() {
         if (target == null) {
             Log.e(TAG, "No app available to handle $actionName intent")
             Toast.makeText(this, missingAppMessage, Toast.LENGTH_SHORT).show()
+            completion(AndroidDeviceExecutionResult.Failure(missingAppMessage))
             return
         }
         if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
@@ -227,18 +253,22 @@ class MainActivity : ComponentActivity() {
                     "background activity starts are refused without an exception"
             )
             Toast.makeText(this, backgroundMessage, Toast.LENGTH_LONG).show()
+            completion(AndroidDeviceExecutionResult.Failure(backgroundMessage))
             return
         }
         try {
             startActivity(intent)
             Log.d(TAG, "$actionName intent dispatched")
             Toast.makeText(this, successMessage, Toast.LENGTH_SHORT).show()
+            completion(AndroidDeviceExecutionResult.Success(successMessage))
         } catch (_: ActivityNotFoundException) {
             Log.e(TAG, "No app available to handle $actionName intent")
             Toast.makeText(this, missingAppMessage, Toast.LENGTH_SHORT).show()
+            completion(AndroidDeviceExecutionResult.Failure(missingAppMessage))
         } catch (error: SecurityException) {
             Log.e(TAG, "Missing permission for $actionName", error)
             Toast.makeText(this, deniedMessage, Toast.LENGTH_SHORT).show()
+            completion(AndroidDeviceExecutionResult.Failure(deniedMessage))
         }
     }
 

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -11,6 +11,7 @@ import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class WebSocketManager {
@@ -28,6 +29,8 @@ class WebSocketManager {
     private var webSocket: WebSocket? = null
     private var conversationId: String? = null
     private var connectionId: String? = null
+    private var agentSchemaContent: String? = null
+    private var isClientAgentRegistered = false
     private var pendingUserInteraction: PendingUserInteraction? = null
     private var clientActionHandler: ClientActionHandler? = null
 
@@ -52,11 +55,25 @@ class WebSocketManager {
 
     fun connect(
         url: String,
-        tunnelToken: String? = null
+        tunnelToken: String? = null,
+        schemaContent: String? = null
     ) {
         val targetUrl = url.trim()
         if (targetUrl.isBlank()) {
             val errorMessage = "Missing TYPEAGENT_SERVER_URL. Set it before building the app."
+            Log.e(TAG, errorMessage)
+            _connectionStatus.value = ConnectionStatus(
+                text = errorMessage,
+                state = ConnectionStatus.State.ERROR
+            )
+            return
+        }
+        val resolvedSchemaContent = schemaContent
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: synchronized(lock) { agentSchemaContent }
+        if (resolvedSchemaContent.isNullOrBlank()) {
+            val errorMessage = "The Android alarm and timer schema is unavailable."
             Log.e(TAG, errorMessage)
             _connectionStatus.value = ConnectionStatus(
                 text = errorMessage,
@@ -70,6 +87,8 @@ class WebSocketManager {
             pendingUserInteraction = null
             conversationId = null
             connectionId = null
+            agentSchemaContent = resolvedSchemaContent
+            isClientAgentRegistered = false
             displayThreads.clear()
             displayMessageIds.clear()
         }
@@ -112,6 +131,7 @@ class WebSocketManager {
                     pendingUserInteraction = null
                     conversationId = null
                     connectionId = null
+                    isClientAgentRegistered = false
                     finalizeOpenDisplayThreads()
                 }
                 _pendingYesNoPrompt.value = null
@@ -132,6 +152,7 @@ class WebSocketManager {
                 failPendingInvokes(errorMessage)
                 synchronized(lock) {
                     pendingUserInteraction = null
+                    isClientAgentRegistered = false
                     finalizeOpenDisplayThreads()
                 }
                 _pendingYesNoPrompt.value = null
@@ -213,6 +234,7 @@ class WebSocketManager {
         webSocket = null
         synchronized(lock) {
             pendingUserInteraction = null
+            isClientAgentRegistered = false
             finalizeOpenDisplayThreads()
         }
         _pendingYesNoPrompt.value = null
@@ -291,15 +313,64 @@ class WebSocketManager {
                     TAG,
                     "TypeAgent conversation joined: connectionId=$joinedConnectionId conversationId=$joinedConversationId"
                 )
-                _connectionStatus.value = ConnectionStatus(
-                    text = "Connected",
-                    state = ConnectionStatus.State.CONNECTED
-                )
+                registerClientAgent(joinedConversationId)
             },
             onError = { error ->
                 Log.e(TAG, "joinConversation error: $error")
                 _connectionStatus.value = ConnectionStatus(
                     text = "Error: $error",
+                    state = ConnectionStatus.State.ERROR
+                )
+            }
+        )
+    }
+
+    private fun registerClientAgent(joinedConversationId: String) {
+        val schemaContent = synchronized(lock) { agentSchemaContent }
+        if (schemaContent.isNullOrBlank()) {
+            val errorMessage = "The Android alarm and timer schema is unavailable."
+            Log.e(TAG, errorMessage)
+            _connectionStatus.value = ConnectionStatus(
+                text = errorMessage,
+                state = ConnectionStatus.State.ERROR
+            )
+            return
+        }
+
+        _connectionStatus.value = ConnectionStatus(
+            text = "Registering Android actions...",
+            state = ConnectionStatus.State.CONNECTING
+        )
+        sendInvoke(
+            channelName = AGENT_SERVER_CHANNEL,
+            methodName = "registerClientAgent",
+            args = listOf(
+                AndroidDeviceAgent.createRegistrationParams(
+                    conversationId = joinedConversationId,
+                    schemaContent = schemaContent
+                )
+            ),
+            onResult = {
+                synchronized(lock) {
+                    isClientAgentRegistered = true
+                }
+                Log.d(
+                    TAG,
+                    "Registered client agent ${AndroidDeviceAgent.NAME} " +
+                        "for conversation $joinedConversationId"
+                )
+                _connectionStatus.value = ConnectionStatus(
+                    text = "Connected - Android actions registered",
+                    state = ConnectionStatus.State.CONNECTED
+                )
+            },
+            onError = { error ->
+                synchronized(lock) {
+                    isClientAgentRegistered = false
+                }
+                Log.e(TAG, "registerClientAgent error: $error")
+                _connectionStatus.value = ConnectionStatus(
+                    text = "Agent registration failed: $error",
                     state = ConnectionStatus.State.ERROR
                 )
             }
@@ -386,6 +457,16 @@ class WebSocketManager {
             TAG,
             "RPC invoke channel=$channelName method=$methodName callId=$callId argCount=${args.length()}"
         )
+        if (channelName == AndroidDeviceAgent.CHANNEL_NAME) {
+            handleAndroidDeviceInvoke(
+                channelName = channelName,
+                methodName = methodName,
+                callId = callId,
+                args = args
+            )
+            return
+        }
+
         val result = when (methodName) {
             "getUserContext" -> JSONObject.NULL
             "question" -> handleQuestionInvoke(args)
@@ -396,6 +477,93 @@ class WebSocketManager {
             sendRpcResult(channelName, callId, result)
         } else {
             sendRpcError(channelName, callId, "Unsupported client RPC method: $methodName")
+        }
+    }
+
+    private fun handleAndroidDeviceInvoke(
+        channelName: String,
+        methodName: String,
+        callId: Int,
+        args: JSONArray
+    ) {
+        if (callId < 0) {
+            Log.e(TAG, "Android agent invocation is missing callId.")
+            return
+        }
+        if (methodName != "executeAction") {
+            sendRpcError(
+                channelName,
+                callId,
+                "Unsupported Android agent RPC method: $methodName"
+            )
+            return
+        }
+        if (!synchronized(lock) { isClientAgentRegistered }) {
+            sendRpcError(channelName, callId, "Android client agent is not registered.")
+            return
+        }
+
+        when (val parsed = AndroidDeviceAgent.parseExecuteAction(args)) {
+            is AndroidDeviceActionParseResult.ProtocolError -> {
+                sendRpcError(channelName, callId, parsed.message)
+            }
+
+            is AndroidDeviceActionParseResult.ActionError -> {
+                sendRpcResult(
+                    channelName,
+                    callId,
+                    AndroidDeviceAgent.createErrorResult(parsed.message)
+                )
+            }
+
+            is AndroidDeviceActionParseResult.Success -> {
+                executeAndroidDeviceAction(
+                    channelName = channelName,
+                    callId = callId,
+                    action = parsed.action
+                )
+            }
+        }
+    }
+
+    private fun executeAndroidDeviceAction(
+        channelName: String,
+        callId: Int,
+        action: AndroidDeviceAction
+    ) {
+        val handler = synchronized(lock) { clientActionHandler }
+        if (handler == null) {
+            sendRpcResult(
+                channelName,
+                callId,
+                AndroidDeviceAgent.createErrorResult(
+                    "The Android activity is not ready to execute actions."
+                )
+            )
+            return
+        }
+
+        val completed = AtomicBoolean(false)
+        val generation = connectionGeneration.get()
+        val completion: (AndroidDeviceExecutionResult) -> Unit = { result ->
+            if (!completed.compareAndSet(false, true)) {
+                Log.w(TAG, "Ignoring duplicate completion for agent callId=$callId")
+            } else if (connectionGeneration.get() != generation) {
+                Log.w(TAG, "Ignoring completion for stale agent callId=$callId")
+            } else {
+                val actionResult = when (result) {
+                    is AndroidDeviceExecutionResult.Success ->
+                        AndroidDeviceAgent.createSuccessResult(result.message)
+                    is AndroidDeviceExecutionResult.Failure ->
+                        AndroidDeviceAgent.createErrorResult(result.message)
+                }
+                sendRpcResult(channelName, callId, actionResult)
+            }
+        }
+
+        when (action) {
+            is AndroidDeviceAction.Alarm -> handler.onSetAlarm(action.action, completion)
+            is AndroidDeviceAction.Timer -> handler.onSetTimer(action.action, completion)
         }
     }
 
@@ -576,7 +744,7 @@ class WebSocketManager {
             TAG,
             "Dispatching set-alarm to client handler hour=${alarm.hour} minute=${alarm.minute}"
         )
-        handler.onSetAlarm(alarm)
+        handler.onSetAlarm(alarm) {}
     }
 
     private fun handleSetTimerAction(actionData: Any?) {
@@ -596,7 +764,7 @@ class WebSocketManager {
             TAG,
             "Dispatching set-timer to client handler durationInSeconds=${timer.durationInSeconds}"
         )
-        handler.onSetTimer(timer)
+        handler.onSetTimer(timer) {}
     }
 
     private fun handleSearchNearbyAction(actionData: Any?) {
@@ -1296,8 +1464,16 @@ class WebSocketManager {
     }
 
     internal interface ClientActionHandler {
-        fun onSetAlarm(action: SetAlarmAction)
-        fun onSetTimer(action: SetTimerAction)
+        fun onSetAlarm(
+            action: SetAlarmAction,
+            completion: (AndroidDeviceExecutionResult) -> Unit
+        )
+
+        fun onSetTimer(
+            action: SetTimerAction,
+            completion: (AndroidDeviceExecutionResult) -> Unit
+        )
+
         fun onSearchNearby(action: SearchNearbyAction)
     }
 }

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AlarmActionParserTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AlarmActionParserTest.kt
@@ -21,11 +21,24 @@ class AlarmActionParserTest {
     }
 
     @Test
-    fun `rejects invalid set-alarm payload format`() {
+    fun `parses time-of-day set-alarm payload`() {
         val alarm = parseSetAlarmActionPayload(
             JSONObject()
                 .put("originalRequest", "Set alarm")
                 .put("time", "06:30")
+        )
+
+        requireNotNull(alarm)
+        assertEquals(6, alarm.hour)
+        assertEquals(30, alarm.minute)
+    }
+
+    @Test
+    fun `rejects invalid set-alarm payload format`() {
+        val alarm = parseSetAlarmActionPayload(
+            JSONObject()
+                .put("originalRequest", "Set alarm")
+                .put("time", "6:30 PM")
         )
 
         assertNull(alarm)

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceAgentTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceAgentTest.kt
@@ -1,0 +1,109 @@
+package com.example.typeagentchat
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidDeviceAgentTest {
+    @Test
+    fun registrationIncludesInlineSchemaAndExecuteAction() {
+        val registration = AndroidDeviceAgent.createRegistrationParams(
+            conversationId = "conversation-1",
+            schemaContent = "export type AndroidDeviceAction = never;"
+        )
+
+        assertEquals(AndroidDeviceAgent.NAME, registration.getString("name"))
+        assertEquals("conversation-1", registration.getString("conversationId"))
+        assertEquals(
+            "executeAction",
+            registration.getJSONArray("agentInterface").getString(0)
+        )
+        assertEquals(
+            "export type AndroidDeviceAction = never;",
+            registration
+                .getJSONObject("manifest")
+                .getJSONObject("schema")
+                .getJSONObject("schemaFile")
+                .getString("content")
+        )
+    }
+
+    @Test
+    fun parsesSetTimerExecuteAction() {
+        val parameters = JSONObject()
+            .put("originalRequest", "Set a timer for 30 seconds")
+            .put("durationInSeconds", 30)
+        val action = JSONObject()
+            .put("actionName", "setTimer")
+            .put("parameters", parameters)
+        val args = JSONArray().put(JSONObject().put("action", action))
+
+        val parsed = AndroidDeviceAgent.parseExecuteAction(args)
+
+        assertTrue(parsed is AndroidDeviceActionParseResult.Success)
+        val timer = (parsed as AndroidDeviceActionParseResult.Success).action
+            as AndroidDeviceAction.Timer
+        assertEquals(30, timer.action.durationInSeconds)
+    }
+
+    @Test
+    fun parsesSetAlarmExecuteAction() {
+        val parameters = JSONObject()
+            .put("originalRequest", "Set an alarm for 6:30")
+            .put("time", "06:30")
+        val action = JSONObject()
+            .put("actionName", "setAlarm")
+            .put("parameters", parameters)
+        val args = JSONArray().put(JSONObject().put("action", action))
+
+        val parsed = AndroidDeviceAgent.parseExecuteAction(args)
+
+        assertTrue(parsed is AndroidDeviceActionParseResult.Success)
+        val alarm = (parsed as AndroidDeviceActionParseResult.Success).action
+            as AndroidDeviceAction.Alarm
+        assertEquals(6, alarm.action.hour)
+        assertEquals(30, alarm.action.minute)
+    }
+
+    @Test
+    fun classifiesInvalidParametersAsActionError() {
+        val action = JSONObject()
+            .put("actionName", "setTimer")
+            .put(
+                "parameters",
+                JSONObject()
+                    .put("originalRequest", "Set an invalid timer")
+                    .put("durationInSeconds", 0)
+            )
+        val args = JSONArray().put(JSONObject().put("action", action))
+
+        val parsed = AndroidDeviceAgent.parseExecuteAction(args)
+
+        assertTrue(parsed is AndroidDeviceActionParseResult.ActionError)
+    }
+
+    @Test
+    fun classifiesUnsupportedActionAsActionError() {
+        val action = JSONObject()
+            .put("actionName", "openMaps")
+            .put("parameters", JSONObject())
+        val args = JSONArray().put(JSONObject().put("action", action))
+
+        val parsed = AndroidDeviceAgent.parseExecuteAction(args)
+
+        assertTrue(parsed is AndroidDeviceActionParseResult.ActionError)
+    }
+
+    @Test
+    fun serializesActionResults() {
+        val success = AndroidDeviceAgent.createSuccessResult("Timer request sent for 30 seconds")
+        val failure = AndroidDeviceAgent.createErrorResult("No timer app")
+
+        assertEquals("Timer request sent for 30 seconds", success.getString("historyText"))
+        assertEquals("Timer request sent for 30 seconds", success.getString("displayContent"))
+        assertEquals(0, success.getJSONArray("entities").length())
+        assertEquals("No timer app", failure.getString("error"))
+    }
+}


### PR DESCRIPTION
# Summary

Enable the `mobile-2` Android sample to register itself with TypeAgent as
a client-hosted `androidDevice` agent using `registerClientAgent`.

The app supplies an inline schema for alarm and timer actions, receives
typed `executeAction` callbacks over the existing WebSocket connection,
dispatches them through Android intents, and returns success or failure
results to TypeAgent.

The existing `takeAction` handlers remain available for compatibility
with the static `androidMobile` agent.

# Example

## Before

The Android app depended on the server-side `androidMobile` agent and
received fire-and-forget client actions:

```text
TypeAgent androidMobile agent -> takeAction("set-timer", ...) -> Android intent

The app could not register its own schema or report the device operation
result to TypeAgent.

After

The Android app registers its own schema and action implementation:

Android app -> registerClientAgent("androidDevice", inlineSchema) -> executeAction(setTimer) -> Android intent -> ActionResult

A deterministic action can be tested with:

@action --parameters {"originalRequest":"timer","durationInSeconds":30} androidDevice setTimer

Timer request sent for 30 seconds
