### PR TITLE
Add model-agnostic prompt token estimator

### DIFF
--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=9020ad3b4340208500500b4a02eeee73948e278f18dc05dc5e10a59fafc558b1 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=d44d146be9d637f265637a8290e184cf5485c4152b0a25777e2866945e1874ee -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
 - [./src/core/types.ts](./src/core/types.ts)
-- _…and 35 more under `./src/`._
+- _…and 36 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `4e44414378e9f8f370bf12c647a306386d7f285e` on `2026-08-13T03:34:44.132Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `ced33869a1369ff7c998a3517bf17bc9739a05e5` on `2026-08-13T05:25:43.204Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=e4f31fe584d0b8a15131f184988d666199983827c0242eda49e7d99352642868 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=871b66e5cebfeefbf7c8b659a6e2ee975d0bd3b1bd67d5262caea8a6f9d3be5b -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
 - [./src/core/types.ts](./src/core/types.ts)
 - [./src/translationBench/action-parameters-grader.generated.json](./src/translationBench/action-parameters-grader.generated.json)
-- _…and 30 more under `./src/`._
+- _…and 32 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `4d9e9cb525dad7a61eb856ef197b7a64b2eea933` on `2026-08-12T22:15:08.507Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `9c0f9bde5a2142583732522ef8ed1dbc20cf8997` on `2026-08-12T23:27:36.029Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=18e93ccbeb725145e3c4e7bca9519458b1faf5346537c63d903247b2e5b42b01 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=9020ad3b4340208500500b4a02eeee73948e278f18dc05dc5e10a59fafc558b1 -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -49,13 +49,13 @@ _None._
 - [./src/core/model-prices.generated.json](./src/core/model-prices.generated.json)
 - [./src/core/paths.ts](./src/core/paths.ts)
 - [./src/core/prices.ts](./src/core/prices.ts)
+- [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
 - [./src/core/types.ts](./src/core/types.ts)
-- [./src/translationBench/action-parameters-grader.generated.json](./src/translationBench/action-parameters-grader.generated.json)
-- _…and 33 more under `./src/`._
+- _…and 35 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `1312ddf43add38c5aabe051fd8f9043686fd658b` on `2026-08-13T01:31:16.754Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `4e44414378e9f8f370bf12c647a306386d7f285e` on `2026-08-13T03:34:44.132Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=7f7e158592ba88a68bbf0957cce86942c6091a3925b946d21c9c7b13b3cb5fd2 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=e4f31fe584d0b8a15131f184988d666199983827c0242eda49e7d99352642868 -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -34,7 +34,7 @@ Workspace:
 - [agent-dispatcher](../../packages/dispatcher/dispatcher/README.md)
 - [default-agent-provider](../../packages/defaultAgentProvider/README.md)
 
-External: `commander`, `js-yaml`, `zod`
+External: `commander`, `gpt-tokenizer`, `js-yaml`, `zod`
 
 ### Used by
 
@@ -49,13 +49,13 @@ _None._
 - [./src/core/model-prices.generated.json](./src/core/model-prices.generated.json)
 - [./src/core/paths.ts](./src/core/paths.ts)
 - [./src/core/prices.ts](./src/core/prices.ts)
+- [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
 - [./src/core/types.ts](./src/core/types.ts)
 - [./src/translationBench/action-parameters-grader.generated.json](./src/translationBench/action-parameters-grader.generated.json)
-- [./src/translationBench/catalog.generated.json](./src/translationBench/catalog.generated.json)
-- _…and 29 more under `./src/`._
+- _…and 30 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `2f1ae13a34a138343a5b5113783950a8f1746724` on `2026-08-08T02:25:27.234Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `4d9e9cb525dad7a61eb856ef197b7a64b2eea933` on `2026-08-12T22:15:08.507Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=871b66e5cebfeefbf7c8b659a6e2ee975d0bd3b1bd67d5262caea8a6f9d3be5b -->
+<!-- AUTOGEN:DOCS:HASH:sha256=18e93ccbeb725145e3c4e7bca9519458b1faf5346537c63d903247b2e5b42b01 -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
 - [./src/core/types.ts](./src/core/types.ts)
 - [./src/translationBench/action-parameters-grader.generated.json](./src/translationBench/action-parameters-grader.generated.json)
-- _…and 32 more under `./src/`._
+- _…and 33 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `9c0f9bde5a2142583732522ef8ed1dbc20cf8997` on `2026-08-12T23:27:36.029Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `1312ddf43add38c5aabe051fd8f9043686fd658b` on `2026-08-13T01:31:16.754Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/package.json
+++ b/ts/packages/benchmarks/package.json
@@ -39,6 +39,7 @@
     "agent-dispatcher": "workspace:*",
     "commander": "^12.1.0",
     "default-agent-provider": "workspace:*",
+    "gpt-tokenizer": "^2.9.0",
     "js-yaml": "^4.3.1",
     "zod": "^4.1.13"
   },

--- a/ts/packages/benchmarks/src/core/tokenEstimate.ts
+++ b/ts/packages/benchmarks/src/core/tokenEstimate.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { countTokens } from "gpt-tokenizer/encoding/o200k_base";
+
+// o200k_base is a model-agnostic approximation of prompt-token cost for every
+// model the benchmark drives (GPT and non-GPT). It backs the rate limiter's
+// pre-flight reservation, which is later settled to actual reported usage; the
+// +5% overhead absorbs cross-tokenizer drift so we never underestimate.
+export const TOKEN_ESTIMATE_OVERHEAD = 0.05;
+
+export function estimatePromptTokens(text: string): number {
+    const base = countTokens(text);
+    return Math.ceil(base * (1 + TOKEN_ESTIMATE_OVERHEAD));
+}

--- a/ts/packages/benchmarks/src/index.ts
+++ b/ts/packages/benchmarks/src/index.ts
@@ -5,3 +5,4 @@ export * from "./core/paths.js";
 export * from "./core/types.js";
 export * from "./core/prices.js";
 export * from "./translationBench/index.js";
+export * from "./core/tokenEstimate.js";

--- a/ts/packages/benchmarks/test/tokenEstimate.spec.ts
+++ b/ts/packages/benchmarks/test/tokenEstimate.spec.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "@jest/globals";
+import { countTokens } from "gpt-tokenizer/encoding/o200k_base";
+
+import {
+    estimatePromptTokens,
+    TOKEN_ESTIMATE_OVERHEAD,
+} from "../src/core/tokenEstimate.js";
+
+describe("core tokenEstimate", () => {
+    it("adds the overhead offset over the raw o200k count", () => {
+        const text = "The quick brown fox jumps over the lazy dog.";
+        const raw = countTokens(text);
+        expect(estimatePromptTokens(text)).toBe(
+            Math.ceil(raw * (1 + TOKEN_ESTIMATE_OVERHEAD)),
+        );
+    });
+
+    it("never underestimates the raw token count", () => {
+        for (const text of ["", "a", "hello world", "x".repeat(2000)]) {
+            expect(estimatePromptTokens(text)).toBeGreaterThanOrEqual(
+                countTokens(text),
+            );
+        }
+    });
+
+    it("returns an integer token budget", () => {
+        const n = estimatePromptTokens(
+            "tokenization produces fractional overhead",
+        );
+        expect(Number.isInteger(n)).toBe(true);
+    });
+});

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -4075,6 +4075,9 @@ importers:
       default-agent-provider:
         specifier: workspace:*
         version: link:../defaultAgentProvider
+      gpt-tokenizer:
+        specifier: ^2.9.0
+        version: 2.9.0
       js-yaml:
         specifier: ^4.3.1
         version: 4.3.1
@@ -14017,6 +14020,9 @@ packages:
   got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
+
+  gpt-tokenizer@2.9.0:
+    resolution: {integrity: sha512-YSpexBL/k4bfliAzMrRqn3M6+it02LutVyhVpDeMKrC/O9+pCe/5s8U2hYKa2vFLD5/vHhsKc8sOn/qGqII8Kg==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -28692,6 +28698,8 @@ snapshots:
       lowercase-keys: 2.0.0
       p-cancelable: 2.1.1
       responselike: 2.0.1
+
+  gpt-tokenizer@2.9.0: {}
 
   graceful-fs@4.2.11: {}
 


### PR DESCRIPTION
Estimate prompt tokens with o200k_base plus overhead for rate-limiter reservations.