### PR TITLE
Enhance PowerShell capability synthesis for Copilot dev actions

### DIFF
--- a/ts/packages/agents/powershell/README.md
+++ b/ts/packages/agents/powershell/README.md
@@ -2,6 +2,18 @@
 
 Agent to create and execute PowerShell workflows
 
+## Copilot capability fallback
+
+When the PowerShell fast path cannot match a Copilot dev-mode request, the
+reasoning agent checks whether PowerShell can safely complete it. It prefers to
+reuse an existing flow, adds validated grammar aliases when only the phrasing
+is new, and creates a reusable flow only when no equivalent exists.
+
+New flows are transactional: a pending draft executes once, is promoted only
+after success, and is removed if execution or schema activation fails. Existing
+flow names are never overwritten. A typed capability outcome distinguishes
+reuse, creation, fallthrough, and failure without parsing display text.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft

--- a/ts/packages/agents/powershell/benchmark/harness/benchmarkRunner.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/benchmarkRunner.mts
@@ -16,6 +16,7 @@ import {
     evaluateFallback,
 } from "./evaluators/executionEvaluator.mjs";
 import { evaluateDisposition } from "./evaluators/dispositionEvaluator.mjs";
+import { evaluateCapabilityOutcome } from "./evaluators/capabilityOutcomeEvaluator.mjs";
 import {
     buildScorecard,
     printScorecard,
@@ -292,6 +293,9 @@ export class BenchmarkRunner {
             );
             evaluations.push(
                 ...evaluateDisposition(resolvedUtterance, commandResult),
+            );
+            evaluations.push(
+                ...evaluateCapabilityOutcome(resolvedUtterance, commandResult),
             );
 
             const passed = evaluations.every((e) => e.passed);

--- a/ts/packages/agents/powershell/benchmark/harness/evaluators/capabilityOutcomeEvaluator.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/evaluators/capabilityOutcomeEvaluator.mts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { EvaluationResult, TestUtterance } from "../types.mjs";
+
+export function evaluateCapabilityOutcome(
+    utterance: TestUtterance,
+    commandResult: unknown,
+): EvaluationResult[] {
+    const expected = utterance.expected.capabilityOutcome;
+    if (!expected) {
+        return [];
+    }
+
+    const actual = (
+        commandResult as {
+            capabilityOutcome?: Record<string, unknown>;
+        }
+    )?.capabilityOutcome;
+    const differences: string[] = [];
+    for (const [key, expectedValue] of Object.entries(expected)) {
+        const actualValue = actual?.[key];
+        if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
+            differences.push(
+                `${key}: expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(actualValue)}`,
+            );
+        }
+    }
+
+    return [
+        {
+            passed: differences.length === 0,
+            component: "capability-outcome",
+            expected,
+            actual: actual ?? null,
+            message:
+                differences.length > 0 ? differences.join("; ") : undefined,
+        },
+    ];
+}

--- a/ts/packages/agents/powershell/benchmark/harness/types.mts
+++ b/ts/packages/agents/powershell/benchmark/harness/types.mts
@@ -48,8 +48,26 @@ export interface TestUtterance {
         disposition?: {
             status: "handled" | "notHandled" | "failed";
             path?: "action" | "reasoning" | "command";
-            reason?: "unknown" | "clarification" | "noActiveSchema";
+            reason?:
+                | "unknown"
+                | "clarification"
+                | "noActiveSchema"
+                | "notPowerShellCapable";
             schemas?: string[];
+            mayHaveSideEffects?: boolean;
+        };
+        capabilityOutcome?: {
+            status: "handledExisting" | "created" | "notSuitable" | "failed";
+            schema?: string;
+            actionName?: string;
+            flowName?: string;
+            reasonCode?: string;
+            phase?:
+                | "classify"
+                | "discover"
+                | "validate"
+                | "execute"
+                | "persist";
             mayHaveSideEffects?: boolean;
         };
         llmJudge?: { question: string; context?: string };
@@ -60,7 +78,10 @@ export interface BenchmarkCommandOptions {
     noReasoning?: boolean;
     activeSchemas?: string[];
     activeSchemaFamilies?: string[];
-    reasoningProfile?: "default" | "powershellFlowRecording";
+    reasoningProfile?:
+        | "default"
+        | "powershellFlowRecording"
+        | "powershellCapabilityFallback";
 }
 
 export interface PipelineTrace {
@@ -92,6 +113,7 @@ export interface EvaluationResult {
         | "execution"
         | "fallback"
         | "disposition"
+        | "capability-outcome"
         | "llm-judge";
     expected: unknown;
     actual: unknown;

--- a/ts/packages/agents/powershell/benchmark/scenarios/dev-actions-routing.json
+++ b/ts/packages/agents/powershell/benchmark/scenarios/dev-actions-routing.json
@@ -12,10 +12,11 @@
         "text": "show me the processes using ports on my machine",
         "options": {
           "activeSchemaFamilies": ["powershell"],
-          "noReasoning": true
+          "noReasoning": false,
+          "reasoningProfile": "powershellCapabilityFallback"
         },
         "expected": {
-          "routedTo": "llm-translation",
+          "routedTo": "grammar",
           "matchedFlow": "portListeners",
           "matchedAgent": "powershell",
           "disposition": {
@@ -40,7 +41,8 @@
         "text": "list files",
         "options": {
           "activeSchemaFamilies": ["powershell"],
-          "noReasoning": true
+          "noReasoning": false,
+          "reasoningProfile": "powershellCapabilityFallback"
         },
         "expected": {
           "routedTo": "grammar",
@@ -58,6 +60,35 @@
   {
     "id": "dev-route-03",
     "category": "dev-actions-routing",
+    "description": "Unmodeled PowerShell capabilities use reasoning",
+    "required": true,
+    "setup": {},
+    "utterances": [
+      {
+        "text": "show me the five environment variables with the longest values on my machine",
+        "options": {
+          "activeSchemaFamilies": ["powershell"],
+          "noReasoning": false,
+          "reasoningProfile": "powershellCapabilityFallback"
+        },
+        "expected": {
+          "routedTo": "reasoning",
+          "matchedAgent": "powershell",
+          "disposition": {
+            "status": "handled",
+            "path": "reasoning",
+            "schemas": ["powershell"]
+          },
+          "capabilityOutcome": {
+            "status": "created"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "dev-route-04",
+    "category": "dev-actions-routing",
     "description": "Non-PowerShell development work remains unhandled",
     "required": true,
     "setup": {},
@@ -66,14 +97,17 @@
         "text": "add unit tests for the hook router",
         "options": {
           "activeSchemaFamilies": ["powershell"],
-          "noReasoning": true
+          "noReasoning": false,
+          "reasoningProfile": "powershellCapabilityFallback"
         },
         "expected": {
-          "routedTo": "llm-translation",
-          "matchedFlow": null,
+          "routedTo": "reasoning",
           "disposition": {
             "status": "notHandled",
-            "reason": "unknown"
+            "reason": "notPowerShellCapable"
+          },
+          "capabilityOutcome": {
+            "status": "notSuitable"
           }
         }
       }

--- a/ts/packages/agents/powershell/benchmark/scenarios/grammar-subschemas.json
+++ b/ts/packages/agents/powershell/benchmark/scenarios/grammar-subschemas.json
@@ -969,6 +969,14 @@
           "matchedFlow": "portListeners",
           "extractedParams": {}
         }
+      },
+      {
+        "text": "show me the processes using ports on my machine",
+        "expected": {
+          "routedTo": "grammar",
+          "matchedFlow": "portListeners",
+          "extractedParams": {}
+        }
       }
     ]
   },

--- a/ts/packages/agents/powershell/jest.config.cjs
+++ b/ts/packages/agents/powershell/jest.config.cjs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const base = require("../../../jest.config.js");
+module.exports = {
+    ...base,
+    moduleNameMapper: {
+        ...base.moduleNameMapper,
+        "^(?:\\.\\./)+src/(.*)$": "<rootDir>/dist/$1",
+    },
+};

--- a/ts/packages/agents/powershell/package.json
+++ b/ts/packages/agents/powershell/package.json
@@ -48,8 +48,11 @@
     "build": "concurrently npm:tsc npm:asc:all npm:agc:all",
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log",
     "compile": "node scripts/compileRecipes.mjs",
+    "jest-esm": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
+    "test": "pnpm run test:local",
+    "test:local": "pnpm run jest-esm --testPathPattern=\".*[.]spec[.]js\"",
     "tsc": "tsc -b"
   },
   "dependencies": {
@@ -59,10 +62,13 @@
     "debug": "^4.3.4"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@typeagent/action-grammar-compiler": "workspace:*",
     "@typeagent/action-schema-compiler": "workspace:*",
     "@types/debug": "^4.1.12",
+    "@types/jest": "^29.5.7",
     "concurrently": "^9.1.2",
+    "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.4.5"

--- a/ts/packages/agents/powershell/src/actionHandler.mts
+++ b/ts/packages/agents/powershell/src/actionHandler.mts
@@ -12,6 +12,7 @@ import {
     AppAgentEvent,
 } from "@typeagent/agent-sdk";
 import {
+    createActionResultNoDisplay,
     createActionResultFromTextDisplay,
     createActionResultFromError,
 } from "@typeagent/agent-sdk/helpers/action";
@@ -45,6 +46,113 @@ const SAMPLES_DIR = join(__dirname, "..", "samples");
 
 interface PowerShellAgentContext {
     store?: PowerShellStore | undefined;
+}
+
+type StaticPowerShellAction = {
+    script: string;
+    allowedCmdlets: string[];
+};
+
+const NETWORK_ACTIONS: Record<string, StaticPowerShellAction> = {
+    testConnection: {
+        script: `param([string]$ComputerName, [int]$Port)
+if ($Port -gt 0) {
+    Test-NetConnection -ComputerName $ComputerName -Port $Port
+} else {
+    Test-NetConnection -ComputerName $ComputerName
+}`,
+        allowedCmdlets: ["Test-NetConnection"],
+    },
+    portListeners: {
+        script: `param([int]$Port)
+$listeners = Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue
+if ($Port -gt 0) {
+    $listeners = $listeners | Where-Object { $_.LocalPort -eq $Port }
+}
+$listeners |
+    Sort-Object LocalPort, OwningProcess |
+    ForEach-Object {
+        $process = Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue
+        [PSCustomObject]@{
+            LocalAddress = $_.LocalAddress
+            LocalPort = $_.LocalPort
+            ProcessId = $_.OwningProcess
+            ProcessName = if ($process) { $process.ProcessName } else { "(unknown)" }
+        }
+    }`,
+        allowedCmdlets: [
+            "Get-NetTCPConnection",
+            "Where-Object",
+            "Sort-Object",
+            "ForEach-Object",
+            "Get-Process",
+        ],
+    },
+    networkAdapters: {
+        script: `param([string]$Name)
+if ($Name) {
+    Get-NetAdapter -Name $Name
+} else {
+    Get-NetAdapter
+}`,
+        allowedCmdlets: ["Get-NetAdapter"],
+    },
+    ipConfig: {
+        script: `param([string]$InterfaceAlias)
+if ($InterfaceAlias) {
+    Get-NetIPConfiguration -InterfaceAlias $InterfaceAlias
+} else {
+    Get-NetIPConfiguration
+}`,
+        allowedCmdlets: ["Get-NetIPConfiguration"],
+    },
+    dnsLookup: {
+        script: `param([string]$Name, [string]$Type)
+if ($Type) {
+    Resolve-DnsName -Name $Name -Type $Type
+} else {
+    Resolve-DnsName -Name $Name
+}`,
+        allowedCmdlets: ["Resolve-DnsName"],
+    },
+};
+
+async function executeStaticNetworkAction(action: {
+    schemaName?: string;
+    actionName: string;
+    parameters?: Record<string, unknown>;
+}): Promise<ActionResult | undefined> {
+    if (action.schemaName !== "powershell.powershell-network") {
+        return undefined;
+    }
+    const definition = NETWORK_ACTIONS[action.actionName];
+    if (!definition) {
+        return undefined;
+    }
+
+    const result = await executeScript({
+        script: definition.script,
+        parameters: action.parameters ?? {},
+        sandbox: {
+            allowedCmdlets: definition.allowedCmdlets,
+            allowedPaths: [],
+            allowedModules: [],
+            maxExecutionTime: 30,
+            networkAccess: true,
+        },
+        workingDirectory: homedir(),
+    });
+
+    if (!result.success) {
+        return {
+            error:
+                result.stderr || `Script exited with code ${result.exitCode}`,
+            fallbackToReasoning: true,
+        };
+    }
+    return createActionResultFromTextDisplay(
+        result.stdout.trim() || "(no output)",
+    );
 }
 
 async function seedSampleFlows(store: PowerShellStore): Promise<number> {
@@ -225,10 +333,182 @@ function validateParameterRules(
     return undefined;
 }
 
+type FlowGrammarPatternInput = {
+    pattern: string;
+    isAlias?: boolean;
+};
+
+async function validateFlowGrammarPatterns(
+    actionName: string,
+    description: string,
+    grammarPatterns: FlowGrammarPatternInput[],
+    context: ActionContext<PowerShellAgentContext>,
+): Promise<{ patterns: FlowGrammarPatternInput[] } | { error: ActionResult }> {
+    if (
+        grammarPatterns.length === 0 ||
+        !context.sessionContext.validateGrammarPatterns
+    ) {
+        return { patterns: grammarPatterns };
+    }
+
+    const validationResult =
+        await context.sessionContext.validateGrammarPatterns({
+            actionName,
+            description,
+            patterns: grammarPatterns.map((pattern) => pattern.pattern),
+        });
+    if (!validationResult.approved) {
+        const message = [
+            "Grammar pattern validation failed:",
+            ...(validationResult.errors ?? []),
+            ...(validationResult.suggestions?.length
+                ? ["Suggestions:", ...validationResult.suggestions]
+                : []),
+        ].join("\n");
+        return { error: createActionResultFromError(message) };
+    }
+
+    if (validationResult.warnings?.length) {
+        context.sessionContext.notify(
+            AppAgentEvent.Warning,
+            `Pattern validation warnings:\n${validationResult.warnings.join("\n")}`,
+        );
+    }
+
+    return {
+        patterns:
+            validationResult.patterns?.map((pattern) => ({
+                pattern,
+                isAlias: false,
+            })) ?? grammarPatterns,
+    };
+}
+
+function buildPowerShellRecipe(
+    params: Record<string, unknown>,
+    grammarPatterns: FlowGrammarPatternInput[],
+): ScriptRecipe {
+    const actionName = params.actionName as string;
+    const scriptParameters = (params.scriptParameters as any[]) ?? [];
+    return {
+        version: 1,
+        actionName,
+        description: (params.description as string) ?? "",
+        displayName: (params.displayName as string) ?? actionName,
+        parameters: scriptParameters.map((parameter: any) => ({
+            name: parameter.name,
+            type: parameter.type ?? "string",
+            required: parameter.required ?? false,
+            description: parameter.description ?? "",
+            default: parameter.default,
+        })),
+        script: {
+            language: "powershell",
+            body: params.script as string,
+            expectedOutputFormat: "text",
+        },
+        grammarPatterns: grammarPatterns.map((pattern) => ({
+            pattern: pattern.pattern,
+            isAlias: pattern.isAlias ?? false,
+            examples: [],
+        })),
+        sandbox: {
+            allowedCmdlets: (params.allowedCmdlets as string[]) ?? [],
+            allowedPaths: ["$env:USERPROFILE", "$PWD", "$env:TEMP"],
+            allowedModules: (params.allowedModules as string[]) ?? [
+                "Microsoft.PowerShell.Management",
+            ],
+            maxExecutionTime: 30,
+            networkAccess: (params.networkAccess as boolean) ?? false,
+        },
+        source: {
+            type: "reasoning",
+            timestamp: new Date().toISOString(),
+        },
+    };
+}
+
+function parseNamedParameters(
+    value: unknown,
+    parameterName: string,
+): { parameters: Record<string, unknown> } | { error: ActionResult } {
+    if (value === undefined) {
+        return { parameters: {} };
+    }
+    if (typeof value !== "string") {
+        return {
+            error: createActionResultFromError(
+                `${parameterName} must be a JSON string`,
+            ),
+        };
+    }
+    try {
+        const parsed = JSON.parse(value);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed)
+        ) {
+            throw new Error("expected a JSON object");
+        }
+        return { parameters: parsed as Record<string, unknown> };
+    } catch (error) {
+        return {
+            error: createActionResultFromError(
+                `Invalid JSON in ${parameterName}: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        };
+    }
+}
+
+async function executeDraftRecipe(
+    recipe: ScriptRecipe,
+    suppliedParameters: Record<string, unknown>,
+): Promise<{ output: string } | { error: ActionResult }> {
+    const executionParameters: Record<string, unknown> = {};
+    mapParamsToFlowDefs(
+        suppliedParameters,
+        recipe.parameters,
+        executionParameters,
+    );
+    expandEnvVarsInParams(executionParameters, recipe.parameters);
+
+    const validationError =
+        validatePathParameters(executionParameters, recipe.parameters) ??
+        validateParameterRules(executionParameters, recipe.parameters);
+    if (validationError) {
+        return { error: createActionResultFromError(validationError) };
+    }
+
+    const result = await executeScript({
+        script: recipe.script.body,
+        parameters: executionParameters,
+        sandbox: recipe.sandbox,
+        workingDirectory: homedir(),
+    });
+    if (!result.success) {
+        return {
+            error: createActionResultFromError(
+                result.stderr || `Script exited with code ${result.exitCode}`,
+            ),
+        };
+    }
+    return { output: result.stdout.trim() || "(no output)" };
+}
+
 async function handlePowerShellFlowAction(
-    action: { actionName: string; parameters?: Record<string, unknown> },
+    action: {
+        schemaName?: string;
+        actionName: string;
+        parameters?: Record<string, unknown>;
+    },
     context: ActionContext<PowerShellAgentContext>,
 ): Promise<ActionResult> {
+    const networkResult = await executeStaticNetworkAction(action);
+    if (networkResult) {
+        return networkResult;
+    }
+
     const flowStore = (context as any).__store as PowerShellStore | undefined;
 
     switch (action.actionName) {
@@ -290,109 +570,30 @@ async function handlePowerShellFlowAction(
                     "Missing required parameter: actionName",
                 );
             }
+            if (flowStore.hasFlow(newActionName)) {
+                return createActionResultFromError(
+                    `A PowerShell flow named '${newActionName}' already exists. Reuse it or add grammar patterns instead of overwriting it.`,
+                );
+            }
             const scriptBody = params.script as string;
             if (!scriptBody) {
                 return createActionResultFromError(
                     "Missing required parameter: script",
                 );
             }
-            const scriptParams = (params.scriptParameters as any[]) ?? [];
-            const grammarPats = (params.grammarPatterns as any[]) ?? [];
-            const allowedCmdlets = (params.allowedCmdlets as string[]) ?? [];
-            const allowedModules = (params.allowedModules as string[]) ?? [
-                "Microsoft.PowerShell.Management",
-            ];
-
-            // Validate grammar patterns before saving
-            if (
-                grammarPats.length > 0 &&
-                context.sessionContext.validateGrammarPatterns
-            ) {
-                const patterns = grammarPats.map((g: any) => g.pattern);
-
-                const validationResult =
-                    await context.sessionContext.validateGrammarPatterns({
-                        actionName: newActionName,
-                        description: (params.description as string) ?? "",
-                        patterns,
-                    });
-
-                if (!validationResult.approved) {
-                    const errorMsg = [
-                        "❌ Grammar pattern validation failed:",
-                        "",
-                        ...(validationResult.errors ?? []),
-                    ].join("\n");
-
-                    const suggestionMsg = validationResult.suggestions
-                        ? [
-                              "",
-                              "Suggestions:",
-                              ...validationResult.suggestions,
-                          ].join("\n")
-                        : "";
-
-                    return createActionResultFromError(
-                        errorMsg + suggestionMsg,
-                    );
-                }
-
-                if (
-                    validationResult.warnings &&
-                    validationResult.warnings.length > 0
-                ) {
-                    context.sessionContext.notify(
-                        AppAgentEvent.Warning,
-                        `⚠️ Pattern validation warnings:\n${validationResult.warnings.join("\n")}`,
-                    );
-                }
-
-                // Use refined patterns if provided
-                if (
-                    validationResult.patterns &&
-                    validationResult.patterns.length > 0
-                ) {
-                    grammarPats.length = 0;
-                    for (const pattern of validationResult.patterns) {
-                        grammarPats.push({ pattern, isAlias: false });
-                    }
-                }
+            const grammarValidation = await validateFlowGrammarPatterns(
+                newActionName,
+                (params.description as string) ?? "",
+                (params.grammarPatterns as FlowGrammarPatternInput[]) ?? [],
+                context,
+            );
+            if ("error" in grammarValidation) {
+                return grammarValidation.error;
             }
-
-            const recipe: ScriptRecipe = {
-                version: 1,
-                actionName: newActionName,
-                description: (params.description as string) ?? "",
-                displayName: (params.displayName as string) ?? newActionName,
-                parameters: scriptParams.map((p: any) => ({
-                    name: p.name,
-                    type: p.type ?? "string",
-                    required: p.required ?? false,
-                    description: p.description ?? "",
-                    default: p.default,
-                })),
-                script: {
-                    language: "powershell",
-                    body: scriptBody,
-                    expectedOutputFormat: "text",
-                },
-                grammarPatterns: grammarPats.map((g: any) => ({
-                    pattern: g.pattern,
-                    isAlias: g.isAlias ?? false,
-                    examples: [],
-                })),
-                sandbox: {
-                    allowedCmdlets,
-                    allowedPaths: ["$env:USERPROFILE", "$PWD", "$env:TEMP"],
-                    allowedModules,
-                    maxExecutionTime: 30,
-                    networkAccess: false,
-                },
-                source: {
-                    type: "reasoning",
-                    timestamp: new Date().toISOString(),
-                },
-            };
+            const recipe = buildPowerShellRecipe(
+                params,
+                grammarValidation.patterns,
+            );
 
             await flowStore.saveFlow(recipe, "reasoning");
             await context.sessionContext.reloadAgentSchema();
@@ -400,6 +601,135 @@ async function handlePowerShellFlowAction(
                 `Created PowerShell flow '${newActionName}': ${recipe.description}`,
             );
         }
+
+        case "createAndExecutePowerShellFlow": {
+            if (!flowStore) {
+                return createActionResultFromError(
+                    "Script flow store not available",
+                );
+            }
+            const params = action.parameters as Record<string, unknown>;
+            const actionName = params.actionName as string | undefined;
+            const script = params.script as string | undefined;
+            if (!actionName) {
+                return createActionResultFromError(
+                    "Missing required parameter: actionName",
+                );
+            }
+            if (!script) {
+                return createActionResultFromError(
+                    "Missing required parameter: script",
+                );
+            }
+            if (flowStore.hasFlow(actionName)) {
+                return createActionResultFromError(
+                    `A PowerShell flow named '${actionName}' already exists. Reuse it or add grammar patterns instead of creating a duplicate.`,
+                );
+            }
+
+            const grammarValidation = await validateFlowGrammarPatterns(
+                actionName,
+                (params.description as string) ?? "",
+                (params.grammarPatterns as FlowGrammarPatternInput[]) ?? [],
+                context,
+            );
+            if ("error" in grammarValidation) {
+                return grammarValidation.error;
+            }
+            const executionParameters = parseNamedParameters(
+                params.executionParametersJson,
+                "executionParametersJson",
+            );
+            if ("error" in executionParameters) {
+                return executionParameters.error;
+            }
+
+            const recipe = buildPowerShellRecipe(
+                params,
+                grammarValidation.patterns,
+            );
+            const pendingId = await flowStore.savePending(recipe);
+            const execution = await executeDraftRecipe(
+                recipe,
+                executionParameters.parameters,
+            );
+            if ("error" in execution) {
+                await flowStore.deletePending(`${pendingId}.recipe.json`);
+                return execution.error;
+            }
+
+            const pendingFile = `${pendingId}.recipe.json`;
+            const promoted = await flowStore.promotePending(pendingFile);
+            if (!promoted) {
+                await flowStore.deletePending(pendingFile);
+                return createActionResultFromError(
+                    `The script executed, but flow '${actionName}' could not be promoted because that name is already registered. The operation may have caused side effects and was not executed again.`,
+                );
+            }
+            try {
+                await context.sessionContext.reloadAgentSchema();
+            } catch (error) {
+                await flowStore.deleteFlow(promoted);
+                return createActionResultFromError(
+                    `The script executed, but the new flow could not be activated: ${error instanceof Error ? error.message : String(error)}. The operation may have caused side effects and was not executed again.`,
+                );
+            }
+
+            return createActionResultFromTextDisplay(
+                `${execution.output}\n\nCreated reusable PowerShell flow '${promoted}'.`,
+            );
+        }
+
+        case "addPowerShellFlowPatterns": {
+            if (!flowStore) {
+                return createActionResultFromError(
+                    "Script flow store not available",
+                );
+            }
+            const flowName = action.parameters?.flowName as string | undefined;
+            if (!flowName) {
+                return createActionResultFromError(
+                    "Missing required parameter: flowName",
+                );
+            }
+            const flow = await flowStore.getFlow(flowName);
+            if (!flow) {
+                return createActionResultFromError(
+                    `Script flow not found: ${flowName}`,
+                );
+            }
+            const validation = await validateFlowGrammarPatterns(
+                flowName,
+                flow.description,
+                (action.parameters
+                    ?.grammarPatterns as FlowGrammarPatternInput[]) ?? [],
+                context,
+            );
+            if ("error" in validation) {
+                return validation.error;
+            }
+            const added = await flowStore.addGrammarPatterns(
+                flowName,
+                validation.patterns.map((pattern) => ({
+                    pattern: pattern.pattern,
+                    isAlias: pattern.isAlias ?? true,
+                    examples: [],
+                })),
+            );
+            if (added > 0) {
+                await context.sessionContext.reloadAgentSchema();
+            }
+            return createActionResultFromTextDisplay(
+                added > 0
+                    ? `Added ${added} grammar pattern(s) to PowerShell flow '${flowName}'.`
+                    : `PowerShell flow '${flowName}' already contains those grammar patterns.`,
+            );
+        }
+
+        case "reportPowerShellCapabilityOutcome":
+            return createActionResultNoDisplay(
+                "PowerShell capability outcome reported.",
+            );
 
         case "editPowerShellFlow": {
             if (!flowStore) {
@@ -1033,10 +1363,13 @@ const POWERSHELL_BUILTIN_ACTIONS = new Set([
     "listPowerShellFlows",
     "deletePowerShellFlow",
     "executePowerShellFlow",
+    "testPowerShellFlow",
     "createPowerShellFlow",
+    "createAndExecutePowerShellFlow",
+    "addPowerShellFlowPatterns",
+    "reportPowerShellCapabilityOutcome",
     "editPowerShellFlow",
     "importPowerShellFlow",
-    "testPowerShellFlow",
 ]);
 
 export function instantiate(): AppAgent {
@@ -1083,6 +1416,7 @@ export function instantiate(): AppAgent {
             (context as any).__store = agentContext.store;
             return handlePowerShellFlowAction(
                 action as {
+                    schemaName?: string;
                     actionName: string;
                     parameters?: Record<string, unknown>;
                 },

--- a/ts/packages/agents/powershell/src/manifest.json
+++ b/ts/packages/agents/powershell/src/manifest.json
@@ -9,5 +9,17 @@
     "schemaFile": "../dist/powershellSchema.pas.json",
     "grammarFile": "../dist/powershellSchema.ag.json",
     "schemaType": "PowerShellActions"
+  },
+  "subActionManifests": {
+    "powershell-network": {
+      "defaultEnabled": true,
+      "schema": {
+        "description": "PowerShell actions for network connectivity, listening ports, adapters, IP configuration, and DNS lookup.",
+        "originalSchemaFile": "./namespaces/network/networkActionsSchema.mts",
+        "schemaFile": "../dist/networkSchema.pas.json",
+        "grammarFile": "../dist/networkSchema.ag.json",
+        "schemaType": "PowerShellNetworkActions"
+      }
+    }
   }
 }

--- a/ts/packages/agents/powershell/src/namespaces/network/networkSchema.agr
+++ b/ts/packages/agents/powershell/src/namespaces/network/networkSchema.agr
@@ -31,6 +31,8 @@ import { PowerShellNetworkActions } from "./networkActionsSchema.mts";
       -> { actionName: "portListeners", parameters: {} }
   | (show|list) port listeners
       -> { actionName: "portListeners", parameters: {} }
+  | (show|list) (me)? (the)? (processes|programs) (using|on) (network)? ports (on my machine)?
+      -> { actionName: "portListeners", parameters: {} }
   | (which|what) (process|program) is (using|on) port $(port:number)
       -> { actionName: "portListeners", parameters: { port } }
   | netstat

--- a/ts/packages/agents/powershell/src/schema/scriptActions.mts
+++ b/ts/packages/agents/powershell/src/schema/scriptActions.mts
@@ -63,6 +63,81 @@ export type CreatePowerShellFlow = {
     };
 };
 
+// Create a reusable flow transactionally and execute the requested operation once
+export type CreateAndExecutePowerShellFlow = {
+    actionName: "createAndExecutePowerShellFlow";
+    parameters: {
+        // camelCase identifier for the new flow
+        actionName: string;
+        // What this script does
+        description: string;
+        // Human-readable name
+        displayName: string;
+        // PowerShell script body (should include param() block)
+        script: string;
+        // Script parameters
+        scriptParameters: {
+            name: string;
+            type: "string" | "number" | "boolean" | "path";
+            required: boolean;
+            description: string;
+            default?: string;
+        }[];
+        // Grammar patterns for matching future requests
+        grammarPatterns: {
+            pattern: string;
+            isAlias: boolean;
+        }[];
+        // PowerShell cmdlets the script uses
+        allowedCmdlets: string[];
+        // PowerShell modules required by the allowed cmdlets
+        allowedModules?: string[];
+        // JSON string of named parameters for this one execution
+        executionParametersJson?: string;
+        // Whether the script needs network access
+        networkAccess?: boolean;
+    };
+};
+
+// Add validated phrases to an existing flow without creating a duplicate
+export type AddPowerShellFlowPatterns = {
+    actionName: "addPowerShellFlowPatterns";
+    parameters: {
+        flowName: string;
+        grammarPatterns: {
+            pattern: string;
+            isAlias: boolean;
+        }[];
+    };
+};
+
+// Report the machine-readable result of PowerShell capability reasoning
+export type ReportPowerShellCapabilityOutcome = {
+    actionName: "reportPowerShellCapabilityOutcome";
+    parameters: {
+        status: "handledExisting" | "created" | "notSuitable" | "failed";
+        schema?: string;
+        actionName?: string;
+        flowName?: string;
+        reasonCode?: string;
+        phase?: "classify" | "discover" | "validate" | "execute" | "persist";
+        mayHaveSideEffects?: boolean;
+        reason?: string;
+    };
+};
+
+// Test a script without registering it
+export type TestPowerShellFlow = {
+    actionName: "testPowerShellFlow";
+    parameters: {
+        script: string;
+        allowedCmdlets: string[];
+        allowedModules?: string[];
+        networkAccess?: boolean;
+        testParameters?: string;
+    };
+};
+
 // Edit an existing PowerShell flow's script body (preserves grammar patterns and parameters)
 export type EditPowerShellFlow = {
     actionName: "editPowerShellFlow";
@@ -93,6 +168,10 @@ export type PowerShellActions =
     | ListPowerShellFlows
     | DeletePowerShellFlow
     | ExecutePowerShellFlow
+    | TestPowerShellFlow
     | CreatePowerShellFlow
+    | CreateAndExecutePowerShellFlow
+    | AddPowerShellFlowPatterns
+    | ReportPowerShellCapabilityOutcome
     | EditPowerShellFlow
     | ImportPowerShellFlow;

--- a/ts/packages/agents/powershell/src/store/powerShellStore.mts
+++ b/ts/packages/agents/powershell/src/store/powerShellStore.mts
@@ -107,6 +107,9 @@ export class PowerShellStore {
         this.ensureInitialized();
 
         const { actionName } = recipe;
+        if (this.hasFlow(actionName)) {
+            throw new Error(`Flow already exists: ${actionName}`);
+        }
         const flowPath = `flows/${actionName}.flow.json`;
         const scriptPath = `scripts/${actionName}.ps1`;
 
@@ -189,6 +192,39 @@ export class PowerShellStore {
         this.index.lastModified = entry.updated;
         await this.saveIndex();
         debug(`Flow script updated: ${actionName}`);
+    }
+
+    async addGrammarPatterns(
+        actionName: string,
+        patterns: GrammarPattern[],
+    ): Promise<number> {
+        this.ensureInitialized();
+        const entry = this.index.flows[actionName];
+        if (!entry) throw new Error(`Flow not found: ${actionName}`);
+
+        const json = await this.storage.read(entry.flowPath, "utf8");
+        const flow = JSON.parse(json) as PowerShellFlowDefinition;
+        const existing = new Set(
+            flow.grammarPatterns.map((pattern) => pattern.pattern),
+        );
+        const additions = patterns.filter(
+            (pattern) => !existing.has(pattern.pattern),
+        );
+        if (additions.length === 0) {
+            return 0;
+        }
+
+        flow.grammarPatterns.push(...additions);
+        await this.storage.write(entry.flowPath, JSON.stringify(flow, null, 2));
+        entry.grammarRuleText = generateGrammarRuleText(
+            actionName,
+            flow.grammarPatterns,
+        );
+        entry.updated = new Date().toISOString();
+        this.index.lastModified = entry.updated;
+        await this.saveIndex();
+        await this.writeDynamicGrammarFile();
+        return additions.length;
     }
 
     async getFlow(
@@ -296,12 +332,20 @@ export class PowerShellStore {
         this.ensureInitialized();
         const recipe = await this.getPending(filename);
         if (!recipe) return null;
+        if (this.hasFlow(recipe.actionName)) return null;
 
         const actionName = await this.saveFlow(recipe, "reasoning");
+        await this.deletePending(filename);
+        return actionName;
+    }
+
+    async deletePending(filename: string): Promise<void> {
+        this.ensureInitialized();
         try {
             await this.storage.delete(`pending/${filename}`);
-        } catch {}
-        return actionName;
+        } catch {
+            debug(`Could not delete pending recipe: ${filename}`);
+        }
     }
 
     // ── Usage tracking ─────────────────────────────────────────────────
@@ -416,6 +460,59 @@ export class PowerShellStore {
             "    };",
             "};",
             "",
+            "// Create, execute once, and promote a reusable PowerShell flow",
+            "export type CreateAndExecutePowerShellFlow = {",
+            '    actionName: "createAndExecutePowerShellFlow";',
+            "    parameters: {",
+            "        actionName: string;",
+            "        description: string;",
+            "        displayName: string;",
+            "        script: string;",
+            "        scriptParameters: {",
+            "            name: string;",
+            '            type: "string" | "number" | "boolean" | "path";',
+            "            required: boolean;",
+            "            description: string;",
+            "            default?: string;",
+            "        }[];",
+            "        grammarPatterns: {",
+            "            pattern: string;",
+            "            isAlias: boolean;",
+            "        }[];",
+            "        allowedCmdlets: string[];",
+            "        allowedModules?: string[];",
+            "        executionParametersJson?: string;",
+            "        networkAccess?: boolean;",
+            "    };",
+            "};",
+            "",
+            "// Add validated phrases to an existing flow",
+            "export type AddPowerShellFlowPatterns = {",
+            '    actionName: "addPowerShellFlowPatterns";',
+            "    parameters: {",
+            `        flowName: ${flowNameType};`,
+            "        grammarPatterns: {",
+            "            pattern: string;",
+            "            isAlias: boolean;",
+            "        }[];",
+            "    };",
+            "};",
+            "",
+            "// Report the machine-readable result of PowerShell capability reasoning",
+            "export type ReportPowerShellCapabilityOutcome = {",
+            '    actionName: "reportPowerShellCapabilityOutcome";',
+            "    parameters: {",
+            '        status: "handledExisting" | "created" | "notSuitable" | "failed";',
+            "        schema?: string;",
+            "        actionName?: string;",
+            "        flowName?: string;",
+            "        reasonCode?: string;",
+            '        phase?: "classify" | "discover" | "validate" | "execute" | "persist";',
+            "        mayHaveSideEffects?: boolean;",
+            "        reason?: string;",
+            "    };",
+            "};",
+            "",
             "// Edit an existing PowerShell flow's script body",
             "export type EditPowerShellFlow = {",
             '    actionName: "editPowerShellFlow";',
@@ -444,6 +541,9 @@ export class PowerShellStore {
             ...typeNames,
             "TestPowerShellFlow",
             "CreatePowerShellFlow",
+            "CreateAndExecutePowerShellFlow",
+            "AddPowerShellFlowPatterns",
+            "ReportPowerShellCapabilityOutcome",
             "EditPowerShellFlow",
             "ImportPowerShellFlow",
         ];

--- a/ts/packages/agents/powershell/test/actionHandler.spec.ts
+++ b/ts/packages/agents/powershell/test/actionHandler.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import type {
     ActionContext,
     SessionContext,

--- a/ts/packages/agents/powershell/test/actionHandler.spec.ts
+++ b/ts/packages/agents/powershell/test/actionHandler.spec.ts
@@ -1,0 +1,275 @@
+import type {
+    ActionContext,
+    SessionContext,
+    Storage,
+    TokenCachePersistence,
+} from "@typeagent/agent-sdk";
+import { jest } from "@jest/globals";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { instantiate } from "../src/actionHandler.mjs";
+
+class MemoryStorage implements Storage {
+    private readonly files = new Map<string, string>();
+
+    async read(path: string): Promise<Uint8Array>;
+    async read(path: string, options: "utf8" | "base64"): Promise<string>;
+    async read(
+        path: string,
+        options?: "utf8" | "base64",
+    ): Promise<Uint8Array | string> {
+        const value = this.files.get(path);
+        if (value === undefined) {
+            throw new Error(`File not found: ${path}`);
+        }
+        return options ? value : new TextEncoder().encode(value);
+    }
+
+    async write(path: string, data: string | Uint8Array): Promise<void> {
+        this.files.set(
+            path,
+            typeof data === "string" ? data : new TextDecoder().decode(data),
+        );
+    }
+
+    async delete(path: string): Promise<void> {
+        this.files.delete(path);
+    }
+
+    async exists(path: string): Promise<boolean> {
+        return this.files.has(path);
+    }
+
+    async list(path: string): Promise<string[]> {
+        const prefix = path.endsWith("/") ? path : `${path}/`;
+        const entries = new Set<string>();
+        for (const filePath of this.files.keys()) {
+            if (!filePath.startsWith(prefix)) continue;
+            const relative = filePath.slice(prefix.length);
+            entries.add(relative.split("/")[0]);
+        }
+        return [...entries];
+    }
+
+    async getTokenCachePersistence(): Promise<TokenCachePersistence> {
+        return {
+            load: async () => null,
+            save: async () => {},
+            delete: async () => true,
+        };
+    }
+}
+
+function createSessionContext(
+    storage: Storage,
+    reloadAgentSchema: () => Promise<void> = jest.fn(async () => {}),
+): SessionContext {
+    return {
+        agentContext: {},
+        sessionStorage: storage,
+        instanceStorage: storage,
+        sessionContextId: "powershell-action-handler-test",
+        notify: jest.fn(),
+        beginAgentThread: jest.fn(),
+        popupQuestion: jest.fn(),
+        toggleTransientAgent: jest.fn(),
+        addDynamicAgent: jest.fn(),
+        removeDynamicAgent: jest.fn(),
+        forceCleanupDynamicAgent: jest.fn(),
+        reloadAgentSchema,
+        notifyReadinessChanged: jest.fn(),
+        notifyClientCountChanged: jest.fn(),
+        registerPort: jest.fn(),
+        unregisterPort: jest.fn(),
+        validateGrammarPatterns: jest.fn(),
+    } as unknown as SessionContext;
+}
+
+function createActionContext(
+    sessionContext: SessionContext,
+): ActionContext<unknown> {
+    return {
+        streamingContext: undefined,
+        activityContext: undefined,
+        actionIO: {
+            setDisplay: jest.fn(),
+            appendDiagnosticData: jest.fn(),
+            appendDisplay: jest.fn(),
+            takeAction: jest.fn(),
+        },
+        sessionContext,
+        isFromReasoningLoop: true,
+        queueToggleTransientAgent: async () => {},
+    };
+}
+
+async function createAgentHarness(reloadAgentSchema?: () => Promise<void>) {
+    const storage = new MemoryStorage();
+    const sessionContext = createSessionContext(storage, reloadAgentSchema);
+    const agent = instantiate();
+    await agent.initializeAgentContext?.();
+    await agent.updateAgentContext?.(true, sessionContext, "powershell");
+    return {
+        agent,
+        storage,
+        sessionContext,
+        context: createActionContext(sessionContext),
+    };
+}
+
+describe("createAndExecutePowerShellFlow", () => {
+    const originalNoSamples = process.env.TYPEAGENT_NO_SAMPLES;
+
+    beforeAll(() => {
+        process.env.TYPEAGENT_NO_SAMPLES = "1";
+    });
+
+    describe("static network actions", () => {
+        it("does not intercept a root flow with the same action name", async () => {
+            const { agent, context } = await createAgentHarness();
+
+            const result = await agent.executeAction?.(
+                {
+                    schemaName: "powershell",
+                    actionName: "portListeners",
+                    parameters: {},
+                },
+                context,
+            );
+
+            expect(result).toMatchObject({
+                error: expect.stringContaining(
+                    "Unknown PowerShell flow 'portListeners'",
+                ),
+            });
+        });
+
+        it("executes portListeners without requiring a dynamic flow", async () => {
+            const { agent, context } = await createAgentHarness();
+
+            const result = await agent.executeAction?.(
+                {
+                    schemaName: "powershell.powershell-network",
+                    actionName: "portListeners",
+                    parameters: {},
+                },
+                context,
+            );
+
+            expect(result).not.toHaveProperty("error");
+        });
+    });
+
+    afterAll(() => {
+        if (originalNoSamples === undefined) {
+            delete process.env.TYPEAGENT_NO_SAMPLES;
+        } else {
+            process.env.TYPEAGENT_NO_SAMPLES = originalNoSamples;
+        }
+    });
+
+    it("removes the pending draft when execution fails", async () => {
+        const { agent, storage, context } = await createAgentHarness();
+
+        const result = await agent.executeAction?.(
+            {
+                schemaName: "powershell",
+                actionName: "createAndExecutePowerShellFlow",
+                parameters: {
+                    actionName: "failingDraft",
+                    description: "A flow that fails during its first execution",
+                    script: "throw 'draft failed'",
+                    executionParametersJson: "{}",
+                },
+            },
+            context,
+        );
+
+        expect(result).toMatchObject({
+            error: expect.stringContaining("draft failed"),
+        });
+        expect(await storage.list("pending")).toEqual([]);
+        expect(await storage.exists("flows/failingDraft.flow.json")).toBe(
+            false,
+        );
+    });
+
+    it("executes once and promotes only after successful execution", async () => {
+        const directory = await mkdtemp(
+            join(tmpdir(), "typeagent-powershell-flow-"),
+        );
+        const outputPath = join(directory, "executions.txt");
+        try {
+            const { agent, storage, context } = await createAgentHarness();
+
+            const result = await agent.executeAction?.(
+                {
+                    schemaName: "powershell",
+                    actionName: "createAndExecutePowerShellFlow",
+                    parameters: {
+                        actionName: "successfulDraft",
+                        description: "Record one execution",
+                        script: "param([string]$Path)\nAdd-Content -LiteralPath $Path -Value 'run'",
+                        scriptParameters: [
+                            {
+                                name: "Path",
+                                type: "path",
+                                required: true,
+                                description: "Output file",
+                            },
+                        ],
+                        allowedCmdlets: ["Add-Content"],
+                        executionParametersJson: JSON.stringify({
+                            Path: outputPath,
+                        }),
+                    },
+                },
+                context,
+            );
+
+            expect(result).not.toHaveProperty("error");
+            expect(await storage.list("pending")).toEqual([]);
+            expect(
+                await storage.exists("flows/successfulDraft.flow.json"),
+            ).toBe(true);
+            expect(
+                (await readFile(outputPath, "utf8")).trim().split(/\r?\n/),
+            ).toEqual(["run"]);
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+
+    it("removes the promoted flow when schema reload fails", async () => {
+        const reloadAgentSchema = jest.fn(async () => {
+            throw new Error("reload failed");
+        });
+        const { agent, storage, context } =
+            await createAgentHarness(reloadAgentSchema);
+
+        const result = await agent.executeAction?.(
+            {
+                schemaName: "powershell",
+                actionName: "createAndExecutePowerShellFlow",
+                parameters: {
+                    actionName: "reloadFailure",
+                    description: "A flow that cannot be activated",
+                    script: "Write-Output 'executed'",
+                    allowedCmdlets: ["Write-Output"],
+                    executionParametersJson: "{}",
+                },
+            },
+            context,
+        );
+
+        expect(reloadAgentSchema).toHaveBeenCalledTimes(1);
+        expect(result).toMatchObject({
+            error: expect.stringContaining("could not be activated"),
+        });
+        expect(await storage.list("pending")).toEqual([]);
+        expect(await storage.exists("flows/reloadFailure.flow.json")).toBe(
+            false,
+        );
+    });
+});

--- a/ts/packages/agents/powershell/test/actionHandler.spec.ts
+++ b/ts/packages/agents/powershell/test/actionHandler.spec.ts
@@ -13,6 +13,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { instantiate } from "../src/actionHandler.mjs";
 
+const itOnWindows = process.platform === "win32" ? it : it.skip;
+
 class MemoryStorage implements Storage {
     private readonly files = new Map<string, string>();
 
@@ -148,20 +150,23 @@ describe("createAndExecutePowerShellFlow", () => {
             });
         });
 
-        it("executes portListeners without requiring a dynamic flow", async () => {
-            const { agent, context } = await createAgentHarness();
+        itOnWindows(
+            "executes portListeners without requiring a dynamic flow",
+            async () => {
+                const { agent, context } = await createAgentHarness();
 
-            const result = await agent.executeAction?.(
-                {
-                    schemaName: "powershell.powershell-network",
-                    actionName: "portListeners",
-                    parameters: {},
-                },
-                context,
-            );
+                const result = await agent.executeAction?.(
+                    {
+                        schemaName: "powershell.powershell-network",
+                        actionName: "portListeners",
+                        parameters: {},
+                    },
+                    context,
+                );
 
-            expect(result).not.toHaveProperty("error");
-        });
+                expect(result).not.toHaveProperty("error");
+            },
+        );
     });
 
     afterAll(() => {
@@ -172,7 +177,7 @@ describe("createAndExecutePowerShellFlow", () => {
         }
     });
 
-    it("removes the pending draft when execution fails", async () => {
+    itOnWindows("removes the pending draft when execution fails", async () => {
         const { agent, storage, context } = await createAgentHarness();
 
         const result = await agent.executeAction?.(
@@ -198,81 +203,87 @@ describe("createAndExecutePowerShellFlow", () => {
         );
     });
 
-    it("executes once and promotes only after successful execution", async () => {
-        const directory = await mkdtemp(
-            join(tmpdir(), "typeagent-powershell-flow-"),
-        );
-        const outputPath = join(directory, "executions.txt");
-        try {
-            const { agent, storage, context } = await createAgentHarness();
+    itOnWindows(
+        "executes once and promotes only after successful execution",
+        async () => {
+            const directory = await mkdtemp(
+                join(tmpdir(), "typeagent-powershell-flow-"),
+            );
+            const outputPath = join(directory, "executions.txt");
+            try {
+                const { agent, storage, context } = await createAgentHarness();
+
+                const result = await agent.executeAction?.(
+                    {
+                        schemaName: "powershell",
+                        actionName: "createAndExecutePowerShellFlow",
+                        parameters: {
+                            actionName: "successfulDraft",
+                            description: "Record one execution",
+                            script: "param([string]$Path)\nAdd-Content -LiteralPath $Path -Value 'run'",
+                            scriptParameters: [
+                                {
+                                    name: "Path",
+                                    type: "path",
+                                    required: true,
+                                    description: "Output file",
+                                },
+                            ],
+                            allowedCmdlets: ["Add-Content"],
+                            executionParametersJson: JSON.stringify({
+                                Path: outputPath,
+                            }),
+                        },
+                    },
+                    context,
+                );
+
+                expect(result).not.toHaveProperty("error");
+                expect(await storage.list("pending")).toEqual([]);
+                expect(
+                    await storage.exists("flows/successfulDraft.flow.json"),
+                ).toBe(true);
+                expect(
+                    (await readFile(outputPath, "utf8")).trim().split(/\r?\n/),
+                ).toEqual(["run"]);
+            } finally {
+                await rm(directory, { recursive: true, force: true });
+            }
+        },
+    );
+
+    itOnWindows(
+        "removes the promoted flow when schema reload fails",
+        async () => {
+            const reloadAgentSchema = jest.fn(async () => {
+                throw new Error("reload failed");
+            });
+            const { agent, storage, context } =
+                await createAgentHarness(reloadAgentSchema);
 
             const result = await agent.executeAction?.(
                 {
                     schemaName: "powershell",
                     actionName: "createAndExecutePowerShellFlow",
                     parameters: {
-                        actionName: "successfulDraft",
-                        description: "Record one execution",
-                        script: "param([string]$Path)\nAdd-Content -LiteralPath $Path -Value 'run'",
-                        scriptParameters: [
-                            {
-                                name: "Path",
-                                type: "path",
-                                required: true,
-                                description: "Output file",
-                            },
-                        ],
-                        allowedCmdlets: ["Add-Content"],
-                        executionParametersJson: JSON.stringify({
-                            Path: outputPath,
-                        }),
+                        actionName: "reloadFailure",
+                        description: "A flow that cannot be activated",
+                        script: "Write-Output 'executed'",
+                        allowedCmdlets: ["Write-Output"],
+                        executionParametersJson: "{}",
                     },
                 },
                 context,
             );
 
-            expect(result).not.toHaveProperty("error");
+            expect(reloadAgentSchema).toHaveBeenCalledTimes(1);
+            expect(result).toMatchObject({
+                error: expect.stringContaining("could not be activated"),
+            });
             expect(await storage.list("pending")).toEqual([]);
-            expect(
-                await storage.exists("flows/successfulDraft.flow.json"),
-            ).toBe(true);
-            expect(
-                (await readFile(outputPath, "utf8")).trim().split(/\r?\n/),
-            ).toEqual(["run"]);
-        } finally {
-            await rm(directory, { recursive: true, force: true });
-        }
-    });
-
-    it("removes the promoted flow when schema reload fails", async () => {
-        const reloadAgentSchema = jest.fn(async () => {
-            throw new Error("reload failed");
-        });
-        const { agent, storage, context } =
-            await createAgentHarness(reloadAgentSchema);
-
-        const result = await agent.executeAction?.(
-            {
-                schemaName: "powershell",
-                actionName: "createAndExecutePowerShellFlow",
-                parameters: {
-                    actionName: "reloadFailure",
-                    description: "A flow that cannot be activated",
-                    script: "Write-Output 'executed'",
-                    allowedCmdlets: ["Write-Output"],
-                    executionParametersJson: "{}",
-                },
-            },
-            context,
-        );
-
-        expect(reloadAgentSchema).toHaveBeenCalledTimes(1);
-        expect(result).toMatchObject({
-            error: expect.stringContaining("could not be activated"),
-        });
-        expect(await storage.list("pending")).toEqual([]);
-        expect(await storage.exists("flows/reloadFailure.flow.json")).toBe(
-            false,
-        );
-    });
+            expect(await storage.exists("flows/reloadFailure.flow.json")).toBe(
+                false,
+            );
+        },
+    );
 });

--- a/ts/packages/agents/powershell/test/powerShellStore.spec.ts
+++ b/ts/packages/agents/powershell/test/powerShellStore.spec.ts
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Storage, TokenCachePersistence } from "@typeagent/agent-sdk";
+import { PowerShellStore } from "../src/store/powerShellStore.mjs";
+import type { ScriptRecipe } from "../src/types/scriptRecipe.js";
+
+class MockStorage implements Storage {
+    private data = new Map<string, string>();
+
+    async read(storagePath: string): Promise<Uint8Array>;
+    async read(
+        storagePath: string,
+        options: "utf8" | "base64",
+    ): Promise<string>;
+    async read(
+        storagePath: string,
+        options?: "utf8" | "base64",
+    ): Promise<Uint8Array | string> {
+        const value = this.data.get(storagePath);
+        if (value === undefined) {
+            throw new Error(`File not found: ${storagePath}`);
+        }
+        return options ? value : new TextEncoder().encode(value);
+    }
+
+    async write(storagePath: string, data: string | Uint8Array): Promise<void> {
+        this.data.set(
+            storagePath,
+            typeof data === "string" ? data : new TextDecoder().decode(data),
+        );
+    }
+
+    async list(storagePath: string): Promise<string[]> {
+        const prefix = `${storagePath}/`;
+        return [...this.data.keys()]
+            .filter((key) => key.startsWith(prefix))
+            .map((key) => key.substring(prefix.length));
+    }
+
+    async exists(storagePath: string): Promise<boolean> {
+        return this.data.has(storagePath);
+    }
+
+    async delete(storagePath: string): Promise<void> {
+        this.data.delete(storagePath);
+    }
+
+    async getTokenCachePersistence(): Promise<TokenCachePersistence> {
+        return {
+            load: async () => null,
+            save: async () => {},
+            delete: async () => true,
+        };
+    }
+}
+
+function createRecipe(actionName = "showPorts"): ScriptRecipe {
+    return {
+        version: 1,
+        actionName,
+        description: "Show listening ports",
+        displayName: "Show Ports",
+        parameters: [],
+        script: {
+            language: "powershell",
+            body: "Get-NetTCPConnection -State Listen",
+            expectedOutputFormat: "text",
+        },
+        grammarPatterns: [
+            {
+                pattern: "show listening ports",
+                isAlias: false,
+                examples: [],
+            },
+        ],
+        sandbox: {
+            allowedCmdlets: ["Get-NetTCPConnection"],
+            allowedPaths: [],
+            allowedModules: ["NetTCPIP"],
+            maxExecutionTime: 30,
+            networkAccess: false,
+        },
+    };
+}
+
+describe("PowerShellStore capability lifecycle", () => {
+    it("does not overwrite an existing flow", async () => {
+        const store = new PowerShellStore(new MockStorage());
+        await store.initialize();
+        await store.saveFlow(createRecipe(), "reasoning");
+
+        await expect(
+            store.saveFlow(createRecipe(), "reasoning"),
+        ).rejects.toThrow("Flow already exists: showPorts");
+    });
+
+    it("promotes a pending recipe and removes the draft", async () => {
+        const store = new PowerShellStore(new MockStorage());
+        await store.initialize();
+        const pendingId = await store.savePending(createRecipe());
+
+        await expect(
+            store.promotePending(`${pendingId}.recipe.json`),
+        ).resolves.toBe("showPorts");
+        await expect(store.listPending()).resolves.toEqual([]);
+        expect(store.hasFlow("showPorts")).toBe(true);
+    });
+
+    it("adds new grammar patterns without duplicating existing ones", async () => {
+        const store = new PowerShellStore(new MockStorage());
+        await store.initialize();
+        await store.saveFlow(createRecipe(), "reasoning");
+
+        await expect(
+            store.addGrammarPatterns("showPorts", [
+                {
+                    pattern: "show listening ports",
+                    isAlias: true,
+                    examples: [],
+                },
+                {
+                    pattern: "show processes using ports",
+                    isAlias: true,
+                    examples: [],
+                },
+            ]),
+        ).resolves.toBe(1);
+
+        const flow = await store.getFlow("showPorts");
+        expect(flow?.grammarPatterns.map((pattern) => pattern.pattern)).toEqual(
+            ["show listening ports", "show processes using ports"],
+        );
+    });
+
+    it("exposes transactional and outcome actions in the dynamic schema", async () => {
+        const store = new PowerShellStore(new MockStorage());
+        await store.initialize();
+
+        const schema = store.generateDynamicSchemaText();
+        expect(schema).toContain("createAndExecutePowerShellFlow");
+        expect(schema).toContain("addPowerShellFlowPatterns");
+        expect(schema).toContain("reportPowerShellCapabilityOutcome");
+    });
+});

--- a/ts/packages/agents/powershell/test/tsconfig.json
+++ b/ts/packages/agents/powershell/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../dist/test",
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*"],
+  "ts-node": {
+    "esm": true
+  },
+  "references": [{ "path": "../src" }]
+}

--- a/ts/packages/agents/powershell/tsconfig.json
+++ b/ts/packages/agents/powershell/tsconfig.json
@@ -4,5 +4,5 @@
     "composite": true
   },
   "include": [],
-  "references": [{ "path": "./src" }]
+  "references": [{ "path": "./src" }, { "path": "./test" }]
 }

--- a/ts/packages/copilot-plugin/src/hooks/hook-dev-actions.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-dev-actions.ts
@@ -39,7 +39,8 @@ export function getDevActionCommandOptions(
     }
     return {
         activeSchemaFamilies: ["powershell"],
-        noReasoning: true,
+        noReasoning: false,
+        reasoningProfile: "powershellCapabilityFallback",
     };
 }
 

--- a/ts/packages/copilot-plugin/test/hookDevActions.spec.ts
+++ b/ts/packages/copilot-plugin/test/hookDevActions.spec.ts
@@ -52,7 +52,8 @@ describe("Copilot dev actions hook", () => {
     it("uses the PowerShell schema family for ordinary prompts", () => {
         expect(getDevActionCommandOptions("show running processes")).toEqual({
             activeSchemaFamilies: ["powershell"],
-            noReasoning: true,
+            noReasoning: false,
+            reasoningProfile: "powershellCapabilityFallback",
         });
     });
 
@@ -76,7 +77,8 @@ describe("Copilot dev actions hook", () => {
         const options = submitCommand.mock.calls[0][2] as ProcessCommandOptions;
         expect(options).toEqual({
             activeSchemaFamilies: ["powershell"],
-            noReasoning: true,
+            noReasoning: false,
+            reasoningProfile: "powershellCapabilityFallback",
         });
         expect(close).toHaveBeenCalledTimes(1);
     });

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -60,6 +60,10 @@ import {
     type CommandDisposition,
 } from "@typeagent/dispatcher-types";
 import { resolveActiveSchemaScope } from "../../../translation/activeSchemaScope.js";
+import {
+    getPowerShellCapabilityDisposition,
+    getPowerShellCapabilityOutcome,
+} from "../../../reasoning/powershellCapabilityOutcome.js";
 
 type ReasoningFallbackContext = {
     failedSchema: string;
@@ -78,6 +82,37 @@ function getActionSchemas(
     actions: { action: { schemaName: string } }[],
 ): string[] {
     return [...new Set(actions.map(({ action }) => action.schemaName))];
+}
+
+function applyPowerShellCapabilityOutcome(
+    context: CommandHandlerContext,
+): boolean {
+    if (
+        context.currentOptions?.reasoningProfile !==
+        "powershellCapabilityFallback"
+    ) {
+        return false;
+    }
+
+    const commandResult = ensureCommandResult(context);
+    const outcome = getPowerShellCapabilityOutcome(commandResult.actions);
+    if (!outcome) {
+        commandResult.lastError =
+            "PowerShell capability reasoning did not report a typed outcome.";
+        setDisposition(context, {
+            status: "failed",
+            path: "reasoning",
+            mayHaveSideEffects: false,
+        });
+        return true;
+    }
+
+    commandResult.capabilityOutcome = outcome;
+    if (outcome.status === "failed") {
+        commandResult.lastError = outcome.reason;
+    }
+    setDisposition(context, getPowerShellCapabilityDisposition(outcome));
+    return true;
 }
 
 async function runConfiguredReasoning(
@@ -872,10 +907,12 @@ export class RequestCommandHandler implements CommandHandler {
                 try {
                     await runConfiguredReasoning(request, context);
                     reasoningHandled = true;
-                    setDisposition(systemContext, {
-                        status: "handled",
-                        path: "reasoning",
-                    });
+                    if (!applyPowerShellCapabilityOutcome(systemContext)) {
+                        setDisposition(systemContext, {
+                            status: "handled",
+                            path: "reasoning",
+                        });
+                    }
                 } catch (e: any) {
                     debugRequest(
                         `Reasoning fallback failed, using default handler: ${e.message}`,

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
@@ -7,7 +7,10 @@ import {
     TypeAgentAction,
     DisplayAppendMode,
 } from "@typeagent/agent-sdk";
-import { CommandHandlerContext } from "../context/commandHandlerContext.js";
+import {
+    CommandHandlerContext,
+    ensureCommandResult,
+} from "../context/commandHandlerContext.js";
 import { ReasoningAction } from "../context/dispatcher/schema/reasoningActionSchema.js";
 import {
     CopilotClient,
@@ -813,6 +816,17 @@ function getCopilotSessionConfig(
                         context,
                         actionIndex++,
                     );
+                    if (actionResult.error === undefined) {
+                        const commandResult =
+                            ensureCommandResult(systemContext);
+                        commandResult.actions = [
+                            ...(commandResult.actions ?? []),
+                            {
+                                schemaName,
+                                ...actionJson,
+                            } as TypeAgentAction,
+                        ];
+                    }
                     systemContext.clientIO = savedClientIO;
 
                     // Surface the action's history text (its full, model-facing

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/powershellCapabilityOutcome.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/powershellCapabilityOutcome.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { TypeAgentAction } from "@typeagent/agent-sdk";
+import type {
+    CommandDisposition,
+    PowerShellCapabilityOutcome,
+} from "@typeagent/dispatcher-types";
+
+const outcomeActionName = "reportPowerShellCapabilityOutcome";
+
+export function getPowerShellCapabilityOutcome(
+    actions: readonly TypeAgentAction[] | undefined,
+): PowerShellCapabilityOutcome | undefined {
+    const action = actions
+        ? [...actions]
+              .reverse()
+              .find(
+                  (candidate: TypeAgentAction) =>
+                      candidate.schemaName === "powershell" &&
+                      candidate.actionName === outcomeActionName,
+              )
+        : undefined;
+    const parameters = action?.parameters as
+        | Record<string, unknown>
+        | undefined;
+    if (!parameters) {
+        return undefined;
+    }
+    const status = parameters?.status;
+    switch (status) {
+        case "handledExisting": {
+            const schema = parameters.schema;
+            const actionName = parameters.actionName;
+            if (typeof schema !== "string" || typeof actionName !== "string") {
+                return undefined;
+            }
+            return {
+                status,
+                schema,
+                actionName,
+                ...(typeof parameters.flowName === "string"
+                    ? { flowName: parameters.flowName }
+                    : {}),
+            };
+        }
+        case "created":
+            return typeof parameters.flowName === "string"
+                ? { status, flowName: parameters.flowName }
+                : undefined;
+        case "notSuitable":
+            return typeof parameters.reasonCode === "string"
+                ? { status, reasonCode: parameters.reasonCode }
+                : undefined;
+        case "failed": {
+            const phase = parameters.phase;
+            const reason = parameters.reason;
+            if (
+                !isFailurePhase(phase) ||
+                typeof parameters.mayHaveSideEffects !== "boolean" ||
+                typeof reason !== "string"
+            ) {
+                return undefined;
+            }
+            return {
+                status,
+                phase,
+                mayHaveSideEffects: parameters.mayHaveSideEffects,
+                reason,
+            };
+        }
+        default:
+            return undefined;
+    }
+}
+
+export function getPowerShellCapabilityDisposition(
+    outcome: PowerShellCapabilityOutcome,
+): CommandDisposition {
+    if (outcome.status === "notSuitable") {
+        return {
+            status: "notHandled",
+            reason: "notPowerShellCapable",
+        };
+    }
+    if (outcome.status === "failed") {
+        return {
+            status: "failed",
+            path: "reasoning",
+            mayHaveSideEffects: outcome.mayHaveSideEffects,
+        };
+    }
+    return {
+        status: "handled",
+        path: "reasoning",
+        schemas:
+            outcome.status === "handledExisting"
+                ? [outcome.schema]
+                : ["powershell"],
+    };
+}
+
+function isFailurePhase(
+    value: unknown,
+): value is Extract<
+    PowerShellCapabilityOutcome,
+    { status: "failed" }
+>["phase"] {
+    return (
+        value === "classify" ||
+        value === "discover" ||
+        value === "validate" ||
+        value === "execute" ||
+        value === "persist"
+    );
+}

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningProfile.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/reasoningProfile.ts
@@ -6,17 +6,40 @@ import type { ProcessCommandOptions } from "@typeagent/dispatcher-types";
 export function getReasoningProfileGuidance(
     options?: ProcessCommandOptions,
 ): string | undefined {
-    if (options?.reasoningProfile !== "powershellFlowRecording") {
-        return undefined;
+    switch (options?.reasoningProfile) {
+        case "powershellFlowRecording":
+            return getPowerShellFlowRecordingGuidance();
+        case "powershellCapabilityFallback":
+            return getPowerShellCapabilityFallbackGuidance();
+        default:
+            return undefined;
     }
+}
 
+function getPowerShellFlowRecordingGuidance(): string {
     return [
         "[PowerShell flow recording profile]",
         "Handle this request as a reusable PowerShell development action.",
         "Use discover_actions for the powershell schema, then use its typed actions.",
-        "If no matching flow exists, create one with createPowerShellFlow and execute it to test it.",
+        "If no matching flow exists, use createAndExecutePowerShellFlow so the script executes once and is promoted only after success.",
         "Do not create a TaskFlow or WebFlow unless the user explicitly asks for one.",
         "Do not use shell or Bash as a substitute for PowerShell agent actions.",
         "If the task is not suitable for a PowerShell flow, explain that clearly instead of recording a different workflow type.",
+    ].join("\n");
+}
+
+function getPowerShellCapabilityFallbackGuidance(): string {
+    return [
+        "[PowerShell capability fallback profile]",
+        "Decide whether the user's request can be safely completed as a reusable PowerShell flow.",
+        "Use discover_actions for the powershell schema and listPowerShellFlows before creating anything.",
+        "Prefer an existing executable action or flow. If an existing flow covers the task but misses this phrasing, add validated patterns with addPowerShellFlowPatterns, then execute the existing flow once.",
+        "If no equivalent exists, use createAndExecutePowerShellFlow. It executes the draft once and promotes it only after success. Do not execute the promoted flow again.",
+        "Do not use shell, Bash, TaskFlow, or WebFlow as substitutes.",
+        "You MUST finish by calling reportPowerShellCapabilityOutcome exactly once.",
+        "Report handledExisting after an existing action or flow succeeds.",
+        "Report created after createAndExecutePowerShellFlow succeeds.",
+        "Report notSuitable when the request is not a PowerShell task or classification is uncertain.",
+        "Report failed with the precise phase and whether execution may have caused side effects.",
     ].join("\n");
 }

--- a/ts/packages/dispatcher/dispatcher/test/devActionRouting.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/devActionRouting.spec.ts
@@ -4,6 +4,10 @@
 import { parseRecordingDirective } from "@typeagent/dispatcher-types";
 import { resolveActiveSchemaScope } from "../src/translation/activeSchemaScope.js";
 import { getReasoningProfileGuidance } from "../src/reasoning/reasoningProfile.js";
+import {
+    getPowerShellCapabilityDisposition,
+    getPowerShellCapabilityOutcome,
+} from "../src/reasoning/powershellCapabilityOutcome.js";
 import { createDispatcher } from "../src/dispatcher.js";
 import { awaitCommand, type Dispatcher } from "@typeagent/dispatcher-types";
 
@@ -130,8 +134,81 @@ describe("dev action routing", () => {
         const guidance = getReasoningProfileGuidance({
             reasoningProfile: "powershellFlowRecording",
         });
-        expect(guidance).toContain("createPowerShellFlow");
+        expect(guidance).toContain("createAndExecutePowerShellFlow");
         expect(guidance).toContain("Do not create a TaskFlow or WebFlow");
+    });
+
+    it("adds typed PowerShell capability fallback guidance", () => {
+        const guidance = getReasoningProfileGuidance({
+            reasoningProfile: "powershellCapabilityFallback",
+        });
+        expect(guidance).toContain("reportPowerShellCapabilityOutcome");
+        expect(guidance).toContain("addPowerShellFlowPatterns");
+        expect(guidance).toContain("executes the draft once");
+    });
+
+    describe("capability outcomes", () => {
+        it("reads the final typed outcome action", () => {
+            expect(
+                getPowerShellCapabilityOutcome([
+                    {
+                        schemaName: "powershell",
+                        actionName: "reportPowerShellCapabilityOutcome",
+                        parameters: {
+                            status: "created",
+                            flowName: "showPortProcesses",
+                        },
+                    },
+                ]),
+            ).toEqual({
+                status: "created",
+                flowName: "showPortProcesses",
+            });
+        });
+
+        it("rejects malformed outcomes", () => {
+            expect(
+                getPowerShellCapabilityOutcome([
+                    {
+                        schemaName: "powershell",
+                        actionName: "reportPowerShellCapabilityOutcome",
+                        parameters: {
+                            status: "failed",
+                            phase: "execute",
+                            mayHaveSideEffects: "yes",
+                            reason: "failed",
+                        },
+                    },
+                ]),
+            ).toBeUndefined();
+        });
+
+        it("maps notSuitable to clean fallthrough", () => {
+            expect(
+                getPowerShellCapabilityDisposition({
+                    status: "notSuitable",
+                    reasonCode: "not-a-system-task",
+                }),
+            ).toEqual({
+                status: "notHandled",
+                reason: "notPowerShellCapable",
+            });
+        });
+
+        it("preserves side-effect risk for failures", () => {
+            expect(
+                getPowerShellCapabilityDisposition({
+                    status: "failed",
+                    phase: "persist",
+                    mayHaveSideEffects: true,
+                    reason: "schema reload failed",
+                }),
+            ).toEqual({
+                status: "failed",
+                path: "reasoning",
+                mayHaveSideEffects: true,
+            });
+        });
     });
 
     describe("dispatcher disposition", () => {

--- a/ts/packages/dispatcher/types/src/dispatcher.ts
+++ b/ts/packages/dispatcher/types/src/dispatcher.ts
@@ -94,13 +94,39 @@ export type CommandDisposition =
       }
     | {
           status: "notHandled";
-          reason: "unknown" | "clarification" | "noActiveSchema";
+          reason:
+              | "unknown"
+              | "clarification"
+              | "noActiveSchema"
+              | "notPowerShellCapable";
       }
     | {
           status: "failed";
           path: "action" | "reasoning" | "command";
           mayHaveSideEffects: boolean;
           schemas?: string[];
+      };
+
+export type PowerShellCapabilityOutcome =
+    | {
+          status: "handledExisting";
+          schema: string;
+          actionName: string;
+          flowName?: string;
+      }
+    | {
+          status: "created";
+          flowName: string;
+      }
+    | {
+          status: "notSuitable";
+          reasonCode: string;
+      }
+    | {
+          status: "failed";
+          phase: "classify" | "discover" | "validate" | "execute" | "persist";
+          mayHaveSideEffects: boolean;
+          reason: string;
       };
 
 export type CommandResult = {
@@ -115,6 +141,8 @@ export type CommandResult = {
     // Explicit routing outcome for callers that need safe handled/fallthrough
     // behavior without inferring it from actions or display output.
     disposition?: CommandDisposition;
+    // Machine-readable completion reported by PowerShell capability reasoning.
+    capabilityOutcome?: PowerShellCapabilityOutcome;
     metrics?: RequestMetrics;
     // Token usage for translating the user's request into actions (the LLM
     // "translation" step). Absent for @-commands and cached translations.
@@ -325,7 +353,10 @@ export type ProcessCommandOptions = {
     /**
      * Add request-scoped instructions to the configured reasoning engine.
      */
-    reasoningProfile?: "default" | "powershellFlowRecording";
+    reasoningProfile?:
+        | "default"
+        | "powershellFlowRecording"
+        | "powershellCapabilityFallback";
     /**
      * User-environment context for translation prompts.
      * Provides information about which app/host the user is currently in

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -3285,6 +3285,9 @@ importers:
         specifier: ^4.3.4
         version: 4.4.3(supports-color@8.1.1)
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@typeagent/action-grammar-compiler':
         specifier: workspace:*
         version: link:../../actionGrammarCompiler
@@ -3294,9 +3297,15 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
+      '@types/jest':
+        specifier: ^29.5.7
+        version: 29.5.14
       concurrently:
         specifier: ^9.1.2
         version: 9.1.2
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.20.1)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.4.5))
       prettier:
         specifier: ^3.5.3
         version: 3.5.3


### PR DESCRIPTION
- add typed reasoning outcomes and safe non-PowerShell fallthrough
- create reusable flows transactionally with rollback and deduplication
- register network actions and route port-listener requests directly
- expand routing benchmarks and lifecycle coverage
