### PR TITLE
[OTEL] Wire logging into TypeAgent hosts

### DIFF
--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -411,5 +411,6 @@ typeagent:
 #   otlpEndpoint: http://localhost:4318
 #   logFile: ~/.typeagent/logs/typeagent-{service}-{pid}.jsonl
 #   debugBridge: true
+#   structuredLogs: true
 #   tracesSampler: parentbased_traceidratio
 #   tracesSamplerArg: 0.1

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -107,12 +107,13 @@ Logs require explicit composition:
 - Installing an OTel SDK alone does neither.
 
 TypeAgent-owned Node composition roots attach `OtelLoggerSink` alongside the
-existing debug and database sinks by explicitly enabling
-`DispatcherOptions.telemetry.structuredLogs`. The option defaults to false so
-embedded dispatcher consumers do not export event payloads merely because
-another component installed a global OTel logs provider. Hosts also pass each
-process's `debug` module instance to `initTelemetry()` so the optional bridge
-can preserve existing output while copying eligible records into OTel.
+existing debug and database sinks when `telemetry.structuredLogs` is enabled.
+The setting defaults to false so embedded dispatcher consumers do not export
+event payloads merely because another component installed a global OTel logs
+provider. The environment override is
+`TYPEAGENT_OTEL_STRUCTURED_LOGS=true`. Hosts also pass each process's `debug`
+module instance to `initTelemetry()` so the optional bridge can preserve
+existing output while copying eligible records into OTel.
 
 The dispatcher prompt logger is intentionally not connected to
 `OtelLoggerSink`, and its debug namespace remains excluded from the bridge.

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -106,10 +106,14 @@ Logs require explicit composition:
 - Install the debug bridge to copy enabled TypeAgent debug output.
 - Installing an OTel SDK alone does neither.
 
-The logger severity contract and `OtelLoggerSink` in this PR are library
-foundation only. They do not attach the sink to a runtime logger or configure a
-provider. A later host-wiring PR performs that composition in TypeAgent-owned
-Node hosts.
+TypeAgent-owned Node composition roots attach `OtelLoggerSink` alongside the
+existing debug and database sinks. They pass each process's `debug` module
+instance to `initTelemetry()` so the optional bridge can preserve existing
+output while copying eligible records into OTel.
+
+The dispatcher prompt logger is intentionally not connected to
+`OtelLoggerSink`, and its debug namespace remains excluded from the bridge.
+Prompt capture requires a separate explicit privacy-reviewed design.
 
 The sink emits through the host's global Logs API and does not create a provider.
 Embeddable libraries never install a process-wide debug hook. A partner may
@@ -120,6 +124,11 @@ TypeAgent-owned Node hosts call `initTelemetry()` once and
 `shutdownTelemetry()` on exit. Each process installs at most one global provider
 per enabled signal and exports directly. Libraries, agents, requests, and
 sessions do not create providers.
+
+The bridge includes `typeagent:*` namespaces by default. TypeAgent-owned hosts
+may explicitly include a stable legacy prefix that they own. Agent server hosts
+include `agent-server:*` this way rather than renaming existing namespaces and
+breaking current `DEBUG` configurations.
 
 Global provider registration is first-writer-wins. TypeAgent bootstrap runs
 before instrumentation and reports an unexpected existing provider as a

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -107,9 +107,12 @@ Logs require explicit composition:
 - Installing an OTel SDK alone does neither.
 
 TypeAgent-owned Node composition roots attach `OtelLoggerSink` alongside the
-existing debug and database sinks. They pass each process's `debug` module
-instance to `initTelemetry()` so the optional bridge can preserve existing
-output while copying eligible records into OTel.
+existing debug and database sinks by explicitly enabling
+`DispatcherOptions.telemetry.structuredLogs`. The option defaults to false so
+embedded dispatcher consumers do not export event payloads merely because
+another component installed a global OTel logs provider. Hosts also pass each
+process's `debug` module instance to `initTelemetry()` so the optional bridge
+can preserve existing output while copying eligible records into OTel.
 
 The dispatcher prompt logger is intentionally not connected to
 `OtelLoggerSink`, and its debug namespace remains excluded from the bridge.

--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -178,7 +178,12 @@ process.once("message", (message) => {
 // Load config from YAML layers + Key Vault (replacing legacy dotenv).
 // vault.shared is auto-discovered from config.local.yaml / config.defaults.yaml.
 await loadConfig({ keyVault: {}, strict: false });
-const telemetryInit = otel.initTelemetry();
+const telemetryInit = otel.initTelemetry({
+    debugModules: [registerDebug],
+    debugBridge: {
+        includedNamespacePrefixes: ["typeagent:", "agent-server:"],
+    },
+});
 
 // Snapshot whether this server's local config differs from the shared Key
 // Vault, so clients can be warned on connect (same delivery path as the

--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -178,7 +178,9 @@ process.once("message", (message) => {
 // Load config from YAML layers + Key Vault (replacing legacy dotenv).
 // vault.shared is auto-discovered from config.local.yaml / config.defaults.yaml.
 await loadConfig({ keyVault: {}, strict: false });
+const telemetryConfig = otel.resolveTelemetryConfig();
 const telemetryInit = otel.initTelemetry({
+    config: telemetryConfig,
     debugModules: [registerDebug],
     debugBridge: {
         includedNamespacePrefixes: ["typeagent:", "agent-server:"],
@@ -346,7 +348,7 @@ async function main() {
                 developerMode,
                 traceId,
                 telemetry: {
-                    structuredLogs: true,
+                    structuredLogs: telemetryConfig.structuredLogs === true,
                 },
                 indexingServiceRegistry: await getIndexingServiceRegistry(
                     instanceDir,

--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -345,6 +345,9 @@ async function main() {
                 dblogging: true,
                 developerMode,
                 traceId,
+                telemetry: {
+                    structuredLogs: true,
+                },
                 indexingServiceRegistry: await getIndexingServiceRegistry(
                     instanceDir,
                     configName,

--- a/ts/packages/api/src/index.ts
+++ b/ts/packages/api/src/index.ts
@@ -41,7 +41,9 @@ process.once("SIGTERM", () => {
 async function main(): Promise<void> {
     // Load config from YAML layers + Key Vault (replacing legacy dotenv).
     await loadConfig({ keyVault: {}, strict: false });
+    const telemetryConfig = otel.resolveTelemetryConfig();
     await otel.initTelemetry({
+        config: telemetryConfig,
         debugModules: [registerDebug],
         debugBridge: {
             includedNamespacePrefixes: ["typeagent:", "agent-server:"],
@@ -53,7 +55,7 @@ async function main(): Promise<void> {
 
     typeAgentServer = new TypeAgentServer((exitCode) => {
         void shutdownHost(exitCode);
-    });
+    }, telemetryConfig.structuredLogs === true);
 
     await typeAgentServer.start();
 }

--- a/ts/packages/api/src/index.ts
+++ b/ts/packages/api/src/index.ts
@@ -4,6 +4,7 @@
 import { TypeAgentServer } from "./typeAgentServer.js";
 import { loadConfig } from "@typeagent/config";
 import { otel } from "@typeagent/telemetry";
+import registerDebug from "debug";
 
 let typeAgentServer: TypeAgentServer | undefined;
 let shutdownPromise: Promise<void> | undefined;
@@ -40,7 +41,12 @@ process.once("SIGTERM", () => {
 async function main(): Promise<void> {
     // Load config from YAML layers + Key Vault (replacing legacy dotenv).
     await loadConfig({ keyVault: {}, strict: false });
-    await otel.initTelemetry();
+    await otel.initTelemetry({
+        debugModules: [registerDebug],
+        debugBridge: {
+            includedNamespacePrefixes: ["typeagent:", "agent-server:"],
+        },
+    });
     if (shutdownRequested) {
         return;
     }

--- a/ts/packages/api/src/typeAgentServer.ts
+++ b/ts/packages/api/src/typeAgentServer.ts
@@ -40,7 +40,10 @@ export class TypeAgentServer {
     private storageProvider: TypeAgentStorageProvider | undefined;
     private config: TypeAgentAPIServerConfig;
 
-    constructor(private readonly requestExit: (exitCode: number) => void) {
+    constructor(
+        private readonly requestExit: (exitCode: number) => void,
+        private readonly structuredLogs: boolean,
+    ) {
         // Build typed runtime Config from process.env (already populated
         // by loadConfig in the entry point) so aiclient consumers can
         // use the typed accessor; legacy callers still see the same
@@ -83,7 +86,7 @@ export class TypeAgentServer {
             sw.stop("Downloaded Session Backup");
         }
 
-        this.webDispatcher = await createWebDispatcher();
+        this.webDispatcher = await createWebDispatcher(this.structuredLogs);
         debug("Web Dispatcher created.");
 
         // web server

--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -62,6 +62,9 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
         metrics: true,
         dblogging: true,
         traceId: getTraceId(),
+        telemetry: {
+            structuredLogs: true,
+        },
         clientIO: clientIO,
         constructionProvider: getDefaultConstructionProvider(),
         indexingServiceRegistry: await getIndexingServiceRegistry(instanceDir),

--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -34,7 +34,9 @@ export interface WebDispatcher {
     handleAction(action: FullAction): Promise<CommandResult>;
 }
 
-export async function createWebDispatcher(): Promise<WebDispatcher> {
+export async function createWebDispatcher(
+    structuredLogs: boolean,
+): Promise<WebDispatcher> {
     let ws: WebSocket | null = null;
     const clientIOChannel = createChannelAdapter((message: any) =>
         ws?.send(
@@ -63,7 +65,7 @@ export async function createWebDispatcher(): Promise<WebDispatcher> {
         dblogging: true,
         traceId: getTraceId(),
         telemetry: {
-            structuredLogs: true,
+            structuredLogs,
         },
         clientIO: clientIO,
         constructionProvider: getDefaultConstructionProvider(),

--- a/ts/packages/cli/bin/dev.js
+++ b/ts/packages/cli/bin/dev.js
@@ -4,6 +4,7 @@
 
 import { loadConfigSync } from "@typeagent/config";
 import { otel } from "@typeagent/telemetry";
+import registerDebug from "debug";
 import { registerEarlyTelemetrySignalHandlers } from "../src/telemetry.ts";
 loadConfigSync();
 
@@ -15,7 +16,7 @@ async function main() {
     process.env.NODE_ENV = "development";
     settings.debug = true;
     try {
-        await otel.initTelemetry();
+        await otel.initTelemetry({ debugModules: [registerDebug] });
         await run(process.argv.slice(2), import.meta.url);
         await flush();
         await otel.shutdownTelemetry();

--- a/ts/packages/cli/bin/run.js
+++ b/ts/packages/cli/bin/run.js
@@ -4,6 +4,7 @@
 
 import { loadConfigSync } from "@typeagent/config";
 import { otel } from "@typeagent/telemetry";
+import registerDebug from "debug";
 import { registerEarlyTelemetrySignalHandlers } from "../dist/telemetry.js";
 loadConfigSync();
 
@@ -12,7 +13,7 @@ registerEarlyTelemetrySignalHandlers();
 async function main() {
     const { flush, handle, run } = await import("@oclif/core");
     try {
-        await otel.initTelemetry();
+        await otel.initTelemetry({ debugModules: [registerDebug] });
         await run(process.argv.slice(2), import.meta.url);
         await flush();
         await otel.shutdownTelemetry();

--- a/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
@@ -13,6 +13,7 @@ import {
     MultiSinkLogger,
     createDebugLoggerSink,
     createDatabaseLoggerSink,
+    createOtelLoggerSink,
     CosmosContainerClientFactory,
     CosmosPartitionKeyBuilderFactory,
     PromptLogger,
@@ -729,6 +730,7 @@ function getCosmosFactories(): PromptLoggerOptions {
 
 function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
     const debugLoggerSink = createDebugLoggerSink();
+    const otelLoggerSink = createOtelLoggerSink();
     let dbLoggerSink: LoggerSink | undefined;
 
     try {
@@ -761,8 +763,8 @@ function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
 
     return new MultiSinkLogger(
         dbLoggerSink === undefined
-            ? [debugLoggerSink]
-            : [debugLoggerSink, dbLoggerSink],
+            ? [debugLoggerSink, otelLoggerSink]
+            : [debugLoggerSink, dbLoggerSink, otelLoggerSink],
     );
 }
 

--- a/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/commandHandlerContext.ts
@@ -600,6 +600,11 @@ export type DispatcherOptions = DeepPartialUndefined<DispatcherConfig> & {
          * Default false: each request starts a new trace.
          */
         joinActiveTrace?: boolean;
+        /**
+         * Export structured dispatcher events through the global OTel logs
+         * provider. Default false because event payloads may contain user data.
+         */
+        structuredLogs?: boolean;
     };
 
     // Additional integration options
@@ -728,9 +733,12 @@ function getCosmosFactories(): PromptLoggerOptions {
     return result;
 }
 
-function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
+function getLoggerSink(
+    isDbEnabled: () => boolean,
+    clientIO: ClientIO,
+    structuredLogs: boolean,
+) {
     const debugLoggerSink = createDebugLoggerSink();
-    const otelLoggerSink = createOtelLoggerSink();
     let dbLoggerSink: LoggerSink | undefined;
 
     try {
@@ -761,11 +769,14 @@ function getLoggerSink(isDbEnabled: () => boolean, clientIO: ClientIO) {
         );
     }
 
-    return new MultiSinkLogger(
+    const sinks =
         dbLoggerSink === undefined
-            ? [debugLoggerSink, otelLoggerSink]
-            : [debugLoggerSink, dbLoggerSink, otelLoggerSink],
-    );
+            ? [debugLoggerSink]
+            : [debugLoggerSink, dbLoggerSink];
+    if (structuredLogs) {
+        sinks.push(createOtelLoggerSink());
+    }
+    return new MultiSinkLogger(sinks);
 }
 
 async function lockEmbeddingCacheDir(context: CommandHandlerContext) {
@@ -1208,7 +1219,11 @@ export async function initializeCommandHandlerContext(
         const sessionDirPath = session.getSessionDirPath();
         debug(`Session directory: ${sessionDirPath}`);
         const clientIO = options?.clientIO ?? nullClientIO;
-        const loggerSink = getLoggerSink(() => context.dblogging, clientIO);
+        const loggerSink = getLoggerSink(
+            () => context.dblogging,
+            clientIO,
+            options?.telemetry?.structuredLogs === true,
+        );
         const activationId = randomUUID();
         const traceId = options?.traceId;
         const logger = new ChildLogger(loggerSink, DispatcherName, {

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentDebug.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentDebug.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import registerDebug from "debug";
+import { createRequire } from "node:module";
+
+export interface AgentDebugModule {
+    readonly debug: typeof registerDebug;
+    readonly path: string;
+}
+
+export function loadAgentDebug(
+    modulePath: string,
+    hostDebug: typeof registerDebug,
+): AgentDebugModule | undefined {
+    try {
+        const require = createRequire(modulePath);
+        const debugPath = require.resolve("debug");
+        const agentDebug = require(debugPath) as typeof registerDebug;
+        return agentDebug === hostDebug
+            ? undefined
+            : { debug: agentDebug, path: debugPath };
+    } catch {
+        return undefined;
+    }
+}

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -9,8 +9,8 @@ import {
     createAgentRpcServer,
 } from "@typeagent/agent-rpc/server";
 import { createChannelProvider } from "@typeagent/agent-rpc/channel";
-import { createRequire } from "node:module";
 import { otel } from "@typeagent/telemetry";
+import { loadAgentDebug } from "./agentDebug.js";
 
 //=================================================================
 // Get arguments from command line
@@ -73,23 +73,13 @@ process.on("SIGINT", () => {
 });
 
 async function startAgentProcess(): Promise<void> {
-    async function getAgentDebug(): Promise<typeof registerDebug | undefined> {
-        try {
-            // get the "debug" package from the module.
-            const require = createRequire(modulePath);
-            const debugPath = require.resolve("debug");
-            const agentDebug = (await import(debugPath)).default;
-            if (agentDebug === registerDebug) {
-                return undefined;
-            }
-            debug(`'${agentName}': Agent debug trace loaded. ${debugPath}`);
-            return agentDebug;
-        } catch {
-            return undefined;
-        }
+    const loadedAgentDebug = loadAgentDebug(modulePath, registerDebug);
+    const agentDebug = loadedAgentDebug?.debug;
+    if (loadedAgentDebug !== undefined) {
+        debug(
+            `'${agentName}': Agent debug trace loaded. ${loadedAgentDebug.path}`,
+        );
     }
-
-    const agentDebug = await getAgentDebug();
     const debugModules =
         agentDebug === undefined
             ? [registerDebug]

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -37,7 +37,6 @@ if (!isIPCProcess(process)) {
 }
 const ipcProcess = process;
 
-const telemetryInit = otel.initTelemetry();
 let exitPromise: Promise<void> | undefined;
 
 function exitAgentProcess(exitCode: number, message: string): Promise<void> {
@@ -74,10 +73,32 @@ process.on("SIGINT", () => {
 });
 
 async function startAgentProcess(): Promise<void> {
+    async function getAgentDebug(): Promise<typeof registerDebug | undefined> {
+        try {
+            // get the "debug" package from the module.
+            const require = createRequire(modulePath);
+            const debugPath = require.resolve("debug");
+            const agentDebug = (await import(debugPath)).default;
+            if (agentDebug === registerDebug) {
+                return undefined;
+            }
+            debug(`'${agentName}': Agent debug trace loaded. ${debugPath}`);
+            return agentDebug;
+        } catch {
+            return undefined;
+        }
+    }
+
+    const agentDebug = await getAgentDebug();
+    const debugModules =
+        agentDebug === undefined
+            ? [registerDebug]
+            : [registerDebug, agentDebug];
+    await otel.initTelemetry({ debugModules });
+
     //=================================================================
     // Load the module.
     //=================================================================
-    await telemetryInit;
     const module = await import(modulePath);
     if (typeof module.instantiate !== "function") {
         throw new Error(
@@ -115,23 +136,6 @@ async function startAgentProcess(): Promise<void> {
     //=================================================================
     // Set up debug trace coordination
     //=================================================================
-    async function getAgentDebug(): Promise<typeof registerDebug | undefined> {
-        try {
-            // get the "debug" package from the module.
-            const require = createRequire(modulePath);
-            const debugPath = require.resolve("debug");
-            const agentDebug = (await import(debugPath)).default;
-            if (agentDebug === registerDebug) {
-                return undefined;
-            }
-            debug(`'${agentName}': Agent debug trace loaded. ${debugPath}`);
-            return agentDebug;
-        } catch {
-            return undefined;
-        }
-    }
-
-    const agentDebug = await getAgentDebug();
     const traceChannel = channelProvider.createChannel<string>("trace");
     traceChannel.on("message", (message) => {
         registerDebug.enable(message);

--- a/ts/packages/dispatcher/nodeProviders/test/agentDebug.spec.ts
+++ b/ts/packages/dispatcher/nodeProviders/test/agentDebug.spec.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import registerDebug from "debug";
+
+import { loadAgentDebug } from "../src/agentProvider/process/agentDebug.js";
+
+describe("loadAgentDebug", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-debug-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test("loads an agent-local CommonJS debug module by absolute path", () => {
+        const modulePath = path.join(tempDir, "agent.js");
+        const debugDir = path.join(tempDir, "node_modules", "debug");
+        fs.mkdirSync(debugDir, { recursive: true });
+        fs.writeFileSync(modulePath, "export function instantiate() {}\n");
+        fs.writeFileSync(
+            path.join(debugDir, "index.js"),
+            "module.exports = function agentDebug() {};\n",
+        );
+
+        const loaded = loadAgentDebug(modulePath, registerDebug);
+
+        expect(loaded).toBeDefined();
+        expect(loaded?.debug).not.toBe(registerDebug);
+        expect(loaded?.path).toBe(path.join(debugDir, "index.js"));
+    });
+
+    test("does not return the host debug module as a second instance", () => {
+        expect(
+            loadAgentDebug(fileURLToPath(import.meta.url), registerDebug),
+        ).toBe(undefined);
+    });
+});

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -209,12 +209,15 @@ async function initialize() {
 
     const appPath = app.getAppPath();
     await initializeKeys(appPath);
+    const telemetryConfig = otel.resolveTelemetryConfig();
     await otel.initTelemetry({
+        config: telemetryConfig,
         debugModules: [registerDebug],
         debugBridge: {
             includedNamespacePrefixes: ["typeagent:", "agent-server:"],
         },
     });
+    structuredLogs = telemetryConfig.structuredLogs === true;
     // Standalone hosts the agent-server in-process, so warm up the aiclient
     // runtime config locally. The connect-only shell delegates all model work
     // to the remote server and never imports aiclient here.
@@ -389,6 +392,7 @@ async function initialize() {
                 parsedArgs.hidden,
                 parsedArgs.idleTimeout,
                 parsedArgs.resume,
+                structuredLogs,
             );
     });
 
@@ -403,6 +407,7 @@ async function initialize() {
         parsedArgs.hidden,
         parsedArgs.idleTimeout,
         parsedArgs.resume,
+        structuredLogs,
     );
 
     shellWindow.waitForReady().then(() => {
@@ -438,6 +443,7 @@ process.on("unhandledRejection", (reason: any) => {
 });
 
 let reloadingInstance = false;
+let structuredLogs = false;
 export async function reloadInstance() {
     reloadingInstance = true;
     try {
@@ -453,6 +459,7 @@ export async function reloadInstance() {
             parsedArgs.hidden,
             parsedArgs.idleTimeout,
             parsedArgs.resume,
+            structuredLogs,
         );
     } finally {
         reloadingInstance = false;

--- a/ts/packages/shell/src/main/index.ts
+++ b/ts/packages/shell/src/main/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./instance.js";
 import { AGENT_SERVER_DEFAULT_PORT } from "@typeagent/agent-server-client";
 import { otel } from "@typeagent/telemetry";
+import registerDebug from "debug";
 import {
     isAllowedConfigFilePath,
     resolveLocalConfigPath,
@@ -208,7 +209,12 @@ async function initialize() {
 
     const appPath = app.getAppPath();
     await initializeKeys(appPath);
-    await otel.initTelemetry();
+    await otel.initTelemetry({
+        debugModules: [registerDebug],
+        debugBridge: {
+            includedNamespacePrefixes: ["typeagent:", "agent-server:"],
+        },
+    });
     // Standalone hosts the agent-server in-process, so warm up the aiclient
     // runtime config locally. The connect-only shell delegates all model work
     // to the remote server and never imports aiclient here.

--- a/ts/packages/shell/src/main/instance.ts
+++ b/ts/packages/shell/src/main/instance.ts
@@ -631,6 +631,9 @@ async function initializeDispatcher(
                     metrics: true,
                     dblogging: true,
                     traceId: getTraceId(),
+                    telemetry: {
+                        structuredLogs: true,
+                    },
                     indexingServiceRegistry,
                     constructionProvider: getDefaultConstructionProvider(),
                     allowSharedLocalView: ["browser"],

--- a/ts/packages/shell/src/main/instance.ts
+++ b/ts/packages/shell/src/main/instance.ts
@@ -632,7 +632,7 @@ async function initializeDispatcher(
                     dblogging: true,
                     traceId: getTraceId(),
                     telemetry: {
-                        structuredLogs: true,
+                        structuredLogs,
                     },
                     indexingServiceRegistry,
                     constructionProvider: getDefaultConstructionProvider(),
@@ -874,6 +874,7 @@ export function initializeInstance(
     hidden?: boolean,
     idleTimeout?: number,
     _resume?: boolean, // reserved: shell conversation resume not yet implemented
+    structuredLogs: boolean = false,
 ) {
     if (instance !== undefined) {
         throw new Error("Instance already initialized");

--- a/ts/packages/telemetry/src/logger/otelLoggerSink.ts
+++ b/ts/packages/telemetry/src/logger/otelLoggerSink.ts
@@ -207,8 +207,8 @@ function mapSeverity(severity: LogEventSeverity | undefined): {
  * *and* global provider replacement (e.g. `logs.disable()` followed by
  * `setGlobalLoggerProvider(...)`) transparent to a sink created earlier.
  *
- * This class is the library foundation only. A later host-wiring PR
- * composes it into TypeAgent-owned runtimes and configures providers.
+ * The sink does not own or configure a provider. TypeAgent-owned composition
+ * roots attach it to runtime loggers and configure providers separately.
  */
 export class OtelLoggerSink implements LoggerSink {
     private readonly options: OtelLoggerSinkOptions | undefined;

--- a/ts/packages/telemetry/src/otel/config.ts
+++ b/ts/packages/telemetry/src/otel/config.ts
@@ -84,6 +84,8 @@ export interface TelemetryConfig {
     readonly logs?: LogConfig;
     /** Copy enabled TypeAgent debug output into the OTel logs pipeline. */
     readonly debugBridge?: boolean;
+    /** Export structured dispatcher events into the OTel logs pipeline. */
+    readonly structuredLogs?: boolean;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -184,6 +186,10 @@ export function resolveTelemetryConfig(
         yaml.TELEMETRY_DEBUGBRIDGE,
         "telemetry.debugBridge",
     );
+    const yamlStructuredLogs = parseBoolean(
+        yaml.TELEMETRY_STRUCTUREDLOGS,
+        "telemetry.structuredLogs",
+    );
 
     // ---- Env values.
     const envGlobalEndpoint = requireNonEmpty(
@@ -206,6 +212,10 @@ export function resolveTelemetryConfig(
     const envDebugBridge = parseBoolean(
         env.TYPEAGENT_OTEL_DEBUG_BRIDGE,
         "TYPEAGENT_OTEL_DEBUG_BRIDGE",
+    );
+    const envStructuredLogs = parseBoolean(
+        env.TYPEAGENT_OTEL_STRUCTURED_LOGS,
+        "TYPEAGENT_OTEL_STRUCTURED_LOGS",
     );
 
     const signalEndpoints: Record<Signal, string | undefined> = {
@@ -301,6 +311,7 @@ export function resolveTelemetryConfig(
         metrics?: MetricConfig;
         logs?: LogConfig;
         debugBridge?: boolean;
+        structuredLogs?: boolean;
     } = {};
 
     if (tracesOtlp !== undefined) {
@@ -333,6 +344,10 @@ export function resolveTelemetryConfig(
     const debugBridge = envDebugBridge ?? yamlDebugBridge;
     if (debugBridge !== undefined) {
         result.debugBridge = debugBridge;
+    }
+    const structuredLogs = envStructuredLogs ?? yamlStructuredLogs;
+    if (structuredLogs !== undefined) {
+        result.structuredLogs = structuredLogs;
     }
 
     return result;

--- a/ts/packages/telemetry/src/otel/debugBridge.ts
+++ b/ts/packages/telemetry/src/otel/debugBridge.ts
@@ -17,6 +17,7 @@ export interface DebugModule {
 }
 
 export interface DebugBridgeOptions extends RedactionOptions {
+    readonly includedNamespacePrefixes?: readonly string[];
     readonly excludedNamespacePrefixes?: readonly string[];
 }
 
@@ -54,6 +55,7 @@ export function installDebugBridge(
         }
 
         const priorLog = debugModule.log;
+        const inclusions = options.includedNamespacePrefixes ?? ["typeagent:"];
         const exclusions =
             options.excludedNamespacePrefixes ?? DEFAULT_EXCLUSIONS;
         const wrappedLog: DebugModule["log"] = function (
@@ -65,7 +67,7 @@ export function installDebugBridge(
             if (
                 emitting ||
                 namespace === undefined ||
-                !namespace.startsWith("typeagent:") ||
+                !inclusions.some((prefix) => namespace.startsWith(prefix)) ||
                 exclusions.some((prefix) => namespace.startsWith(prefix))
             ) {
                 return result;

--- a/ts/packages/telemetry/src/otel/debugBridge.ts
+++ b/ts/packages/telemetry/src/otel/debugBridge.ts
@@ -28,7 +28,13 @@ export interface DebugBridge {
 interface InstalledBridge {
     readonly priorLog: DebugModule["log"];
     readonly wrappedLog: DebugModule["log"];
+    readonly options: EffectiveDebugBridgeOptions;
     refCount: number;
+}
+
+interface EffectiveDebugBridgeOptions extends RedactionOptions {
+    readonly includedNamespacePrefixes: readonly string[];
+    readonly excludedNamespacePrefixes: readonly string[];
 }
 
 const installedBridges = new WeakMap<DebugModule, InstalledBridge>();
@@ -45,8 +51,31 @@ export function installDebugBridge(
     debugModules: readonly DebugModule[],
     options: DebugBridgeOptions = {},
 ): DebugBridge {
+    const effectiveOptions: EffectiveDebugBridgeOptions = {
+        includedNamespacePrefixes: options.includedNamespacePrefixes ?? [
+            "typeagent:",
+        ],
+        excludedNamespacePrefixes:
+            options.excludedNamespacePrefixes ?? DEFAULT_EXCLUSIONS,
+        ...(options.secretFilter === undefined
+            ? {}
+            : { secretFilter: options.secretFilter }),
+    };
+    const uniqueModules = [...new Set(debugModules)];
+    for (const debugModule of uniqueModules) {
+        const existing = installedBridges.get(debugModule);
+        if (
+            existing !== undefined &&
+            !hasEquivalentOptions(existing.options, effectiveOptions)
+        ) {
+            throw new Error(
+                "Cannot install a debug bridge with different options on an already bridged debug module.",
+            );
+        }
+    }
+
     const installed: DebugModule[] = [];
-    for (const debugModule of new Set(debugModules)) {
+    for (const debugModule of uniqueModules) {
         const existing = installedBridges.get(debugModule);
         if (existing !== undefined) {
             existing.refCount++;
@@ -55,9 +84,6 @@ export function installDebugBridge(
         }
 
         const priorLog = debugModule.log;
-        const inclusions = options.includedNamespacePrefixes ?? ["typeagent:"];
-        const exclusions =
-            options.excludedNamespacePrefixes ?? DEFAULT_EXCLUSIONS;
         const wrappedLog: DebugModule["log"] = function (
             this: { namespace?: string },
             ...args: unknown[]
@@ -67,8 +93,12 @@ export function installDebugBridge(
             if (
                 emitting ||
                 namespace === undefined ||
-                !inclusions.some((prefix) => namespace.startsWith(prefix)) ||
-                exclusions.some((prefix) => namespace.startsWith(prefix))
+                !effectiveOptions.includedNamespacePrefixes.some((prefix) =>
+                    namespace.startsWith(prefix),
+                ) ||
+                effectiveOptions.excludedNamespacePrefixes.some((prefix) =>
+                    namespace.startsWith(prefix),
+                )
             ) {
                 return result;
             }
@@ -91,7 +121,7 @@ export function installDebugBridge(
                     const rendered = format(...args).replace(ANSI_ESCAPE, "");
                     const redacted =
                         rendered.length <= MAX_BODY_LENGTH
-                            ? redactText(rendered, options)
+                            ? redactText(rendered, effectiveOptions)
                             : undefined;
                     const body =
                         redacted !== undefined &&
@@ -121,6 +151,7 @@ export function installDebugBridge(
         installedBridges.set(debugModule, {
             priorLog,
             wrappedLog,
+            options: effectiveOptions,
             refCount: 1,
         });
         installed.push(debugModule);
@@ -149,4 +180,31 @@ export function installDebugBridge(
             }
         },
     };
+}
+
+function hasEquivalentOptions(
+    left: EffectiveDebugBridgeOptions,
+    right: EffectiveDebugBridgeOptions,
+): boolean {
+    return (
+        left.secretFilter === right.secretFilter &&
+        arraysEqual(
+            left.includedNamespacePrefixes,
+            right.includedNamespacePrefixes,
+        ) &&
+        arraysEqual(
+            left.excludedNamespacePrefixes,
+            right.excludedNamespacePrefixes,
+        )
+    );
+}
+
+function arraysEqual(
+    left: readonly string[],
+    right: readonly string[],
+): boolean {
+    return (
+        left.length === right.length &&
+        left.every((value, index) => value === right[index])
+    );
 }

--- a/ts/packages/telemetry/test/otelBootstrap.spec.ts
+++ b/ts/packages/telemetry/test/otelBootstrap.spec.ts
@@ -117,6 +117,24 @@ describe("telemetry bootstrap", () => {
         expect(configReads).toBe(1);
     });
 
+    it("installs and restores the configured debug bridge", async () => {
+        const coordinator = createCoordinator();
+        const priorLog = () => undefined;
+        const debugModule = { log: priorLog };
+
+        await coordinator.init({
+            config: { debugBridge: true },
+            debugModules: [debugModule],
+            debugBridge: {
+                includedNamespacePrefixes: ["typeagent:", "agent-server:"],
+            },
+        });
+
+        expect(debugModule.log).not.toBe(priorLog);
+        await coordinator.shutdown();
+        expect(debugModule.log).toBe(priorLog);
+    });
+
     it("creates only requested signals and shares one resource", async () => {
         const coordinator = createCoordinator();
         const resources: Resource[] = [];

--- a/ts/packages/telemetry/test/otelConfig.spec.ts
+++ b/ts/packages/telemetry/test/otelConfig.spec.ts
@@ -84,6 +84,27 @@ describe("resolveTelemetryConfig", () => {
         });
     });
 
+    it("resolves structured logs from YAML and environment", () => {
+        withTempWorkspace((root) => {
+            writeYaml(
+                root,
+                "config.local.yaml",
+                "telemetry:\n  structuredLogs: true\n",
+            );
+            expect(resolve(root).structuredLogs).toBe(true);
+            expect(
+                resolve(root, {
+                    env: { TYPEAGENT_OTEL_STRUCTURED_LOGS: "off" },
+                }).structuredLogs,
+            ).toBe(false);
+            expect(() =>
+                resolve(root, {
+                    env: { TYPEAGENT_OTEL_STRUCTURED_LOGS: "sometimes" },
+                }),
+            ).toThrow(/expected true\/false/);
+        });
+    });
+
     /* ------------------------------------------------------------------ */
     /* YAML endpoint                                                       */
     /* ------------------------------------------------------------------ */

--- a/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
+++ b/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
@@ -16,6 +16,7 @@ import {
     type ReadableLogRecord,
 } from "@opentelemetry/sdk-logs";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import registerDebug from "debug";
 
 import { createOtelLoggerSink } from "../src/logger/otelLoggerSink.js";
 import { installDebugBridge } from "../src/otel/debugBridge.js";
@@ -264,12 +265,49 @@ describe("debug bridge", () => {
 
         debugModule.log.call({ namespace: "agent-server:startup" }, "ready");
         debugModule.log.call({ namespace: "other:startup" }, "ignored");
+        debugModule.log.call(
+            { namespace: "typeagent:telemetry:promptLogger" },
+            "prompt",
+        );
 
         expect(exporter.getFinishedLogRecords()).toHaveLength(1);
         expect(
             exporter.getFinishedLogRecords()[0].attributes["debug.namespace"],
         ).toBe("agent-server:startup");
         bridge.shutdown();
+    });
+
+    it("captures real debug instances created before and after installation", () => {
+        const exporter = new InMemoryLogRecordExporter();
+        provider = new LoggerProvider({
+            processors: [new SimpleLogRecordProcessor({ exporter })],
+        });
+        logs.setGlobalLoggerProvider(provider);
+        const priorNamespaces = registerDebug.disable();
+        const priorLog = registerDebug.log;
+        registerDebug.log = () => undefined;
+        const before = registerDebug("typeagent:test:before");
+        const bridge = installDebugBridge([registerDebug]);
+
+        try {
+            registerDebug.enable("typeagent:test:*");
+            const after = registerDebug("typeagent:test:after");
+            before("created before installation");
+            after("created after installation");
+
+            const records = exporter.getFinishedLogRecords();
+            expect(records.map((record) => record.body)).toEqual([
+                "created before installation",
+                "created after installation",
+            ]);
+            expect(
+                records.map((record) => record.attributes["debug.namespace"]),
+            ).toEqual(["typeagent:test:before", "typeagent:test:after"]);
+        } finally {
+            bridge.shutdown();
+            registerDebug.log = priorLog;
+            registerDebug.enable(priorNamespaces);
+        }
     });
 
     it("does not overwrite a later owner during restoration", () => {
@@ -294,6 +332,21 @@ describe("debug bridge", () => {
         expect(debugModule.log).toBe(wrapped);
         second.shutdown();
         expect(debugModule.log).toBe(prior);
+    });
+
+    it("rejects conflicting options on an already bridged module", () => {
+        const debugModule = createDebugModule([]);
+        const first = installDebugBridge([debugModule]);
+        const wrapped = debugModule.log;
+
+        expect(() =>
+            installDebugBridge([debugModule], {
+                includedNamespacePrefixes: ["agent-server:"],
+            }),
+        ).toThrow(/different options/);
+        expect(debugModule.log).toBe(wrapped);
+
+        first.shutdown();
     });
 
     it("suppresses reentrant debug output from the OTel logger path", () => {

--- a/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
+++ b/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
@@ -247,6 +247,31 @@ describe("debug bridge", () => {
         expect(second.log).toBe(secondPrior);
     });
 
+    it("can include host-owned legacy debug namespace prefixes", () => {
+        const exporter = new InMemoryLogRecordExporter();
+        provider = new LoggerProvider({
+            processors: [new SimpleLogRecordProcessor({ exporter })],
+        });
+        logs.setGlobalLoggerProvider(provider);
+        const output: Array<{
+            namespace: string | undefined;
+            args: unknown[];
+        }> = [];
+        const debugModule = createDebugModule(output);
+        const bridge = installDebugBridge([debugModule], {
+            includedNamespacePrefixes: ["typeagent:", "agent-server:"],
+        });
+
+        debugModule.log.call({ namespace: "agent-server:startup" }, "ready");
+        debugModule.log.call({ namespace: "other:startup" }, "ignored");
+
+        expect(exporter.getFinishedLogRecords()).toHaveLength(1);
+        expect(
+            exporter.getFinishedLogRecords()[0].attributes["debug.namespace"],
+        ).toBe("agent-server:startup");
+        bridge.shutdown();
+    });
+
     it("does not overwrite a later owner during restoration", () => {
         const debugModule = createDebugModule([]);
         const bridge = installDebugBridge([debugModule]);


### PR DESCRIPTION
### Summary
Builds on the previously-landed `OtelLoggerSink`, debug bridge, and JSONL
exporter by **wiring them into every TypeAgent-owned Node host** and making
structured-log export **explicitly opt-in**. No new telemetry primitives — this
is composition, gating, and hardening. Existing `debug`/`DEBUG` output is
unchanged.

### Changes

**Configuration-driven structured logs**

• Adds  telemetry.structuredLogs , defaulting to  false  because dispatcher event payloads may contain user data.
• Supports the  TYPEAGENT_OTEL_STRUCTURED_LOGS  environment override.
• Hosts resolve telemetry configuration once and pass the effective value into  DispatcherOptions.telemetry.structuredLogs .
•  getLoggerSink  attaches  OtelLoggerSink  only when structured logging is enabled. Existing debug and database sinks are unchanged.
• Agent server, API, and standalone shell apply the setting to the dispatchers they create.

**Host telemetry and debug-bridge wiring**

• Wires  initTelemetry({ config, debugModules, debugBridge })  into the agent server, API, and shell composition roots.
• CLI entry points and agent subprocesses provide their  debug  module instances to telemetry initialization.
• Agent-server hosts include the legacy  agent-server:*  namespace without renaming namespaces or breaking existing  DEBUG  configurations.
• Prompt logger output remains intentionally excluded from the debug bridge.

**Agent subprocess support**

• Resolves an agent’s local  debug  package before telemetry initialization so separately installed module instances are bridged.
• Uses CommonJS resolution rather than importing an absolute filesystem path, preserving Windows compatibility.
• Extracts this behavior into  agentDebug.ts  with coverage for agent-local and shared module instances.

**Debug-bridge hardening**

• Adds configurable included namespace prefixes while retaining  typeagent:*  as the default.
• Tracks effective bridge options for each installed module.
• Rejects repeated installation with conflicting namespace or redaction options instead of silently ignoring the later policy.
• Preserves idempotent, reference-counted installation when options match.

**Tests**

• Covers real  debug  instances created before and after bridge installation.
• Covers multiple debug module instances, restoration, reference counting, and conflicting options.
• Verifies legacy namespace inclusion and continued prompt logger exclusion.
• Covers YAML and environment resolution for  telemetry.structuredLogs .
• Covers Windows-safe agent-local debug module loading.