### PR TITLE
Complete MCP v2 extension management and security

### DIFF
--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -15,8 +15,7 @@ import {
 } from "agent-dispatcher/helpers/data";
 import {
     getDefaultAppAgentProviders,
-    getDefaultAppAgentSource,
-    getMcpAppAgentSource,
+    getDefaultAppAgentSources,
     getIndexingServiceRegistry,
     getDefaultConstructionProvider,
 } from "default-agent-provider";
@@ -340,10 +339,9 @@ async function main() {
                     instanceDir,
                     configName,
                 ),
-                appAgentSources: [
-                    getDefaultAppAgentSource(instanceDir, { configName }),
-                    getMcpAppAgentSource(instanceDir),
-                ],
+                appAgentSources: getDefaultAppAgentSources(instanceDir, {
+                    configName,
+                }),
                 persistSession: true,
                 storageProvider: getFsStorageProvider(),
                 metrics: true,

--- a/ts/packages/api/src/webDispatcher.ts
+++ b/ts/packages/api/src/webDispatcher.ts
@@ -16,8 +16,7 @@ import { createDispatcherRpcServer } from "@typeagent/dispatcher-rpc/dispatcher/
 import { createChannelAdapter } from "@typeagent/agent-rpc/channel";
 import {
     getDefaultAppAgentProviders,
-    getDefaultAppAgentSource,
-    getMcpAppAgentSource,
+    getDefaultAppAgentSources,
     getDefaultConstructionProvider,
     getIndexingServiceRegistry,
 } from "default-agent-provider";
@@ -54,12 +53,9 @@ export async function createWebDispatcher(
     const clientIO = createClientIORpcClient(clientIOChannel.channel);
     const dispatcher = await createDispatcher("api", {
         appAgentProviders: getDefaultAppAgentProviders(instanceDir),
-        appAgentSources: [
-            getDefaultAppAgentSource(instanceDir, {
-                excludePathSources: true,
-            }),
-            getMcpAppAgentSource(instanceDir),
-        ],
+        appAgentSources: getDefaultAppAgentSources(instanceDir, {
+            excludePathSources: true,
+        }),
         persistSession: true,
         persistDir: instanceDir,
         storageProvider: getFsStorageProvider(),

--- a/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
+++ b/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
@@ -22,9 +22,11 @@ import {
     InstallPreview,
     InstallPreviewMatch,
     InstallResult,
+    McpInstallCandidate,
     UpdateResult,
     deriveMatchKind,
 } from "./installSources/config.js";
+import { cleanupOwnedMcpPaths } from "./installSources/mcpRegistryMaterializer.js";
 import {
     createPackageAppAgentProvider,
     AgentSourceGroup,
@@ -32,6 +34,8 @@ import {
     InstalledAgentInfo,
     InstalledAgentSourceApi,
 } from "./installSources/packageAgent.js";
+import type { McpServerSourceApi } from "./mcp/mcpAppAgentSource.js";
+import type { NormalizedMcpServerConfig } from "./mcp/mcpServerConfig.js";
 
 import fs from "node:fs";
 import path from "node:path";
@@ -375,6 +379,8 @@ export function createDefaultInstalledAgentSource(
     sourceFactory?: InstallSourceFactory,
     /** @internal Test-only store writer for exercising commit failures. */
     storeWriter: typeof writeAgentsJson = writeAgentsJson,
+    /** MCP runtime API shared with this source's per-session @package agent. */
+    mcpSource?: McpServerSourceApi,
 ): InstalledAgentSourceForTest {
     const instanceConfigs = getInstanceConfigProvider(instanceDir);
     const installDir = getInstallDir(instanceConfigs);
@@ -1265,9 +1271,18 @@ export function createDefaultInstalledAgentSource(
                 registry,
                 recordsUsingSource: (sourceName: string) => {
                     const agents = readAgentsJson(instanceDir)?.agents ?? {};
-                    return Object.values(agents)
+                    const agentNames = Object.values(agents)
                         .filter((record) => record.source === sourceName)
                         .map((record) => record.name);
+                    const mcpNames =
+                        mcpSource
+                            ?.listServers()
+                            .filter(
+                                (config) =>
+                                    config.provenance.source === sourceName,
+                            )
+                            .map((config) => config.name) ?? [];
+                    return [...agentNames, ...mcpNames];
                 },
             });
         },
@@ -1442,6 +1457,36 @@ export function createDefaultInstalledAgentSource(
                 matches: result.matches.map(toMatch),
             };
         },
+        async resolveMcp(
+            ref: string,
+            sourceName?: string,
+            onStatus?: SourceStatus,
+        ): Promise<McpInstallCandidate[]> {
+            return registry.resolveMcp(ref, sourceName, undefined, onStatus);
+        },
+        async materializeMcp(
+            candidate: McpInstallCandidate,
+            abortSignal?: AbortSignal,
+        ): Promise<NormalizedMcpServerConfig> {
+            return candidate.materialize === undefined
+                ? candidate.config
+                : candidate.materialize(abortSignal);
+        },
+        cleanupMcp(config: NormalizedMcpServerConfig): void {
+            const referencedPaths = new Set(
+                mcpSource
+                    ?.listServers()
+                    .filter((other) => other.id !== config.id)
+                    .flatMap((other) => other.provenance.ownedPaths ?? []) ??
+                    [],
+            );
+            cleanupOwnedMcpPaths(
+                resolvedInstallDir,
+                config.provenance.ownedPaths?.filter(
+                    (ownedPath) => !referencedPaths.has(ownedPath),
+                ),
+            );
+        },
         async refresh(sourceName?: string): Promise<void> {
             // Refresh cache-backed source metadata; a fetch failure propagates
             // so the `--refresh` command fails rather than acting on stale data.
@@ -1460,6 +1505,7 @@ export function createDefaultInstalledAgentSource(
             const packageProvider = createPackageAppAgentProvider({
                 appAgentProviderSetController: controller,
                 source,
+                ...(mcpSource === undefined ? {} : { mcpSource }),
             });
             // Torn down before the initial set resolved: a connection disposed
             // while still parked on an in-flight barrier must NOT join the

--- a/ts/packages/defaultAgentProvider/src/defaultAgentRuntime.ts
+++ b/ts/packages/defaultAgentProvider/src/defaultAgentRuntime.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { AppAgentSource } from "agent-dispatcher";
+import {
+    createDefaultInstalledAgentSource,
+    DefaultAppAgentSourceOptions,
+} from "./defaultAgentProviders.js";
+import { createMcpAppAgentSourceForInstance } from "./mcpDefaultAgentProvider.js";
+import { getInstanceConfigProvider } from "./utils/config.js";
+import type { InstalledAgentSourceApi } from "./installSources/packageAgent.js";
+import type { McpServerSourceApi } from "./mcp/mcpAppAgentSource.js";
+import type { McpHostServices } from "./mcp/mcpServerProvider.js";
+import { SessionMcpCredentialStore } from "./mcp/mcpCredentialStore.js";
+import { defaultMcpPolicy } from "./mcp/mcpPolicy.js";
+import { JsonlMcpAuditSink } from "./mcp/mcpAudit.js";
+
+export interface DefaultAgentRuntime {
+    readonly appAgentSources: [AppAgentSource, AppAgentSource];
+    readonly installedAgentSourceApi: InstalledAgentSourceApi;
+    readonly mcpServerSourceApi: McpServerSourceApi;
+}
+
+export function createDefaultAgentRuntime(
+    instanceDir: string,
+    options?: DefaultAppAgentSourceOptions,
+    mcpServices?: Partial<McpHostServices>,
+): DefaultAgentRuntime {
+    const services: McpHostServices = {
+        credentialStore:
+            mcpServices?.credentialStore ?? new SessionMcpCredentialStore(),
+        policy: mcpServices?.policy ?? defaultMcpPolicy,
+        audit: mcpServices?.audit ?? new JsonlMcpAuditSink(instanceDir),
+        ...(mcpServices?.oauthInteraction === undefined
+            ? {}
+            : { oauthInteraction: mcpServices.oauthInteraction }),
+    };
+    const mcp = createMcpAppAgentSourceForInstance(
+        getInstanceConfigProvider(instanceDir),
+        services,
+    );
+    const installed = createDefaultInstalledAgentSource(
+        instanceDir,
+        options,
+        undefined,
+        undefined,
+        mcp.testApi,
+    );
+    const { testApi: installedAgentSourceApi, ...installedSource } = installed;
+    const { testApi: mcpServerSourceApi, ...mcpSource } = mcp;
+    return {
+        appAgentSources: [installedSource, mcpSource],
+        installedAgentSourceApi,
+        mcpServerSourceApi,
+    };
+}
+
+export function getDefaultAppAgentSources(
+    instanceDir: string,
+    options?: DefaultAppAgentSourceOptions,
+): [AppAgentSource, AppAgentSource] {
+    return createDefaultAgentRuntime(instanceDir, options).appAgentSources;
+}

--- a/ts/packages/defaultAgentProvider/src/index.ts
+++ b/ts/packages/defaultAgentProvider/src/index.ts
@@ -8,7 +8,29 @@ export {
     getIndexingServiceRegistry,
 } from "./defaultAgentProviders.js";
 export { getMcpAppAgentSource } from "./mcpDefaultAgentProvider.js";
+export {
+    createDefaultAgentRuntime,
+    getDefaultAppAgentSources,
+    type DefaultAgentRuntime,
+} from "./defaultAgentRuntime.js";
 export { getDefaultConstructionProvider } from "./defaultConstructionProvider.js";
+export {
+    SessionMcpCredentialStore,
+    type McpCredentialStore,
+} from "./mcp/mcpCredentialStore.js";
+export {
+    defaultMcpPolicy,
+    enforceMcpPolicy,
+    type McpPolicy,
+} from "./mcp/mcpPolicy.js";
+export {
+    JsonlMcpAuditSink,
+    sanitizeMcpAuditEvent,
+    type McpAuditEvent,
+    type McpAuditSink,
+} from "./mcp/mcpAudit.js";
+export type { McpOAuthInteraction } from "./mcp/mcpOAuth.js";
+export type { McpHostServices } from "./mcp/mcpServerProvider.js";
 export {
     createOnboardingOnlyDispatcher,
     type OnboardingDispatcherHandle,

--- a/ts/packages/defaultAgentProvider/src/installSources/addSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/addSource.ts
@@ -14,6 +14,7 @@ import {
     FeedSourceConfig,
     McpConfigSourceConfig,
     PathSourceConfig,
+    RegistrySourceConfig,
 } from "./config.js";
 import { DefaultInstallSourceRegistry } from "./registry.js";
 import { expandHome } from "./paths.js";
@@ -35,9 +36,28 @@ function validateFeedRegistry(url: string): void {
     } catch {
         throw new Error(`'${url}' is not a well-formed URL`);
     }
+
     if (parsed.protocol !== "https:") {
         throw new Error(`feed registry URL must be https: '${url}'`);
     }
+}
+
+function validateRegistryUrl(url: string): string {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`'${url}' is not a well-formed URL`);
+    }
+    if (parsed.protocol !== "https:") {
+        throw new Error(`MCP Registry URL must be https: '${url}'`);
+    }
+    parsed.search = "";
+    parsed.hash = "";
+    if (!parsed.pathname.endsWith("/")) {
+        parsed.pathname += "/";
+    }
+    return parsed.toString();
 }
 
 function validateCatalogFile(catalog: string): void {
@@ -208,6 +228,7 @@ class McpConfigAddCommandHandler implements CommandHandler {
                 "--file <path> is required for an mcp-config source",
             );
         }
+
         const normalizedFile = normalizeAbsolutePath(file);
         try {
             JSON.parse(fs.readFileSync(normalizedFile, "utf8"));
@@ -218,6 +239,7 @@ class McpConfigAddCommandHandler implements CommandHandler {
                     `MCP config file '${normalizedFile}' is not accessible: ${err.message}`,
                 );
             }
+
             throw new Error(
                 `MCP config '${normalizedFile}' is not valid JSON: ${err.message}`,
             );
@@ -229,6 +251,53 @@ class McpConfigAddCommandHandler implements CommandHandler {
         };
         this.registry.add(config);
         displayResult(`Added mcp-config source '${name}'.`, context);
+    }
+}
+
+class RegistryAddCommandHandler implements CommandHandler {
+    public readonly description = "Add an MCP Registry v0.1 install source";
+    public readonly parameters = {
+        args: {
+            name: { description: "Unique source name", type: "string" },
+        },
+        flags: {
+            url: {
+                description: "MCP Registry base URL (https)",
+                char: "u",
+                type: "string",
+            },
+            "cache-ttl": {
+                description: "Metadata cache TTL in seconds",
+                type: "number",
+                optional: true,
+            },
+        },
+    } as const;
+    constructor(private readonly registry: DefaultInstallSourceRegistry) {}
+    public async run(
+        context: ActionContext<unknown>,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ) {
+        const url = params.flags.url;
+        if (url === undefined) {
+            throw new Error(
+                "--url <https-url> is required for a registry source",
+            );
+        }
+        const ttlSeconds = params.flags["cache-ttl"];
+        if (ttlSeconds !== undefined && ttlSeconds <= 0) {
+            throw new Error("--cache-ttl must be greater than zero");
+        }
+        const config: RegistrySourceConfig = {
+            kind: "registry",
+            name: params.args.name,
+            baseUrl: validateRegistryUrl(url),
+            ...(ttlSeconds === undefined
+                ? {}
+                : { cacheTtlMs: ttlSeconds * 1000 }),
+        };
+        this.registry.add(config);
+        displayResult(`Added registry source '${params.args.name}'.`, context);
     }
 }
 
@@ -247,6 +316,7 @@ export function getAddSourceCommandHandlers(
             catalog: new CatalogAddCommandHandler(registry),
             path: new PathAddCommandHandler(registry),
             "mcp-config": new McpConfigAddCommandHandler(registry),
+            registry: new RegistryAddCommandHandler(registry),
         },
     };
 }

--- a/ts/packages/defaultAgentProvider/src/installSources/config.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/config.ts
@@ -14,6 +14,8 @@
 // core, and lets the host decide how a source is added, listed, ordered,
 // removed, and persisted, including any future auth UI.
 
+import type { NormalizedMcpServerConfig } from "../mcp/mcpServerConfig.js";
+
 /**
  * The result of a source's `find`: which source matched and how the agent
  * should be acquired. If `find` returns a candidate, `materialize` must
@@ -78,6 +80,24 @@ export interface ResolvedCandidate {
  * one `@package` command surface can manage both.
  */
 export type ExtensionKind = "agent" | "mcp";
+
+/**
+ * A normalized MCP artifact resolved by an install source. MCP candidates stay
+ * separate from native {@link ResolvedCandidate} records because they are
+ * persisted by the MCP server store and never pass through native agent
+ * materialization or agents.json.
+ */
+export interface McpInstallCandidate {
+    readonly extensionKind: "mcp";
+    readonly source: string;
+    readonly sourceKind: string;
+    readonly ref: string;
+    readonly config: NormalizedMcpServerConfig;
+    /** Materialize owned local content after user confirmation. */
+    readonly materialize?: (
+        abortSignal?: AbortSignal,
+    ) => Promise<NormalizedMcpServerConfig>;
+}
 
 /**
  * One enumerable install target advertised by a source for `@package available`
@@ -308,7 +328,12 @@ export type UninstallOutcomeStatus = "uninstalled" | "reverted";
  * provider, not an install source (they are never installed/uninstalled/
  * updated). Install sources only resolve user-installed agents.
  */
-export type InstallSourceKind = "path" | "catalog" | "feed" | "mcp-config";
+export type InstallSourceKind =
+    | "path"
+    | "catalog"
+    | "feed"
+    | "mcp-config"
+    | "registry";
 
 /**
  * A `path` source validates a filesystem path the user supplies. `ref` is a
@@ -365,7 +390,8 @@ export type InstallSourceConfig =
     | PathSourceConfig
     | FeedSourceConfig
     | CatalogSourceConfig
-    | McpConfigSourceConfig;
+    | McpConfigSourceConfig
+    | RegistrySourceConfig;
 
 /**
  * An `mcp-config` source enumerates MCP servers declared in a local MCP config
@@ -381,6 +407,16 @@ export interface McpConfigSourceConfig {
     kind: "mcp-config";
     name: string; // e.g. "mcp-config"
     file: string; // local filesystem path to the MCP config JSON
+}
+
+/** A read-only MCP Registry v0.1 discovery and installation source. */
+export interface RegistrySourceConfig {
+    kind: "registry";
+    name: string;
+    baseUrl: string;
+    cachePath?: string;
+    cacheTtlMs?: number;
+    maxPages?: number;
 }
 
 /**
@@ -415,6 +451,14 @@ export interface InstallSource {
         ref: string,
         onWarn?: SourceWarning,
     ): Promise<ResolvedCandidate | undefined>;
+    /**
+     * Resolve an MCP artifact by its source-local ref. Sources that do not
+     * provide MCP artifacts omit this method.
+     */
+    findMcp?(
+        ref: string,
+        onWarn?: SourceWarning,
+    ): Promise<McpInstallCandidate | undefined>;
     /**
      * Optional default-agent-name lookup for one-argument install (phase 1).
      * Matches the package's declared `typeagent.defaultAgentName`. Returning a

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpConfigSource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpConfigSource.ts
@@ -7,6 +7,7 @@ import {
     InstallSource,
     McpConfigSourceConfig,
     MaterializedInstallRecord,
+    McpInstallCandidate,
     ResolvedCandidate,
     SourceWarning,
     AvailableInstallRow,
@@ -63,26 +64,13 @@ function loadFile(file: string): unknown {
  * and enumerates the normalized servers as `extensionKind: "mcp"` rows for
  * `@package available --type mcp`.
  *
- * It deliberately does NOT participate in the native-agent resolution walk:
- * `find` / `findName` return `undefined` so an MCP server name never resolves
- * as an installable npm agent. Actually adding an MCP server routes through the
- * MCP server store / {@link ../mcp/mcpAppAgentSource.McpServerSourceApi}, kept as
- * a separate store behind the unified `@package` facade per the near-term
- * staging plan; `materialize` therefore throws if ever reached.
- *
- * `getServers` exposes the normalized snapshot so the facade (and tests) can
- * pull a named server's config to hand to the MCP source.
+ * It deliberately does NOT participate in the native-agent resolution walk.
+ * MCP artifacts resolve through `findMcp`, which returns a normalized
+ * candidate for the MCP store without materializing an InstalledAgentRecord.
  */
-export interface McpConfigInstallSource extends InstallSource {
-    // The normalized configs of every server that imported cleanly, keyed by
-    // server name. Used by the `@package` facade to route an MCP install to the
-    // MCP server store.
-    getServers(): ReadonlyMap<string, NormalizedMcpServerConfig>;
-}
-
 export function createMcpConfigSource(
     config: McpConfigSourceConfig,
-): McpConfigInstallSource {
+): InstallSource {
     function buildSnapshot(): McpConfigSnapshot {
         const entryWarnings: string[] = [];
         let parsed: unknown;
@@ -108,17 +96,21 @@ export function createMcpConfigSource(
         return { serversByName, entryWarnings };
     }
 
-    const snapshot = buildSnapshot();
-
-    function warnLoad(onWarn?: SourceWarning): void {
+    function warnLoad(
+        snapshot: McpConfigSnapshot,
+        onWarn?: SourceWarning,
+    ): void {
         if (snapshot.loadWarning !== undefined) {
             debug(snapshot.loadWarning);
             onWarn?.(snapshot.loadWarning);
         }
     }
 
-    function warnAll(onWarn?: SourceWarning): void {
-        warnLoad(onWarn);
+    function warnAll(
+        snapshot: McpConfigSnapshot,
+        onWarn?: SourceWarning,
+    ): void {
+        warnLoad(snapshot, onWarn);
         for (const message of snapshot.entryWarnings) {
             debug(message);
             onWarn?.(message);
@@ -131,14 +123,40 @@ export function createMcpConfigSource(
         describe(): string {
             return config.file;
         },
-        getServers(): ReadonlyMap<string, NormalizedMcpServerConfig> {
-            return snapshot.serversByName;
-        },
         // An MCP server is not a native npm agent: never resolve one through the
         // agent resolution walk. The unified `@package` facade routes MCP
         // installs to the MCP server store instead (see class doc).
         async find(): Promise<ResolvedCandidate | undefined> {
             return undefined;
+        },
+        async findMcp(
+            ref: string,
+            onWarn?: SourceWarning,
+        ): Promise<McpInstallCandidate | undefined> {
+            const snapshot = buildSnapshot();
+            warnLoad(snapshot, onWarn);
+            const imported = snapshot.serversByName.get(ref);
+            if (imported === undefined) {
+                return undefined;
+            }
+            return {
+                extensionKind: "mcp",
+                source: config.name,
+                sourceKind: config.kind,
+                ref,
+                config: {
+                    ...imported,
+                    id: `mcp:${encodeURIComponent(config.name)}:${encodeURIComponent(ref)}`,
+                    enabled: false,
+                    trust: "untrusted",
+                    scope: "workspace",
+                    provenance: {
+                        source: config.name,
+                        sourceKind: config.kind,
+                        ref,
+                    },
+                },
+            };
         },
         async materialize(): Promise<MaterializedInstallRecord> {
             throw new Error(
@@ -149,7 +167,8 @@ export function createMcpConfigSource(
         async listAgents(
             onWarn?: SourceWarning,
         ): Promise<AvailableInstallRow[]> {
-            warnAll(onWarn);
+            const snapshot = buildSnapshot();
+            warnAll(snapshot, onWarn);
             const rows: AvailableInstallRow[] = [];
             for (const [name, server] of snapshot.serversByName) {
                 const row: AvailableInstallRow = {

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryCache.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryCache.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import path from "node:path";
+import type { RegistryServerEntry } from "./mcpRegistryClient.js";
+
+export interface RegistryCacheData {
+    fetchedAt: number;
+    updatedSince: string;
+    entries: RegistryServerEntry[];
+}
+
+export interface RegistryCacheStorage {
+    read(): RegistryCacheData | undefined;
+    write(data: RegistryCacheData): void;
+}
+
+export function createRegistryCacheStorage(
+    filePath: string,
+): RegistryCacheStorage {
+    return {
+        read() {
+            try {
+                return JSON.parse(
+                    fs.readFileSync(filePath, "utf8"),
+                ) as RegistryCacheData;
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                    return undefined;
+                }
+                throw error;
+            }
+        },
+        write(data) {
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            const temp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+            try {
+                fs.writeFileSync(temp, JSON.stringify(data, null, 2));
+                fs.renameSync(temp, filePath);
+            } finally {
+                fs.rmSync(temp, { force: true });
+            }
+        },
+    };
+}
+
+export function mergeRegistryCache(
+    previous: RegistryServerEntry[],
+    updates: RegistryServerEntry[],
+): RegistryServerEntry[] {
+    const byKey = new Map(
+        previous.map((entry) => [
+            `${entry.server.name}\0${entry.server.version}`,
+            entry,
+        ]),
+    );
+    for (const entry of updates) {
+        const key = `${entry.server.name}\0${entry.server.version}`;
+        if (entry.meta.status === "deleted") {
+            byKey.delete(key);
+        } else {
+            if (entry.meta.isLatest) {
+                for (const [existingKey, existing] of byKey) {
+                    if (
+                        existing.server.name === entry.server.name &&
+                        existing.meta.isLatest
+                    ) {
+                        byKey.delete(existingKey);
+                    }
+                }
+            }
+            byKey.set(key, entry);
+        }
+    }
+    return [...byKey.values()];
+}

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryClient.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryClient.ts
@@ -1,0 +1,358 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type RegistryStatus = "active" | "deprecated" | "deleted";
+
+export interface RegistryInput {
+    value?: string | undefined;
+    default?: string | undefined;
+    isRequired?: boolean | undefined;
+    isSecret?: boolean | undefined;
+    format?: string | undefined;
+}
+
+export interface RegistryArgument extends RegistryInput {
+    type: string;
+    name?: string | undefined;
+    valueHint?: string | undefined;
+    variables?: Record<string, RegistryInput> | undefined;
+}
+
+export interface RegistryKeyValue extends RegistryInput {
+    name: string;
+    variables?: Record<string, RegistryInput> | undefined;
+}
+
+export interface RegistryTransport {
+    type: string;
+    url?: string | undefined;
+    headers?: RegistryKeyValue[] | undefined;
+    variables?: Record<string, RegistryInput> | undefined;
+}
+
+export interface RegistryPackage {
+    registryType: string;
+    identifier: string;
+    version?: string | undefined;
+    registryBaseUrl?: string | undefined;
+    fileSha256?: string | undefined;
+    runtimeHint?: string | undefined;
+    runtimeArguments?: RegistryArgument[] | undefined;
+    packageArguments?: RegistryArgument[] | undefined;
+    environmentVariables?: RegistryKeyValue[] | undefined;
+    transport: RegistryTransport;
+}
+
+export interface RegistryServer {
+    name: string;
+    title?: string | undefined;
+    description: string;
+    version: string;
+    repository?: Record<string, unknown> | undefined;
+    packages?: RegistryPackage[] | undefined;
+    remotes?: RegistryTransport[] | undefined;
+    publisher?: Record<string, unknown> | undefined;
+}
+
+export interface RegistryServerEntry {
+    server: RegistryServer;
+    meta: {
+        status: RegistryStatus;
+        statusMessage?: string | undefined;
+        updatedAt?: string | undefined;
+        publishedAt: string;
+        isLatest: boolean;
+    };
+}
+
+export interface RegistryListOptions {
+    search?: string | undefined;
+    version?: string | undefined;
+    updatedSince?: string | undefined;
+    includeDeleted?: boolean | undefined;
+    limit?: number | undefined;
+    maxPages?: number | undefined;
+}
+
+export interface McpRegistryClient {
+    list(options?: RegistryListOptions): Promise<RegistryServerEntry[]>;
+    get(
+        name: string,
+        version?: string,
+    ): Promise<RegistryServerEntry | undefined>;
+}
+
+type FetchFn = typeof fetch;
+
+function object(value: unknown, label: string): Record<string, unknown> {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`MCP Registry returned invalid ${label}`);
+    }
+    return value as Record<string, unknown>;
+}
+
+function string(value: unknown, label: string): string {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new Error(`MCP Registry returned invalid ${label}`);
+    }
+    return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function parseInput(value: unknown): RegistryInput {
+    const raw = object(value, "input");
+    return {
+        ...(optionalString(raw.value) === undefined
+            ? {}
+            : { value: optionalString(raw.value) }),
+        ...(optionalString(raw.default) === undefined
+            ? {}
+            : { default: optionalString(raw.default) }),
+        ...(typeof raw.isRequired === "boolean"
+            ? { isRequired: raw.isRequired }
+            : {}),
+        ...(typeof raw.isSecret === "boolean"
+            ? { isSecret: raw.isSecret }
+            : {}),
+        ...(optionalString(raw.format) === undefined
+            ? {}
+            : { format: optionalString(raw.format) }),
+    };
+}
+
+function parseVariables(
+    value: unknown,
+): Record<string, RegistryInput> | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    const raw = object(value, "variables");
+    return Object.fromEntries(
+        Object.entries(raw).map(([name, input]) => [name, parseInput(input)]),
+    );
+}
+
+function parseKeyValues(value: unknown): RegistryKeyValue[] | undefined {
+    if (value == null) {
+        return undefined;
+    }
+    if (!Array.isArray(value)) {
+        throw new Error("MCP Registry returned invalid key/value inputs");
+    }
+    return value.map((entry) => {
+        const raw = object(entry, "key/value input");
+        return {
+            ...parseInput(raw),
+            name: string(raw.name, "key/value input name"),
+            ...(parseVariables(raw.variables) === undefined
+                ? {}
+                : { variables: parseVariables(raw.variables) }),
+        };
+    });
+}
+
+function parseArguments(value: unknown): RegistryArgument[] | undefined {
+    if (value == null) {
+        return undefined;
+    }
+    if (!Array.isArray(value)) {
+        throw new Error("MCP Registry returned invalid arguments");
+    }
+    return value.map((entry) => {
+        const raw = object(entry, "argument");
+        return {
+            ...parseInput(raw),
+            type: string(raw.type, "argument type"),
+            ...(optionalString(raw.name) === undefined
+                ? {}
+                : { name: optionalString(raw.name) }),
+            ...(optionalString(raw.valueHint) === undefined
+                ? {}
+                : { valueHint: optionalString(raw.valueHint) }),
+            ...(parseVariables(raw.variables) === undefined
+                ? {}
+                : { variables: parseVariables(raw.variables) }),
+        };
+    });
+}
+
+function parseTransport(value: unknown): RegistryTransport {
+    const raw = object(value, "transport");
+    return {
+        type: string(raw.type, "transport type"),
+        ...(optionalString(raw.url) === undefined
+            ? {}
+            : { url: optionalString(raw.url) }),
+        ...(parseKeyValues(raw.headers) === undefined
+            ? {}
+            : { headers: parseKeyValues(raw.headers) }),
+        ...(parseVariables(raw.variables) === undefined
+            ? {}
+            : { variables: parseVariables(raw.variables) }),
+    };
+}
+
+function parsePackage(value: unknown): RegistryPackage {
+    const raw = object(value, "package");
+    return {
+        registryType: string(raw.registryType, "package registryType"),
+        identifier: string(raw.identifier, "package identifier"),
+        transport: parseTransport(raw.transport),
+        ...(optionalString(raw.version) === undefined
+            ? {}
+            : { version: optionalString(raw.version) }),
+        ...(optionalString(raw.registryBaseUrl) === undefined
+            ? {}
+            : { registryBaseUrl: optionalString(raw.registryBaseUrl) }),
+        ...(optionalString(raw.fileSha256) === undefined
+            ? {}
+            : { fileSha256: optionalString(raw.fileSha256) }),
+        ...(optionalString(raw.runtimeHint) === undefined
+            ? {}
+            : { runtimeHint: optionalString(raw.runtimeHint) }),
+        ...(parseArguments(raw.runtimeArguments) === undefined
+            ? {}
+            : { runtimeArguments: parseArguments(raw.runtimeArguments) }),
+        ...(parseArguments(raw.packageArguments) === undefined
+            ? {}
+            : { packageArguments: parseArguments(raw.packageArguments) }),
+        ...(parseKeyValues(raw.environmentVariables) === undefined
+            ? {}
+            : {
+                  environmentVariables: parseKeyValues(
+                      raw.environmentVariables,
+                  ),
+              }),
+    };
+}
+
+export function parseRegistryEntry(value: unknown): RegistryServerEntry {
+    const raw = object(value, "server entry");
+    const serverRaw = object(raw.server, "server");
+    const responseMeta = object(raw._meta, "server metadata");
+    const metaRaw = object(
+        responseMeta["io.modelcontextprotocol.registry/official"],
+        "official registry metadata",
+    );
+    const status = string(metaRaw.status, "server status");
+    if (!["active", "deprecated", "deleted"].includes(status)) {
+        throw new Error(
+            `MCP Registry returned unknown server status '${status}'`,
+        );
+    }
+    const packages = serverRaw.packages;
+    const remotes = serverRaw.remotes;
+    return {
+        server: {
+            name: string(serverRaw.name, "server name"),
+            description: string(serverRaw.description, "server description"),
+            version: string(serverRaw.version, "server version"),
+            ...(optionalString(serverRaw.title) === undefined
+                ? {}
+                : { title: optionalString(serverRaw.title) }),
+            ...(serverRaw.repository === undefined
+                ? {}
+                : { repository: object(serverRaw.repository, "repository") }),
+            ...(serverRaw._meta === undefined
+                ? {}
+                : {
+                      publisher: object(serverRaw._meta, "publisher metadata"),
+                  }),
+            ...(packages == null
+                ? {}
+                : Array.isArray(packages)
+                  ? { packages: packages.map(parsePackage) }
+                  : (() => {
+                        throw new Error(
+                            "MCP Registry returned invalid packages",
+                        );
+                    })()),
+            ...(remotes == null
+                ? {}
+                : Array.isArray(remotes)
+                  ? { remotes: remotes.map(parseTransport) }
+                  : (() => {
+                        throw new Error(
+                            "MCP Registry returned invalid remotes",
+                        );
+                    })()),
+        },
+        meta: {
+            status: status as RegistryStatus,
+            statusMessage: optionalString(metaRaw.statusMessage),
+            updatedAt: optionalString(metaRaw.updatedAt),
+            publishedAt: string(metaRaw.publishedAt, "publishedAt"),
+            isLatest: metaRaw.isLatest === true,
+        },
+    };
+}
+
+export function createMcpRegistryClient(
+    baseUrl: string,
+    fetchFn: FetchFn = fetch,
+    defaultMaxPages = 20,
+): McpRegistryClient {
+    const base = new URL(baseUrl);
+    async function request(url: URL): Promise<unknown | undefined> {
+        const response = await fetchFn(url, {
+            headers: { accept: "application/json" },
+        });
+        if (response.status === 404) {
+            return undefined;
+        }
+        if (!response.ok) {
+            throw new Error(
+                `MCP Registry request failed (${response.status} ${response.statusText})`,
+            );
+        }
+        return response.json();
+    }
+    return {
+        async list(options = {}) {
+            const entries: RegistryServerEntry[] = [];
+            let cursor: string | undefined;
+            const maxPages = options.maxPages ?? defaultMaxPages;
+            for (let page = 0; page < maxPages; page++) {
+                const url = new URL("v0.1/servers", base);
+                if (options.search !== undefined)
+                    url.searchParams.set("search", options.search);
+                if (options.version !== undefined)
+                    url.searchParams.set("version", options.version);
+                if (options.updatedSince !== undefined)
+                    url.searchParams.set("updated_since", options.updatedSince);
+                if (options.includeDeleted !== undefined)
+                    url.searchParams.set(
+                        "include_deleted",
+                        String(options.includeDeleted),
+                    );
+                url.searchParams.set("limit", String(options.limit ?? 100));
+                if (cursor !== undefined)
+                    url.searchParams.set("cursor", cursor);
+                const body = object(await request(url), "list response");
+                if (!Array.isArray(body.servers)) {
+                    throw new Error(
+                        "MCP Registry returned invalid servers list",
+                    );
+                }
+                entries.push(...body.servers.map(parseRegistryEntry));
+                const metadata = object(body.metadata, "pagination metadata");
+                cursor = optionalString(metadata.nextCursor);
+                if (cursor === undefined) return entries;
+            }
+            throw new Error(
+                `MCP Registry pagination exceeded the ${maxPages}-page limit`,
+            );
+        },
+        async get(name, version = "latest") {
+            const url = new URL(
+                `v0.1/servers/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`,
+                base,
+            );
+            const body = await request(url);
+            return body === undefined ? undefined : parseRegistryEntry(body);
+        },
+    };
+}

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryDescriptor.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryDescriptor.ts
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import crypto from "node:crypto";
+import type {
+    CredentialRef,
+    EnvValue,
+    NormalizedMcpServerConfig,
+} from "../mcp/mcpServerConfig.js";
+import type { McpInstallCandidate } from "./config.js";
+import type {
+    RegistryInput,
+    RegistryKeyValue,
+    RegistryServerEntry,
+    RegistryTransport,
+} from "./mcpRegistryClient.js";
+import {
+    materializeRegistryNpmPackage,
+    type RegistryMaterializerDeps,
+} from "./mcpRegistryMaterializer.js";
+
+function canonicalJson(value: unknown): string {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalJson).join(",")}]`;
+    }
+    if (typeof value === "object" && value !== null) {
+        return `{${Object.entries(value as Record<string, unknown>)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(
+                ([key, child]) =>
+                    `${JSON.stringify(key)}:${canonicalJson(child)}`,
+            )
+            .join(",")}}`;
+    }
+    return JSON.stringify(value);
+}
+
+export function registryDescriptorDigest(entry: RegistryServerEntry): string {
+    return crypto
+        .createHash("sha256")
+        .update(canonicalJson(entry))
+        .digest("hex");
+}
+
+function inputRef(input: RegistryInput, name: string): string | CredentialRef {
+    const value = input.value ?? input.default;
+    return value ?? { kind: "input", name };
+}
+
+function valueFromKeyValue(entry: RegistryKeyValue): EnvValue {
+    const value = inputRef(entry, entry.name);
+    if (typeof value !== "string" || entry.variables === undefined) {
+        return value;
+    }
+    return {
+        value,
+        variables: Object.fromEntries(
+            Object.entries(entry.variables).map(([name, input]) => [
+                name,
+                inputRef(input, name),
+            ]),
+        ),
+    };
+}
+
+function httpTransport(transport: RegistryTransport) {
+    if (transport.type !== "streamable-http" && transport.type !== "sse") {
+        throw new Error(
+            `Unsupported registry remote transport '${transport.type}'`,
+        );
+    }
+    if (transport.url === undefined) {
+        throw new Error(
+            `Registry ${transport.type} transport is missing its URL`,
+        );
+    }
+    return {
+        kind: "http" as const,
+        url: transport.url,
+        ...(transport.variables === undefined
+            ? {}
+            : {
+                  urlVariables: Object.fromEntries(
+                      Object.entries(transport.variables).map(
+                          ([name, input]) => [name, inputRef(input, name)],
+                      ),
+                  ),
+              }),
+        ...(transport.headers === undefined
+            ? {}
+            : {
+                  headers: Object.fromEntries(
+                      transport.headers.map((entry) => [
+                          entry.name,
+                          valueFromKeyValue(entry),
+                      ]),
+                  ),
+              }),
+        timeoutMs: 30_000,
+    };
+}
+
+export function registryEntryToCandidate(
+    entry: RegistryServerEntry,
+    sourceName: string,
+    baseUrl: string,
+    materializerDeps: RegistryMaterializerDeps,
+): McpInstallCandidate {
+    if (entry.meta.status === "deleted") {
+        throw new Error(
+            `Registry server '${entry.server.name}@${entry.server.version}' is deleted`,
+        );
+    }
+    const digest = registryDescriptorDigest(entry);
+    const ref = `${entry.server.name}@${entry.server.version}`;
+    const description =
+        entry.meta.status === "deprecated"
+            ? `[DEPRECATED${entry.meta.statusMessage ? `: ${entry.meta.statusMessage}` : ""}] ${entry.server.description}`
+            : entry.server.description;
+    const commonProvenance = {
+        source: sourceName,
+        sourceKind: "registry",
+        ref,
+        version: entry.server.version,
+        digest,
+        registryBaseUrl: baseUrl,
+        canonicalServerName: entry.server.name,
+        serverVersion: entry.server.version,
+        ...(entry.server.publisher === undefined
+            ? {}
+            : { publisher: entry.server.publisher }),
+        ...(entry.server.repository === undefined
+            ? {}
+            : { repository: entry.server.repository }),
+    };
+    const id = `mcp:${encodeURIComponent(sourceName)}:${encodeURIComponent(entry.server.name)}`;
+    const remote = entry.server.remotes?.find(
+        (candidate) =>
+            candidate.type === "streamable-http" || candidate.type === "sse",
+    );
+    if (remote !== undefined) {
+        return {
+            extensionKind: "mcp",
+            source: sourceName,
+            sourceKind: "registry",
+            ref,
+            config: {
+                id,
+                name: entry.server.title ?? entry.server.name,
+                description,
+                transport: httpTransport(remote),
+                enabled: false,
+                trust: "untrusted",
+                scope: "user",
+                provenance: {
+                    ...commonProvenance,
+                    transportType: remote.type,
+                },
+            },
+        };
+    }
+    const pkg = entry.server.packages?.find(
+        (candidate) =>
+            candidate.registryType === "npm" &&
+            candidate.transport.type === "stdio",
+    );
+    if (pkg === undefined) {
+        const advertised = [
+            ...(entry.server.remotes ?? []).map(
+                (candidate) => `remote:${candidate.type}`,
+            ),
+            ...(entry.server.packages ?? []).map(
+                (candidate) =>
+                    `package:${candidate.registryType}/${candidate.transport.type}`,
+            ),
+        ];
+        throw new Error(
+            `Registry server '${entry.server.name}@${entry.server.version}' has no supported remote or package definition${advertised.length === 0 ? "" : ` (${advertised.join(", ")})`}`,
+        );
+    }
+    if (pkg.version === undefined) {
+        throw new Error(
+            `Registry npm package '${pkg.identifier}' does not specify an exact version`,
+        );
+    }
+    const config: NormalizedMcpServerConfig = {
+        id,
+        name: entry.server.title ?? entry.server.name,
+        description,
+        transport: {
+            kind: "stdio",
+            command: process.execPath,
+            args: [],
+        },
+        enabled: false,
+        trust: "untrusted",
+        scope: "user",
+        provenance: {
+            ...commonProvenance,
+            packageIdentifier: pkg.identifier,
+            packageVersion: pkg.version,
+            npmRegistryUrl:
+                pkg.registryBaseUrl ?? "https://registry.npmjs.org/",
+            ...(pkg.fileSha256 === undefined
+                ? {}
+                : { packageHash: pkg.fileSha256 }),
+            transportType: pkg.transport.type,
+        },
+    };
+    return {
+        extensionKind: "mcp",
+        source: sourceName,
+        sourceKind: "registry",
+        ref,
+        config,
+        materialize: (signal) =>
+            materializeRegistryNpmPackage(
+                config,
+                pkg,
+                digest,
+                materializerDeps,
+                signal,
+            ),
+    };
+}

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
@@ -35,6 +35,11 @@ export interface RegistryMaterializerDeps {
     npxCliPath?: string;
 }
 
+type ValidatedRegistryPackage = RegistryPackage & {
+    registryType: "npm";
+    version: string;
+};
+
 function findNpxCli(): string {
     const candidates =
         process.platform === "win32"
@@ -245,13 +250,9 @@ export function cleanupOwnedMcpPaths(
     }
 }
 
-export async function materializeRegistryNpmPackage(
-    config: NormalizedMcpServerConfig,
+function validateRegistryNpmPackage(
     pkg: RegistryPackage,
-    descriptorDigest: string,
-    deps: RegistryMaterializerDeps,
-    signal?: AbortSignal,
-): Promise<NormalizedMcpServerConfig> {
+): ValidatedRegistryPackage {
     if (pkg.registryType !== "npm") {
         throw new Error(
             `Unsupported registry package type '${pkg.registryType}'`,
@@ -276,20 +277,33 @@ export async function materializeRegistryNpmPackage(
             `Invalid registry npm package version '${pkg.version}'`,
         );
     }
+    return {
+        ...pkg,
+        registryType: "npm",
+        version: pkg.version,
+    };
+}
+
+function validateRuntimeHint(pkg: RegistryPackage): "npx" | "node" {
     const runtimeHint = pkg.runtimeHint ?? "npx";
     if (runtimeHint !== "npx" && runtimeHint !== "node") {
         throw new Error(`Unsupported registry runtime hint '${runtimeHint}'`);
     }
-    const runtimeArguments = registryArgumentsToArgv(pkg.runtimeArguments);
-    const packageArguments = registryArgumentsToArgv(pkg.packageArguments);
-    const environment = registryEnvironment(pkg.environmentVariables);
-    const registry = pkg.registryBaseUrl ?? "https://registry.npmjs.org/";
-    const fetchFn = deps.fetchFn ?? fetch;
+    return runtimeHint;
+}
+
+async function downloadRegistryPackage(
+    pkg: ValidatedRegistryPackage,
+    registry: string,
+    fetchFn: typeof fetch,
+    signal?: AbortSignal,
+): Promise<{ bytes: Buffer; packageHash: string }> {
+    const requestOptions = signal === undefined ? {} : { signal };
     const packumentResponse = await fetchFn(
         packageUrl(registry, pkg.identifier),
         {
             headers: { accept: "application/json" },
-            ...(signal === undefined ? {} : { signal }),
+            ...requestOptions,
         },
     );
     if (!packumentResponse.ok) {
@@ -298,24 +312,15 @@ export async function materializeRegistryNpmPackage(
         );
     }
     const packument = (await packumentResponse.json()) as {
-        versions?: Record<
-            string,
-            {
-                dist?: { tarball?: string };
-                bin?: string | Record<string, string>;
-            }
-        >;
+        versions?: Record<string, { dist?: { tarball?: string } }>;
     };
-    const manifest = packument.versions?.[pkg.version];
-    const tarball = manifest?.dist?.tarball;
-    if (manifest === undefined || typeof tarball !== "string") {
+    const tarball = packument.versions?.[pkg.version]?.dist?.tarball;
+    if (typeof tarball !== "string") {
         throw new Error(
             `npm package '${pkg.identifier}' has no published version '${pkg.version}'`,
         );
     }
-    const tarballResponse = await fetchFn(tarball, {
-        ...(signal === undefined ? {} : { signal }),
-    });
+    const tarballResponse = await fetchFn(tarball, requestOptions);
     if (!tarballResponse.ok) {
         throw new Error(
             `Could not download npm package '${pkg.identifier}@${pkg.version}' (${tarballResponse.status})`,
@@ -331,58 +336,117 @@ export async function materializeRegistryNpmPackage(
             `SHA-256 mismatch for '${pkg.identifier}@${pkg.version}': expected ${pkg.fileSha256}, got ${packageHash}`,
         );
     }
+    return { bytes, packageHash };
+}
+
+async function installRegistryPackage(
+    pkg: ValidatedRegistryPackage,
+    bytes: Buffer,
+    registry: string,
+    finalRoot: string,
+    deps: RegistryMaterializerDeps,
+    signal?: AbortSignal,
+): Promise<void> {
+    const rootsDir = path.dirname(finalRoot);
+    fs.mkdirSync(rootsDir, { recursive: true });
+    const randomId =
+        deps.randomId?.() ??
+        `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tempRoot = validateOwnedRoot(
+        deps.installDir,
+        path.join(rootsDir, `.tmp-${safeLeaf(randomId)}`),
+    );
+    fs.mkdirSync(tempRoot, { recursive: true });
+    const tarPath = path.join(tempRoot, "package.tgz");
+    try {
+        fs.writeFileSync(
+            path.join(tempRoot, "package.json"),
+            JSON.stringify({ private: true }),
+        );
+        fs.writeFileSync(tarPath, bytes);
+        await (deps.npmInstall ?? defaultNpmInstall)({
+            spec: tarPath,
+            cwd: tempRoot,
+            registry,
+            ...(signal === undefined ? {} : { signal }),
+        });
+        if (
+            !fs.existsSync(path.join(tempRoot, "node_modules", pkg.identifier))
+        ) {
+            throw new Error(
+                `npm install did not materialize '${pkg.identifier}@${pkg.version}'`,
+            );
+        }
+        readPackageBin(tempRoot, pkg.identifier, pkg.version);
+        fs.rmSync(tarPath, { force: true });
+        if (fs.existsSync(finalRoot)) {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        } else {
+            fs.renameSync(tempRoot, finalRoot);
+        }
+    } catch (error) {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+export async function materializeRegistryNpmPackage(
+    config: NormalizedMcpServerConfig,
+    pkg: RegistryPackage,
+    descriptorDigest: string,
+    deps: RegistryMaterializerDeps,
+    signal?: AbortSignal,
+): Promise<NormalizedMcpServerConfig> {
+    const validatedPackage = validateRegistryNpmPackage(pkg);
+    const runtimeHint = validateRuntimeHint(validatedPackage);
+    const runtimeArguments = registryArgumentsToArgv(
+        validatedPackage.runtimeArguments,
+    );
+    const packageArguments = registryArgumentsToArgv(
+        validatedPackage.packageArguments,
+    );
+    const environment = registryEnvironment(
+        validatedPackage.environmentVariables,
+    );
+    const registry =
+        validatedPackage.registryBaseUrl ?? "https://registry.npmjs.org/";
+    const fetchFn = deps.fetchFn ?? fetch;
+    const { bytes, packageHash } = await downloadRegistryPackage(
+        validatedPackage,
+        registry,
+        fetchFn,
+        signal,
+    );
     const rootsDir = path.join(deps.installDir, MCP_INSTALL_ROOTS_SUBDIR);
-    const leaf = `${safeLeaf(pkg.identifier)}@${safeLeaf(pkg.version)}-${descriptorDigest.slice(0, 16)}`;
+    const leaf = `${safeLeaf(validatedPackage.identifier)}@${safeLeaf(validatedPackage.version)}-${descriptorDigest.slice(0, 16)}`;
     const finalRoot = validateOwnedRoot(
         deps.installDir,
         path.join(rootsDir, leaf),
     );
-    if (!fs.existsSync(path.join(finalRoot, "node_modules", pkg.identifier))) {
-        fs.mkdirSync(rootsDir, { recursive: true });
-        const randomId =
-            deps.randomId?.() ??
-            `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        const tempRoot = validateOwnedRoot(
-            deps.installDir,
-            path.join(rootsDir, `.tmp-${safeLeaf(randomId)}`),
+    if (
+        !fs.existsSync(
+            path.join(finalRoot, "node_modules", validatedPackage.identifier),
+        )
+    ) {
+        await installRegistryPackage(
+            validatedPackage,
+            bytes,
+            registry,
+            finalRoot,
+            deps,
+            signal,
         );
-        fs.mkdirSync(tempRoot, { recursive: true });
-        const tarPath = path.join(tempRoot, "package.tgz");
-        try {
-            fs.writeFileSync(
-                path.join(tempRoot, "package.json"),
-                JSON.stringify({ private: true }),
-            );
-            fs.writeFileSync(tarPath, bytes);
-            await (deps.npmInstall ?? defaultNpmInstall)({
-                spec: tarPath,
-                cwd: tempRoot,
-                registry,
-                ...(signal === undefined ? {} : { signal }),
-            });
-            if (
-                !fs.existsSync(
-                    path.join(tempRoot, "node_modules", pkg.identifier),
-                )
-            ) {
-                throw new Error(
-                    `npm install did not materialize '${pkg.identifier}@${pkg.version}'`,
-                );
-            }
-            readPackageBin(tempRoot, pkg.identifier, pkg.version);
-            fs.rmSync(tarPath, { force: true });
-            if (fs.existsSync(finalRoot)) {
-                fs.rmSync(tempRoot, { recursive: true, force: true });
-            } else {
-                fs.renameSync(tempRoot, finalRoot);
-            }
-        } catch (error) {
-            fs.rmSync(tempRoot, { recursive: true, force: true });
-            throw error;
-        }
     }
-    const binPath = readPackageBin(finalRoot, pkg.identifier, pkg.version);
-    const packageDir = path.resolve(finalRoot, "node_modules", pkg.identifier);
+    const binPath = readPackageBin(
+        finalRoot,
+        validatedPackage.identifier,
+        validatedPackage.version,
+    );
+    const packageDir = path.resolve(
+        finalRoot,
+        "node_modules",
+        validatedPackage.identifier,
+    );
     const args =
         runtimeHint === "npx"
             ? [
@@ -390,7 +454,7 @@ export async function materializeRegistryNpmPackage(
                   ...runtimeArguments,
                   "--offline",
                   "--no-install",
-                  pkg.identifier,
+                  validatedPackage.identifier,
                   ...packageArguments,
               ]
             : [...runtimeArguments, binPath, ...packageArguments];
@@ -403,15 +467,15 @@ export async function materializeRegistryNpmPackage(
             ...(environment === undefined
                 ? {}
                 : {
-                      env: environment as Record<string, EnvValue>,
+                      env: environment,
                   }),
             cwd: packageDir,
         },
         provenance: {
             ...config.provenance,
             ownedPaths: [finalRoot],
-            packageIdentifier: pkg.identifier,
-            packageVersion: pkg.version,
+            packageIdentifier: validatedPackage.identifier,
+            packageVersion: validatedPackage.version,
             packageHash,
         },
     };

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
@@ -172,7 +172,7 @@ async function defaultNpmInstall(args: RegistryNpmInstallArgs): Promise<void> {
 
 function packageUrl(registry: string, identifier: string): URL {
     const encoded = identifier.startsWith("@")
-        ? identifier.replace("/", "%2F")
+        ? identifier.replaceAll("/", "%2F")
         : encodeURIComponent(identifier);
     return new URL(encoded, registry.endsWith("/") ? registry : `${registry}/`);
 }

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistryMaterializer.ts
@@ -1,0 +1,418 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type {
+    EnvValue,
+    NormalizedMcpServerConfig,
+} from "../mcp/mcpServerConfig.js";
+import type {
+    RegistryArgument,
+    RegistryInput,
+    RegistryKeyValue,
+    RegistryPackage,
+} from "./mcpRegistryClient.js";
+
+const execFileAsync = promisify(execFile);
+export const MCP_INSTALL_ROOTS_SUBDIR = "mcp";
+
+export interface RegistryNpmInstallArgs {
+    spec: string;
+    cwd: string;
+    registry: string;
+    signal?: AbortSignal;
+}
+
+export interface RegistryMaterializerDeps {
+    installDir: string;
+    fetchFn?: typeof fetch;
+    npmInstall?: (args: RegistryNpmInstallArgs) => Promise<void>;
+    randomId?: () => string;
+    npxCliPath?: string;
+}
+
+function findNpxCli(): string {
+    const candidates =
+        process.platform === "win32"
+            ? [
+                  path.resolve(
+                      path.dirname(process.execPath),
+                      "node_modules",
+                      "npm",
+                      "bin",
+                      "npx-cli.js",
+                  ),
+              ]
+            : [
+                  path.resolve(
+                      path.dirname(process.execPath),
+                      "..",
+                      "lib",
+                      "node_modules",
+                      "npm",
+                      "bin",
+                      "npx-cli.js",
+                  ),
+              ];
+    const found = candidates.find((candidate) => fs.existsSync(candidate));
+    if (found === undefined) {
+        throw new Error(
+            "Could not locate the npm npx CLI required by registry runtimeHint 'npx'",
+        );
+    }
+    return found;
+}
+
+function inputValue(
+    input: RegistryInput,
+    name: string,
+): string | { kind: "input"; name: string } {
+    const value = input.value ?? input.default;
+    return value === undefined ? { kind: "input", name } : value;
+}
+
+function convertTemplate(
+    value: string,
+    variables: Record<string, RegistryInput> | undefined,
+): EnvValue {
+    if (variables === undefined) {
+        return value;
+    }
+    return {
+        value,
+        variables: Object.fromEntries(
+            Object.entries(variables).map(([name, input]) => [
+                name,
+                inputValue(input, name),
+            ]),
+        ),
+    };
+}
+
+export function registryArgumentsToArgv(
+    args: RegistryArgument[] | undefined,
+): EnvValue[] {
+    const argv: EnvValue[] = [];
+    for (const arg of args ?? []) {
+        const inputName = arg.valueHint ?? arg.name ?? "argument";
+        const raw = inputValue(arg, inputName);
+        const value =
+            typeof raw === "string" ? convertTemplate(raw, arg.variables) : raw;
+        if (arg.type === "named") {
+            if (arg.name === undefined) {
+                throw new Error("Registry named argument is missing its name");
+            }
+            argv.push(arg.name);
+            if (!(arg.format === "boolean" && raw === "true")) {
+                argv.push(value);
+            }
+        } else if (arg.type === "positional") {
+            argv.push(value);
+        } else {
+            throw new Error(`Unsupported registry argument type '${arg.type}'`);
+        }
+    }
+    return argv;
+}
+
+export function registryEnvironment(
+    entries: RegistryKeyValue[] | undefined,
+): Record<string, EnvValue> | undefined {
+    if (entries === undefined) return undefined;
+    return Object.fromEntries(
+        entries.map((entry) => {
+            const raw = inputValue(entry, entry.name);
+            return [
+                entry.name,
+                typeof raw === "string"
+                    ? convertTemplate(raw, entry.variables)
+                    : raw,
+            ];
+        }),
+    );
+}
+
+async function defaultNpmInstall(args: RegistryNpmInstallArgs): Promise<void> {
+    const npmArgs = [
+        "install",
+        args.spec,
+        "--save=false",
+        "--ignore-scripts",
+        "--registry",
+        args.registry,
+    ];
+    if (process.platform === "win32") {
+        const npmCli = path.resolve(
+            path.dirname(process.execPath),
+            "node_modules",
+            "npm",
+            "bin",
+            "npm-cli.js",
+        );
+        if (!fs.existsSync(npmCli)) {
+            throw new Error(
+                `Could not locate npm CLI at '${npmCli}' for registry package installation`,
+            );
+        }
+        await execFileAsync(process.execPath, [npmCli, ...npmArgs], {
+            cwd: args.cwd,
+            signal: args.signal,
+        });
+        return;
+    }
+    await execFileAsync("npm", npmArgs, {
+        cwd: args.cwd,
+        signal: args.signal,
+    });
+}
+
+function packageUrl(registry: string, identifier: string): URL {
+    const encoded = identifier.startsWith("@")
+        ? identifier.replace("/", "%2F")
+        : encodeURIComponent(identifier);
+    return new URL(encoded, registry.endsWith("/") ? registry : `${registry}/`);
+}
+
+function safeLeaf(value: string): string {
+    return value.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function validateOwnedRoot(installDir: string, candidate: string): string {
+    const root = path.resolve(installDir, MCP_INSTALL_ROOTS_SUBDIR);
+    const resolved = path.resolve(candidate);
+    if (resolved === root || !resolved.startsWith(`${root}${path.sep}`)) {
+        throw new Error(`Invalid owned MCP install path '${candidate}'`);
+    }
+    return resolved;
+}
+
+function readPackageBin(
+    root: string,
+    identifier: string,
+    version: string,
+): string {
+    const packageDir = path.resolve(root, "node_modules", identifier);
+    const installedPackageJson = JSON.parse(
+        fs.readFileSync(path.join(packageDir, "package.json"), "utf8"),
+    ) as {
+        name?: string;
+        version?: string;
+        bin?: string | Record<string, string>;
+    };
+    if (
+        installedPackageJson.name !== undefined &&
+        installedPackageJson.name !== identifier
+    ) {
+        throw new Error(
+            `Installed npm package name '${installedPackageJson.name}' does not match '${identifier}'`,
+        );
+    }
+    if (
+        installedPackageJson.version !== undefined &&
+        installedPackageJson.version !== version
+    ) {
+        throw new Error(
+            `Installed npm package version '${installedPackageJson.version}' does not match '${version}'`,
+        );
+    }
+    const bin =
+        typeof installedPackageJson.bin === "string"
+            ? installedPackageJson.bin
+            : Object.values(installedPackageJson.bin ?? {})[0];
+    if (bin === undefined) {
+        throw new Error(`npm package '${identifier}' declares no executable`);
+    }
+    const binPath = path.resolve(packageDir, bin);
+    if (!binPath.startsWith(`${packageDir}${path.sep}`)) {
+        throw new Error(`npm package '${identifier}' has an unsafe bin path`);
+    }
+    return binPath;
+}
+
+export function cleanupOwnedMcpPaths(
+    installDir: string,
+    ownedPaths: readonly string[] | undefined,
+): void {
+    for (const ownedPath of ownedPaths ?? []) {
+        fs.rmSync(validateOwnedRoot(installDir, ownedPath), {
+            recursive: true,
+            force: true,
+        });
+    }
+}
+
+export async function materializeRegistryNpmPackage(
+    config: NormalizedMcpServerConfig,
+    pkg: RegistryPackage,
+    descriptorDigest: string,
+    deps: RegistryMaterializerDeps,
+    signal?: AbortSignal,
+): Promise<NormalizedMcpServerConfig> {
+    if (pkg.registryType !== "npm") {
+        throw new Error(
+            `Unsupported registry package type '${pkg.registryType}'`,
+        );
+    }
+    if (pkg.version === undefined) {
+        throw new Error(
+            `Registry npm package '${pkg.identifier}' has no exact version`,
+        );
+    }
+    if (
+        !/^(?:@[A-Za-z0-9][A-Za-z0-9._-]*\/)?[A-Za-z0-9][A-Za-z0-9._-]*$/.test(
+            pkg.identifier,
+        )
+    ) {
+        throw new Error(
+            `Invalid registry npm package name '${pkg.identifier}'`,
+        );
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(pkg.version)) {
+        throw new Error(
+            `Invalid registry npm package version '${pkg.version}'`,
+        );
+    }
+    const runtimeHint = pkg.runtimeHint ?? "npx";
+    if (runtimeHint !== "npx" && runtimeHint !== "node") {
+        throw new Error(`Unsupported registry runtime hint '${runtimeHint}'`);
+    }
+    const runtimeArguments = registryArgumentsToArgv(pkg.runtimeArguments);
+    const packageArguments = registryArgumentsToArgv(pkg.packageArguments);
+    const environment = registryEnvironment(pkg.environmentVariables);
+    const registry = pkg.registryBaseUrl ?? "https://registry.npmjs.org/";
+    const fetchFn = deps.fetchFn ?? fetch;
+    const packumentResponse = await fetchFn(
+        packageUrl(registry, pkg.identifier),
+        {
+            headers: { accept: "application/json" },
+            ...(signal === undefined ? {} : { signal }),
+        },
+    );
+    if (!packumentResponse.ok) {
+        throw new Error(
+            `Could not resolve npm package '${pkg.identifier}@${pkg.version}' (${packumentResponse.status})`,
+        );
+    }
+    const packument = (await packumentResponse.json()) as {
+        versions?: Record<
+            string,
+            {
+                dist?: { tarball?: string };
+                bin?: string | Record<string, string>;
+            }
+        >;
+    };
+    const manifest = packument.versions?.[pkg.version];
+    const tarball = manifest?.dist?.tarball;
+    if (manifest === undefined || typeof tarball !== "string") {
+        throw new Error(
+            `npm package '${pkg.identifier}' has no published version '${pkg.version}'`,
+        );
+    }
+    const tarballResponse = await fetchFn(tarball, {
+        ...(signal === undefined ? {} : { signal }),
+    });
+    if (!tarballResponse.ok) {
+        throw new Error(
+            `Could not download npm package '${pkg.identifier}@${pkg.version}' (${tarballResponse.status})`,
+        );
+    }
+    const bytes = Buffer.from(await tarballResponse.arrayBuffer());
+    const packageHash = crypto.createHash("sha256").update(bytes).digest("hex");
+    if (
+        pkg.fileSha256 !== undefined &&
+        packageHash.toLowerCase() !== pkg.fileSha256.toLowerCase()
+    ) {
+        throw new Error(
+            `SHA-256 mismatch for '${pkg.identifier}@${pkg.version}': expected ${pkg.fileSha256}, got ${packageHash}`,
+        );
+    }
+    const rootsDir = path.join(deps.installDir, MCP_INSTALL_ROOTS_SUBDIR);
+    const leaf = `${safeLeaf(pkg.identifier)}@${safeLeaf(pkg.version)}-${descriptorDigest.slice(0, 16)}`;
+    const finalRoot = validateOwnedRoot(
+        deps.installDir,
+        path.join(rootsDir, leaf),
+    );
+    if (!fs.existsSync(path.join(finalRoot, "node_modules", pkg.identifier))) {
+        fs.mkdirSync(rootsDir, { recursive: true });
+        const randomId =
+            deps.randomId?.() ??
+            `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const tempRoot = validateOwnedRoot(
+            deps.installDir,
+            path.join(rootsDir, `.tmp-${safeLeaf(randomId)}`),
+        );
+        fs.mkdirSync(tempRoot, { recursive: true });
+        const tarPath = path.join(tempRoot, "package.tgz");
+        try {
+            fs.writeFileSync(
+                path.join(tempRoot, "package.json"),
+                JSON.stringify({ private: true }),
+            );
+            fs.writeFileSync(tarPath, bytes);
+            await (deps.npmInstall ?? defaultNpmInstall)({
+                spec: tarPath,
+                cwd: tempRoot,
+                registry,
+                ...(signal === undefined ? {} : { signal }),
+            });
+            if (
+                !fs.existsSync(
+                    path.join(tempRoot, "node_modules", pkg.identifier),
+                )
+            ) {
+                throw new Error(
+                    `npm install did not materialize '${pkg.identifier}@${pkg.version}'`,
+                );
+            }
+            readPackageBin(tempRoot, pkg.identifier, pkg.version);
+            fs.rmSync(tarPath, { force: true });
+            if (fs.existsSync(finalRoot)) {
+                fs.rmSync(tempRoot, { recursive: true, force: true });
+            } else {
+                fs.renameSync(tempRoot, finalRoot);
+            }
+        } catch (error) {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+            throw error;
+        }
+    }
+    const binPath = readPackageBin(finalRoot, pkg.identifier, pkg.version);
+    const packageDir = path.resolve(finalRoot, "node_modules", pkg.identifier);
+    const args =
+        runtimeHint === "npx"
+            ? [
+                  deps.npxCliPath ?? findNpxCli(),
+                  ...runtimeArguments,
+                  "--offline",
+                  "--no-install",
+                  pkg.identifier,
+                  ...packageArguments,
+              ]
+            : [...runtimeArguments, binPath, ...packageArguments];
+    return {
+        ...config,
+        transport: {
+            kind: "stdio",
+            command: process.execPath,
+            args,
+            ...(environment === undefined
+                ? {}
+                : {
+                      env: environment as Record<string, EnvValue>,
+                  }),
+            cwd: packageDir,
+        },
+        provenance: {
+            ...config.provenance,
+            ownedPaths: [finalRoot],
+            packageIdentifier: pkg.identifier,
+            packageVersion: pkg.version,
+            packageHash,
+        },
+    };
+}

--- a/ts/packages/defaultAgentProvider/src/installSources/mcpRegistrySource.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/mcpRegistrySource.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import path from "node:path";
+import type {
+    AvailableInstallRow,
+    InstallSource,
+    MaterializedInstallRecord,
+    RegistrySourceConfig,
+    ResolvedCandidate,
+    SourceWarning,
+} from "./config.js";
+import {
+    createMcpRegistryClient,
+    type McpRegistryClient,
+    type RegistryServerEntry,
+} from "./mcpRegistryClient.js";
+import {
+    createRegistryCacheStorage,
+    mergeRegistryCache,
+    type RegistryCacheData,
+    type RegistryCacheStorage,
+} from "./mcpRegistryCache.js";
+import { registryEntryToCandidate } from "./mcpRegistryDescriptor.js";
+import type { RegistryMaterializerDeps } from "./mcpRegistryMaterializer.js";
+
+export interface RegistrySourceDeps extends RegistryMaterializerDeps {
+    client?: McpRegistryClient;
+    cacheStorage?: RegistryCacheStorage;
+    now?: () => number;
+}
+
+function parseRef(ref: string): { name: string; version: string } {
+    const at = ref.lastIndexOf("@");
+    return at > 0
+        ? { name: ref.slice(0, at), version: ref.slice(at + 1) }
+        : { name: ref, version: "latest" };
+}
+
+export function createMcpRegistrySource(
+    config: RegistrySourceConfig,
+    deps: RegistrySourceDeps,
+): InstallSource {
+    const now = deps.now ?? Date.now;
+    const ttl = config.cacheTtlMs ?? 60 * 60 * 1000;
+    const parsedBaseUrl = new URL(config.baseUrl);
+    if (!parsedBaseUrl.pathname.endsWith("/")) {
+        parsedBaseUrl.pathname += "/";
+    }
+    const baseUrl = parsedBaseUrl.toString();
+    const client =
+        deps.client ??
+        createMcpRegistryClient(baseUrl, deps.fetchFn, config.maxPages);
+    const storage =
+        deps.cacheStorage ??
+        createRegistryCacheStorage(
+            config.cachePath ??
+                path.join(
+                    deps.installDir,
+                    "mcp",
+                    `.registry-cache-${config.name.replace(/[^A-Za-z0-9._-]/g, "_")}.json`,
+                ),
+        );
+    let memory: RegistryCacheData | undefined;
+
+    function readCache(): RegistryCacheData | undefined {
+        if (memory === undefined) {
+            memory = storage.read();
+        }
+        return memory;
+    }
+
+    async function refreshCache(): Promise<RegistryCacheData> {
+        const previous = readCache();
+        const fetchedAt = now();
+        const updatedSince = new Date(fetchedAt).toISOString();
+        const pageOptions =
+            previous === undefined
+                ? {
+                      version: "latest",
+                      ...(config.maxPages === undefined
+                          ? {}
+                          : { maxPages: config.maxPages }),
+                  }
+                : {
+                      version: "latest",
+                      updatedSince: previous.updatedSince,
+                      includeDeleted: true,
+                      ...(config.maxPages === undefined
+                          ? {}
+                          : { maxPages: config.maxPages }),
+                  };
+        const updates = await client.list(pageOptions);
+        const next: RegistryCacheData = {
+            fetchedAt,
+            updatedSince,
+            entries:
+                previous === undefined
+                    ? updates.filter((entry) => entry.meta.status !== "deleted")
+                    : mergeRegistryCache(previous.entries, updates),
+        };
+        storage.write(next);
+        memory = next;
+        return next;
+    }
+
+    async function cache(): Promise<RegistryCacheData> {
+        const current = readCache();
+        if (current !== undefined && now() - current.fetchedAt <= ttl) {
+            return current;
+        }
+        try {
+            return await refreshCache();
+        } catch (error) {
+            if (current !== undefined) return current;
+            throw error;
+        }
+    }
+
+    function warnDeprecated(
+        entry: RegistryServerEntry,
+        onWarn?: SourceWarning,
+    ): void {
+        if (entry.meta.status === "deprecated") {
+            onWarn?.(
+                `Registry server '${entry.server.name}@${entry.server.version}' is deprecated${entry.meta.statusMessage ? `: ${entry.meta.statusMessage}` : "."}`,
+            );
+        }
+    }
+
+    return {
+        name: config.name,
+        kind: "registry",
+        describe: () => baseUrl,
+        async find(): Promise<ResolvedCandidate | undefined> {
+            return undefined;
+        },
+        async findMcp(ref, onWarn) {
+            const { name, version } = parseRef(ref);
+            const cached = await cache();
+            let entry = cached.entries.find(
+                (candidate) =>
+                    candidate.server.name === name &&
+                    (version === "latest"
+                        ? candidate.meta.isLatest
+                        : candidate.server.version === version),
+            );
+            if (entry === undefined) {
+                entry = await client.get(name, version);
+            }
+            if (entry === undefined || entry.meta.status === "deleted") {
+                return undefined;
+            }
+            warnDeprecated(entry, onWarn);
+            return registryEntryToCandidate(entry, config.name, baseUrl, deps);
+        },
+        async listAgents(onWarn): Promise<AvailableInstallRow[]> {
+            const rows: AvailableInstallRow[] = [];
+            for (const entry of (await cache()).entries) {
+                if (entry.meta.status === "deleted") continue;
+                try {
+                    registryEntryToCandidate(entry, config.name, baseUrl, deps);
+                } catch (error) {
+                    onWarn?.(
+                        `registry source '${config.name}': '${entry.server.name}@${entry.server.version}' unavailable - ${(error as Error).message}`,
+                    );
+                    continue;
+                }
+                warnDeprecated(entry, onWarn);
+                rows.push({
+                    source: config.name,
+                    ref: entry.server.name,
+                    defaultAgentName: entry.server.name,
+                    description:
+                        entry.meta.status === "deprecated"
+                            ? `[DEPRECATED] ${entry.server.description}`
+                            : entry.server.description,
+                    extensionKind: "mcp",
+                });
+            }
+            return rows;
+        },
+        async refresh() {
+            await refreshCache();
+        },
+        async materialize(): Promise<MaterializedInstallRecord> {
+            throw new Error(
+                `registry source '${config.name}' materializes MCP candidates through the MCP transaction`,
+            );
+        },
+    };
+}

--- a/ts/packages/defaultAgentProvider/src/installSources/packageAgent.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/packageAgent.ts
@@ -25,12 +25,19 @@ import {
     AppAgentProvider,
     AppAgentProviderSetController,
 } from "agent-dispatcher";
+import type { McpServerSourceApi } from "../mcp/mcpAppAgentSource.js";
+import type {
+    EnvValue,
+    NormalizedMcpServerConfig,
+} from "../mcp/mcpServerConfig.js";
 import chalk from "chalk";
+import { enforceMcpPolicy } from "../mcp/mcpPolicy.js";
 import {
     ExtensionKind,
     InstallMatchKind,
     InstallPreview,
     InstallResult,
+    McpInstallCandidate,
     deriveMatchKind,
     SourceStatus,
     UninstallOutcomeStatus,
@@ -108,6 +115,18 @@ export interface InstalledAgentSourceApi {
         sourceName: string | undefined,
         onStatus?: SourceStatus,
     ): Promise<InstallPreview | undefined>;
+    // Resolve normalized MCP artifacts without native materialization. The
+    // full match set lets the command reject source ambiguity.
+    resolveMcp(
+        ref: string,
+        sourceName?: string,
+        onStatus?: SourceStatus,
+    ): Promise<McpInstallCandidate[]>;
+    materializeMcp?(
+        candidate: McpInstallCandidate,
+        abortSignal?: AbortSignal,
+    ): Promise<NormalizedMcpServerConfig>;
+    cleanupMcp?(config: NormalizedMcpServerConfig): void;
     // Refresh cache-backed source metadata (feed descriptor caches) before an
     // install/preview/listing. When `sourceName` is given, only that source is
     // refreshed. A fetch failure throws so the `--refresh` command fails rather
@@ -169,10 +188,147 @@ export interface InstalledAgentSourceApi {
 export interface PackageAgentContext {
     readonly appAgentProviderSetController: AppAgentProviderSetController;
     readonly source: InstalledAgentSourceApi;
+    readonly mcpSource?: McpServerSourceApi;
 }
 
 type PackageActionContext = ActionContext<PackageAgentContext>;
 type PackageSessionContext = SessionContext<PackageAgentContext>;
+type PackageType = ExtensionKind | "all";
+
+function parsePackageType(
+    value: string | undefined,
+    defaultValue: PackageType,
+): PackageType {
+    const type = value ?? defaultValue;
+    if (type !== "agent" && type !== "mcp" && type !== "all") {
+        throw new Error(
+            `Invalid --type '${type}'. Expected 'agent', 'mcp', or 'all'.`,
+        );
+    }
+    return type;
+}
+
+function requireMcpSource(context: PackageSessionContext): McpServerSourceApi {
+    const source = context.agentContext.mcpSource;
+    if (source === undefined) {
+        throw new Error("MCP server management is not available on this host.");
+    }
+    return source;
+}
+
+function mcpServerNames(context: PackageSessionContext): string[] {
+    return (
+        context.agentContext.mcpSource
+            ?.listServers()
+            .map((config) => config.name)
+            .sort((a, b) => a.localeCompare(b)) ?? []
+    );
+}
+
+function findMcpServer(
+    mcpSource: McpServerSourceApi,
+    nameOrId: string,
+    sourceName?: string,
+): NormalizedMcpServerConfig | undefined {
+    return mcpSource
+        .listServers()
+        .find(
+            (config) =>
+                (config.id === nameOrId || config.name === nameOrId) &&
+                (sourceName === undefined ||
+                    config.provenance.source === sourceName),
+        );
+}
+
+function materializeMcp(
+    source: InstalledAgentSourceApi,
+    candidate: McpInstallCandidate,
+    signal?: AbortSignal,
+): Promise<NormalizedMcpServerConfig> {
+    return (
+        source.materializeMcp?.(candidate, signal) ??
+        candidate.materialize?.(signal) ??
+        Promise.resolve(candidate.config)
+    );
+}
+
+function cleanupMcp(
+    source: InstalledAgentSourceApi,
+    config: NormalizedMcpServerConfig,
+): void {
+    source.cleanupMcp?.(config);
+}
+
+function describeEnvValue(value: EnvValue): string {
+    return typeof value === "string"
+        ? "<literal>"
+        : "kind" in value
+          ? `<credential ${value.kind}:${value.name}>`
+          : "<template>";
+}
+
+function describeMcpConfig(config: NormalizedMcpServerConfig): string {
+    const lines = [
+        `MCP server '${config.name}' (${config.id})`,
+        `Source: ${config.provenance.source}${config.provenance.ref === undefined ? "" : ` / ${config.provenance.ref}`}`,
+        `State: ${config.trust}, ${config.enabled ? "enabled" : "disabled"}`,
+    ];
+    if (config.transport.kind === "stdio") {
+        lines.push(
+            `Command: ${[config.transport.command, ...(config.transport.args ?? [])].join(" ")}`,
+        );
+        if (config.transport.cwd !== undefined) {
+            lines.push(`Cwd: ${config.transport.cwd}`);
+        }
+        const env = config.transport.env;
+        if (env !== undefined) {
+            lines.push(
+                `Environment: ${Object.entries(env)
+                    .map(
+                        ([name, value]) => `${name}=${describeEnvValue(value)}`,
+                    )
+                    .join(", ")}`,
+            );
+        }
+    } else {
+        lines.push(`URL: ${config.transport.url}`);
+        if (config.transport.headers !== undefined) {
+            lines.push(
+                `Headers: ${Object.entries(config.transport.headers)
+                    .map(
+                        ([name, value]) => `${name}=${describeEnvValue(value)}`,
+                    )
+                    .join(", ")}`,
+            );
+        }
+    }
+    lines.push(
+        `Tools: ${config.enabledTools?.join(", ") ?? "all advertised tools"}`,
+    );
+    return lines.join("\n");
+}
+
+function describeMcpChanges(
+    current: NormalizedMcpServerConfig,
+    next: NormalizedMcpServerConfig,
+): string {
+    const changes: string[] = [];
+    if (JSON.stringify(current.transport) !== JSON.stringify(next.transport)) {
+        changes.push("transport");
+    }
+    if (current.description !== next.description) {
+        changes.push("description");
+    }
+    if (
+        JSON.stringify(current.enabledTools) !==
+        JSON.stringify(next.enabledTools)
+    ) {
+        changes.push("enabled tools");
+    }
+    return changes.length === 0
+        ? "No configuration changes."
+        : changes.join(", ");
+}
 
 // Names of agents that can be uninstalled/updated.
 function managedAgentNames(context: PackageSessionContext): string[] {
@@ -219,44 +375,102 @@ function displaySourceTables<T>(
 }
 
 class ListInstalledCommandHandler implements CommandHandler {
-    public readonly description = "List installed agents";
-    public readonly parameters = {} as const;
+    public readonly description = "List installed agents and MCP servers";
+    public readonly parameters = {
+        flags: {
+            type: {
+                description: "List 'agent', 'mcp', or 'all'",
+                char: "t",
+                type: "string",
+                default: "agent",
+            },
+        },
+    } as const;
     public async run(
         context: PackageActionContext,
-        _params: ParsedCommandParams<typeof this.parameters>,
+        params: ParsedCommandParams<typeof this.parameters>,
     ) {
-        const { source } = context.sessionContext.agentContext;
+        const type = parsePackageType(params.flags?.type, "agent");
+        const { source, mcpSource } = context.sessionContext.agentContext;
         // `@package list` shows mutable installed records only.
         const groups = source.listInstalled();
-        if (groups.length === 0) {
+        const servers = mcpSource?.listServers() ?? [];
+        if (
+            (type === "agent" && groups.length === 0) ||
+            (type === "mcp" && servers.length === 0) ||
+            (type === "all" && groups.length === 0 && servers.length === 0)
+        ) {
+            if (type === "mcp") {
+                displayResult("No installed MCP servers found.", context);
+                return;
+            }
             displayResult("No installed agents found.", context);
             return;
         }
 
-        // Preserve source order, matching `@package available`. Sort agents
-        // within each source and render each heading and table as a block.
-        displaySourceTables(
-            context,
-            groups,
-            ["Name", "Reference"],
-            (a, b) => a.name.localeCompare(b.name),
-            (record) => [
-                chalk.cyanBright(record.name),
-                record.ref !== undefined
-                    ? chalk.gray(record.ref)
-                    : chalk.gray("—"),
-            ],
-        );
+        if (type !== "mcp") {
+            // Preserve source order, matching `@package available`. Sort agents
+            // within each source and render each heading and table as a block.
+            displaySourceTables(
+                context,
+                groups,
+                ["Name", "Reference"],
+                (a, b) => a.name.localeCompare(b.name),
+                (record) => [
+                    chalk.cyanBright(record.name),
+                    record.ref !== undefined
+                        ? chalk.gray(record.ref)
+                        : chalk.gray("—"),
+                ],
+            );
 
-        context.actionIO.appendDisplay(
-            {
-                type: "text",
-                content: chalk.gray(
-                    "\nShowing installable installed agents only. Use '@config agent' to see all available agents and their status.",
-                ),
-            },
-            "block",
-        );
+            context.actionIO.appendDisplay(
+                {
+                    type: "text",
+                    content: chalk.gray(
+                        "\nShowing installable installed agents only. Use '@config agent' to see all available agents and their status.",
+                    ),
+                },
+                "block",
+            );
+        }
+        if (type !== "agent" && servers.length > 0) {
+            displaySourceTables(
+                context,
+                [
+                    {
+                        source: "MCP servers",
+                        agents: servers,
+                    },
+                ],
+                ["Name", "Transport", "Trust", "Enabled", "Source"],
+                (a, b) => a.name.localeCompare(b.name),
+                (config) => [
+                    chalk.cyanBright(config.name),
+                    config.transport.kind === "stdio"
+                        ? config.transport.command
+                        : config.transport.url,
+                    config.trust,
+                    config.enabled ? "yes" : "no",
+                    config.provenance.source,
+                ],
+            );
+        }
+    }
+
+    public async getCompletion(
+        _context: PackageSessionContext,
+        _params: PartialParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ): Promise<{ groups: CompletionGroup[] }> {
+        return {
+            groups: names
+                .filter((name) => name === "--type")
+                .map((name) => ({
+                    name,
+                    completions: ["agent", "mcp", "all"],
+                })),
+        };
     }
 }
 
@@ -375,6 +589,12 @@ class InstallCommandHandler implements CommandHandler {
             },
         },
         flags: {
+            type: {
+                description: "Install an 'agent', 'mcp', or infer with 'all'",
+                char: "t",
+                type: "string",
+                default: "all",
+            },
             source: {
                 description:
                     "Resolve only against this named source, bypassing the order.",
@@ -426,6 +646,83 @@ class InstallCommandHandler implements CommandHandler {
             : `source '${m.source}'`;
     }
 
+    private async runMcpInstall(
+        context: PackageActionContext,
+        candidate: McpInstallCandidate,
+        installedName: string,
+        dryRun: boolean,
+    ): Promise<void> {
+        const mcpSource = requireMcpSource(context.sessionContext);
+        const existing = mcpSource
+            .listServers()
+            .find(
+                (config) =>
+                    config.id === candidate.config.id ||
+                    config.name === installedName,
+            );
+        if (existing !== undefined && !dryRun) {
+            throw new Error(
+                `MCP server '${existing.name}' is already installed. Use '@package update ${existing.name} --type mcp'.`,
+            );
+        }
+        const previewConfig: NormalizedMcpServerConfig = {
+            ...candidate.config,
+            name: installedName,
+            enabled: false,
+            trust: "untrusted",
+        };
+        const policy = mcpSource.getPolicy?.();
+        if (policy !== undefined) {
+            enforceMcpPolicy(policy, "install", previewConfig);
+        }
+        displayResult(describeMcpConfig(previewConfig), context);
+        if (dryRun) {
+            displayResult(
+                `MCP server '${installedName}' would be installed disabled and untrusted.`,
+                context,
+            );
+            return;
+        }
+        const choice = await context.sessionContext.popupQuestion(
+            `Install MCP server '${installedName}' from ${candidate.sourceKind} source '${candidate.source}'? It will remain disabled and untrusted.`,
+            ["Install", "Cancel"],
+            1,
+        );
+        if (choice !== 0) {
+            displayResult("MCP installation cancelled.", context);
+            return;
+        }
+        const source = context.sessionContext.agentContext.source;
+        const materialized = await materializeMcp(
+            source,
+            candidate,
+            context.abortSignal,
+        );
+        const config: NormalizedMcpServerConfig = {
+            ...materialized,
+            name: installedName,
+            enabled: false,
+            trust: "untrusted",
+        };
+        try {
+            if (policy !== undefined) {
+                enforceMcpPolicy(policy, "install", config);
+            }
+            await mcpSource.addServer(
+                config,
+                context.sessionContext.agentContext
+                    .appAgentProviderSetController,
+            );
+        } catch (error) {
+            cleanupMcp(source, config);
+            throw error;
+        }
+        displayResult(
+            `MCP server '${installedName}' installed disabled and untrusted via ${candidate.sourceKind} source '${candidate.source}'.`,
+            context,
+        );
+    }
+
     public async run(
         context: PackageActionContext,
         params: ParsedCommandParams<typeof this.parameters>,
@@ -438,6 +735,7 @@ class InstallCommandHandler implements CommandHandler {
         const { target, name } = args;
         const sourceName = flags.source ?? undefined;
         const explicit = name !== undefined;
+        const type = parsePackageType(flags.type, "all");
 
         // Two-argument form: the explicit installed name must be legal. This
         // runs before any resolution so a bad name fails fast.
@@ -460,13 +758,62 @@ class InstallCommandHandler implements CommandHandler {
             await source.refresh(sourceName);
         }
 
-        if (flags["dry-run"]) {
-            const preview = await source.preview(
-                nameOrTarget,
-                ref,
+        let nativePreview: InstallPreview | undefined;
+        if (type !== "agent") {
+            const mcpMatches = await source.resolveMcp(
+                target,
                 sourceName,
-                (message) => displayStatus(message, context),
+                type === "mcp"
+                    ? (message) => displayStatus(message, context)
+                    : undefined,
             );
+            if (mcpMatches.length > 1) {
+                throw new Error(
+                    `Multiple MCP sources resolve '${target}': ${mcpMatches
+                        .map((match) => match.source)
+                        .join(", ")}. Use --source to choose one.`,
+                );
+            }
+            if (type === "all" && mcpMatches.length > 0) {
+                nativePreview = await source.preview(
+                    nameOrTarget,
+                    ref,
+                    sourceName,
+                    (message) => displayStatus(message, context),
+                );
+                if (nativePreview !== undefined) {
+                    throw new Error(
+                        `'${target}' matches both a native agent and an MCP server. Use --type agent|mcp or --source.`,
+                    );
+                }
+            }
+            if (mcpMatches.length === 1) {
+                await this.runMcpInstall(
+                    context,
+                    mcpMatches[0],
+                    name ?? mcpMatches[0].config.name,
+                    flags["dry-run"],
+                );
+                return;
+            }
+            if (type === "mcp") {
+                throw new Error(
+                    sourceName === undefined
+                        ? `No MCP source could resolve '${target}'.`
+                        : `'${target}' not found in MCP source '${sourceName}'.`,
+                );
+            }
+        }
+
+        if (flags["dry-run"]) {
+            const preview =
+                nativePreview ??
+                (await source.preview(
+                    nameOrTarget,
+                    ref,
+                    sourceName,
+                    (message) => displayStatus(message, context),
+                ));
             if (preview === undefined) {
                 displayResult(`No source would resolve '${target}'.`, context);
                 return;
@@ -554,9 +901,14 @@ class InstallCommandHandler implements CommandHandler {
                 // Complete default agent names and package names. The second
                 // argument (explicit installed name) is not completed.
                 const sourceName = params.flags?.source as string | undefined;
-                const groups = await source.listAvailableAgents(
-                    sourceName !== undefined ? { sourceName } : undefined,
+                const type = parsePackageType(
+                    params.flags?.type as string | undefined,
+                    "all",
                 );
+                const groups = await source.listAvailableAgents({
+                    ...(sourceName === undefined ? {} : { sourceName }),
+                    ...(type === "all" ? {} : { type }),
+                });
                 const values = new Set<string>();
                 for (const group of groups) {
                     for (const agent of group.agents) {
@@ -574,6 +926,11 @@ class InstallCommandHandler implements CommandHandler {
                     name,
                     completions: source.listSources(),
                 });
+            } else if (name === "--type") {
+                completions.push({
+                    name,
+                    completions: ["agent", "mcp", "all"],
+                });
             }
         }
         return { groups: completions };
@@ -581,12 +938,26 @@ class InstallCommandHandler implements CommandHandler {
 }
 
 class UninstallCommandHandler implements CommandHandler {
-    public readonly description = "Uninstall an agent";
+    public readonly description = "Uninstall an agent or MCP server";
     public readonly parameters = {
         args: {
             name: {
                 description: "Name of the agent",
                 type: "string",
+            },
+        },
+        flags: {
+            type: {
+                description: "Uninstall an 'agent', 'mcp', or infer with 'all'",
+                char: "t",
+                type: "string",
+                default: "all",
+            },
+            source: {
+                description: "Require the installed entry to use this source",
+                char: "s",
+                type: "string",
+                optional: true,
             },
         },
     } as const;
@@ -597,8 +968,50 @@ class UninstallCommandHandler implements CommandHandler {
         const {
             appAgentProviderSetController: appAgentProviderSetController,
             source,
+            mcpSource,
         } = context.sessionContext.agentContext;
         const name = params.args.name;
+        const type = parsePackageType(params.flags?.type, "all");
+        const sourceName = params.flags?.source ?? undefined;
+        const agentMatch = source
+            .listInstalled()
+            .some(
+                (group) =>
+                    (sourceName === undefined || group.source === sourceName) &&
+                    group.agents.some((record) => record.name === name),
+            );
+        const mcpMatch =
+            mcpSource === undefined
+                ? undefined
+                : findMcpServer(mcpSource, name, sourceName);
+        if (type === "all" && agentMatch && mcpMatch !== undefined) {
+            throw new Error(
+                `'${name}' names both an installed agent and MCP server. Use --type agent|mcp or --source.`,
+            );
+        }
+        if (type === "mcp" || (type === "all" && mcpMatch !== undefined)) {
+            const api = requireMcpSource(context.sessionContext);
+            const config = mcpMatch ?? findMcpServer(api, name, sourceName);
+            if (config === undefined) {
+                throw new Error(`MCP server '${name}' not found`);
+            }
+            if (
+                !(await api.removeServer(
+                    config.id,
+                    appAgentProviderSetController,
+                ))
+            ) {
+                throw new Error(`MCP server '${name}' not found`);
+            }
+            cleanupMcp(source, config);
+            displayResult(`MCP server '${config.name}' uninstalled.`, context);
+            return;
+        }
+        if (sourceName !== undefined && !agentMatch) {
+            throw new Error(
+                `Agent '${name}' is not installed from source '${sourceName}'.`,
+            );
+        }
         // Start the coordinated teardown and fan out the removal to every
         // session — including this one — through its idle-gated applicator, each
         // notified with a system message ("Agent 'x' was removed."), exactly as
@@ -640,9 +1053,26 @@ class UninstallCommandHandler implements CommandHandler {
         const completions: CompletionGroup[] = [];
         for (const name of names) {
             if (name === "name") {
+                const type = parsePackageType(
+                    _params.flags?.type as string | undefined,
+                    "all",
+                );
                 completions.push({
                     name,
-                    completions: managedAgentNames(context),
+                    completions: [
+                        ...(type === "mcp" ? [] : managedAgentNames(context)),
+                        ...(type === "agent" ? [] : mcpServerNames(context)),
+                    ],
+                });
+            } else if (name === "--type") {
+                completions.push({
+                    name,
+                    completions: ["agent", "mcp", "all"],
+                });
+            } else if (name === "--source") {
+                completions.push({
+                    name,
+                    completions: context.agentContext.source.listSources(),
                 });
             }
         }
@@ -651,7 +1081,7 @@ class UninstallCommandHandler implements CommandHandler {
 }
 
 class UpdateCommandHandler implements CommandHandler {
-    public readonly description = "Update an installed agent";
+    public readonly description = "Update an installed agent or MCP server";
     public readonly parameters = {
         args: {
             name: {
@@ -660,9 +1090,29 @@ class UpdateCommandHandler implements CommandHandler {
             },
             range: {
                 description:
-                    "Optional version range for feed agents (e.g. ^1.4, ~2.0, '>=3 <4'). Updates are supported only for feed-sourced agents.",
+                    "Optional version range for feed agents, or exact server version for registry MCP servers.",
                 type: "string",
                 optional: true,
+            },
+        },
+        flags: {
+            type: {
+                description: "Update an 'agent', 'mcp', or infer with 'all'",
+                char: "t",
+                type: "string",
+                default: "all",
+            },
+            source: {
+                description: "Require the installed entry to use this source",
+                char: "s",
+                type: "string",
+                optional: true,
+            },
+            "dry-run": {
+                description: "Preview the update without replacing the entry",
+                char: "n",
+                type: "boolean",
+                default: false,
             },
         },
     } as const;
@@ -673,8 +1123,131 @@ class UpdateCommandHandler implements CommandHandler {
         const {
             appAgentProviderSetController: appAgentProviderSetController,
             source,
+            mcpSource,
         } = context.sessionContext.agentContext;
         const { name, range } = params.args;
+        const type = parsePackageType(params.flags?.type, "all");
+        const sourceName = params.flags?.source ?? undefined;
+        const agentMatch = source
+            .listInstalled()
+            .some(
+                (group) =>
+                    (sourceName === undefined || group.source === sourceName) &&
+                    group.agents.some((record) => record.name === name),
+            );
+        const mcpMatch =
+            mcpSource === undefined
+                ? undefined
+                : findMcpServer(mcpSource, name, sourceName);
+        if (type === "all" && agentMatch && mcpMatch !== undefined) {
+            throw new Error(
+                `'${name}' names both an installed agent and MCP server. Use --type agent|mcp or --source.`,
+            );
+        }
+
+        if (type === "mcp" || (type === "all" && mcpMatch !== undefined)) {
+            const api = requireMcpSource(context.sessionContext);
+            const current = mcpMatch ?? findMcpServer(api, name, sourceName);
+            if (current === undefined) {
+                throw new Error(`MCP server '${name}' not found`);
+            }
+            const sourceKind = current.provenance.sourceKind;
+            if (
+                (sourceKind !== "mcp-config" && sourceKind !== "registry") ||
+                current.provenance.ref === undefined
+            ) {
+                throw new Error(
+                    `MCP server '${current.name}' was installed from unsupported source kind '${sourceKind ?? "unknown"}'.`,
+                );
+            }
+            if (sourceKind === "mcp-config" && range !== undefined) {
+                throw new Error(
+                    "A version is not supported for mcp-config updates.",
+                );
+            }
+            const updateRef =
+                sourceKind === "registry"
+                    ? `${current.provenance.canonicalServerName ?? current.provenance.ref.split("@")[0]}@${range ?? "latest"}`
+                    : current.provenance.ref;
+            const matches = await source.resolveMcp(
+                updateRef,
+                current.provenance.source,
+                (message) => displayStatus(message, context),
+            );
+            if (matches.length !== 1) {
+                throw new Error(
+                    `MCP server '${current.name}' can no longer be resolved from source '${current.provenance.source}' using ref '${updateRef}'.`,
+                );
+            }
+            const previewNext: NormalizedMcpServerConfig = {
+                ...matches[0].config,
+                id: current.id,
+                name: current.name,
+                trust: current.trust,
+                enabled: current.enabled,
+                scope: current.scope,
+            };
+            const descriptorChanged =
+                current.provenance.digest !== undefined &&
+                previewNext.provenance.digest !== undefined &&
+                current.provenance.digest !== previewNext.provenance.digest;
+            const describedChanges = describeMcpChanges(current, previewNext);
+            const changes = descriptorChanged
+                ? describedChanges === "No configuration changes."
+                    ? "registry descriptor"
+                    : `${describedChanges}, registry descriptor`
+                : describedChanges;
+            displayResult(
+                `${describeMcpConfig(previewNext)}\nChanges: ${changes}`,
+                context,
+            );
+            if (changes === "No configuration changes.") {
+                displayResult(
+                    `MCP server '${current.name}' is already up to date.`,
+                    context,
+                );
+                return;
+            }
+            if (params.flags?.["dry-run"]) {
+                return;
+            }
+            const choice = await context.sessionContext.popupQuestion(
+                `Replace MCP server '${current.name}' with the resolved config changes (${changes})?`,
+                ["Update", "Cancel"],
+                1,
+            );
+            if (choice !== 0) {
+                displayResult("MCP update cancelled.", context);
+                return;
+            }
+            const materialized = await materializeMcp(
+                source,
+                matches[0],
+                context.abortSignal,
+            );
+            const next: NormalizedMcpServerConfig = {
+                ...materialized,
+                id: current.id,
+                name: current.name,
+                trust: current.trust,
+                enabled: current.enabled,
+                scope: current.scope,
+            };
+            try {
+                await api.addServer(next, appAgentProviderSetController);
+            } catch (error) {
+                cleanupMcp(source, next);
+                throw error;
+            }
+            cleanupMcp(source, current);
+            displayResult(`MCP server '${current.name}' updated.`, context);
+            return;
+        }
+        if (sourceName !== undefined && !agentMatch) {
+            throw new Error(
+                `Agent '${name}' is not installed from source '${sourceName}'.`,
+            );
+        }
 
         // The source materializes the new version first and only rewrites the
         // record after it succeeds, so a failed update is a no-op and that
@@ -726,14 +1299,288 @@ class UpdateCommandHandler implements CommandHandler {
         const completions: CompletionGroup[] = [];
         for (const name of names) {
             if (name === "name") {
+                const type = parsePackageType(
+                    _params.flags?.type as string | undefined,
+                    "all",
+                );
                 completions.push({
                     name,
-                    completions: managedAgentNames(context),
+                    completions: [
+                        ...(type === "mcp" ? [] : managedAgentNames(context)),
+                        ...(type === "agent" ? [] : mcpServerNames(context)),
+                    ],
+                });
+            } else if (name === "--type") {
+                completions.push({
+                    name,
+                    completions: ["agent", "mcp", "all"],
+                });
+            } else if (name === "--source") {
+                completions.push({
+                    name,
+                    completions: context.agentContext.source.listSources(),
                 });
             }
         }
         return { groups: completions };
     }
+}
+
+class McpStateCommandHandler implements CommandHandler {
+    public readonly parameters = {
+        args: {
+            name: { description: "MCP server name or id", type: "string" },
+        },
+    } as const;
+
+    public constructor(
+        public readonly description: string,
+        private readonly operation: "trust" | "untrust" | "enable" | "disable",
+    ) {}
+
+    public async run(
+        context: PackageActionContext,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ): Promise<void> {
+        const source = requireMcpSource(context.sessionContext);
+        const config = findMcpServer(source, params.args.name);
+        if (config === undefined) {
+            throw new Error(`MCP server '${params.args.name}' not found`);
+        }
+        const controller =
+            context.sessionContext.agentContext.appAgentProviderSetController;
+        const updated =
+            this.operation === "trust" || this.operation === "untrust"
+                ? await source.setTrust(
+                      config.id,
+                      this.operation === "trust" ? "trusted" : "untrusted",
+                      controller,
+                  )
+                : await source.setEnabled(
+                      config.id,
+                      this.operation === "enable",
+                      controller,
+                  );
+        const state =
+            this.operation === "trust"
+                ? "trusted"
+                : this.operation === "untrust"
+                  ? "untrusted"
+                  : this.operation === "enable"
+                    ? "enabled"
+                    : "disabled";
+        displayResult(`MCP server '${updated.name}' is now ${state}.`, context);
+    }
+
+    public async getCompletion(
+        context: PackageSessionContext,
+        _params: PartialParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ): Promise<{ groups: CompletionGroup[] }> {
+        return {
+            groups: names
+                .filter((name) => name === "name")
+                .map((name) => ({
+                    name,
+                    completions: mcpServerNames(context),
+                })),
+        };
+    }
+}
+
+class McpInspectCommandHandler implements CommandHandler {
+    public readonly description: string = "Inspect an MCP server config";
+    public readonly parameters = {
+        args: {
+            name: { description: "MCP server name or id", type: "string" },
+        },
+    } as const;
+
+    public async run(
+        context: PackageActionContext,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ): Promise<void> {
+        const source = requireMcpSource(context.sessionContext);
+        const config = findMcpServer(source, params.args.name);
+        if (config === undefined) {
+            throw new Error(`MCP server '${params.args.name}' not found`);
+        }
+        displayResult(describeMcpConfig(config), context);
+    }
+
+    public async getCompletion(
+        context: PackageSessionContext,
+        _params: PartialParsedCommandParams<typeof this.parameters>,
+        names: string[],
+    ): Promise<{ groups: CompletionGroup[] }> {
+        return {
+            groups: names
+                .filter((name) => name === "name")
+                .map((name) => ({
+                    name,
+                    completions: mcpServerNames(context),
+                })),
+        };
+    }
+}
+
+class McpStatusCommandHandler extends McpInspectCommandHandler {
+    public readonly description: string =
+        "Show MCP trust, enablement, and authentication status";
+
+    public async run(
+        context: PackageActionContext,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ): Promise<void> {
+        const source = requireMcpSource(context.sessionContext);
+        const config = findMcpServer(source, params.args.name);
+        if (config === undefined) {
+            throw new Error(`MCP server '${params.args.name}' not found`);
+        }
+        const auth = (await source.getAuthState?.(config.id)) ?? "unavailable";
+        displayResult(
+            `MCP server '${config.name}': ${config.enabled ? "enabled" : "disabled"}, ${config.trust}, auth=${auth}, transport=${config.transport.kind}.`,
+            context,
+        );
+    }
+}
+
+class McpCredentialSetCommandHandler implements CommandHandler {
+    public readonly description =
+        "Set an MCP credential from an environment variable without echoing it";
+    public readonly parameters = {
+        args: {
+            server: { description: "MCP server name or id", type: "string" },
+            credential: {
+                description: "Credential reference name",
+                type: "string",
+            },
+            environment: {
+                description: "Environment variable containing the secret",
+                type: "string",
+            },
+        },
+        flags: {
+            persist: {
+                description: "Require durable host secure storage",
+                type: "boolean",
+                default: false,
+            },
+        },
+    } as const;
+
+    public async run(
+        context: PackageActionContext,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ): Promise<void> {
+        const source = requireMcpSource(context.sessionContext);
+        const config = findMcpServer(source, params.args.server);
+        if (config === undefined) {
+            throw new Error(`MCP server '${params.args.server}' not found`);
+        }
+        const value = process.env[params.args.environment];
+        if (value === undefined) {
+            throw new Error(
+                `Environment variable '${params.args.environment}' is not set.`,
+            );
+        }
+        if (source.setCredential === undefined) {
+            throw new Error(
+                "MCP credential storage is not available on this host.",
+            );
+        }
+        await source.setCredential(
+            config.id,
+            params.args.credential,
+            value,
+            params.flags.persist,
+        );
+        displayResult(
+            `Credential '${params.args.credential}' was stored for this host${params.flags.persist ? " durably" : " session"}.`,
+            context,
+        );
+    }
+}
+
+class McpPolicyCommandHandler implements CommandHandler {
+    public readonly description = "Show the host-enforced MCP policy";
+    public readonly parameters = {} as const;
+
+    public async run(context: PackageActionContext): Promise<void> {
+        const policy = requireMcpSource(context.sessionContext).getPolicy?.();
+        displayResult(
+            policy === undefined
+                ? "MCP policy details are unavailable on this host."
+                : JSON.stringify(policy, null, 2),
+            context,
+        );
+    }
+}
+
+class McpTestCommandHandler extends McpInspectCommandHandler {
+    public readonly description: string =
+        "Connect to an MCP server and list its tools";
+
+    public async run(
+        context: PackageActionContext,
+        params: ParsedCommandParams<typeof this.parameters>,
+    ): Promise<void> {
+        const source = requireMcpSource(context.sessionContext);
+        const config = findMcpServer(source, params.args.name);
+        if (config === undefined) {
+            throw new Error(`MCP server '${params.args.name}' not found`);
+        }
+        let allowUntrusted = false;
+        if (config.trust !== "trusted") {
+            const choice = await context.sessionContext.popupQuestion(
+                `MCP server '${config.name}' is untrusted. Connect once for this test without changing its trust state?`,
+                ["Test once", "Cancel"],
+                1,
+            );
+            if (choice !== 0) {
+                displayResult("MCP test cancelled.", context);
+                return;
+            }
+            allowUntrusted = true;
+        }
+        const result = await source.testServer(config.id, allowUntrusted);
+        displayResult(
+            `MCP server '${config.name}' connected${result.protocolVersion === undefined ? "" : ` using protocol ${result.protocolVersion}`}. Tools: ${result.tools.join(", ") || "none"}.`,
+            context,
+        );
+    }
+}
+
+function buildMcpCommandTable(): CommandHandlerTable {
+    return {
+        description: "Manage installed MCP servers",
+        defaultSubCommand: "inspect",
+        commands: {
+            inspect: new McpInspectCommandHandler(),
+            status: new McpStatusCommandHandler(),
+            test: new McpTestCommandHandler(),
+            auth: new McpTestCommandHandler(),
+            policy: new McpPolicyCommandHandler(),
+            credentials: {
+                description: "Manage MCP credentials",
+                defaultSubCommand: "set",
+                commands: { set: new McpCredentialSetCommandHandler() },
+            },
+            trust: new McpStateCommandHandler("Trust an MCP server", "trust"),
+            untrust: new McpStateCommandHandler(
+                "Mark an MCP server untrusted",
+                "untrust",
+            ),
+            enable: new McpStateCommandHandler(
+                "Enable an MCP server",
+                "enable",
+            ),
+            disable: new McpStateCommandHandler(
+                "Disable an MCP server",
+                "disable",
+            ),
+        },
+    };
 }
 
 /**
@@ -771,6 +1618,7 @@ export function buildPackageCommandTable(
             install: new InstallCommandHandler(),
             update: new UpdateCommandHandler(),
             uninstall: new UninstallCommandHandler(),
+            mcp: buildMcpCommandTable(),
             source: sourceCommands,
         },
     };

--- a/ts/packages/defaultAgentProvider/src/installSources/packageAgent.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/packageAgent.ts
@@ -723,14 +723,160 @@ class InstallCommandHandler implements CommandHandler {
         );
     }
 
+    private async tryRunMcpInstall(
+        context: PackageActionContext,
+        target: string,
+        explicitName: string | undefined,
+        nameOrTarget: string,
+        ref: string | undefined,
+        sourceName: string | undefined,
+        type: PackageType,
+        dryRun: boolean,
+    ): Promise<{ handled: boolean; nativePreview?: InstallPreview }> {
+        if (type === "agent") {
+            return { handled: false };
+        }
+        const source = context.sessionContext.agentContext.source;
+        const mcpMatches = await source.resolveMcp(
+            target,
+            sourceName,
+            type === "mcp"
+                ? (message) => displayStatus(message, context)
+                : undefined,
+        );
+        if (mcpMatches.length > 1) {
+            throw new Error(
+                `Multiple MCP sources resolve '${target}': ${mcpMatches
+                    .map((match) => match.source)
+                    .join(", ")}. Use --source to choose one.`,
+            );
+        }
+        let nativePreview: InstallPreview | undefined;
+        if (type === "all" && mcpMatches.length > 0) {
+            nativePreview = await source.preview(
+                nameOrTarget,
+                ref,
+                sourceName,
+                (message) => displayStatus(message, context),
+            );
+            if (nativePreview !== undefined) {
+                throw new Error(
+                    `'${target}' matches both a native agent and an MCP server. Use --type agent|mcp or --source.`,
+                );
+            }
+        }
+        if (mcpMatches.length === 1) {
+            await this.runMcpInstall(
+                context,
+                mcpMatches[0],
+                explicitName ?? mcpMatches[0].config.name,
+                dryRun,
+            );
+            return { handled: true };
+        }
+        if (type === "mcp") {
+            throw new Error(
+                sourceName === undefined
+                    ? `No MCP source could resolve '${target}'.`
+                    : `'${target}' not found in MCP source '${sourceName}'.`,
+            );
+        }
+        return {
+            handled: false,
+            ...(nativePreview === undefined ? {} : { nativePreview }),
+        };
+    }
+
+    private async runNativePreview(
+        context: PackageActionContext,
+        target: string,
+        nameOrTarget: string,
+        ref: string | undefined,
+        sourceName: string | undefined,
+        existingPreview: InstallPreview | undefined,
+    ): Promise<void> {
+        const source = context.sessionContext.agentContext.source;
+        const preview =
+            existingPreview ??
+            (await source.preview(nameOrTarget, ref, sourceName, (message) =>
+                displayStatus(message, context),
+            ));
+        if (preview === undefined) {
+            displayResult(`No source would resolve '${target}'.`, context);
+            return;
+        }
+        const { winner, matches } = preview;
+        let message = `'${target}' would resolve via ${this.describeSource(
+            winner,
+        )} as ${this.describeMatch(winner)} and install as '${winner.name}'.`;
+        const shadows = matches.slice(1);
+        if (shadows.length > 0) {
+            const list = shadows
+                .map(
+                    (match) =>
+                        `${this.describeSource(match)} (${this.describeMatch(
+                            match,
+                        )})`,
+                )
+                .join(", ");
+            message += ` Also matched: ${list}.`;
+        }
+        displayResult(message, context);
+    }
+
+    private async runNativeInstall(
+        context: PackageActionContext,
+        target: string,
+        nameOrTarget: string,
+        ref: string | undefined,
+        sourceName: string | undefined,
+        explicit: boolean,
+    ): Promise<void> {
+        const { appAgentProviderSetController, source } =
+            context.sessionContext.agentContext;
+        displayStatus(`Resolving '${target}'...`, context);
+        const result = await source.install(
+            nameOrTarget,
+            ref,
+            sourceName,
+            appAgentProviderSetController,
+            (message) => displayStatus(message, context),
+            context.abortSignal,
+        );
+        for (const warning of result.warnings ?? []) {
+            displayWarn(warning, context);
+        }
+        const pkgPart =
+            result.packageName !== undefined
+                ? ` from package '${result.packageName}'`
+                : "";
+        if (!explicit) {
+            const matchKind: InstallMatchKind = deriveMatchKind({
+                matchedByName: result.matchedByName,
+                path: result.path,
+            });
+            displayResult(
+                `Matched ${this.describeMatch({
+                    matchKind,
+                    name: result.name,
+                    packageName: result.packageName,
+                    path: result.path,
+                })}.`,
+                context,
+            );
+        }
+        let message = `Agent '${result.name}' installed${pkgPart} via ${this.describeSource(result)}; it will load in each session shortly.`;
+        if (result.ref !== undefined && result.ref !== result.packageName) {
+            message += ` Durable ref: ${result.ref}.`;
+        }
+        displayResult(message, context);
+    }
+
     public async run(
         context: PackageActionContext,
         params: ParsedCommandParams<typeof this.parameters>,
     ) {
-        const {
-            appAgentProviderSetController: appAgentProviderSetController,
-            source,
-        } = context.sessionContext.agentContext;
+        const { source } = context.sessionContext.agentContext;
         const { args, flags } = params;
         const { target, name } = args;
         const sourceName = flags.source ?? undefined;
@@ -758,135 +904,40 @@ class InstallCommandHandler implements CommandHandler {
             await source.refresh(sourceName);
         }
 
-        let nativePreview: InstallPreview | undefined;
-        if (type !== "agent") {
-            const mcpMatches = await source.resolveMcp(
-                target,
-                sourceName,
-                type === "mcp"
-                    ? (message) => displayStatus(message, context)
-                    : undefined,
-            );
-            if (mcpMatches.length > 1) {
-                throw new Error(
-                    `Multiple MCP sources resolve '${target}': ${mcpMatches
-                        .map((match) => match.source)
-                        .join(", ")}. Use --source to choose one.`,
-                );
-            }
-            if (type === "all" && mcpMatches.length > 0) {
-                nativePreview = await source.preview(
-                    nameOrTarget,
-                    ref,
-                    sourceName,
-                    (message) => displayStatus(message, context),
-                );
-                if (nativePreview !== undefined) {
-                    throw new Error(
-                        `'${target}' matches both a native agent and an MCP server. Use --type agent|mcp or --source.`,
-                    );
-                }
-            }
-            if (mcpMatches.length === 1) {
-                await this.runMcpInstall(
-                    context,
-                    mcpMatches[0],
-                    name ?? mcpMatches[0].config.name,
-                    flags["dry-run"],
-                );
-                return;
-            }
-            if (type === "mcp") {
-                throw new Error(
-                    sourceName === undefined
-                        ? `No MCP source could resolve '${target}'.`
-                        : `'${target}' not found in MCP source '${sourceName}'.`,
-                );
-            }
-        }
-
-        if (flags["dry-run"]) {
-            const preview =
-                nativePreview ??
-                (await source.preview(
-                    nameOrTarget,
-                    ref,
-                    sourceName,
-                    (message) => displayStatus(message, context),
-                ));
-            if (preview === undefined) {
-                displayResult(`No source would resolve '${target}'.`, context);
-                return;
-            }
-            const { winner, matches } = preview;
-            let message = `'${target}' would resolve via ${this.describeSource(
-                winner,
-            )} as ${this.describeMatch(
-                winner,
-            )} and install as '${winner.name}'.`;
-            const shadows = matches.slice(1);
-            if (shadows.length > 0) {
-                const list = shadows
-                    .map(
-                        (m) =>
-                            `${this.describeSource(m)} (${this.describeMatch(
-                                m,
-                            )})`,
-                    )
-                    .join(", ");
-                message += ` Also matched: ${list}.`;
-            }
-            displayResult(message, context);
-            return;
-        }
-
-        displayStatus(`Resolving '${target}'...`, context);
-        // The source resolves + writes the record + fans out to every connected
-        // session. Resolve/materialize errors are thrown here
-        // (it fails fast on the record commit); the apply then lands asynchronously
-        // on every session — including this one — through its idle-gated
-        // applicator, each honoring the agent's manifest default.
-        const result = await source.install(
+        const mcpResult = await this.tryRunMcpInstall(
+            context,
+            target,
+            name,
             nameOrTarget,
             ref,
             sourceName,
-            appAgentProviderSetController,
-            (message) => displayStatus(message, context),
-            context.abortSignal,
+            type,
+            flags["dry-run"],
         );
-        // Show any non-fatal source warnings once, for this command.
-        for (const warning of result.warnings ?? []) {
-            displayWarn(warning, context);
+        if (mcpResult.handled) {
+            return;
         }
-        const pkgPart =
-            result.packageName !== undefined
-                ? ` from package '${result.packageName}'`
-                : "";
-        const sourceLabel = this.describeSource(result);
-        // One-argument (inferred) installs clarify HOW the single ambiguous
-        // token matched, on a separate line shown before the install
-        // confirmation. A two-argument install typed the name explicitly, so
-        // there is nothing to clarify.
-        if (!explicit) {
-            const matchKind: InstallMatchKind = deriveMatchKind({
-                matchedByName: result.matchedByName,
-                path: result.path,
-            });
-            displayResult(
-                `Matched ${this.describeMatch({
-                    matchKind,
-                    name: result.name,
-                    packageName: result.packageName,
-                    path: result.path,
-                })}.`,
+
+        if (flags["dry-run"]) {
+            await this.runNativePreview(
                 context,
+                target,
+                nameOrTarget,
+                ref,
+                sourceName,
+                mcpResult.nativePreview,
             );
+            return;
         }
-        let message = `Agent '${result.name}' installed${pkgPart} via ${sourceLabel}; it will load in each session shortly.`;
-        if (result.ref !== undefined && result.ref !== result.packageName) {
-            message += ` Durable ref: ${result.ref}.`;
-        }
-        displayResult(message, context);
+
+        await this.runNativeInstall(
+            context,
+            target,
+            nameOrTarget,
+            ref,
+            sourceName,
+            explicit,
+        );
     }
 
     public async getCompletion(
@@ -1116,6 +1167,108 @@ class UpdateCommandHandler implements CommandHandler {
             },
         },
     } as const;
+
+    private async runMcpUpdate(
+        context: PackageActionContext,
+        current: NormalizedMcpServerConfig,
+        range: string | undefined,
+        dryRun: boolean,
+    ): Promise<void> {
+        const { appAgentProviderSetController, source } =
+            context.sessionContext.agentContext;
+        const api = requireMcpSource(context.sessionContext);
+        const sourceKind = current.provenance.sourceKind;
+        if (
+            (sourceKind !== "mcp-config" && sourceKind !== "registry") ||
+            current.provenance.ref === undefined
+        ) {
+            throw new Error(
+                `MCP server '${current.name}' was installed from unsupported source kind '${sourceKind ?? "unknown"}'.`,
+            );
+        }
+        if (sourceKind === "mcp-config" && range !== undefined) {
+            throw new Error(
+                "A version is not supported for mcp-config updates.",
+            );
+        }
+        const updateRef =
+            sourceKind === "registry"
+                ? `${current.provenance.canonicalServerName ?? current.provenance.ref.split("@")[0]}@${range ?? "latest"}`
+                : current.provenance.ref;
+        const matches = await source.resolveMcp(
+            updateRef,
+            current.provenance.source,
+            (message) => displayStatus(message, context),
+        );
+        if (matches.length !== 1) {
+            throw new Error(
+                `MCP server '${current.name}' can no longer be resolved from source '${current.provenance.source}' using ref '${updateRef}'.`,
+            );
+        }
+        const previewNext: NormalizedMcpServerConfig = {
+            ...matches[0].config,
+            id: current.id,
+            name: current.name,
+            trust: current.trust,
+            enabled: current.enabled,
+            scope: current.scope,
+        };
+        const descriptorChanged =
+            current.provenance.digest !== undefined &&
+            previewNext.provenance.digest !== undefined &&
+            current.provenance.digest !== previewNext.provenance.digest;
+        const describedChanges = describeMcpChanges(current, previewNext);
+        const changes = descriptorChanged
+            ? describedChanges === "No configuration changes."
+                ? "registry descriptor"
+                : `${describedChanges}, registry descriptor`
+            : describedChanges;
+        displayResult(
+            `${describeMcpConfig(previewNext)}\nChanges: ${changes}`,
+            context,
+        );
+        if (changes === "No configuration changes.") {
+            displayResult(
+                `MCP server '${current.name}' is already up to date.`,
+                context,
+            );
+            return;
+        }
+        if (dryRun) {
+            return;
+        }
+        const choice = await context.sessionContext.popupQuestion(
+            `Replace MCP server '${current.name}' with the resolved config changes (${changes})?`,
+            ["Update", "Cancel"],
+            1,
+        );
+        if (choice !== 0) {
+            displayResult("MCP update cancelled.", context);
+            return;
+        }
+        const materialized = await materializeMcp(
+            source,
+            matches[0],
+            context.abortSignal,
+        );
+        const next: NormalizedMcpServerConfig = {
+            ...materialized,
+            id: current.id,
+            name: current.name,
+            trust: current.trust,
+            enabled: current.enabled,
+            scope: current.scope,
+        };
+        try {
+            await api.addServer(next, appAgentProviderSetController);
+        } catch (error) {
+            cleanupMcp(source, next);
+            throw error;
+        }
+        cleanupMcp(source, current);
+        displayResult(`MCP server '${current.name}' updated.`, context);
+    }
+
     public async run(
         context: PackageActionContext,
         params: ParsedCommandParams<typeof this.parameters>,
@@ -1151,96 +1304,12 @@ class UpdateCommandHandler implements CommandHandler {
             if (current === undefined) {
                 throw new Error(`MCP server '${name}' not found`);
             }
-            const sourceKind = current.provenance.sourceKind;
-            if (
-                (sourceKind !== "mcp-config" && sourceKind !== "registry") ||
-                current.provenance.ref === undefined
-            ) {
-                throw new Error(
-                    `MCP server '${current.name}' was installed from unsupported source kind '${sourceKind ?? "unknown"}'.`,
-                );
-            }
-            if (sourceKind === "mcp-config" && range !== undefined) {
-                throw new Error(
-                    "A version is not supported for mcp-config updates.",
-                );
-            }
-            const updateRef =
-                sourceKind === "registry"
-                    ? `${current.provenance.canonicalServerName ?? current.provenance.ref.split("@")[0]}@${range ?? "latest"}`
-                    : current.provenance.ref;
-            const matches = await source.resolveMcp(
-                updateRef,
-                current.provenance.source,
-                (message) => displayStatus(message, context),
-            );
-            if (matches.length !== 1) {
-                throw new Error(
-                    `MCP server '${current.name}' can no longer be resolved from source '${current.provenance.source}' using ref '${updateRef}'.`,
-                );
-            }
-            const previewNext: NormalizedMcpServerConfig = {
-                ...matches[0].config,
-                id: current.id,
-                name: current.name,
-                trust: current.trust,
-                enabled: current.enabled,
-                scope: current.scope,
-            };
-            const descriptorChanged =
-                current.provenance.digest !== undefined &&
-                previewNext.provenance.digest !== undefined &&
-                current.provenance.digest !== previewNext.provenance.digest;
-            const describedChanges = describeMcpChanges(current, previewNext);
-            const changes = descriptorChanged
-                ? describedChanges === "No configuration changes."
-                    ? "registry descriptor"
-                    : `${describedChanges}, registry descriptor`
-                : describedChanges;
-            displayResult(
-                `${describeMcpConfig(previewNext)}\nChanges: ${changes}`,
+            await this.runMcpUpdate(
                 context,
+                current,
+                range,
+                params.flags?.["dry-run"] ?? false,
             );
-            if (changes === "No configuration changes.") {
-                displayResult(
-                    `MCP server '${current.name}' is already up to date.`,
-                    context,
-                );
-                return;
-            }
-            if (params.flags?.["dry-run"]) {
-                return;
-            }
-            const choice = await context.sessionContext.popupQuestion(
-                `Replace MCP server '${current.name}' with the resolved config changes (${changes})?`,
-                ["Update", "Cancel"],
-                1,
-            );
-            if (choice !== 0) {
-                displayResult("MCP update cancelled.", context);
-                return;
-            }
-            const materialized = await materializeMcp(
-                source,
-                matches[0],
-                context.abortSignal,
-            );
-            const next: NormalizedMcpServerConfig = {
-                ...materialized,
-                id: current.id,
-                name: current.name,
-                trust: current.trust,
-                enabled: current.enabled,
-                scope: current.scope,
-            };
-            try {
-                await api.addServer(next, appAgentProviderSetController);
-            } catch (error) {
-                cleanupMcp(source, next);
-                throw error;
-            }
-            cleanupMcp(source, current);
-            displayResult(`MCP server '${current.name}' updated.`, context);
             return;
         }
         if (sourceName !== undefined && !agentMatch) {

--- a/ts/packages/defaultAgentProvider/src/installSources/registry.ts
+++ b/ts/packages/defaultAgentProvider/src/installSources/registry.ts
@@ -7,6 +7,7 @@ import {
     InstallSourceInfo,
     InstallSourceUpdateResult,
     InstalledAgentRecord,
+    McpInstallCandidate,
     ResolveResult,
     ResolvedCandidate,
     AvailableInstallRow,
@@ -17,6 +18,7 @@ import { createPathSource } from "./pathSource.js";
 import { createCatalogSource } from "./catalogSource.js";
 import { createFeedSource } from "./feedSource.js";
 import { createMcpConfigSource } from "./mcpConfigSource.js";
+import { createMcpRegistrySource } from "./mcpRegistrySource.js";
 import { readPackageMeta, isLegalAgentName } from "./packageMeta.js";
 import { createLimiter, Limiter } from "@typeagent/common-utils";
 
@@ -101,6 +103,15 @@ export interface DefaultInstallSourceRegistry {
         onWarn?: SourceWarning,
         onStatus?: SourceStatus,
     ): Promise<PreviewResult | undefined>;
+    // Resolve every MCP artifact matching `ref` in source order. Callers use
+    // the full set to reject ambiguous names rather than silently taking the
+    // first source.
+    resolveMcp(
+        ref: string,
+        sourceName?: string,
+        onWarn?: SourceWarning,
+        onStatus?: SourceStatus,
+    ): Promise<McpInstallCandidate[]>;
     // Refresh cache-backed source metadata (feed descriptor caches). When
     // `sourceName` is given, only that source is refreshed. A fetch failure
     // throws (the prior cache is left intact) so `--refresh` fails the command.
@@ -186,6 +197,10 @@ function buildSource(
             });
         case "mcp-config":
             return createMcpConfigSource(config);
+        case "registry":
+            return createMcpRegistrySource(config, {
+                installDir: deps.installDir,
+            });
         default: {
             const exhaustive: never = config;
             throw new Error(
@@ -233,8 +248,16 @@ export function createInstallSourceRegistry(
     // access path - resolve, where, get()->listAgents - gets the server-log
     // dedup. Optional methods are only re-wrapped when the source provides them.
     function build(config: InstallSourceConfig): InstallSource {
-        const { find, findName, update, load, listAgents, refresh, ...rest } =
-            sourceFactory(config);
+        const {
+            find,
+            findMcp,
+            findName,
+            update,
+            load,
+            listAgents,
+            refresh,
+            ...rest
+        } = sourceFactory(config);
         const wrapped: InstallSource = {
             ...rest,
             find: (ref, onWarn) => find(ref, composeWarn(onWarn)),
@@ -242,6 +265,10 @@ export function createInstallSourceRegistry(
         if (findName !== undefined) {
             wrapped.findName = (name, onWarn) =>
                 findName(name, composeWarn(onWarn));
+        }
+        if (findMcp !== undefined) {
+            wrapped.findMcp = (ref, onWarn) =>
+                findMcp(ref, composeWarn(onWarn));
         }
         if (update !== undefined) {
             wrapped.update = (record, opts, onWarn) =>
@@ -584,6 +611,25 @@ export function createInstallSourceRegistry(
                     abortSignal,
                 ),
             );
+        },
+        async resolveMcp(
+            ref: string,
+            sourceName?: string,
+            onWarn?: SourceWarning,
+            onStatus?: SourceStatus,
+        ): Promise<McpInstallCandidate[]> {
+            const matches: McpInstallCandidate[] = [];
+            for (const source of sourcesFor(sourceName)) {
+                if (source.findMcp === undefined) {
+                    continue;
+                }
+                onStatus?.(`Trying ${describeSource(source.name)}...`);
+                const candidate = await source.findMcp(ref, onWarn);
+                if (candidate !== undefined) {
+                    matches.push(candidate);
+                }
+            }
+            return matches;
         },
         async update(
             record: InstalledAgentRecord,

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpAppAgentSource.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpAppAgentSource.ts
@@ -12,10 +12,21 @@ import { createLimiter } from "@typeagent/common-utils";
 import {
     createMcpServerAppAgentProvider,
     McpClientInfo,
+    McpHostServices,
 } from "./mcpServerProvider.js";
-import { NormalizedMcpServerConfig } from "./mcpServerConfig.js";
+import {
+    NormalizedMcpServerConfig,
+    resolveTransportConfig,
+} from "./mcpServerConfig.js";
 import { McpServerStore } from "./mcpServerStore.js";
+import { McpConnection } from "./mcpConnection.js";
 import registerDebug from "debug";
+import { enforceMcpPolicy } from "./mcpPolicy.js";
+import { defaultMcpPolicy } from "./mcpPolicy.js";
+import type { McpPolicy } from "./mcpPolicy.js";
+import { McpOAuthProvider, getMcpAuthState } from "./mcpOAuth.js";
+import { SessionMcpCredentialStore } from "./mcpCredentialStore.js";
+import { nullMcpAuditSink } from "./mcpAudit.js";
 
 const debug = registerDebug("typeagent:mcp:source");
 
@@ -36,11 +47,50 @@ export interface McpServerSourceApi {
     // Remove a user-managed MCP server: drop the record and fan `removeProvider`
     // out to every connected session. Returns true when a server was removed.
     removeServer(
-        name: string,
+        id: string,
         issuingController?: AppAgentProviderSetController,
     ): Promise<boolean>;
-    // Names of the currently-active MCP servers (shipped seed + user store).
-    listServers(): string[];
+    listServers(): NormalizedMcpServerConfig[];
+    getServer(id: string): NormalizedMcpServerConfig | undefined;
+    setTrust(
+        id: string,
+        trust: NormalizedMcpServerConfig["trust"],
+        issuingController?: AppAgentProviderSetController,
+    ): Promise<NormalizedMcpServerConfig>;
+    setEnabled(
+        id: string,
+        enabled: boolean,
+        issuingController?: AppAgentProviderSetController,
+    ): Promise<NormalizedMcpServerConfig>;
+    updateServer(
+        id: string,
+        update: Partial<
+            Omit<
+                NormalizedMcpServerConfig,
+                "id" | "scope" | "trust" | "enabled"
+            >
+        >,
+        issuingController?: AppAgentProviderSetController,
+    ): Promise<NormalizedMcpServerConfig>;
+    // Connect and list tools without mutating trust, enabled state, or the
+    // persisted config. Untrusted configs require an explicit caller override
+    // after user confirmation.
+    testServer(
+        id: string,
+        allowUntrusted?: boolean,
+    ): Promise<{
+        protocolEra?: string;
+        protocolVersion?: string;
+        tools: string[];
+    }>;
+    setCredential?(
+        id: string,
+        name: string,
+        value: string,
+        durable?: boolean,
+    ): Promise<void>;
+    getAuthState?(id: string): Promise<string>;
+    getPolicy?(): McpPolicy;
 }
 
 export type McpAppAgentSourceForTest = AppAgentSource & {
@@ -96,78 +146,283 @@ export function createMcpAppAgentSource(
     store: McpServerStore,
     seed: Record<string, NormalizedMcpServerConfig>,
     clientInfo: McpClientInfo,
+    services: McpHostServices = {
+        credentialStore: new SessionMcpCredentialStore(),
+        policy: defaultMcpPolicy,
+        audit: nullMcpAuditSink,
+    },
 ): McpAppAgentSourceForTest {
-    // One shared provider per active server name (seed + store).
+    // One shared provider per active config id (seed + store).
     const providers = new Map<string, AppAgentProvider>();
-    const seedNames = new Set(Object.keys(seed));
+    const configs = new Map<string, NormalizedMcpServerConfig>();
+    const seedIds = new Set<string>();
     // Connected sessions, for cross-session fan-out.
     const clients = new Set<AppAgentProviderSetController>();
     // Serialize writes so a connect() snapshot never races a half-applied swap.
     const limiter = createLimiter(1);
 
     function buildProvider(
-        name: string,
         config: NormalizedMcpServerConfig,
     ): AppAgentProvider {
-        return createMcpServerAppAgentProvider(name, config, clientInfo);
+        return createMcpServerAppAgentProvider(
+            config.name,
+            config,
+            clientInfo,
+            services,
+        );
+    }
+
+    function isActive(config: NormalizedMcpServerConfig): boolean {
+        return config.enabled && config.trust === "trusted";
     }
 
     // Seed the always-present shipped servers, then the user store on top.
-    for (const [name, config] of Object.entries(seed)) {
-        providers.set(name, buildProvider(name, { ...config, name }));
+    for (const config of Object.values(seed)) {
+        configs.set(config.id, config);
+        seedIds.add(config.id);
+        if (isActive(config)) {
+            providers.set(config.id, buildProvider(config));
+        }
     }
     for (const config of store.list()) {
-        if (!seedNames.has(config.name)) {
-            providers.set(config.name, buildProvider(config.name, config));
+        configs.set(config.id, config);
+        if (isActive(config)) {
+            providers.set(config.id, buildProvider(config));
         }
+    }
+
+    async function replaceUserConfig(
+        config: NormalizedMcpServerConfig,
+        issuingController?: AppAgentProviderSetController,
+    ): Promise<NormalizedMcpServerConfig> {
+        if (seedIds.has(config.id) || config.scope === "shipped") {
+            throw new Error(
+                `Cannot update shipped MCP server config '${config.id}'`,
+            );
+        }
+        const previousProvider = providers.get(config.id);
+        store.set(config);
+        configs.set(config.id, config);
+        const nextProvider = isActive(config)
+            ? buildProvider(config)
+            : undefined;
+        if (nextProvider === undefined) {
+            providers.delete(config.id);
+        } else {
+            providers.set(config.id, nextProvider);
+        }
+        if (previousProvider !== undefined || nextProvider !== undefined) {
+            await fanOut(clients, issuingController, async (mutation) => {
+                if (previousProvider !== undefined) {
+                    await mutation.removeProvider(previousProvider, {
+                        dropConfig: false,
+                    });
+                }
+                if (nextProvider !== undefined) {
+                    await mutation.addProvider(nextProvider);
+                }
+            });
+        }
+        return config;
+    }
+
+    function requireUserConfig(id: string): NormalizedMcpServerConfig {
+        const config = configs.get(id);
+        if (config === undefined) {
+            throw new Error(`Unknown MCP server config '${id}'`);
+        }
+        if (seedIds.has(id) || config.scope === "shipped") {
+            throw new Error(`Cannot update shipped MCP server config '${id}'`);
+        }
+        return config;
     }
 
     const testApi: McpServerSourceApi = {
         async addServer(config, issuingController) {
             await limiter(async () => {
-                if (seedNames.has(config.name)) {
+                enforceMcpPolicy(services.policy, "install", config);
+                if (seedIds.has(config.id)) {
                     throw new Error(
-                        `Cannot add MCP server '${config.name}': name is reserved by a shipped server`,
+                        `Cannot add MCP server config '${config.id}': id is reserved by a shipped server`,
                     );
                 }
-                store.set(config);
-                const existing = providers.get(config.name);
-                const next = buildProvider(config.name, config);
-                providers.set(config.name, next);
-                await fanOut(clients, issuingController, async (mutation) => {
-                    // Replace in place: remove the old provider before adding the
-                    // new one so the name is never registered twice.
-                    if (existing !== undefined) {
-                        await mutation.removeProvider(existing, {
-                            dropConfig: false,
-                        });
-                    }
-                    await mutation.addProvider(next);
+                await replaceUserConfig(config, issuingController);
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: "install",
+                    configId: config.id,
+                    configName: config.name,
+                    transport: config.transport.kind,
+                    source: config.provenance.source,
+                    status: "success",
                 });
             });
         },
-        async removeServer(name, issuingController) {
+        async removeServer(id, issuingController) {
             return limiter(async () => {
-                if (seedNames.has(name)) {
-                    throw new Error(
-                        `Cannot remove shipped MCP server '${name}'`,
-                    );
+                if (seedIds.has(id)) {
+                    throw new Error(`Cannot remove shipped MCP server '${id}'`);
                 }
-                const existing = providers.get(name);
-                if (existing === undefined) {
+                const config = configs.get(id);
+                if (config === undefined) {
                     return false;
                 }
-                store.remove(name);
-                providers.delete(name);
-                await fanOut(clients, issuingController, async (mutation) => {
-                    await mutation.removeProvider(existing, {
-                        dropConfig: true,
-                    });
+                const existing = providers.get(id);
+                store.remove(id);
+                configs.delete(id);
+                providers.delete(id);
+                if (existing !== undefined) {
+                    await fanOut(
+                        clients,
+                        issuingController,
+                        async (mutation) => {
+                            await mutation.removeProvider(existing, {
+                                dropConfig: true,
+                            });
+                        },
+                    );
+                }
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: "uninstall",
+                    configId: config.id,
+                    configName: config.name,
+                    transport: config.transport.kind,
+                    source: config.provenance.source,
+                    status: "success",
                 });
                 return true;
             });
         },
-        listServers: () => [...providers.keys()],
+        listServers: () => [...configs.values()],
+        getServer: (id) => configs.get(id),
+        async setTrust(id, trust, issuingController) {
+            return limiter(async () => {
+                const config = requireUserConfig(id);
+                if (trust === "trusted") {
+                    enforceMcpPolicy(services.policy, "trust", config);
+                }
+                const updated = await replaceUserConfig(
+                    { ...config, trust },
+                    issuingController,
+                );
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: "trust",
+                    configId: config.id,
+                    configName: config.name,
+                    decision: trust,
+                    status: "success",
+                });
+                return updated;
+            });
+        },
+        async setEnabled(id, enabled, issuingController) {
+            return limiter(async () => {
+                const config = requireUserConfig(id);
+                if (enabled) {
+                    enforceMcpPolicy(services.policy, "enable", config);
+                }
+                const updated = await replaceUserConfig(
+                    { ...config, enabled },
+                    issuingController,
+                );
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: enabled ? "enable" : "disable",
+                    configId: config.id,
+                    configName: config.name,
+                    status: "success",
+                });
+                return updated;
+            });
+        },
+        async updateServer(id, update, issuingController) {
+            return limiter(async () => {
+                const config = requireUserConfig(id);
+                const updated = { ...config, ...update };
+                enforceMcpPolicy(services.policy, "update", updated);
+                const result = await replaceUserConfig(
+                    updated,
+                    issuingController,
+                );
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: "update",
+                    configId: config.id,
+                    configName: updated.name,
+                    status: "success",
+                });
+                return result;
+            });
+        },
+        async testServer(id, allowUntrusted = false) {
+            const config = configs.get(id);
+            if (config === undefined) {
+                throw new Error(`Unknown MCP server config '${id}'`);
+            }
+            if (config.trust !== "trusted" && !allowUntrusted) {
+                throw new Error(
+                    `MCP server '${config.name}' is untrusted; confirm an explicit test before connecting.`,
+                );
+            }
+            enforceMcpPolicy(services.policy, "connect", config);
+            const transport = await resolveTransportConfig(
+                config,
+                services.credentialStore,
+            );
+            if (transport.kind === "http" && config.oauth?.enabled === true) {
+                transport.authProvider = new McpOAuthProvider(
+                    config,
+                    services.credentialStore,
+                    services.oauthInteraction,
+                );
+            }
+            const connection = await McpConnection.create(
+                clientInfo,
+                transport,
+            );
+            try {
+                const tools = await connection.listTools();
+                if (config.oauth?.enabled === true) {
+                    await services.audit.write({
+                        timestamp: new Date().toISOString(),
+                        operation: "auth",
+                        configId: config.id,
+                        configName: config.name,
+                        transport: "http",
+                        source: config.provenance.source,
+                        status: "success",
+                    });
+                }
+                return {
+                    ...(connection.protocolEra === undefined
+                        ? {}
+                        : { protocolEra: connection.protocolEra }),
+                    ...(connection.protocolVersion === undefined
+                        ? {}
+                        : { protocolVersion: connection.protocolVersion }),
+                    tools: tools.map((tool) => tool.name),
+                };
+            } finally {
+                await connection.close();
+            }
+        },
+        async setCredential(id, name, value, durable = false) {
+            const config = configs.get(id);
+            if (config === undefined) {
+                throw new Error(`Unknown MCP server config '${id}'`);
+            }
+            await services.credentialStore.set(name, value, { durable });
+        },
+        async getAuthState(id) {
+            const config = configs.get(id);
+            if (config === undefined) {
+                throw new Error(`Unknown MCP server config '${id}'`);
+            }
+            return getMcpAuthState(config, services.credentialStore);
+        },
+        getPolicy: () => structuredClone(services.policy),
     };
 
     const source: McpAppAgentSourceForTest = {
@@ -181,7 +436,9 @@ export function createMcpAppAgentSource(
             clients.add(controller);
             const snapshot = [...providers.values()];
             return {
-                providers: Promise.resolve(disposed ? [] : snapshot),
+                providers: Promise.resolve().then(() =>
+                    disposed ? [] : snapshot,
+                ),
                 dispose() {
                     disposed = true;
                     clients.delete(controller);

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpAudit.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpAudit.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { filterSecretsFromObject } from "@typeagent/common-utils";
+import fs from "node:fs";
+import path from "node:path";
+
+export type McpAuditOperation =
+    | "install"
+    | "update"
+    | "uninstall"
+    | "trust"
+    | "enable"
+    | "disable"
+    | "connect"
+    | "auth"
+    | "tool-invocation"
+    | "tool-result"
+    | "catalog-refresh";
+
+export interface McpAuditEvent {
+    timestamp: string;
+    operation: McpAuditOperation;
+    configId: string;
+    configName: string;
+    tool?: string;
+    toolId?: string;
+    sessionId?: string;
+    agent?: string;
+    transport?: string;
+    source?: string;
+    decision?: string;
+    status?: "success" | "failure";
+    durationMs?: number;
+    arguments?: unknown;
+    error?: string;
+    previousCount?: number;
+    toolCount?: number;
+    skippedCount?: number;
+    sensitiveValues?: string[];
+}
+
+export interface McpAuditSink {
+    write(event: McpAuditEvent): Promise<void>;
+}
+
+export function sanitizeMcpAuditEvent(
+    event: McpAuditEvent,
+    knownSecrets: Iterable<string> = [],
+): McpAuditEvent {
+    const secrets = [...knownSecrets, ...(event.sensitiveValues ?? [])];
+    const sanitized = filterSecretsFromObject(event, {
+        values: secrets,
+    });
+    delete sanitized.sensitiveValues;
+    if (sanitized.arguments !== undefined) {
+        const redactSensitiveKeys = (value: unknown): unknown => {
+            if (Array.isArray(value)) return value.map(redactSensitiveKeys);
+            if (value === null || typeof value !== "object") return value;
+            return Object.fromEntries(
+                Object.entries(value as Record<string, unknown>).map(
+                    ([key, child]) => [
+                        key,
+                        /authorization|cookie|password|secret|token|api[-_]?key/i.test(
+                            key,
+                        )
+                            ? "******"
+                            : redactSensitiveKeys(child),
+                    ],
+                ),
+            );
+        };
+        sanitized.arguments = redactSensitiveKeys(
+            filterSecretsFromObject(sanitized.arguments, {
+                values: secrets,
+            }),
+        );
+    }
+    return sanitized;
+}
+
+export class JsonlMcpAuditSink implements McpAuditSink {
+    private readonly filePath: string;
+
+    public constructor(
+        instanceDir: string,
+        private readonly maxBytes = 2 * 1024 * 1024,
+    ) {
+        this.filePath = path.join(instanceDir, "mcp-audit.jsonl");
+    }
+
+    async write(event: McpAuditEvent): Promise<void> {
+        fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+        const line = `${JSON.stringify(sanitizeMcpAuditEvent(event))}\n`;
+        if (
+            fs.existsSync(this.filePath) &&
+            fs.statSync(this.filePath).size + Buffer.byteLength(line) >
+                this.maxBytes
+        ) {
+            const existing = fs.readFileSync(this.filePath, "utf8");
+            const midpoint = Math.floor(existing.length / 2);
+            const newline = existing.indexOf("\n", midpoint);
+            fs.writeFileSync(
+                this.filePath,
+                newline === -1 ? "" : existing.slice(newline + 1),
+            );
+        }
+        fs.appendFileSync(this.filePath, line);
+    }
+}
+
+export const nullMcpAuditSink: McpAuditSink = {
+    async write() {},
+};

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpConfigImport.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpConfigImport.ts
@@ -91,6 +91,13 @@ function toTransport(entry: Record<string, unknown>): TransportConfig {
         if (headers !== undefined) {
             transport.headers = headers;
         }
+        if (
+            typeof entry.timeoutMs === "number" &&
+            Number.isFinite(entry.timeoutMs) &&
+            entry.timeoutMs > 0
+        ) {
+            transport.timeoutMs = entry.timeoutMs;
+        }
         return transport;
     }
 
@@ -120,10 +127,17 @@ function toNormalized(
     entry: Record<string, unknown>,
 ): NormalizedMcpServerConfig {
     const config: NormalizedMcpServerConfig = {
+        id: name,
         name,
         transport: toTransport(entry),
         scope: "workspace",
         trust: "untrusted",
+        enabled: true,
+        provenance: {
+            source: "imported-config",
+            sourceKind: "mcp-config",
+            ref: name,
+        },
     };
     if (typeof entry.description === "string") {
         config.description = entry.description;

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpConnection.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpConnection.ts
@@ -4,15 +4,20 @@
 import {
     Client,
     StreamableHTTPClientTransport,
+    UnauthorizedError,
 } from "@modelcontextprotocol/client";
 import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { getDefaultEnvironment } from "@modelcontextprotocol/client/stdio";
 import type { StdioServerParameters } from "@modelcontextprotocol/client/stdio";
 import type {
     CallToolResult,
+    ClientOptions,
     ProtocolEra,
+    StreamableHTTPClientTransportOptions,
     Tool,
+    OAuthClientProvider,
 } from "@modelcontextprotocol/client";
+import type { McpOAuthProvider } from "./mcpOAuth.js";
 import registerDebug from "debug";
 
 const debug = registerDebug("typeagent:mcp:connection");
@@ -28,13 +33,56 @@ export type McpTransportConfig =
           env?: Record<string, string>;
           cwd?: string;
       }
-    | { kind: "http"; url: string };
+    | {
+          kind: "http";
+          url: string;
+          headers?: Record<string, string>;
+          timeoutMs?: number;
+          authProvider?: OAuthClientProvider;
+      };
 
 type McpTransport = StdioClientTransport | StreamableHTTPClientTransport;
 
+export interface McpConnectionOptions {
+    toolsChanged?: (error: Error | null, tools: Tool[] | null) => void;
+    listChangedDebounceMs?: number;
+}
+
+function createTimeoutFetch(timeoutMs: number): typeof fetch {
+    return (input, init) => {
+        const timeoutSignal = AbortSignal.timeout(timeoutMs);
+        const signal =
+            init?.signal == null
+                ? timeoutSignal
+                : AbortSignal.any([init.signal, timeoutSignal]);
+        return globalThis.fetch(input, { ...init, signal });
+    };
+}
+
+/** @internal Exported for focused transport configuration tests. */
+export function getHttpTransportOptions(
+    config: Extract<McpTransportConfig, { kind: "http" }>,
+): StreamableHTTPClientTransportOptions | undefined {
+    const options: StreamableHTTPClientTransportOptions = {
+        ...(config.headers === undefined
+            ? {}
+            : { requestInit: { headers: config.headers } }),
+        ...(config.authProvider === undefined
+            ? {}
+            : { authProvider: config.authProvider }),
+        ...(config.timeoutMs === undefined
+            ? {}
+            : { fetch: createTimeoutFetch(config.timeoutMs) }),
+    };
+    return Object.keys(options).length === 0 ? undefined : options;
+}
+
 function createTransport(config: McpTransportConfig): McpTransport {
     if (config.kind === "http") {
-        return new StreamableHTTPClientTransport(new URL(config.url));
+        return new StreamableHTTPClientTransport(
+            new URL(config.url),
+            getHttpTransportOptions(config),
+        );
     }
     const params: StdioServerParameters = {
         command: config.command,
@@ -60,19 +108,54 @@ export class McpConnection {
     private constructor(
         private readonly client: Client,
         private readonly transport: McpTransport,
+        private readonly timeoutMs: number | undefined,
     ) {}
 
     static async create(
         clientInfo: { name: string; version: string },
         config: McpTransportConfig,
+        options: McpConnectionOptions = {},
     ): Promise<McpConnection> {
         const transport = createTransport(config);
-        const client = new Client(clientInfo, {
+        const clientOptions: ClientOptions = {
             versionNegotiation: { mode: "auto" },
             capabilities: {},
-        });
+        };
+        if (options.toolsChanged !== undefined) {
+            clientOptions.listChanged = {
+                tools: {
+                    autoRefresh: true,
+                    ...(options.listChangedDebounceMs === undefined
+                        ? {}
+                        : { debounceMs: options.listChangedDebounceMs }),
+                    onChanged: options.toolsChanged,
+                },
+            };
+        }
+        const client = new Client(clientInfo, clientOptions);
+        const connect = () =>
+            client.connect(
+                transport,
+                config.kind === "http" && config.timeoutMs !== undefined
+                    ? { timeout: config.timeoutMs }
+                    : undefined,
+            );
         try {
-            await client.connect(transport);
+            try {
+                await connect();
+            } catch (error) {
+                if (
+                    config.kind !== "http" ||
+                    !(error instanceof UnauthorizedError) ||
+                    config.authProvider === undefined ||
+                    !(await (
+                        config.authProvider as McpOAuthProvider
+                    ).finishAuth?.(transport as StreamableHTTPClientTransport))
+                ) {
+                    throw error;
+                }
+                await connect();
+            }
         } catch (e) {
             // connect() may leave the transport partially open; make sure the
             // child process / socket is torn down before the error propagates.
@@ -84,7 +167,11 @@ export class McpConnection {
         debug(
             `connected: era=${client.getProtocolEra()} version=${client.getNegotiatedProtocolVersion()}`,
         );
-        return new McpConnection(client, transport);
+        return new McpConnection(
+            client,
+            transport,
+            config.kind === "http" ? config.timeoutMs : undefined,
+        );
     }
 
     // The negotiated era ('legacy' | 'modern') and wire protocol version, for
@@ -97,6 +184,10 @@ export class McpConnection {
         return this.client.getNegotiatedProtocolVersion();
     }
 
+    get supportsToolListChanged(): boolean {
+        return this.client.getServerCapabilities()?.tools?.listChanged === true;
+    }
+
     // True for HTTP transports, false for stdio. Callers that need to reason
     // about process lifecycle (e.g. whether a child process must be killed)
     // use this instead of an `instanceof` check against the transport.
@@ -105,19 +196,31 @@ export class McpConnection {
     }
 
     async listTools(): Promise<Tool[]> {
-        return (await this.client.listTools()).tools;
+        return (
+            await this.client.listTools(
+                undefined,
+                this.timeoutMs === undefined
+                    ? undefined
+                    : { timeout: this.timeoutMs },
+            )
+        ).tools;
     }
 
     async callTool(
         name: string,
         args: Record<string, unknown> | undefined,
     ): Promise<CallToolResult> {
-        return this.client.callTool({ name, arguments: args });
+        return this.client.callTool(
+            { name, arguments: args },
+            this.timeoutMs === undefined
+                ? undefined
+                : { timeout: this.timeoutMs },
+        );
     }
 
     async close(): Promise<void> {
         if (this.transport instanceof StreamableHTTPClientTransport) {
-            await this.transport.close();
+            await this.client.close();
             return;
         }
         // The stdio transport resolves `close()` synchronously but only fires
@@ -125,7 +228,7 @@ export class McpConnection {
         // callers can rely on the process being gone when close() resolves.
         await new Promise<void>((resolve) => {
             this.transport.onclose = resolve;
-            void this.transport.close();
+            void this.client.close();
         });
     }
 }

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpCredentialStore.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpCredentialStore.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { CredentialRef } from "./mcpServerConfig.js";
+
+export interface McpCredentialStore {
+    get(ref: CredentialRef): Promise<string | undefined>;
+    set(
+        name: string,
+        value: string,
+        options?: { durable?: boolean },
+    ): Promise<CredentialRef>;
+    delete(ref: CredentialRef): Promise<void>;
+}
+
+export class SessionMcpCredentialStore implements McpCredentialStore {
+    private readonly values = new Map<string, string>();
+
+    public constructor(
+        private readonly environment: Record<
+            string,
+            string | undefined
+        > = process.env,
+    ) {}
+
+    async get(ref: CredentialRef): Promise<string | undefined> {
+        if (ref.kind === "env") {
+            return this.environment[ref.name];
+        }
+        return this.values.get(ref.name);
+    }
+
+    async set(
+        name: string,
+        value: string,
+        options?: { durable?: boolean },
+    ): Promise<CredentialRef> {
+        if (options?.durable) {
+            throw new Error(
+                "Durable MCP secret storage is not configured. Inject a secure McpCredentialStore or omit --persist.",
+            );
+        }
+        this.values.set(name, value);
+        return { kind: "secure", name };
+    }
+
+    async delete(ref: CredentialRef): Promise<void> {
+        if (ref.kind !== "env") {
+            this.values.delete(ref.name);
+        }
+    }
+}
+
+export async function requireCredential(
+    store: McpCredentialStore,
+    ref: CredentialRef,
+    configName: string,
+): Promise<string> {
+    const value = await store.get(ref);
+    if (value === undefined) {
+        throw new Error(
+            `MCP server '${configName}' is missing credential '${ref.name}'. Set it with '@package mcp credentials set ${configName} ${ref.name}'.`,
+        );
+    }
+    return value;
+}

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpOAuth.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpOAuth.ts
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+    OAuthClientMetadata,
+    OAuthClientProvider,
+    StoredOAuthClientInformation,
+    StoredOAuthTokens,
+    StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import type { McpCredentialStore } from "./mcpCredentialStore.js";
+import type {
+    CredentialRef,
+    NormalizedMcpServerConfig,
+} from "./mcpServerConfig.js";
+
+export interface McpOAuthInteraction {
+    authorize(serverName: string, authorizationUrl: URL): Promise<string | URL>;
+}
+
+export type McpAuthState =
+    | "not-configured"
+    | "signed-out"
+    | "authorization-required"
+    | "authenticated";
+
+async function readJson<T>(
+    store: McpCredentialStore,
+    ref: CredentialRef | undefined,
+): Promise<T | undefined> {
+    if (ref === undefined) return undefined;
+    const value = await store.get(ref);
+    return value === undefined ? undefined : (JSON.parse(value) as T);
+}
+
+export class McpOAuthProvider implements OAuthClientProvider {
+    private authorizationUrl: URL | undefined;
+    private codeVerifierValue: string | undefined;
+    private stateValue: string | undefined;
+
+    public constructor(
+        private readonly config: NormalizedMcpServerConfig,
+        private readonly store: McpCredentialStore,
+        private readonly interaction?: McpOAuthInteraction,
+    ) {}
+
+    get redirectUrl(): URL {
+        return new URL(
+            this.config.oauth?.redirectUrl ??
+                "http://127.0.0.1/typeagent-mcp-oauth",
+        );
+    }
+
+    get clientMetadata(): OAuthClientMetadata {
+        return {
+            client_name: "TypeAgent",
+            redirect_uris: [this.redirectUrl.toString()],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+            ...(this.config.oauth?.scopes === undefined
+                ? {}
+                : { scope: this.config.oauth.scopes.join(" ") }),
+        };
+    }
+
+    async clientInformation(): Promise<
+        StoredOAuthClientInformation | undefined
+    > {
+        const stored = await readJson<StoredOAuthClientInformation>(
+            this.store,
+            this.config.oauth?.clientInformationRef ?? {
+                kind: "secure",
+                name: `mcp:${this.config.id}:oauth-client`,
+            },
+        );
+        if (stored !== undefined) return stored;
+        const clientId = this.config.oauth?.clientId;
+        return clientId === undefined ? undefined : { client_id: clientId };
+    }
+
+    async saveClientInformation(
+        value: StoredOAuthClientInformation,
+    ): Promise<void> {
+        await this.store.set(
+            `mcp:${this.config.id}:oauth-client`,
+            JSON.stringify(value),
+            { durable: true },
+        );
+    }
+
+    async tokens(): Promise<StoredOAuthTokens | undefined> {
+        return readJson(
+            this.store,
+            this.config.oauth?.tokensRef ?? {
+                kind: "secure",
+                name: `mcp:${this.config.id}:oauth-tokens`,
+            },
+        );
+    }
+
+    async saveTokens(value: StoredOAuthTokens): Promise<void> {
+        await this.store.set(
+            `mcp:${this.config.id}:oauth-tokens`,
+            JSON.stringify(value),
+            { durable: true },
+        );
+    }
+
+    async redirectToAuthorization(url: URL): Promise<void> {
+        this.authorizationUrl = url;
+    }
+
+    async saveCodeVerifier(value: string): Promise<void> {
+        this.codeVerifierValue = value;
+        try {
+            await this.store.set(`mcp:${this.config.id}:oauth-verifier`, value);
+        } catch {}
+    }
+
+    async codeVerifier(): Promise<string> {
+        const value =
+            this.codeVerifierValue ??
+            (this.config.oauth?.verifierRef === undefined
+                ? await this.store.get({
+                      kind: "secure",
+                      name: `mcp:${this.config.id}:oauth-verifier`,
+                  })
+                : await this.store.get(this.config.oauth.verifierRef));
+        if (value === undefined) {
+            throw new Error("OAuth PKCE verifier is unavailable.");
+        }
+        return value;
+    }
+
+    async finishAuth(
+        transport: StreamableHTTPClientTransport,
+    ): Promise<boolean> {
+        if (this.authorizationUrl === undefined) return false;
+        if (this.interaction === undefined) {
+            throw new Error(
+                `MCP server '${this.config.name}' requires OAuth authorization. Run '@package mcp auth ${this.config.name}' on a host with an OAuth interaction provider.`,
+            );
+        }
+        const callback = await this.interaction.authorize(
+            this.config.name,
+            this.authorizationUrl,
+        );
+        const callbackParams = new URL(callback.toString(), this.redirectUrl)
+            .searchParams;
+        if (
+            this.stateValue !== undefined &&
+            callbackParams.get("state") !== this.stateValue
+        ) {
+            throw new Error("OAuth callback state did not match the request.");
+        }
+        await transport.finishAuth(callbackParams);
+        return true;
+    }
+
+    async state(): Promise<string> {
+        this.stateValue = crypto.randomUUID();
+        return this.stateValue;
+    }
+}
+
+export async function getMcpAuthState(
+    config: NormalizedMcpServerConfig,
+    store: McpCredentialStore,
+): Promise<McpAuthState> {
+    if (config.oauth?.enabled !== true) return "not-configured";
+    return (await readJson(
+        store,
+        config.oauth.tokensRef ?? {
+            kind: "secure",
+            name: `mcp:${config.id}:oauth-tokens`,
+        },
+    )) === undefined
+        ? "signed-out"
+        : "authenticated";
+}

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpPolicy.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpPolicy.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { NormalizedMcpServerConfig } from "./mcpServerConfig.js";
+
+export interface McpPolicy {
+    allowedTransports?: readonly ("stdio" | "http")[];
+    allowedCommands?: readonly string[];
+    allowedRuntimeHints?: readonly string[];
+    allowedHttpDomains?: readonly string[];
+    allowedNpmPackages?: readonly string[];
+    allowedNpmRegistries?: readonly string[];
+    allowPublicNpmRegistry?: boolean;
+}
+
+export const defaultMcpPolicy: McpPolicy = {
+    allowedTransports: ["stdio", "http"],
+    allowedRuntimeHints: ["node", "npx"],
+    allowPublicNpmRegistry: false,
+};
+
+function matches(value: string, patterns: readonly string[] | undefined) {
+    return (
+        patterns === undefined ||
+        patterns.some(
+            (pattern) =>
+                pattern === value ||
+                (pattern.startsWith("*.") && value.endsWith(pattern.slice(1))),
+        )
+    );
+}
+
+export function enforceMcpPolicy(
+    policy: McpPolicy,
+    operation: string,
+    config: NormalizedMcpServerConfig,
+): void {
+    if (!policy.allowedTransports?.includes(config.transport.kind)) {
+        throw new Error(
+            `MCP policy denied ${operation} for '${config.name}': transport '${config.transport.kind}' is not allowed.`,
+        );
+    }
+    if (config.transport.kind === "http") {
+        const host = new URL(config.transport.url).hostname;
+        if (!matches(host, policy.allowedHttpDomains)) {
+            throw new Error(
+                `MCP policy denied ${operation} for '${config.name}': HTTP domain '${host}' is not allowed.`,
+            );
+        }
+    } else if (
+        policy.allowedCommands !== undefined &&
+        !policy.allowedCommands.includes(config.transport.command)
+    ) {
+        throw new Error(
+            `MCP policy denied ${operation} for '${config.name}': command '${config.transport.command}' is not allowed.`,
+        );
+    }
+    const packageName = config.provenance.packageIdentifier;
+    if (
+        packageName !== undefined &&
+        !matches(packageName, policy.allowedNpmPackages)
+    ) {
+        throw new Error(
+            `MCP policy denied ${operation} for '${config.name}': npm package '${packageName}' is not allowed.`,
+        );
+    }
+    const registry = config.provenance.npmRegistryUrl;
+    if (registry !== undefined) {
+        const normalized = new URL(registry).origin;
+        if (
+            normalized === "https://registry.npmjs.org" &&
+            policy.allowPublicNpmRegistry !== true
+        ) {
+            throw new Error(
+                `MCP policy denied ${operation} for '${config.name}': public npm registry materialization is disabled.`,
+            );
+        }
+        if (
+            policy.allowedNpmRegistries !== undefined &&
+            !policy.allowedNpmRegistries.includes(normalized)
+        ) {
+            throw new Error(
+                `MCP policy denied ${operation} for '${config.name}': npm registry '${normalized}' is not allowed.`,
+            );
+        }
+    }
+}

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpSchema.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpSchema.ts
@@ -15,7 +15,7 @@ const debug = registerDebug("typeagent:mcp:schema");
 // human-readable reason (unsupported JSON Schema construct, name collision,
 // etc.). Surfaced as a diagnostic so one problematic tool does not silently
 // disappear or take the whole server down with it.
-export type SkippedTool = { name: string; reason: string };
+export type SkippedTool = { id: string; name: string; reason: string };
 
 export type ConvertToolsResult = {
     // Serialized JSONParsedActionSchema for the accepted tools.
@@ -68,6 +68,7 @@ function toParserTool(tool: Tool): ParserTool {
 export function convertToolsSchema(
     tools: Tool[],
     entryTypeName: string,
+    serverConfigId = "",
 ): ConvertToolsResult {
     const accepted: string[] = [];
     const acceptedTools: ParserTool[] = [];
@@ -76,6 +77,7 @@ export function convertToolsSchema(
 
     for (const tool of tools) {
         const name = typeof tool?.name === "string" ? tool.name : "(unnamed)";
+        const id = JSON.stringify([serverConfigId, name]);
 
         // Two distinct tool names can collapse to the same PascalCase type
         // name (e.g. "get_weather" and "get-weather"); keep the first and skip
@@ -84,7 +86,7 @@ export function convertToolsSchema(
         const collidesWith = seenTypeNames.get(typeName);
         if (collidesWith !== undefined) {
             const reason = `type name '${typeName}' collides with tool '${collidesWith}'`;
-            skipped.push({ name, reason });
+            skipped.push({ id, name, reason });
             debug(`skipping tool '${name}': ${reason}`);
             continue;
         }
@@ -96,7 +98,7 @@ export function convertToolsSchema(
             parseToolsJsonSchema([parserTool], entryTypeName);
         } catch (e: any) {
             const reason = e?.message ?? String(e);
-            skipped.push({ name, reason });
+            skipped.push({ id, name, reason });
             debug(`skipping tool '${name}': ${reason}`);
             continue;
         }

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpSeed.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpSeed.ts
@@ -37,11 +37,25 @@ export function mcpInfoToNormalized(
 ): NormalizedMcpServerConfig | undefined {
     const base: Pick<
         NormalizedMcpServerConfig,
-        "name" | "description" | "emojiChar" | "scope" | "trust"
+        | "id"
+        | "name"
+        | "description"
+        | "emojiChar"
+        | "scope"
+        | "trust"
+        | "enabled"
+        | "provenance"
     > = {
+        id: `shipped:${name}`,
         name,
         scope: "shipped",
         trust: "trusted",
+        enabled: true,
+        provenance: {
+            source: "shipped",
+            sourceKind: "shipped",
+            ref: name,
+        },
     };
     if (info.description !== undefined) {
         base.description = info.description;

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpServerConfig.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpServerConfig.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import type { McpTransportConfig } from "./mcpConnection.js";
+import type { McpCredentialStore } from "./mcpCredentialStore.js";
+import { requireCredential } from "./mcpCredentialStore.js";
 
 // A reference to a secret value resolved at launch time from a credential
 // store, never the plaintext secret itself. Persisted configs store the
@@ -11,7 +13,7 @@ import type { McpTransportConfig } from "./mcpConnection.js";
 // - `input`: resolve from a named input the user is prompted for (e.g. a
 //            VS Code `${input:api-key}` placeholder), keyed by `name`.
 export type CredentialRef = {
-    kind: "env" | "input";
+    kind: "env" | "input" | "secure";
     name: string;
 };
 
@@ -19,7 +21,12 @@ export type CredentialRef = {
 // to a credential resolved at launch. Keeping these distinct lets the importer
 // preserve `${input:...}` / `${env:...}` placeholders as references instead of
 // baking a (possibly empty) literal into the persisted config.
-export type EnvValue = string | CredentialRef;
+export type ValueTemplate = {
+    value: string;
+    variables: Record<string, string | CredentialRef>;
+};
+
+export type EnvValue = string | CredentialRef | ValueTemplate;
 
 // How much the user has authorized a server to run. New servers start
 // `untrusted` and must be explicitly promoted before first launch (Phase 5
@@ -31,13 +38,32 @@ export type TrustLevel = "untrusted" | "trusted";
 // (`.mcp.json`, `.vscode/mcp.json`, etc.); `shipped` = seeded with the app.
 export type ConfigScope = "user" | "workspace" | "shipped";
 
+export type McpInstallProvenance = {
+    source: string;
+    sourceKind?: string;
+    ref?: string;
+    version?: string;
+    digest?: string;
+    ownedPaths?: string[];
+    registryBaseUrl?: string;
+    npmRegistryUrl?: string;
+    canonicalServerName?: string;
+    serverVersion?: string;
+    publisher?: Record<string, unknown>;
+    repository?: Record<string, unknown>;
+    packageIdentifier?: string;
+    packageVersion?: string;
+    packageHash?: string;
+    transportType?: string;
+};
+
 // Launch a local server process over stdio. `command` is a generic executable
 // (not restricted to `.js`/`.py`); `args`, `env`, and `cwd` are passed through
 // to the child process. Secret env values are stored as credential references.
 export type StdioTransport = {
     kind: "stdio";
     command: string;
-    args?: string[];
+    args?: EnvValue[];
     env?: Record<string, EnvValue>;
     cwd?: string;
 };
@@ -47,6 +73,7 @@ export type StdioTransport = {
 export type HttpTransport = {
     kind: "http";
     url: string;
+    urlVariables?: Record<string, string | CredentialRef>;
     headers?: Record<string, EnvValue>;
     timeoutMs?: number;
 };
@@ -58,8 +85,9 @@ export type TransportConfig = StdioTransport | HttpTransport;
 // is mapped onto, so downstream code never has to branch on where a server came
 // from. Secrets live as references in `env`/`headers`, never as values.
 export type NormalizedMcpServerConfig = {
-    // Stable identifier within its source (e.g. the key in a `mcpServers`
-    // object). Combined with the owning source id to form the catalog identity.
+    // Stable persisted identity. Unlike `name`, this does not change when the
+    // dispatcher-facing display/agent name is updated.
+    id: string;
     name: string;
     description?: string;
     emojiChar?: string;
@@ -67,8 +95,26 @@ export type NormalizedMcpServerConfig = {
     // When set, only these tool names are exposed; others are hidden. Absent =
     // expose all tools the server advertises.
     enabledTools?: string[];
-    trust?: TrustLevel;
-    scope?: ConfigScope;
+    deniedTools?: string[];
+    toolApproval?: {
+        prompt?: string[];
+        allow?: string[];
+        deny?: string[];
+        persisted?: Record<string, "allow" | "deny">;
+    };
+    oauth?: {
+        enabled: boolean;
+        clientId?: string;
+        scopes?: string[];
+        redirectUrl?: string;
+        tokensRef?: CredentialRef;
+        clientInformationRef?: CredentialRef;
+        verifierRef?: CredentialRef;
+    };
+    enabled: boolean;
+    trust: TrustLevel;
+    scope: ConfigScope;
+    provenance: McpInstallProvenance;
 };
 
 // Resolve a credential reference / env value to a concrete environment string.
@@ -84,14 +130,127 @@ export function resolveEnvValue(
     if (typeof value === "string") {
         return value;
     }
+    if ("value" in value) {
+        return value.value.replace(/\{([^{}]+)\}/g, (_match, name: string) => {
+            const variable = value.variables[name];
+            const resolved =
+                variable === undefined
+                    ? undefined
+                    : resolveEnvValue(variable, inputs, sourceEnv);
+            if (resolved === undefined) {
+                throw new Error(
+                    `could not resolve template variable '${name}'`,
+                );
+            }
+            return resolved;
+        });
+    }
     if (value.kind === "env") {
         return sourceEnv[value.name];
     }
     return inputs?.[value.name];
 }
 
+async function resolveStoredValue(
+    value: EnvValue,
+    store: McpCredentialStore,
+    configName: string,
+): Promise<string> {
+    if (typeof value === "string") {
+        return value;
+    }
+    if ("value" in value) {
+        let result = value.value;
+        for (const [name, variable] of Object.entries(value.variables)) {
+            const resolved =
+                typeof variable === "string"
+                    ? variable
+                    : await requireCredential(store, variable, configName);
+            result = result.replaceAll(`{${name}}`, resolved);
+        }
+        return result;
+    }
+    return requireCredential(store, value, configName);
+}
+
+export async function resolveTransportConfig(
+    config: NormalizedMcpServerConfig,
+    store: McpCredentialStore,
+): Promise<McpTransportConfig> {
+    if (config.transport.kind === "http") {
+        const headers =
+            config.transport.headers === undefined
+                ? undefined
+                : Object.fromEntries(
+                      await Promise.all(
+                          Object.entries(config.transport.headers).map(
+                              async ([name, value]) => [
+                                  name,
+                                  await resolveStoredValue(
+                                      value,
+                                      store,
+                                      config.name,
+                                  ),
+                              ],
+                          ),
+                      ),
+                  );
+        const url =
+            config.transport.urlVariables === undefined
+                ? config.transport.url
+                : await resolveStoredValue(
+                      {
+                          value: config.transport.url,
+                          variables: config.transport.urlVariables,
+                      },
+                      store,
+                      config.name,
+                  );
+        return {
+            kind: "http",
+            url,
+            ...(headers === undefined ? {} : { headers }),
+            ...(config.transport.timeoutMs === undefined
+                ? {}
+                : { timeoutMs: config.transport.timeoutMs }),
+        };
+    }
+    return {
+        kind: "stdio",
+        command: config.transport.command,
+        args: await Promise.all(
+            (config.transport.args ?? []).map((value) =>
+                resolveStoredValue(value, store, config.name),
+            ),
+        ),
+        ...(config.transport.env === undefined
+            ? {}
+            : {
+                  env: Object.fromEntries(
+                      await Promise.all(
+                          Object.entries(config.transport.env).map(
+                              async ([name, value]) => [
+                                  name,
+                                  await resolveStoredValue(
+                                      value,
+                                      store,
+                                      config.name,
+                                  ),
+                              ],
+                          ),
+                      ),
+                  ),
+              }),
+        ...(config.transport.cwd === undefined
+            ? {}
+            : { cwd: config.transport.cwd }),
+    };
+}
+
 function resolveEnvRecord(
     env: Record<string, EnvValue> | undefined,
+    configName: string,
+    valueKind: "environment variable" | "HTTP header",
     inputs?: Record<string, string>,
     sourceEnv?: Record<string, string | undefined>,
 ): Record<string, string> | undefined {
@@ -101,17 +260,26 @@ function resolveEnvRecord(
     const resolved: Record<string, string> = {};
     for (const [key, value] of Object.entries(env)) {
         const v = resolveEnvValue(value, inputs, sourceEnv);
-        if (v !== undefined) {
-            resolved[key] = v;
+        if (v === undefined) {
+            const reference =
+                typeof value === "string"
+                    ? key
+                    : "kind" in value
+                      ? `${value.kind}:${value.name}`
+                      : "template";
+            throw new Error(
+                `MCP server '${configName}' could not resolve required ${valueKind} '${key}' (${reference})`,
+            );
         }
+        resolved[key] = v;
     }
     return resolved;
 }
 
 // Lower a normalized config to the connection-layer transport config, resolving
-// any credential references in `env`. HTTP header resolution is not yet plumbed
-// through the connection layer, so `headers` are carried on the normalized
-// config but not applied here; only `url` is forwarded for now.
+// any credential references in `env` or `headers`. References are required:
+// launching with a silently omitted secret would produce a misleading remote
+// authentication or child-process failure.
 export function toTransportConfig(
     config: NormalizedMcpServerConfig,
     inputs?: Record<string, string>,
@@ -119,13 +287,57 @@ export function toTransportConfig(
 ): McpTransportConfig {
     const transport = config.transport;
     if (transport.kind === "http") {
-        return { kind: "http", url: transport.url };
+        const headers = resolveEnvRecord(
+            transport.headers,
+            config.name,
+            "HTTP header",
+            inputs,
+            sourceEnv,
+        );
+        const resolvedUrl =
+            transport.urlVariables === undefined
+                ? transport.url
+                : resolveEnvValue(
+                      {
+                          value: transport.url,
+                          variables: transport.urlVariables,
+                      },
+                      inputs,
+                      sourceEnv,
+                  );
+        if (resolvedUrl === undefined) {
+            throw new Error(
+                `MCP server '${config.name}' could not resolve its URL`,
+            );
+        }
+        return {
+            kind: "http",
+            url: resolvedUrl,
+            ...(headers === undefined ? {} : { headers }),
+            ...(transport.timeoutMs === undefined
+                ? {}
+                : { timeoutMs: transport.timeoutMs }),
+        };
     }
-    const env = resolveEnvRecord(transport.env, inputs, sourceEnv);
+    const env = resolveEnvRecord(
+        transport.env,
+        config.name,
+        "environment variable",
+        inputs,
+        sourceEnv,
+    );
     const result: McpTransportConfig = {
         kind: "stdio",
         command: transport.command,
-        args: transport.args ?? [],
+        args: (transport.args ?? []).map((arg) => {
+            const value = resolveEnvValue(arg, inputs, sourceEnv);
+            if (value === undefined) {
+                throw new Error(
+                    `MCP server '${config.name}' could not resolve a required command argument`,
+                );
+            }
+            return value;
+        }),
     };
     if (env !== undefined) {
         result.env = env;

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpServerProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpServerProvider.ts
@@ -1,139 +1,598 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { AppAgent, AppAgentManifest } from "@typeagent/agent-sdk";
+import type {
+    AppAgent,
+    AppAgentManifest,
+    SessionContext,
+} from "@typeagent/agent-sdk";
+import { createActionResultFromError } from "@typeagent/agent-sdk/helpers/action";
 import type { AppAgentProvider } from "agent-dispatcher";
-import { McpConnection } from "./mcpConnection.js";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import {
+    McpConnection,
+    type McpConnectionOptions,
+    type McpTransportConfig,
+} from "./mcpConnection.js";
 import { convertToolResult } from "./mcpResult.js";
-import { convertToolsSchema } from "./mcpSchema.js";
 import {
     NormalizedMcpServerConfig,
-    toTransportConfig,
+    resolveTransportConfig,
 } from "./mcpServerConfig.js";
 import registerDebug from "debug";
+import type { McpCredentialStore } from "./mcpCredentialStore.js";
+import type { McpAuditSink } from "./mcpAudit.js";
+import { sanitizeMcpAuditEvent } from "./mcpAudit.js";
+import type { McpOAuthInteraction } from "./mcpOAuth.js";
+import { McpOAuthProvider } from "./mcpOAuth.js";
+import type { McpPolicy } from "./mcpPolicy.js";
+import { enforceMcpPolicy } from "./mcpPolicy.js";
+import {
+    buildMcpToolCatalog,
+    getMcpToolIdentity,
+    type McpToolCatalog,
+} from "./mcpToolCatalog.js";
 
 const debug = registerDebug("typeagent:mcp:server");
 const debugError = registerDebug("typeagent:mcp:server:error");
-
 const entryTypeName = "AgentActions";
 
 export type McpClientInfo = { name: string; version: string };
 
-// One connected MCP server plus the loaded agent it backs. Shared across
-// sessions; `connection` is undefined until (and after a failed) connect.
-type McpServerAgent = {
-    manifest: AppAgentManifest;
-    agent: AppAgent;
-    connection: McpConnection | undefined;
+export interface McpConnectionLike {
+    readonly protocolEra: string | undefined;
+    readonly protocolVersion: string | undefined;
+    readonly supportsToolListChanged: boolean;
+    listTools(): Promise<Tool[]>;
+    callTool(
+        name: string,
+        args: Record<string, unknown> | undefined,
+    ): Promise<CallToolResult>;
+    close(): Promise<void>;
+}
+
+export interface McpRefreshScheduler {
+    setTimeout(callback: () => void, delayMs: number): unknown;
+    clearTimeout(handle: unknown): void;
+}
+
+const defaultScheduler: McpRefreshScheduler = {
+    setTimeout(callback, delayMs) {
+        return globalThis.setTimeout(callback, delayMs);
+    },
+    clearTimeout(handle) {
+        globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+    },
 };
 
-// A single normalized MCP server config lowered to a live connection, its
-// generated action schema, and an executeAction that round-trips through the
-// server. Composes the Phase 1-3 primitives (McpConnection, convertToolsSchema,
-// convertToolResult, toTransportConfig) instead of the legacy script-only path,
-// so it supports generic stdio (command/args/env/cwd) and resolves credential
-// references at launch.
+export interface McpHostServices {
+    credentialStore: McpCredentialStore;
+    policy: McpPolicy;
+    audit: McpAuditSink;
+    oauthInteraction?: McpOAuthInteraction;
+    connectionFactory?: (
+        clientInfo: McpClientInfo,
+        transport: McpTransportConfig,
+        options: McpConnectionOptions,
+    ) => Promise<McpConnectionLike>;
+    refreshScheduler?: McpRefreshScheduler;
+    refreshDebounceMs?: number;
+}
+
+type CatalogSnapshot = {
+    readonly catalog: McpToolCatalog;
+    readonly manifest: AppAgentManifest;
+};
+
+type McpServerAgent = {
+    readonly agent: AppAgent;
+    readonly connection: McpConnectionLike | undefined;
+    getManifest(): AppAgentManifest;
+    dispose(): Promise<void>;
+};
+
+function filterConfiguredTools(
+    tools: Tool[],
+    config: NormalizedMcpServerConfig,
+): Tool[] {
+    let filtered = tools;
+    if (config.enabledTools !== undefined) {
+        const allow = new Set(config.enabledTools);
+        filtered = filtered.filter((tool) => allow.has(tool.name));
+    }
+    if (config.deniedTools !== undefined) {
+        const denied = new Set(config.deniedTools);
+        filtered = filtered.filter((tool) => !denied.has(tool.name));
+    }
+    return filtered;
+}
+
+function createSnapshot(
+    name: string,
+    config: NormalizedMcpServerConfig,
+    tools: Tool[],
+): CatalogSnapshot {
+    const catalog = buildMcpToolCatalog(
+        config.id,
+        filterConfiguredTools(tools, config),
+        entryTypeName,
+    );
+    if (catalog.entries.size === 0) {
+        throw new Error(`No usable tools found for MCP server '${name}'`);
+    }
+    const schemaFile = Object.freeze({
+        format: "pas" as const,
+        content: catalog.schemaContent,
+    });
+    const manifest = Object.freeze({
+        emojiChar: config.emojiChar ?? "🔌",
+        description: config.description ?? name,
+        schema: Object.freeze({
+            description: config.description ?? name,
+            schemaType: entryTypeName,
+            schemaFile,
+        }),
+    });
+    return Object.freeze({ catalog, manifest });
+}
+
+function logSkippedTools(name: string, catalog: McpToolCatalog): void {
+    if (catalog.skipped.length === 0) {
+        return;
+    }
+    debugError(
+        `[${name}] ${catalog.skipped.length} tool(s) skipped: ${catalog.skipped
+            .map((item) => `${item.id} (${item.reason})`)
+            .join("; ")}`,
+    );
+}
+
+function getTransportSensitiveValues(
+    transport: Awaited<ReturnType<typeof resolveTransportConfig>>,
+): string[] {
+    return transport.kind === "http"
+        ? Object.values(transport.headers ?? {})
+        : Object.values(transport.env ?? {});
+}
+
 async function connectServerAgent(
     name: string,
     config: NormalizedMcpServerConfig,
     clientInfo: McpClientInfo,
-    schemaFile: { format: "pas"; content: string },
-    inputs?: Record<string, string>,
+    services: McpHostServices,
 ): Promise<McpServerAgent> {
-    const manifest: AppAgentManifest = {
-        emojiChar: config.emojiChar ?? "🔌",
-        description: config.description ?? name,
-        schema: {
-            description: config.description ?? name,
-            schemaType: entryTypeName,
-            schemaFile,
-        },
+    let connection: McpConnectionLike | undefined;
+    let disposed = false;
+    let snapshot: CatalogSnapshot | undefined;
+    let refreshTimer: unknown;
+    let refreshRunning = false;
+    let refreshPending = false;
+    let pendingError: Error | null = null;
+    let pendingTools: Tool[] | null = null;
+    const scheduler = services.refreshScheduler ?? defaultScheduler;
+    const sessionContexts = new Set<SessionContext>();
+    const sessionApprovals = new Map<string, Set<string>>();
+
+    const auditRefresh = async (
+        status: "success" | "failure",
+        decision: "updated" | "no-op" | "rollback",
+        error?: string,
+        toolCount?: number,
+        skippedCount?: number,
+    ): Promise<void> => {
+        await services.audit.write({
+            timestamp: new Date().toISOString(),
+            operation: "catalog-refresh",
+            configId: config.id,
+            configName: config.name,
+            transport: config.transport.kind,
+            source: config.provenance.source,
+            status,
+            decision,
+            previousCount: snapshot?.catalog.entries.size ?? 0,
+            ...(toolCount === undefined ? {} : { toolCount }),
+            ...(skippedCount === undefined ? {} : { skippedCount }),
+            ...(error === undefined ? {} : { error }),
+        });
     };
 
-    let connection: McpConnection | undefined;
-    let agent: AppAgent;
-    try {
-        connection = await McpConnection.create(
-            clientInfo,
-            toTransportConfig(config, inputs),
-        );
-        debug(
-            `[${name}] connected (era=${connection.protocolEra}, version=${connection.protocolVersion})`,
-        );
-        let tools = await connection.listTools();
-        // An explicit allowlist hides every other advertised tool.
-        if (config.enabledTools !== undefined) {
-            const allow = new Set(config.enabledTools);
-            tools = tools.filter((t) => allow.has(t.name));
+    const reloadSessions = async (): Promise<void> => {
+        for (const context of [...sessionContexts]) {
+            try {
+                await context.reloadAgentSchema();
+            } catch (error) {
+                debugError(
+                    `[${name}] schema reload failed for session '${context.sessionContextId}': ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
         }
-        if (tools.length === 0) {
-            throw new Error(`No tools found for MCP server '${name}'`);
+    };
+
+    const refreshCatalog = async (
+        error: Error | null,
+        tools: Tool[] | null,
+    ): Promise<void> => {
+        if (disposed) {
+            return;
         }
-        const schema = convertToolsSchema(tools, entryTypeName);
-        if (schema.skipped.length > 0) {
+        if (error !== null) {
+            await auditRefresh("failure", "rollback", error.message);
             debugError(
-                `[${name}] ${schema.skipped.length} tool(s) skipped: ${schema.skipped
-                    .map((s) => `${s.name} (${s.reason})`)
-                    .join("; ")}`,
+                `[${name}] tool catalog refresh failed: ${error.message}`,
+            );
+            return;
+        }
+        try {
+            const listedTools = tools ?? (await connection!.listTools());
+            const next = createSnapshot(name, config, listedTools);
+            logSkippedTools(name, next.catalog);
+            if (disposed) {
+                return;
+            }
+            if (next.catalog.fingerprint === snapshot?.catalog.fingerprint) {
+                await auditRefresh(
+                    "success",
+                    "no-op",
+                    undefined,
+                    next.catalog.entries.size,
+                    next.catalog.skipped.length,
+                );
+                return;
+            }
+            const previousCount = snapshot?.catalog.entries.size ?? 0;
+            snapshot = next;
+            await services.audit.write({
+                timestamp: new Date().toISOString(),
+                operation: "catalog-refresh",
+                configId: config.id,
+                configName: config.name,
+                transport: config.transport.kind,
+                source: config.provenance.source,
+                status: "success",
+                decision: "updated",
+                previousCount,
+                toolCount: next.catalog.entries.size,
+                skippedCount: next.catalog.skipped.length,
+            });
+            await reloadSessions();
+        } catch (refreshError) {
+            const message =
+                refreshError instanceof Error
+                    ? refreshError.message
+                    : String(refreshError);
+            await auditRefresh("failure", "rollback", message, 0);
+            debugError(
+                `[${name}] tool catalog refresh rolled back: ${message}`,
             );
         }
-        schemaFile.content = schema.content;
+    };
 
-        const activeConnection = connection;
-        agent = {
-            executeAction: async (action) => {
-                const result = await activeConnection.callTool(
-                    action.actionName,
-                    action.parameters as Record<string, unknown> | undefined,
+    const runPendingRefresh = async (): Promise<void> => {
+        if (disposed || refreshRunning || !refreshPending) {
+            return;
+        }
+        refreshRunning = true;
+        refreshPending = false;
+        const error = pendingError;
+        const tools = pendingTools;
+        pendingError = null;
+        pendingTools = null;
+        try {
+            await refreshCatalog(error, tools);
+        } finally {
+            refreshRunning = false;
+            if (refreshPending && !disposed) {
+                refreshTimer = scheduler.setTimeout(
+                    () => void runPendingRefresh(),
+                    services.refreshDebounceMs ?? 100,
                 );
-                return convertToolResult(action.actionName, result);
+            }
+        }
+    };
+
+    const queueRefresh = (error: Error | null, tools: Tool[] | null): void => {
+        if (disposed) {
+            return;
+        }
+        pendingError = error;
+        pendingTools = tools;
+        refreshPending = true;
+        if (refreshRunning) {
+            return;
+        }
+        if (refreshTimer !== undefined) {
+            scheduler.clearTimeout(refreshTimer);
+        }
+        refreshTimer = scheduler.setTimeout(() => {
+            refreshTimer = undefined;
+            void runPendingRefresh();
+        }, services.refreshDebounceMs ?? 100);
+    };
+
+    const connectStarted = Date.now();
+    try {
+        enforceMcpPolicy(services.policy, "connect", config);
+        const transport = await resolveTransportConfig(
+            config,
+            services.credentialStore,
+        );
+        const sensitiveValues = getTransportSensitiveValues(transport);
+        if (transport.kind === "http" && config.oauth?.enabled === true) {
+            transport.authProvider = new McpOAuthProvider(
+                config,
+                services.credentialStore,
+                services.oauthInteraction,
+            );
+        }
+        const connectionFactory =
+            services.connectionFactory ??
+            ((info, resolvedTransport, options) =>
+                McpConnection.create(info, resolvedTransport, options));
+        const connected = await connectionFactory(clientInfo, transport, {
+            toolsChanged: queueRefresh,
+            listChangedDebounceMs: 0,
+        });
+        connection = connected;
+        await services.audit.write({
+            timestamp: new Date().toISOString(),
+            operation: "connect",
+            configId: config.id,
+            configName: config.name,
+            transport: config.transport.kind,
+            source: config.provenance.source,
+            status: "success",
+            durationMs: Date.now() - connectStarted,
+        });
+        debug(
+            `[${name}] connected (era=${connected.protocolEra}, version=${connected.protocolVersion}, listChanged=${connected.supportsToolListChanged})`,
+        );
+        snapshot = createSnapshot(name, config, await connected.listTools());
+        logSkippedTools(name, snapshot.catalog);
+
+        const activeConnection = connected;
+        const agent: AppAgent = {
+            startBackgroundTasks: async (context) => {
+                sessionContexts.add(context);
+            },
+            stopBackgroundTasks: async (context) => {
+                sessionContexts.delete(context);
+            },
+            updateAgentContext: async (_enable, context) => {
+                sessionContexts.add(context);
+            },
+            closeAgentContext: async (context) => {
+                sessionContexts.delete(context);
+                sessionApprovals.delete(context.sessionContextId);
+            },
+            executeAction: async (action, context) => {
+                sessionContexts.add(context.sessionContext);
+                enforceMcpPolicy(services.policy, "invoke", config);
+                const toolId = getMcpToolIdentity(config.id, action.actionName);
+                const tool = snapshot?.catalog.entries.get(toolId);
+                if (tool === undefined) {
+                    return createActionResultFromError(
+                        `MCP tool '${action.actionName}' is not enabled for server '${config.name}' (${config.id}).`,
+                    );
+                }
+                const argumentValidation = tool.validateArguments(
+                    action.parameters ?? {},
+                );
+                if (!argumentValidation.valid) {
+                    return createActionResultFromError(
+                        `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) rejected its arguments: ${argumentValidation.errorMessage}`,
+                    );
+                }
+                const configured =
+                    config.toolApproval?.persisted?.[tool.name] ??
+                    (config.toolApproval?.deny?.includes(tool.name)
+                        ? "deny"
+                        : config.toolApproval?.allow?.includes(tool.name)
+                          ? "allow"
+                          : undefined);
+                const prompt =
+                    config.toolApproval?.prompt?.includes(tool.name) ||
+                    tool.annotations?.destructiveHint === true ||
+                    tool.annotations?.readOnlyHint !== true;
+                let decision: string = configured ?? "allow";
+                if (configured === "deny") {
+                    return createActionResultFromError(
+                        `MCP tool '${tool.name}' is denied by server '${config.name}' policy.`,
+                    );
+                }
+                const sessionId = context.sessionContext.sessionContextId;
+                if (
+                    prompt &&
+                    configured !== "allow" &&
+                    !sessionApprovals.get(sessionId)?.has(toolId)
+                ) {
+                    const choice = await context.sessionContext.popupQuestion(
+                        `Allow MCP server '${config.name}' to run potentially mutating tool '${tool.name}'? Tool annotations are untrusted hints. Arguments: ${JSON.stringify(
+                            sanitizeMcpAuditEvent({
+                                timestamp: "",
+                                operation: "tool-invocation",
+                                configId: config.id,
+                                configName: config.name,
+                                arguments: action.parameters,
+                                sensitiveValues,
+                            }).arguments,
+                        )}`,
+                        ["Allow once", "Allow for session", "Deny"],
+                        2,
+                    );
+                    if (choice === 2) {
+                        decision = "deny";
+                        return createActionResultFromError(
+                            `MCP tool '${tool.name}' on server '${config.name}' was denied by the user.`,
+                        );
+                    }
+                    decision = choice === 1 ? "session-allow" : "allow-once";
+                    if (choice === 1) {
+                        const session =
+                            sessionApprovals.get(sessionId) ??
+                            new Set<string>();
+                        session.add(toolId);
+                        sessionApprovals.set(sessionId, session);
+                    }
+                }
+                const started = Date.now();
+                await services.audit.write({
+                    timestamp: new Date().toISOString(),
+                    operation: "tool-invocation",
+                    configId: config.id,
+                    configName: config.name,
+                    tool: tool.name,
+                    toolId,
+                    sessionId,
+                    transport: config.transport.kind,
+                    source: config.provenance.source,
+                    decision,
+                    arguments: action.parameters,
+                    sensitiveValues,
+                });
+                try {
+                    const result = await activeConnection.callTool(
+                        tool.name,
+                        argumentValidation.data,
+                    );
+                    if (!result.isError && tool.validateOutput !== undefined) {
+                        const outputValidation = tool.validateOutput(
+                            result.structuredContent,
+                        );
+                        if (!outputValidation.valid) {
+                            const message = `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned output that does not match outputSchema: ${outputValidation.errorMessage}`;
+                            await services.audit.write({
+                                timestamp: new Date().toISOString(),
+                                operation: "tool-result",
+                                configId: config.id,
+                                configName: config.name,
+                                tool: tool.name,
+                                toolId,
+                                sessionId,
+                                status: "failure",
+                                durationMs: Date.now() - started,
+                                error: message,
+                            });
+                            return createActionResultFromError(message);
+                        }
+                    }
+                    await services.audit.write({
+                        timestamp: new Date().toISOString(),
+                        operation: "tool-result",
+                        configId: config.id,
+                        configName: config.name,
+                        tool: tool.name,
+                        toolId,
+                        sessionId,
+                        status: "success",
+                        durationMs: Date.now() - started,
+                    });
+                    return convertToolResult(tool.name, result);
+                } catch (error) {
+                    const errorMessage =
+                        error instanceof Error ? error.message : String(error);
+                    await services.audit.write({
+                        timestamp: new Date().toISOString(),
+                        operation: "tool-result",
+                        configId: config.id,
+                        configName: config.name,
+                        tool: tool.name,
+                        toolId,
+                        sessionId,
+                        status: "failure",
+                        durationMs: Date.now() - started,
+                        error: errorMessage,
+                    });
+                    if (
+                        /output schema|outputSchema|structured content/i.test(
+                            errorMessage,
+                        )
+                    ) {
+                        return createActionResultFromError(
+                            `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned invalid output: ${errorMessage}`,
+                        );
+                    }
+                    throw error;
+                }
             },
         };
-    } catch (error: any) {
-        debugError(`[${name}] failed to connect: ${error?.message ?? error}`);
+        return {
+            agent,
+            connection: connected,
+            getManifest: () => snapshot!.manifest,
+            async dispose() {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                sessionContexts.clear();
+                sessionApprovals.clear();
+                if (refreshTimer !== undefined) {
+                    scheduler.clearTimeout(refreshTimer);
+                    refreshTimer = undefined;
+                }
+                await activeConnection.close();
+            },
+        };
+    } catch (error) {
+        await services.audit.write({
+            timestamp: new Date().toISOString(),
+            operation: "connect",
+            configId: config.id,
+            configName: config.name,
+            transport: config.transport.kind,
+            source: config.provenance.source,
+            status: "failure",
+            durationMs: Date.now() - connectStarted,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        debugError(
+            `[${name}] failed to connect: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        disposed = true;
+        if (refreshTimer !== undefined) {
+            scheduler.clearTimeout(refreshTimer);
+        }
         if (connection !== undefined) {
             await connection.close().catch(() => {});
-            connection = undefined;
         }
-        // Defer surfacing the failure until the agent is actually used, matching
-        // the legacy provider's behavior so one broken server does not abort the
-        // whole session's agent registration.
-        agent = {
-            updateAgentContext() {
-                throw error;
+        const fallbackManifest: AppAgentManifest = {
+            emojiChar: config.emojiChar ?? "🔌",
+            description: config.description ?? name,
+            schema: {
+                description: config.description ?? name,
+                schemaType: entryTypeName,
+                schemaFile: { format: "pas", content: "" },
             },
         };
+        return {
+            agent: {
+                updateAgentContext() {
+                    throw error;
+                },
+            },
+            connection: undefined,
+            getManifest: () => fallbackManifest,
+            async dispose() {},
+        };
     }
-    return { manifest, agent, connection };
 }
 
-/**
- * Build a single-name {@link AppAgentProvider} for one normalized MCP server
- * config. This is the runtime unit the dynamic MCP source vends — one shared,
- * refcounted provider per configured server (mirroring
- * `createInstalledAppAgentProvider` for npm agents). The connection is
- * established lazily on first `loadAppAgent`/`getAppAgentManifest` and torn down
- * once the refcount returns to zero.
- */
 export function createMcpServerAppAgentProvider(
     name: string,
     config: NormalizedMcpServerConfig,
     clientInfo: McpClientInfo,
-    inputs?: Record<string, string>,
+    services: McpHostServices,
 ): AppAgentProvider {
-    const schemaFile = { format: "pas" as const, content: "" };
     let agentP: Promise<McpServerAgent> | undefined;
     let count = 0;
 
     function ensureAgent(): Promise<McpServerAgent> {
         if (agentP === undefined) {
-            agentP = connectServerAgent(
-                name,
-                config,
-                clientInfo,
-                schemaFile,
-                inputs,
-            );
+            agentP = connectServerAgent(name, config, clientInfo, services);
         }
         return agentP;
     }
@@ -146,18 +605,13 @@ export function createMcpServerAppAgentProvider(
             if (n !== name) {
                 throw new Error(`Unknown MCP agent '${n}'`);
             }
-            // Probe the manifest without holding a refcount: connect, read the
-            // manifest (with its generated schema), then, if nobody loaded the
-            // agent while we awaited, tear the probe connection down so an idle
-            // manifest fetch never leaks a live connection.
             const agentData = await ensureAgent();
+            const manifest = agentData.getManifest();
             if (count === 0 && agentP !== undefined) {
                 agentP = undefined;
-                if (agentData.connection !== undefined) {
-                    await agentData.connection.close().catch(() => {});
-                }
+                await agentData.dispose().catch(() => {});
             }
-            return agentData.manifest;
+            return manifest;
         },
         async loadAppAgent(n: string) {
             if (n !== name) {
@@ -176,10 +630,7 @@ export function createMcpServerAppAgentProvider(
             if (--count === 0 && agentP !== undefined) {
                 const agentData = await agentP;
                 agentP = undefined;
-                schemaFile.content = "";
-                if (agentData.connection !== undefined) {
-                    await agentData.connection.close().catch(() => {});
-                }
+                await agentData.dispose().catch(() => {});
             }
         },
     };

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpServerProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpServerProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type {
+    ActionResult,
     AppAgent,
     AppAgentManifest,
     SessionContext,
@@ -31,6 +32,7 @@ import {
     buildMcpToolCatalog,
     getMcpToolIdentity,
     type McpToolCatalog,
+    type McpToolCatalogEntry,
 } from "./mcpToolCatalog.js";
 
 const debug = registerDebug("typeagent:mcp:server");
@@ -90,6 +92,11 @@ type McpServerAgent = {
     getManifest(): AppAgentManifest;
     dispose(): Promise<void>;
 };
+
+type McpExecuteAction = NonNullable<AppAgent["executeAction"]>;
+type McpAction = Parameters<McpExecuteAction>[0];
+type McpActionContext = Parameters<McpExecuteAction>[1];
+type McpToolDecision = "allow" | "allow-once" | "session-allow" | "deny";
 
 function filterConfiguredTools(
     tools: Tool[],
@@ -153,6 +160,236 @@ function getTransportSensitiveValues(
     return transport.kind === "http"
         ? Object.values(transport.headers ?? {})
         : Object.values(transport.env ?? {});
+}
+
+function getConfiguredToolDecision(
+    config: NormalizedMcpServerConfig,
+    toolName: string,
+): "allow" | "deny" | undefined {
+    return (
+        config.toolApproval?.persisted?.[toolName] ??
+        (config.toolApproval?.deny?.includes(toolName)
+            ? "deny"
+            : config.toolApproval?.allow?.includes(toolName)
+              ? "allow"
+              : undefined)
+    );
+}
+
+function shouldPromptForTool(
+    config: NormalizedMcpServerConfig,
+    tool: McpToolCatalogEntry,
+): boolean {
+    return (
+        config.toolApproval?.prompt?.includes(tool.name) === true ||
+        tool.annotations?.destructiveHint === true ||
+        tool.annotations?.readOnlyHint !== true
+    );
+}
+
+async function requestToolDecision(
+    context: McpActionContext,
+    config: NormalizedMcpServerConfig,
+    tool: McpToolCatalogEntry,
+    toolId: string,
+    configured: "allow" | undefined,
+    sessionApprovals: Map<string, Set<string>>,
+    parameters: Record<string, unknown> | undefined,
+    sensitiveValues: string[],
+): Promise<McpToolDecision> {
+    const sessionId = context.sessionContext.sessionContextId;
+    if (
+        configured === "allow" ||
+        !shouldPromptForTool(config, tool) ||
+        sessionApprovals.get(sessionId)?.has(toolId)
+    ) {
+        return configured ?? "allow";
+    }
+    const choice = await context.sessionContext.popupQuestion(
+        `Allow MCP server '${config.name}' to run potentially mutating tool '${tool.name}'? Tool annotations are untrusted hints. Arguments: ${JSON.stringify(
+            sanitizeMcpAuditEvent({
+                timestamp: "",
+                operation: "tool-invocation",
+                configId: config.id,
+                configName: config.name,
+                arguments: parameters,
+                sensitiveValues,
+            }).arguments,
+        )}`,
+        ["Allow once", "Allow for session", "Deny"],
+        2,
+    );
+    if (choice !== 1) {
+        return choice === 2 ? "deny" : "allow-once";
+    }
+    const session = sessionApprovals.get(sessionId) ?? new Set<string>();
+    session.add(toolId);
+    sessionApprovals.set(sessionId, session);
+    return "session-allow";
+}
+
+async function writeToolResultAudit(
+    services: McpHostServices,
+    config: NormalizedMcpServerConfig,
+    tool: McpToolCatalogEntry,
+    toolId: string,
+    sessionId: string,
+    started: number,
+    status: "success" | "failure",
+    error?: string,
+): Promise<void> {
+    await services.audit.write({
+        timestamp: new Date().toISOString(),
+        operation: "tool-result",
+        configId: config.id,
+        configName: config.name,
+        tool: tool.name,
+        toolId,
+        sessionId,
+        status,
+        durationMs: Date.now() - started,
+        ...(error === undefined ? {} : { error }),
+    });
+}
+
+async function callMcpTool(
+    connection: McpConnectionLike,
+    services: McpHostServices,
+    config: NormalizedMcpServerConfig,
+    tool: McpToolCatalogEntry,
+    toolId: string,
+    sessionId: string,
+    parameters: Record<string, unknown>,
+): Promise<ActionResult | undefined> {
+    const started = Date.now();
+    try {
+        const result = await connection.callTool(tool.name, parameters);
+        if (!result.isError && tool.validateOutput !== undefined) {
+            const outputValidation = tool.validateOutput(
+                result.structuredContent,
+            );
+            if (!outputValidation.valid) {
+                const message = `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned output that does not match outputSchema: ${outputValidation.errorMessage}`;
+                await writeToolResultAudit(
+                    services,
+                    config,
+                    tool,
+                    toolId,
+                    sessionId,
+                    started,
+                    "failure",
+                    message,
+                );
+                return createActionResultFromError(message);
+            }
+        }
+        await writeToolResultAudit(
+            services,
+            config,
+            tool,
+            toolId,
+            sessionId,
+            started,
+            "success",
+        );
+        return convertToolResult(tool.name, result);
+    } catch (error) {
+        const errorMessage =
+            error instanceof Error ? error.message : String(error);
+        await writeToolResultAudit(
+            services,
+            config,
+            tool,
+            toolId,
+            sessionId,
+            started,
+            "failure",
+            errorMessage,
+        );
+        if (
+            /output schema|outputSchema|structured content/i.test(errorMessage)
+        ) {
+            return createActionResultFromError(
+                `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned invalid output: ${errorMessage}`,
+            );
+        }
+        throw error;
+    }
+}
+
+function createMcpExecuteAction(
+    config: NormalizedMcpServerConfig,
+    services: McpHostServices,
+    connection: McpConnectionLike,
+    getSnapshot: () => CatalogSnapshot | undefined,
+    sessionContexts: Set<SessionContext>,
+    sessionApprovals: Map<string, Set<string>>,
+    sensitiveValues: string[],
+): McpExecuteAction {
+    return async (action: McpAction, context: McpActionContext) => {
+        sessionContexts.add(context.sessionContext);
+        enforceMcpPolicy(services.policy, "invoke", config);
+        const toolId = getMcpToolIdentity(config.id, action.actionName);
+        const tool = getSnapshot()?.catalog.entries.get(toolId);
+        if (tool === undefined) {
+            return createActionResultFromError(
+                `MCP tool '${action.actionName}' is not enabled for server '${config.name}' (${config.id}).`,
+            );
+        }
+        const argumentValidation = tool.validateArguments(
+            action.parameters ?? {},
+        );
+        if (!argumentValidation.valid) {
+            return createActionResultFromError(
+                `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) rejected its arguments: ${argumentValidation.errorMessage}`,
+            );
+        }
+        const configured = getConfiguredToolDecision(config, tool.name);
+        if (configured === "deny") {
+            return createActionResultFromError(
+                `MCP tool '${tool.name}' is denied by server '${config.name}' policy.`,
+            );
+        }
+        const sessionId = context.sessionContext.sessionContextId;
+        const decision = await requestToolDecision(
+            context,
+            config,
+            tool,
+            toolId,
+            configured,
+            sessionApprovals,
+            action.parameters,
+            sensitiveValues,
+        );
+        if (decision === "deny") {
+            return createActionResultFromError(
+                `MCP tool '${tool.name}' on server '${config.name}' was denied by the user.`,
+            );
+        }
+        await services.audit.write({
+            timestamp: new Date().toISOString(),
+            operation: "tool-invocation",
+            configId: config.id,
+            configName: config.name,
+            tool: tool.name,
+            toolId,
+            sessionId,
+            transport: config.transport.kind,
+            source: config.provenance.source,
+            decision,
+            arguments: action.parameters,
+            sensitiveValues,
+        });
+        return callMcpTool(
+            connection,
+            services,
+            config,
+            tool,
+            toolId,
+            sessionId,
+            argumentValidation.data,
+        );
+    };
 }
 
 async function connectServerAgent(
@@ -366,156 +603,15 @@ async function connectServerAgent(
                 sessionContexts.delete(context);
                 sessionApprovals.delete(context.sessionContextId);
             },
-            executeAction: async (action, context) => {
-                sessionContexts.add(context.sessionContext);
-                enforceMcpPolicy(services.policy, "invoke", config);
-                const toolId = getMcpToolIdentity(config.id, action.actionName);
-                const tool = snapshot?.catalog.entries.get(toolId);
-                if (tool === undefined) {
-                    return createActionResultFromError(
-                        `MCP tool '${action.actionName}' is not enabled for server '${config.name}' (${config.id}).`,
-                    );
-                }
-                const argumentValidation = tool.validateArguments(
-                    action.parameters ?? {},
-                );
-                if (!argumentValidation.valid) {
-                    return createActionResultFromError(
-                        `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) rejected its arguments: ${argumentValidation.errorMessage}`,
-                    );
-                }
-                const configured =
-                    config.toolApproval?.persisted?.[tool.name] ??
-                    (config.toolApproval?.deny?.includes(tool.name)
-                        ? "deny"
-                        : config.toolApproval?.allow?.includes(tool.name)
-                          ? "allow"
-                          : undefined);
-                const prompt =
-                    config.toolApproval?.prompt?.includes(tool.name) ||
-                    tool.annotations?.destructiveHint === true ||
-                    tool.annotations?.readOnlyHint !== true;
-                let decision: string = configured ?? "allow";
-                if (configured === "deny") {
-                    return createActionResultFromError(
-                        `MCP tool '${tool.name}' is denied by server '${config.name}' policy.`,
-                    );
-                }
-                const sessionId = context.sessionContext.sessionContextId;
-                if (
-                    prompt &&
-                    configured !== "allow" &&
-                    !sessionApprovals.get(sessionId)?.has(toolId)
-                ) {
-                    const choice = await context.sessionContext.popupQuestion(
-                        `Allow MCP server '${config.name}' to run potentially mutating tool '${tool.name}'? Tool annotations are untrusted hints. Arguments: ${JSON.stringify(
-                            sanitizeMcpAuditEvent({
-                                timestamp: "",
-                                operation: "tool-invocation",
-                                configId: config.id,
-                                configName: config.name,
-                                arguments: action.parameters,
-                                sensitiveValues,
-                            }).arguments,
-                        )}`,
-                        ["Allow once", "Allow for session", "Deny"],
-                        2,
-                    );
-                    if (choice === 2) {
-                        decision = "deny";
-                        return createActionResultFromError(
-                            `MCP tool '${tool.name}' on server '${config.name}' was denied by the user.`,
-                        );
-                    }
-                    decision = choice === 1 ? "session-allow" : "allow-once";
-                    if (choice === 1) {
-                        const session =
-                            sessionApprovals.get(sessionId) ??
-                            new Set<string>();
-                        session.add(toolId);
-                        sessionApprovals.set(sessionId, session);
-                    }
-                }
-                const started = Date.now();
-                await services.audit.write({
-                    timestamp: new Date().toISOString(),
-                    operation: "tool-invocation",
-                    configId: config.id,
-                    configName: config.name,
-                    tool: tool.name,
-                    toolId,
-                    sessionId,
-                    transport: config.transport.kind,
-                    source: config.provenance.source,
-                    decision,
-                    arguments: action.parameters,
-                    sensitiveValues,
-                });
-                try {
-                    const result = await activeConnection.callTool(
-                        tool.name,
-                        argumentValidation.data,
-                    );
-                    if (!result.isError && tool.validateOutput !== undefined) {
-                        const outputValidation = tool.validateOutput(
-                            result.structuredContent,
-                        );
-                        if (!outputValidation.valid) {
-                            const message = `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned output that does not match outputSchema: ${outputValidation.errorMessage}`;
-                            await services.audit.write({
-                                timestamp: new Date().toISOString(),
-                                operation: "tool-result",
-                                configId: config.id,
-                                configName: config.name,
-                                tool: tool.name,
-                                toolId,
-                                sessionId,
-                                status: "failure",
-                                durationMs: Date.now() - started,
-                                error: message,
-                            });
-                            return createActionResultFromError(message);
-                        }
-                    }
-                    await services.audit.write({
-                        timestamp: new Date().toISOString(),
-                        operation: "tool-result",
-                        configId: config.id,
-                        configName: config.name,
-                        tool: tool.name,
-                        toolId,
-                        sessionId,
-                        status: "success",
-                        durationMs: Date.now() - started,
-                    });
-                    return convertToolResult(tool.name, result);
-                } catch (error) {
-                    const errorMessage =
-                        error instanceof Error ? error.message : String(error);
-                    await services.audit.write({
-                        timestamp: new Date().toISOString(),
-                        operation: "tool-result",
-                        configId: config.id,
-                        configName: config.name,
-                        tool: tool.name,
-                        toolId,
-                        sessionId,
-                        status: "failure",
-                        durationMs: Date.now() - started,
-                        error: errorMessage,
-                    });
-                    if (
-                        /output schema|outputSchema|structured content/i.test(
-                            errorMessage,
-                        )
-                    ) {
-                        return createActionResultFromError(
-                            `MCP tool '${tool.name}' on server '${config.name}' (${config.id}) returned invalid output: ${errorMessage}`,
-                        );
-                    }
-                    throw error;
-                }
-            },
+            executeAction: createMcpExecuteAction(
+                config,
+                services,
+                activeConnection,
+                () => snapshot,
+                sessionContexts,
+                sessionApprovals,
+                sensitiveValues,
+            ),
         };
         return {
             agent,

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpServerStore.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpServerStore.ts
@@ -14,18 +14,42 @@ export type McpServersJson = {
     servers: Record<string, NormalizedMcpServerConfig>;
 };
 
+type PersistedMcpServerConfig = Partial<NormalizedMcpServerConfig> &
+    Pick<NormalizedMcpServerConfig, "transport">;
+
 function mcpServersJsonPath(instanceDir: string): string {
     return path.join(instanceDir, "mcpServers.json");
 }
 
+function assertNoPlaintextCredentials(config: NormalizedMcpServerConfig): void {
+    const values =
+        config.transport.kind === "http"
+            ? config.transport.headers
+            : config.transport.env;
+    for (const [name, value] of Object.entries(values ?? {})) {
+        if (
+            /authorization|cookie|password|secret|token|api[-_]?key/i.test(
+                name,
+            ) &&
+            typeof value === "string"
+        ) {
+            throw new Error(
+                `MCP server '${config.name}' cannot persist plaintext credential '${name}'. Use an env or secure credential reference.`,
+            );
+        }
+    }
+}
+
 export function readMcpServersJson(
     instanceDir: string,
-): McpServersJson | undefined {
+): { servers: Record<string, PersistedMcpServerConfig> } | undefined {
     const filePath = mcpServersJsonPath(instanceDir);
     if (!fs.existsSync(filePath)) {
         return undefined;
     }
-    return JSON.parse(fs.readFileSync(filePath, "utf8")) as McpServersJson;
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+        servers: Record<string, PersistedMcpServerConfig>;
+    };
 }
 
 export function writeMcpServersJson(
@@ -48,27 +72,58 @@ export function writeMcpServersJson(
  */
 export interface McpServerStore {
     list(): NormalizedMcpServerConfig[];
-    get(name: string): NormalizedMcpServerConfig | undefined;
-    has(name: string): boolean;
+    get(id: string): NormalizedMcpServerConfig | undefined;
+    has(id: string): boolean;
     // Add or replace a server config, writing through to disk. Returns the
     // stored config.
     set(config: NormalizedMcpServerConfig): NormalizedMcpServerConfig;
     // Remove a server config; returns true when a config was removed.
-    remove(name: string): boolean;
+    remove(id: string): boolean;
+}
+
+function migrateConfig(
+    persistedId: string,
+    config: PersistedMcpServerConfig,
+): NormalizedMcpServerConfig {
+    const id = config.id ?? persistedId;
+    const name = config.name ?? persistedId;
+    return {
+        ...config,
+        id,
+        name,
+        enabled: config.enabled ?? true,
+        trust: config.trust ?? "untrusted",
+        scope: config.scope ?? "user",
+        provenance: config.provenance ?? {
+            source: "legacy-mcpServers.json",
+            sourceKind: "legacy",
+            ref: persistedId,
+        },
+    };
 }
 
 export function openMcpServerStore(
     instanceDir: string,
     reservedNames: ReadonlySet<string> = new Set(),
+    reservedIds: ReadonlySet<string> = new Set(),
 ): McpServerStore {
     const servers = new Map<string, NormalizedMcpServerConfig>();
     const existing = readMcpServersJson(instanceDir);
     if (existing !== undefined) {
-        for (const [name, config] of Object.entries(existing.servers)) {
+        for (const [persistedId, rawConfig] of Object.entries(
+            existing.servers ?? {},
+        )) {
+            const config = migrateConfig(persistedId, rawConfig);
             // Drop any stored server whose name collides with a shipped server
             // (the seeded provider owns it).
-            if (!reservedNames.has(name)) {
-                servers.set(name, { ...config, name });
+            if (
+                !reservedNames.has(config.name) &&
+                !reservedIds.has(config.id) &&
+                ![...servers.values()].some(
+                    (existingConfig) => existingConfig.name === config.name,
+                )
+            ) {
+                servers.set(config.id, config);
             }
         }
     }
@@ -78,28 +133,44 @@ export function openMcpServerStore(
 
     function flush(): void {
         const out: Record<string, NormalizedMcpServerConfig> = {};
-        for (const [name, config] of servers) {
-            out[name] = config;
+        for (const [id, config] of servers) {
+            out[id] = config;
         }
         writeMcpServersJson(instanceDir, { servers: out });
     }
 
     return {
         list: () => [...servers.values()],
-        get: (name) => servers.get(name),
-        has: (name) => servers.has(name),
+        get: (id) => servers.get(id),
+        has: (id) => servers.has(id),
         set(config) {
+            assertNoPlaintextCredentials(config);
+            if (reservedIds.has(config.id)) {
+                throw new Error(
+                    `Cannot store MCP server config '${config.id}': id is reserved by a shipped server`,
+                );
+            }
             if (reservedNames.has(config.name)) {
                 throw new Error(
                     `Cannot store MCP server '${config.name}': name is reserved by a shipped server`,
                 );
             }
-            servers.set(config.name, config);
+            for (const existing of servers.values()) {
+                if (
+                    existing.id !== config.id &&
+                    existing.name === config.name
+                ) {
+                    throw new Error(
+                        `Cannot store MCP server '${config.name}': name is already used by config '${existing.id}'`,
+                    );
+                }
+            }
+            servers.set(config.id, config);
             flush();
             return config;
         },
-        remove(name) {
-            const removed = servers.delete(name);
+        remove(id) {
+            const removed = servers.delete(id);
             if (removed) {
                 flush();
             }

--- a/ts/packages/defaultAgentProvider/src/mcp/mcpToolCatalog.ts
+++ b/ts/packages/defaultAgentProvider/src/mcp/mcpToolCatalog.ts
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Tool } from "@modelcontextprotocol/client";
+import type { JsonSchemaValidator } from "@modelcontextprotocol/client";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/ajv";
+import { convertToolsSchema, type SkippedTool } from "./mcpSchema.js";
+
+const maxSchemaBytes = 256 * 1024;
+const maxSchemaDepth = 40;
+const maxSchemaNodes = 2_000;
+const maxCompositionBranches = 128;
+
+export type McpToolIdentity = string;
+
+export function getMcpToolIdentity(
+    serverConfigId: string,
+    toolName: string,
+): McpToolIdentity {
+    return JSON.stringify([serverConfigId, toolName]);
+}
+
+export interface McpToolCatalogEntry {
+    readonly id: McpToolIdentity;
+    readonly serverConfigId: string;
+    readonly name: string;
+    readonly description?: string;
+    readonly title?: string;
+    readonly icons?: Tool["icons"];
+    readonly annotations?: Tool["annotations"];
+    readonly inputSchema: Tool["inputSchema"];
+    readonly outputSchema?: Tool["outputSchema"];
+    readonly validateArguments: JsonSchemaValidator<Record<string, unknown>>;
+    readonly validateOutput?: JsonSchemaValidator<unknown>;
+}
+
+export interface McpToolCatalog {
+    readonly entries: ReadonlyMap<McpToolIdentity, McpToolCatalogEntry>;
+    readonly schemaContent: string;
+    readonly skipped: readonly SkippedTool[];
+    readonly fingerprint: string;
+}
+
+function canonicalize(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(canonicalize);
+    }
+    if (value !== null && typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([key, child]) => [key, canonicalize(child)]),
+        );
+    }
+    return value;
+}
+
+function inspectSchema(schema: unknown, label: string): void {
+    let serialized: string;
+    try {
+        serialized = JSON.stringify(schema);
+    } catch (error) {
+        throw new Error(
+            `${label} is not serializable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+    if (Buffer.byteLength(serialized) > maxSchemaBytes) {
+        throw new Error(
+            `${label} exceeds the ${maxSchemaBytes}-byte safety limit`,
+        );
+    }
+
+    let nodes = 0;
+    let compositionBranches = 0;
+    const visit = (value: unknown, depth: number): void => {
+        if (depth > maxSchemaDepth) {
+            throw new Error(
+                `${label} exceeds the maximum depth of ${maxSchemaDepth}`,
+            );
+        }
+        nodes++;
+        if (nodes > maxSchemaNodes) {
+            throw new Error(
+                `${label} exceeds the maximum node count of ${maxSchemaNodes}`,
+            );
+        }
+        if (value === null || typeof value !== "object") {
+            return;
+        }
+        for (const [key, child] of Object.entries(
+            value as Record<string, unknown>,
+        )) {
+            if (
+                key === "$ref" &&
+                typeof child === "string" &&
+                !child.startsWith("#")
+            ) {
+                throw new Error(
+                    `${label} contains external $ref '${child}'; only local fragment references are allowed`,
+                );
+            }
+            if (
+                (key === "allOf" || key === "anyOf" || key === "oneOf") &&
+                Array.isArray(child)
+            ) {
+                compositionBranches += child.length;
+                if (compositionBranches > maxCompositionBranches) {
+                    throw new Error(
+                        `${label} exceeds the composition branch limit of ${maxCompositionBranches}`,
+                    );
+                }
+            }
+            visit(child, depth + 1);
+        }
+    };
+    visit(schema, 0);
+}
+
+function compileValidator<T>(
+    validator: AjvJsonSchemaValidator,
+    schema: unknown,
+    label: string,
+): JsonSchemaValidator<T> {
+    inspectSchema(schema, label);
+    try {
+        return validator.getValidator<T>(schema as Record<string, unknown>);
+    } catch (error) {
+        throw new Error(
+            `${label} is not a supported safe JSON Schema: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+}
+
+export function buildMcpToolCatalog(
+    serverConfigId: string,
+    tools: Tool[],
+    entryTypeName: string,
+): McpToolCatalog {
+    const validator = new AjvJsonSchemaValidator();
+    const safeTools: Tool[] = [];
+    const validators = new Map<
+        string,
+        {
+            input: JsonSchemaValidator<Record<string, unknown>>;
+            output?: JsonSchemaValidator<unknown>;
+        }
+    >();
+    const skipped: SkippedTool[] = [];
+
+    for (const tool of tools) {
+        const name = typeof tool?.name === "string" ? tool.name : "(unnamed)";
+        const id = getMcpToolIdentity(serverConfigId, name);
+        try {
+            const input = compileValidator<Record<string, unknown>>(
+                validator,
+                tool.inputSchema,
+                `MCP tool '${name}' inputSchema`,
+            );
+            const output =
+                tool.outputSchema === undefined
+                    ? undefined
+                    : compileValidator<unknown>(
+                          validator,
+                          tool.outputSchema,
+                          `MCP tool '${name}' outputSchema`,
+                      );
+            validators.set(id, {
+                input,
+                ...(output === undefined ? {} : { output }),
+            });
+            safeTools.push(tool);
+        } catch (error) {
+            skipped.push({
+                id,
+                name,
+                reason: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    const sortedSafeTools = [...safeTools].sort((a, b) =>
+        a.name.localeCompare(b.name),
+    );
+    const converted = convertToolsSchema(
+        sortedSafeTools,
+        entryTypeName,
+        serverConfigId,
+    );
+    skipped.push(...converted.skipped);
+    const accepted = new Set(converted.accepted);
+    const entries = new Map<McpToolIdentity, McpToolCatalogEntry>();
+    for (const tool of sortedSafeTools) {
+        if (!accepted.has(tool.name)) {
+            continue;
+        }
+        const id = getMcpToolIdentity(serverConfigId, tool.name);
+        const compiled = validators.get(id);
+        if (compiled === undefined) {
+            continue;
+        }
+        entries.set(
+            id,
+            Object.freeze({
+                id,
+                serverConfigId,
+                name: tool.name,
+                ...(tool.description === undefined
+                    ? {}
+                    : { description: tool.description }),
+                ...(tool.title === undefined ? {} : { title: tool.title }),
+                ...(tool.icons === undefined ? {} : { icons: tool.icons }),
+                ...(tool.annotations === undefined
+                    ? {}
+                    : { annotations: tool.annotations }),
+                inputSchema: tool.inputSchema,
+                ...(tool.outputSchema === undefined
+                    ? {}
+                    : { outputSchema: tool.outputSchema }),
+                validateArguments: compiled.input,
+                ...(compiled.output === undefined
+                    ? {}
+                    : { validateOutput: compiled.output }),
+            }),
+        );
+    }
+    const fingerprint = JSON.stringify(
+        canonicalize(
+            [...entries.values()].map((entry) => ({
+                id: entry.id,
+                name: entry.name,
+                description: entry.description,
+                title: entry.title,
+                icons: entry.icons,
+                annotations: entry.annotations,
+                inputSchema: entry.inputSchema,
+                outputSchema: entry.outputSchema,
+            })),
+        ),
+    );
+    return Object.freeze({
+        entries,
+        schemaContent: converted.content,
+        skipped: Object.freeze(skipped),
+        fingerprint,
+    });
+}

--- a/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
+++ b/ts/packages/defaultAgentProvider/src/mcpDefaultAgentProvider.ts
@@ -16,6 +16,7 @@ import {
     McpAppAgentSourceForTest,
 } from "./mcp/mcpAppAgentSource.js";
 import type { NormalizedMcpServerConfig } from "./mcp/mcpServerConfig.js";
+import type { McpHostServices } from "./mcp/mcpServerProvider.js";
 
 const MCP_CLIENT_INFO = { name: "typeagent", version: "0.0.1" };
 
@@ -99,6 +100,7 @@ export function getMcpAppAgentSource(instanceDir: string): AppAgentSource {
  */
 export function createMcpAppAgentSourceForInstance(
     instanceConfigs: InstanceConfigProvider,
+    services?: McpHostServices,
 ): McpAppAgentSourceForTest {
     const instanceDir = instanceConfigs.getInstanceDir();
     if (instanceDir === undefined) {
@@ -110,6 +112,10 @@ export function createMcpAppAgentSourceForInstance(
     // Reserve ALL shipped server names (both seeded and legacy) so the user
     // store can never register a name owned by another provider.
     const reserved = new Set(Object.keys(getProviderConfig().mcpServers ?? {}));
-    const store = openMcpServerStore(instanceDir, reserved);
-    return createMcpAppAgentSource(store, seed, MCP_CLIENT_INFO);
+    const store = openMcpServerStore(
+        instanceDir,
+        reserved,
+        new Set(Object.values(seed).map((config) => config.id)),
+    );
+    return createMcpAppAgentSource(store, seed, MCP_CLIENT_INFO, services);
 }

--- a/ts/packages/defaultAgentProvider/test/defaultAgentRuntime.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/defaultAgentRuntime.spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+    AppAgentProviderSetController,
+    AppAgentProviderSetRunResult,
+} from "agent-dispatcher";
+import { createDefaultAgentRuntime } from "../src/defaultAgentRuntime.js";
+import type { PackageAgentContext } from "../src/installSources/packageAgent.js";
+
+function tmpInstanceDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "ta-default-runtime-"));
+}
+
+describe("createDefaultAgentRuntime", () => {
+    it("binds the package agent to the same MCP API used by the MCP source", async () => {
+        const runtime = createDefaultAgentRuntime(tmpInstanceDir());
+        const controller: AppAgentProviderSetController = {
+            async runExclusive<T>(
+                cb: (mutation: never) => Promise<T> | T,
+            ): Promise<AppAgentProviderSetRunResult<T>> {
+                return {
+                    status: "completed",
+                    value: await cb(undefined as never),
+                };
+            },
+        };
+
+        const installedConnection =
+            runtime.appAgentSources[0].connect(controller);
+        const providers = await installedConnection.providers;
+        const packageProvider = providers.find((provider) =>
+            provider.getAppAgentNames().includes("package"),
+        );
+        expect(packageProvider).toBeDefined();
+
+        const packageAgent = await packageProvider!.loadAppAgent!("package");
+        const initialize =
+            packageAgent.initializeAgentContext as () => Promise<PackageAgentContext>;
+        const context = await initialize();
+        expect(context.mcpSource).toBe(runtime.mcpServerSourceApi);
+        installedConnection.dispose();
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/installSourcesAddSource.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/installSourcesAddSource.spec.ts
@@ -36,7 +36,7 @@ function fakeContext(): any {
 
 // Run a handler and return the single config it added.
 async function run(
-    kind: "feed" | "catalog" | "path" | "mcp-config",
+    kind: "feed" | "catalog" | "path" | "mcp-config" | "registry",
     args: any,
     flags: any = {},
 ) {
@@ -49,7 +49,7 @@ async function run(
 
 // Run a handler expecting it to throw.
 function runExpectThrow(
-    kind: "feed" | "catalog" | "path" | "mcp-config",
+    kind: "feed" | "catalog" | "path" | "mcp-config" | "registry",
     args: any,
     flags: any = {},
 ) {
@@ -60,7 +60,7 @@ function runExpectThrow(
 }
 
 describe("getAddSourceCommandHandlers", () => {
-    it("exposes feed, catalog, path, and mcp-config subcommands", () => {
+    it("exposes all source subcommands", () => {
         const { registry } = makeRegistry();
         const handlers = getAddSourceCommandHandlers(registry);
         expect(Object.keys(handlers.commands).sort()).toEqual([
@@ -68,7 +68,35 @@ describe("getAddSourceCommandHandlers", () => {
             "feed",
             "mcp-config",
             "path",
+            "registry",
         ]);
+    });
+
+    describe("registry", () => {
+        it("requires and normalizes an https base URL", async () => {
+            expect(
+                await run(
+                    "registry",
+                    { name: "official" },
+                    {
+                        url: "https://registry.example/api",
+                        "cache-ttl": 120,
+                    },
+                ),
+            ).toEqual({
+                kind: "registry",
+                name: "official",
+                baseUrl: "https://registry.example/api/",
+                cacheTtlMs: 120000,
+            });
+            await expect(
+                runExpectThrow(
+                    "registry",
+                    { name: "bad" },
+                    { url: "http://registry.example" },
+                ),
+            ).rejects.toThrow(/https/);
+        });
     });
 
     describe("feed", () => {

--- a/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
@@ -2470,6 +2470,43 @@ describe("installed agent source api (install/uninstall/update)", () => {
         expect(fs.existsSync(sharedDir)).toBe(false);
     });
 
+    it("MCP cleanup keeps an owned path until the final config reference is removed", () => {
+        const instanceDir = pathOnlyInstanceDir();
+        const sharedDir = path.join(
+            instanceDir,
+            "installedAgents",
+            "mcp",
+            "shared",
+        );
+        fs.mkdirSync(sharedDir, { recursive: true });
+        const firstConfig = {
+            id: "first",
+            provenance: { ownedPaths: [sharedDir] },
+        } as any;
+        const secondConfig = {
+            id: "second",
+            provenance: { ownedPaths: [sharedDir] },
+        } as any;
+        const configs = [firstConfig, secondConfig];
+        const installer = createDefaultInstalledAgentSource(
+            instanceDir,
+            undefined,
+            undefined,
+            undefined,
+            {
+                listServers: () => configs,
+            } as any,
+        ).testApi;
+
+        configs.splice(0, 1);
+        installer.cleanupMcp!(firstConfig);
+        expect(fs.existsSync(sharedDir)).toBe(true);
+
+        configs.pop();
+        installer.cleanupMcp!(secondConfig);
+        expect(fs.existsSync(sharedDir)).toBe(false);
+    });
+
     it("unsupported path update does not prune a shared root", async () => {
         const instanceDir = pathOnlyInstanceDir();
         const installer =

--- a/ts/packages/defaultAgentProvider/test/installSourcesMcpConfig.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/installSourcesMcpConfig.spec.ts
@@ -60,7 +60,7 @@ describe("mcpConfigSource", () => {
         expect(rows[0].extensionKind).toBe("mcp");
     });
 
-    it("exposes normalized configs via getServers", async () => {
+    it("resolves normalized MCP candidates without native materialization", async () => {
         const file = writeConfig({
             mcpServers: {
                 web: { url: "https://example.com/mcp" },
@@ -71,9 +71,50 @@ describe("mcpConfigSource", () => {
             name: "mcp",
             file,
         });
-        const servers = source.getServers();
-        expect([...servers.keys()]).toEqual(["web"]);
-        expect(servers.get("web")?.transport).toMatchObject({ kind: "http" });
+        const candidate = await source.findMcp!("web");
+        expect(candidate).toMatchObject({
+            source: "mcp",
+            sourceKind: "mcp-config",
+            ref: "web",
+            config: {
+                id: "mcp:mcp:web",
+                enabled: false,
+                trust: "untrusted",
+                transport: { kind: "http" },
+                provenance: {
+                    source: "mcp",
+                    sourceKind: "mcp-config",
+                    ref: "web",
+                },
+            },
+        });
+    });
+
+    it("re-reads the local config when resolving an update", async () => {
+        const file = writeConfig({
+            mcpServers: {
+                web: { url: "https://example.com/v1" },
+            },
+        });
+        const source = createMcpConfigSource({
+            kind: "mcp-config",
+            name: "mcp",
+            file,
+        });
+        expect((await source.findMcp!("web"))?.config.transport).toMatchObject({
+            url: "https://example.com/v1",
+        });
+        fs.writeFileSync(
+            file,
+            JSON.stringify({
+                mcpServers: {
+                    web: { url: "https://example.com/v2" },
+                },
+            }),
+        );
+        expect((await source.findMcp!("web"))?.config.transport).toMatchObject({
+            url: "https://example.com/v2",
+        });
     });
 
     it("never resolves through the agent walk (find/materialize)", async () => {

--- a/ts/packages/defaultAgentProvider/test/mcpAppAgentSource.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpAppAgentSource.spec.ts
@@ -20,12 +20,19 @@ function tmpInstanceDir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), "ta-mcp-src-"));
 }
 
-function makeConfig(name: string): NormalizedMcpServerConfig {
+function makeConfig(
+    name: string,
+    update: Partial<NormalizedMcpServerConfig> = {},
+): NormalizedMcpServerConfig {
     return {
+        id: name,
         name,
         scope: "user",
         trust: "trusted",
+        enabled: true,
+        provenance: { source: "test" },
         transport: { kind: "stdio", command: "node", args: ["server.js"] },
+        ...update,
     };
 }
 
@@ -73,10 +80,12 @@ describe("createMcpAppAgentSource", () => {
             clientInfo,
         );
 
-        expect(source.testApi.listServers().sort()).toEqual([
-            "mine",
-            "shipped",
-        ]);
+        expect(
+            source.testApi
+                .listServers()
+                .map((config) => config.name)
+                .sort(),
+        ).toEqual(["mine", "shipped"]);
 
         const { controller } = fakeController();
         const conn = source.connect(controller);
@@ -102,7 +111,57 @@ describe("createMcpAppAgentSource", () => {
         expect(a.ops).toEqual([{ op: "add", names: ["new"] }]);
         expect(b.ops).toEqual([{ op: "add", names: ["new"] }]);
         expect(store.has("new")).toBe(true);
-        expect(source.testApi.listServers()).toContain("new");
+        expect(source.testApi.getServer("new")).toEqual(makeConfig("new"));
+    });
+
+    it("gates user configs until both trusted and enabled", async () => {
+        const dir = tmpInstanceDir();
+        const store = openMcpServerStore(dir);
+        store.set(
+            makeConfig("gated", {
+                trust: "untrusted",
+                enabled: true,
+            }),
+        );
+        const source = createMcpAppAgentSource(store, {}, clientInfo);
+        const client = fakeController();
+        const conn = source.connect(client.controller);
+        await expect(conn.providers).resolves.toEqual([]);
+
+        await source.testApi.setTrust("gated", "trusted", client.controller);
+        expect(client.ops).toEqual([{ op: "add", names: ["gated"] }]);
+
+        await source.testApi.setEnabled("gated", false, client.controller);
+        expect(client.ops).toEqual([
+            { op: "add", names: ["gated"] },
+            { op: "remove", names: ["gated"] },
+        ]);
+        expect(store.get("gated")).toMatchObject({
+            trust: "trusted",
+            enabled: false,
+        });
+    });
+
+    it("replaces an active provider when its config is updated", async () => {
+        const dir = tmpInstanceDir();
+        const store = openMcpServerStore(dir);
+        store.set(makeConfig("stable", { name: "old-name" }));
+        const source = createMcpAppAgentSource(store, {}, clientInfo);
+        const client = fakeController();
+        source.connect(client.controller);
+
+        const updated = await source.testApi.updateServer(
+            "stable",
+            { name: "new-name" },
+            client.controller,
+        );
+
+        expect(updated.id).toBe("stable");
+        expect(updated.name).toBe("new-name");
+        expect(client.ops).toEqual([
+            { op: "remove", names: ["old-name"] },
+            { op: "add", names: ["new-name"] },
+        ]);
     });
 
     it("replaces in place with remove-then-add on re-add", async () => {
@@ -172,6 +231,18 @@ describe("createMcpAppAgentSource", () => {
 
         await source.testApi.addServer(makeConfig("late"));
         expect(a.ops).toEqual([]);
+    });
+
+    it("returns no providers when disposed before the provider promise settles", async () => {
+        const dir = tmpInstanceDir();
+        const store = openMcpServerStore(dir);
+        store.set(makeConfig("late"));
+        const source = createMcpAppAgentSource(store, {}, clientInfo);
+
+        const conn = source.connect(fakeController().controller);
+        conn.dispose();
+
+        await expect(conn.providers).resolves.toEqual([]);
     });
 
     it("tolerates a closed session during fan-out", async () => {

--- a/ts/packages/defaultAgentProvider/test/mcpConfigImport.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpConfigImport.spec.ts
@@ -40,6 +40,7 @@ describe("importMcpConfig - mcpServers format", () => {
         expect(result.errors).toHaveLength(0);
         expect(result.servers).toHaveLength(1);
         const cfg = result.servers[0].config;
+        expect(cfg.id).toBe("fs");
         expect(cfg.name).toBe("fs");
         expect(cfg.transport).toEqual({
             kind: "stdio",
@@ -49,16 +50,28 @@ describe("importMcpConfig - mcpServers format", () => {
         });
         expect(cfg.scope).toBe("workspace");
         expect(cfg.trust).toBe("untrusted");
+        expect(cfg.enabled).toBe(true);
+        expect(cfg.provenance).toEqual({
+            source: "imported-config",
+            sourceKind: "mcp-config",
+            ref: "fs",
+        });
     });
 
     it("infers http transport from a bare url", () => {
         const result = importMcpConfig({
-            mcpServers: { remote: { url: "https://example.com/mcp" } },
+            mcpServers: {
+                remote: {
+                    url: "https://example.com/mcp",
+                    timeoutMs: 5000,
+                },
+            },
         });
         expect(result.errors).toHaveLength(0);
         expect(result.servers[0].config.transport).toEqual({
             kind: "http",
             url: "https://example.com/mcp",
+            timeoutMs: 5000,
         });
     });
 

--- a/ts/packages/defaultAgentProvider/test/mcpConnection.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpConnection.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getHttpTransportOptions } from "../src/mcp/mcpConnection.js";
+
+describe("HTTP MCP transport options", () => {
+    it("passes resolved headers and installs a per-request timeout fetch", () => {
+        const options = getHttpTransportOptions({
+            kind: "http",
+            url: "https://example.com/mcp",
+            headers: {
+                Authorization: "Bearer secret",
+                "X-Literal": "literal",
+            },
+            timeoutMs: 2500,
+        });
+
+        expect(options?.requestInit?.headers).toEqual({
+            Authorization: "Bearer secret",
+            "X-Literal": "literal",
+        });
+        expect(options?.fetch).toEqual(expect.any(Function));
+    });
+
+    it("does not allocate transport options when none are configured", () => {
+        expect(
+            getHttpTransportOptions({
+                kind: "http",
+                url: "https://example.com/mcp",
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/mcpOAuth.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpOAuth.spec.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { McpCredentialStore } from "../src/mcp/mcpCredentialStore.js";
+import { McpOAuthProvider } from "../src/mcp/mcpOAuth.js";
+
+class FakeStore implements McpCredentialStore {
+    readonly values = new Map<string, string>();
+    async get(ref: { name: string }) {
+        return this.values.get(ref.name);
+    }
+    async set(name: string, value: string) {
+        this.values.set(name, value);
+        return { kind: "secure" as const, name };
+    }
+    async delete(ref: { name: string }) {
+        this.values.delete(ref.name);
+    }
+}
+
+describe("MCP OAuth provider", () => {
+    it("persists tokens through the credential store and completes URL handoff", async () => {
+        const store = new FakeStore();
+        let handedOff: URL | undefined;
+        const config = {
+            id: "oauth",
+            name: "oauth",
+            enabled: true,
+            trust: "trusted" as const,
+            scope: "user" as const,
+            provenance: { source: "test" },
+            transport: {
+                kind: "http" as const,
+                url: "https://example.com/mcp",
+            },
+            oauth: {
+                enabled: true,
+                redirectUrl: "http://127.0.0.1/callback",
+            },
+        };
+        const provider = new McpOAuthProvider(config, store, {
+            async authorize(_name, url) {
+                handedOff = url;
+                return "http://127.0.0.1/callback?code=offline-code";
+            },
+        });
+        await provider.saveTokens({
+            access_token: "access-token",
+            token_type: "bearer",
+        });
+        await expect(provider.tokens()).resolves.toMatchObject({
+            access_token: "access-token",
+        });
+        await provider.redirectToAuthorization(
+            new URL("https://login.example/authorize"),
+        );
+        let callbackParams: URLSearchParams | undefined;
+        const finishAuth = async (params: URLSearchParams) => {
+            callbackParams = params;
+        };
+        await expect(provider.finishAuth({ finishAuth } as any)).resolves.toBe(
+            true,
+        );
+        expect(handedOff?.hostname).toBe("login.example");
+        expect(callbackParams?.get("code")).toBe("offline-code");
+        expect(JSON.stringify(config)).not.toContain("access-token");
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/mcpRegistry.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpRegistry.spec.ts
@@ -1,0 +1,423 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import {
+    createMcpRegistryClient,
+    type RegistryServerEntry,
+} from "../src/installSources/mcpRegistryClient.js";
+import {
+    mergeRegistryCache,
+    type RegistryCacheData,
+} from "../src/installSources/mcpRegistryCache.js";
+import { registryEntryToCandidate } from "../src/installSources/mcpRegistryDescriptor.js";
+import {
+    cleanupOwnedMcpPaths,
+    materializeRegistryNpmPackage,
+} from "../src/installSources/mcpRegistryMaterializer.js";
+import { createMcpRegistrySource } from "../src/installSources/mcpRegistrySource.js";
+
+function entry(
+    overrides: Partial<RegistryServerEntry> = {},
+): RegistryServerEntry {
+    return {
+        server: {
+            name: "io.example/weather",
+            title: "Weather",
+            description: "Weather tools",
+            version: "1.2.3",
+            remotes: [
+                {
+                    type: "streamable-http",
+                    url: "https://example.test/{tenant}/mcp",
+                    variables: {
+                        tenant: { value: "{tenant}", isRequired: true },
+                    },
+                    headers: [
+                        {
+                            name: "Authorization",
+                            value: "Bearer {token}",
+                            variables: {
+                                token: { isSecret: true, isRequired: true },
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        meta: {
+            status: "active",
+            publishedAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+            isLatest: true,
+        },
+        ...overrides,
+    };
+}
+
+function response(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}
+
+function apiEntry(value = entry()): object {
+    return {
+        server: value.server,
+        _meta: {
+            "io.modelcontextprotocol.registry/official": value.meta,
+        },
+    };
+}
+
+describe("MCP Registry v0.1 client", () => {
+    it("paginates search/latest/updated_since and bounds page count", async () => {
+        const urls: string[] = [];
+        const fetchFn: typeof fetch = async (input) => {
+            urls.push(String(input));
+            return response({
+                servers: [apiEntry()],
+                metadata:
+                    urls.length === 1
+                        ? { count: 1, nextCursor: "next/value" }
+                        : { count: 1 },
+            });
+        };
+        const client = createMcpRegistryClient(
+            "https://registry.example/",
+            fetchFn,
+        );
+        await expect(
+            client.list({
+                search: "weather server",
+                version: "latest",
+                updatedSince: "2026-01-01T00:00:00.000Z",
+                maxPages: 2,
+            }),
+        ).resolves.toHaveLength(2);
+        expect(urls[0]).toContain("search=weather+server");
+        expect(urls[0]).toContain("version=latest");
+        expect(urls[0]).toContain("updated_since=2026-01-01T00%3A00%3A00.000Z");
+        expect(urls[1]).toContain("cursor=next%2Fvalue");
+    });
+
+    it("URL-encodes exact server and version path segments", async () => {
+        let requested = "";
+        const client = createMcpRegistryClient(
+            "https://registry.example/",
+            async (input) => {
+                requested = String(input);
+                return response(apiEntry());
+            },
+        );
+        await client.get("io.example/name with space", "1.0.0+build");
+        expect(requested).toContain(
+            "/io.example%2Fname%20with%20space/versions/1.0.0%2Bbuild",
+        );
+    });
+
+    it("rejects malformed response shapes", async () => {
+        const client = createMcpRegistryClient(
+            "https://registry.example/",
+            async () => response({ servers: "wrong", metadata: {} }),
+        );
+        await expect(client.list()).rejects.toThrow(/invalid servers list/);
+    });
+});
+
+describe("MCP Registry cache/source", () => {
+    it("merges incremental deletions without exposing deleted entries", () => {
+        expect(
+            mergeRegistryCache(
+                [entry()],
+                [
+                    entry({
+                        meta: {
+                            ...entry().meta,
+                            status: "deleted",
+                        },
+                    }),
+                ],
+            ),
+        ).toEqual([]);
+    });
+
+    it("replaces a cached latest version during incremental refresh", () => {
+        const next = entry({
+            server: { ...entry().server, version: "2.0.0" },
+        });
+        expect(mergeRegistryCache([entry()], [next])).toEqual([next]);
+    });
+
+    it("keeps the previous cache when refresh fails", async () => {
+        const cached: RegistryCacheData = {
+            fetchedAt: 1,
+            updatedSince: "2026-01-01T00:00:00.000Z",
+            entries: [entry()],
+        };
+        let writes = 0;
+        const source = createMcpRegistrySource(
+            {
+                kind: "registry",
+                name: "official",
+                baseUrl: "https://registry.example/",
+                cacheTtlMs: 1,
+            },
+            {
+                installDir: process.cwd(),
+                now: () => 10,
+                client: {
+                    list: async () => {
+                        throw new Error("offline");
+                    },
+                    get: async () => undefined,
+                },
+                cacheStorage: {
+                    read: () => cached,
+                    write: () => {
+                        writes++;
+                    },
+                },
+            },
+        );
+        await expect(source.refresh?.()).rejects.toThrow("offline");
+        expect(writes).toBe(0);
+        await expect(source.listAgents?.()).resolves.toHaveLength(1);
+    });
+
+    it("warns for deprecated and drops unsupported entries per row", async () => {
+        const deprecated = entry({
+            meta: {
+                ...entry().meta,
+                status: "deprecated",
+                statusMessage: "use v2",
+            },
+        });
+        const unsupported = entry({
+            server: {
+                ...entry().server,
+                name: "io.example/python",
+                remotes: undefined,
+                packages: [
+                    {
+                        registryType: "pypi",
+                        identifier: "thing",
+                        version: "1",
+                        transport: { type: "stdio" },
+                    },
+                ],
+            },
+        });
+        const warnings: string[] = [];
+        const source = createMcpRegistrySource(
+            {
+                kind: "registry",
+                name: "official",
+                baseUrl: "https://registry.example/",
+            },
+            {
+                installDir: process.cwd(),
+                now: () => 1,
+                client: {
+                    list: async () => [deprecated, unsupported],
+                    get: async () => undefined,
+                },
+                cacheStorage: {
+                    read: () => undefined,
+                    write: () => {},
+                },
+            },
+        );
+        const rows = await source.listAgents?.((warning) =>
+            warnings.push(warning),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows?.[0].description).toContain("DEPRECATED");
+        expect(warnings.join("\n")).toMatch(/deprecated.*pypi/is);
+    });
+});
+
+describe("MCP Registry descriptor conversion/materialization", () => {
+    const roots: string[] = [];
+    afterEach(() => {
+        for (const root of roots.splice(0)) {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    function installDir(): string {
+        const root = fs.mkdtempSync(
+            path.join(process.cwd(), ".mcp-registry-test-"),
+        );
+        roots.push(root);
+        return root;
+    }
+
+    it("builds stable HTTP candidates with provenance and input references", () => {
+        const candidate = registryEntryToCandidate(
+            entry(),
+            "official",
+            "https://registry.example/",
+            { installDir: installDir() },
+        );
+        expect(candidate.config.id).toBe("mcp:official:io.example%2Fweather");
+        expect(candidate.config.provenance).toMatchObject({
+            registryBaseUrl: "https://registry.example/",
+            canonicalServerName: "io.example/weather",
+            serverVersion: "1.2.3",
+            transportType: "streamable-http",
+        });
+        expect(candidate.config.transport).toMatchObject({
+            kind: "http",
+            timeoutMs: 30000,
+            headers: {
+                Authorization: {
+                    value: "Bearer {token}",
+                    variables: {
+                        token: { kind: "input", name: "token" },
+                    },
+                },
+            },
+        });
+    });
+
+    it("materializes exact npm content, verifies hash, and builds argv", async () => {
+        const dir = installDir();
+        const bytes = Buffer.from("package tar bytes");
+        const hash = crypto.createHash("sha256").update(bytes).digest("hex");
+        const pkg = {
+            registryType: "npm",
+            identifier: "weather-mcp",
+            version: "1.2.3",
+            fileSha256: hash,
+            runtimeHint: "npx",
+            runtimeArguments: [{ type: "named", name: "--yes", value: "true" }],
+            packageArguments: [
+                { type: "named", name: "--port", value: "8080" },
+            ],
+            environmentVariables: [{ name: "TOKEN", isSecret: true }],
+            transport: { type: "stdio" },
+        };
+        const candidate = registryEntryToCandidate(
+            entry({
+                server: {
+                    ...entry().server,
+                    remotes: undefined,
+                    packages: [pkg],
+                },
+            }),
+            "official",
+            "https://registry.example/",
+            { installDir: dir },
+        );
+        const config = await materializeRegistryNpmPackage(
+            candidate.config,
+            pkg,
+            candidate.config.provenance.digest!,
+            {
+                installDir: dir,
+                randomId: () => "fixed",
+                npxCliPath: "C:\\npm\\npx-cli.js",
+                fetchFn: async (input) =>
+                    String(input).endsWith(".tgz")
+                        ? new Response(bytes)
+                        : response({
+                              versions: {
+                                  "1.2.3": {
+                                      dist: {
+                                          tarball:
+                                              "https://registry.example/pkg.tgz",
+                                      },
+                                  },
+                              },
+                          }),
+                npmInstall: async ({ cwd }) => {
+                    const pkgDir = path.join(
+                        cwd,
+                        "node_modules",
+                        "weather-mcp",
+                    );
+                    fs.mkdirSync(path.join(pkgDir, "dist"), {
+                        recursive: true,
+                    });
+                    fs.writeFileSync(
+                        path.join(pkgDir, "package.json"),
+                        JSON.stringify({
+                            name: "weather-mcp",
+                            version: "1.2.3",
+                            bin: "dist/cli.js",
+                        }),
+                    );
+                    fs.writeFileSync(path.join(pkgDir, "dist", "cli.js"), "");
+                },
+            },
+        );
+        expect(config.provenance.packageHash).toBe(hash);
+        expect(config.provenance.ownedPaths).toHaveLength(1);
+        expect(config.transport).toMatchObject({
+            kind: "stdio",
+            command: process.execPath,
+            env: { TOKEN: { kind: "input", name: "TOKEN" } },
+        });
+        if (config.transport.kind === "stdio") {
+            expect(config.transport.args).toEqual(
+                expect.arrayContaining([
+                    "C:\\npm\\npx-cli.js",
+                    "--yes",
+                    "--offline",
+                    "--no-install",
+                    "weather-mcp",
+                    "--port",
+                    "8080",
+                ]),
+            );
+        }
+        cleanupOwnedMcpPaths(dir, config.provenance.ownedPaths);
+        expect(fs.existsSync(config.provenance.ownedPaths![0])).toBe(false);
+    });
+
+    it("rejects hash mismatch and arbitrary cleanup paths", async () => {
+        const dir = installDir();
+        const config = registryEntryToCandidate(
+            entry(),
+            "official",
+            "https://registry.example/",
+            { installDir: dir },
+        ).config;
+        await expect(
+            materializeRegistryNpmPackage(
+                config,
+                {
+                    registryType: "npm",
+                    identifier: "bad",
+                    version: "1.0.0",
+                    fileSha256: "0".repeat(64),
+                    transport: { type: "stdio" },
+                },
+                "a".repeat(64),
+                {
+                    installDir: dir,
+                    fetchFn: async (input) =>
+                        String(input).endsWith(".tgz")
+                            ? new Response("wrong")
+                            : response({
+                                  versions: {
+                                      "1.0.0": {
+                                          dist: {
+                                              tarball:
+                                                  "https://registry.example/bad.tgz",
+                                          },
+                                      },
+                                  },
+                              }),
+                },
+            ),
+        ).rejects.toThrow(/SHA-256 mismatch/);
+        expect(() =>
+            cleanupOwnedMcpPaths(dir, [path.join(dir, "not-mcp")]),
+        ).toThrow(/Invalid owned MCP install path/);
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/mcpRegistry.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpRegistry.spec.ts
@@ -284,6 +284,38 @@ describe("MCP Registry descriptor conversion/materialization", () => {
         });
     });
 
+    it("URL-encodes scoped npm package names when resolving metadata", async () => {
+        const dir = installDir();
+        let requested: string | undefined;
+        await expect(
+            materializeRegistryNpmPackage(
+                registryEntryToCandidate(
+                    entry(),
+                    "official",
+                    "https://registry.example/",
+                    { installDir: dir },
+                ).config,
+                {
+                    registryType: "npm",
+                    identifier: "@example/weather-mcp",
+                    version: "1.2.3",
+                    transport: { type: "stdio" },
+                },
+                "a".repeat(64),
+                {
+                    installDir: dir,
+                    fetchFn: async (input) => {
+                        requested = String(input);
+                        return response({}, 404);
+                    },
+                },
+            ),
+        ).rejects.toThrow(/Could not resolve npm package/);
+        expect(requested).toBe(
+            "https://registry.npmjs.org/@example%2Fweather-mcp",
+        );
+    });
+
     it("materializes exact npm content, verifies hash, and builds argv", async () => {
         const dir = installDir();
         const bytes = Buffer.from("package tar bytes");

--- a/ts/packages/defaultAgentProvider/test/mcpSecurity.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpSecurity.spec.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SessionMcpCredentialStore, JsonlMcpAuditSink } from "../src/index.js";
+import { resolveTransportConfig } from "../src/mcp/mcpServerConfig.js";
+import { enforceMcpPolicy } from "../src/mcp/mcpPolicy.js";
+import { openMcpServerStore } from "../src/mcp/mcpServerStore.js";
+
+const config = {
+    id: "secure",
+    name: "secure",
+    enabled: true,
+    trust: "trusted" as const,
+    scope: "user" as const,
+    provenance: { source: "test" },
+    transport: {
+        kind: "http" as const,
+        url: "https://example.com/mcp",
+        headers: {
+            Authorization: {
+                value: "Bearer {token}",
+                variables: {
+                    token: { kind: "secure" as const, name: "api-token" },
+                },
+            },
+        },
+    },
+};
+
+describe("MCP security host services", () => {
+    it("resolves named credentials without persisting plaintext", async () => {
+        const store = new SessionMcpCredentialStore({});
+        await store.set("api-token", "secret-value");
+        await expect(
+            resolveTransportConfig(config, store),
+        ).resolves.toMatchObject({
+            headers: { Authorization: "Bearer secret-value" },
+        });
+        await expect(
+            store.set("durable", "secret-value", { durable: true }),
+        ).rejects.toThrow(/Durable MCP secret storage is not configured/);
+        expect(JSON.stringify(config)).not.toContain("secret-value");
+    });
+
+    it("denies unapproved public registry materialization", () => {
+        expect(() =>
+            enforceMcpPolicy(
+                {
+                    allowedTransports: ["stdio"],
+                    allowPublicNpmRegistry: false,
+                },
+                "install",
+                {
+                    ...config,
+                    transport: { kind: "stdio", command: "node", args: [] },
+                    provenance: {
+                        source: "registry",
+                        packageIdentifier: "unsafe-package",
+                        npmRegistryUrl: "https://registry.npmjs.org/",
+                    },
+                },
+            ),
+        ).toThrow(/public npm registry materialization is disabled/);
+    });
+
+    it("refuses to persist plaintext credential headers", () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-store-"));
+        expect(() =>
+            openMcpServerStore(dir).set({
+                ...config,
+                transport: {
+                    kind: "http",
+                    url: "https://example.com/mcp",
+                    headers: { Authorization: "Bearer plaintext-value" },
+                },
+            }),
+        ).toThrow(/cannot persist plaintext credential/);
+    });
+
+    it("writes sanitized bounded audit JSONL", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-audit-"));
+        const sink = new JsonlMcpAuditSink(dir, 1024);
+        await sink.write({
+            timestamp: new Date().toISOString(),
+            operation: "tool-invocation",
+            configId: "secure",
+            configName: "secure",
+            tool: "send",
+            arguments: {
+                Authorization: "Bearer abcdefghijklmnop",
+                password: "super-secret-password",
+            },
+        });
+        const text = fs.readFileSync(path.join(dir, "mcp-audit.jsonl"), "utf8");
+        expect(text).not.toContain("abcdefghijklmnop");
+        expect(text).not.toContain("super-secret-password");
+        expect(text).toContain("******");
+    });
+
+    it("redacts explicit sensitive values and rotates only at JSONL boundaries", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-audit-"));
+        const sink = new JsonlMcpAuditSink(dir, 500);
+        const sensitiveValue = "sensitive-value-under-safe-key";
+
+        for (let index = 0; index < 8; index++) {
+            await sink.write({
+                timestamp: new Date().toISOString(),
+                operation: "tool-invocation",
+                configId: "secure",
+                configName: "secure",
+                arguments: {
+                    note: sensitiveValue,
+                    padding: "x".repeat(80),
+                    index,
+                },
+                sensitiveValues: [sensitiveValue],
+            });
+        }
+
+        const text = fs.readFileSync(path.join(dir, "mcp-audit.jsonl"), "utf8");
+        expect(text).not.toContain(sensitiveValue);
+        const lines = text.split("\n").filter((line) => line.length > 0);
+        expect(lines.length).toBeGreaterThan(0);
+        for (const line of lines) {
+            expect(() => JSON.parse(line)).not.toThrow();
+        }
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/mcpSeed.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpSeed.spec.ts
@@ -23,9 +23,16 @@ describe("mcpInfoToNormalized", () => {
             info({ serverUrl: "https://example.com/mcp" }),
         );
         expect(normalized).toEqual({
+            id: "shipped:web",
             name: "web",
             scope: "shipped",
             trust: "trusted",
+            enabled: true,
+            provenance: {
+                source: "shipped",
+                sourceKind: "shipped",
+                ref: "web",
+            },
             description: "a server",
             emojiChar: "🔌",
             transport: { kind: "http", url: "https://example.com/mcp" },

--- a/ts/packages/defaultAgentProvider/test/mcpServerConfig.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpServerConfig.spec.ts
@@ -39,21 +39,49 @@ describe("resolveEnvValue", () => {
 });
 
 describe("toTransportConfig", () => {
-    it("maps an http config to an http transport", () => {
-        const config: NormalizedMcpServerConfig = {
-            name: "remote",
-            transport: { kind: "http", url: "https://example.com/mcp" },
+    function config(
+        transport: NormalizedMcpServerConfig["transport"],
+    ): NormalizedMcpServerConfig {
+        return {
+            id: "test",
+            name: "test",
+            enabled: true,
+            trust: "trusted",
+            scope: "user",
+            provenance: { source: "test" },
+            transport,
         };
-        expect(toTransportConfig(config)).toEqual({
+    }
+
+    it("maps an http config to an http transport", () => {
+        expect(
+            toTransportConfig(
+                config({
+                    kind: "http",
+                    url: "https://example.com/mcp",
+                    headers: {
+                        Literal: "plain",
+                        Authorization: { kind: "env", name: "TOKEN" },
+                    },
+                    timeoutMs: 1234,
+                }),
+                undefined,
+                { TOKEN: "Bearer secret" },
+            ),
+        ).toEqual({
             kind: "http",
             url: "https://example.com/mcp",
+            headers: {
+                Literal: "plain",
+                Authorization: "Bearer secret",
+            },
+            timeoutMs: 1234,
         });
     });
 
     it("maps a stdio config and resolves env references", () => {
-        const config: NormalizedMcpServerConfig = {
-            name: "local",
-            transport: {
+        const result = toTransportConfig(
+            config({
                 kind: "stdio",
                 command: "node",
                 args: ["server.js"],
@@ -62,9 +90,9 @@ describe("toTransportConfig", () => {
                     SECRET: { kind: "input", name: "key" },
                 },
                 cwd: "/work",
-            },
-        };
-        const result = toTransportConfig(config, { key: "resolved" });
+            }),
+            { key: "resolved" },
+        );
         expect(result).toEqual({
             kind: "stdio",
             command: "node",
@@ -74,30 +102,39 @@ describe("toTransportConfig", () => {
         });
     });
 
-    it("omits unresolved env entries instead of emitting undefined", () => {
-        const config: NormalizedMcpServerConfig = {
-            name: "local",
-            transport: {
-                kind: "stdio",
-                command: "node",
-                env: { MISSING: { kind: "env", name: "NOPE" } },
-            },
-        };
-        const result = toTransportConfig(config, undefined, {});
-        expect(result).toEqual({
-            kind: "stdio",
-            command: "node",
-            args: [],
-            env: {},
-        });
+    it("fails explicitly for unresolved stdio env references", () => {
+        expect(() =>
+            toTransportConfig(
+                config({
+                    kind: "stdio",
+                    command: "node",
+                    env: { MISSING: { kind: "env", name: "NOPE" } },
+                }),
+                undefined,
+                {},
+            ),
+        ).toThrow(/environment variable 'MISSING'.*env:NOPE/);
+    });
+
+    it("fails explicitly for unresolved HTTP header references", () => {
+        expect(() =>
+            toTransportConfig(
+                config({
+                    kind: "http",
+                    url: "https://example.com/mcp",
+                    headers: {
+                        Authorization: { kind: "input", name: "api-key" },
+                    },
+                }),
+                {},
+            ),
+        ).toThrow(/HTTP header 'Authorization'.*input:api-key/);
     });
 
     it("defaults args to an empty array when absent", () => {
-        const config: NormalizedMcpServerConfig = {
-            name: "local",
-            transport: { kind: "stdio", command: "run" },
-        };
-        expect(toTransportConfig(config)).toEqual({
+        expect(
+            toTransportConfig(config({ kind: "stdio", command: "run" })),
+        ).toEqual({
             kind: "stdio",
             command: "run",
             args: [],

--- a/ts/packages/defaultAgentProvider/test/mcpServerProvider.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpServerProvider.spec.ts
@@ -1,0 +1,449 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import type { ActionContext, SessionContext } from "@typeagent/agent-sdk";
+import { SessionMcpCredentialStore } from "../src/mcp/mcpCredentialStore.js";
+import type { McpAuditEvent, McpAuditSink } from "../src/mcp/mcpAudit.js";
+import { defaultMcpPolicy } from "../src/mcp/mcpPolicy.js";
+import type {
+    McpConnectionLike,
+    McpRefreshScheduler,
+} from "../src/mcp/mcpServerProvider.js";
+import { createMcpServerAppAgentProvider } from "../src/mcp/mcpServerProvider.js";
+import type { NormalizedMcpServerConfig } from "../src/mcp/mcpServerConfig.js";
+import { getMcpToolIdentity } from "../src/mcp/mcpToolCatalog.js";
+
+function tool(name: string, update: Partial<Tool> = {}): Tool {
+    return {
+        name,
+        inputSchema: { type: "object", properties: {} },
+        ...update,
+    };
+}
+
+function config(id: string): NormalizedMcpServerConfig {
+    return {
+        id,
+        name: id,
+        scope: "user",
+        trust: "trusted",
+        enabled: true,
+        provenance: { source: "test" },
+        transport: { kind: "stdio", command: "node", args: ["server.js"] },
+    };
+}
+
+class ManualScheduler implements McpRefreshScheduler {
+    private callbacks = new Map<number, () => void>();
+    private nextId = 0;
+
+    setTimeout(callback: () => void): number {
+        const id = ++this.nextId;
+        this.callbacks.set(id, callback);
+        return id;
+    }
+
+    clearTimeout(handle: unknown): void {
+        this.callbacks.delete(handle as number);
+    }
+
+    runAll(): void {
+        const callbacks = [...this.callbacks.values()];
+        this.callbacks.clear();
+        for (const callback of callbacks) {
+            callback();
+        }
+    }
+
+    get size(): number {
+        return this.callbacks.size;
+    }
+}
+
+class FakeConnection implements McpConnectionLike {
+    readonly protocolEra = "legacy";
+    readonly protocolVersion = "2025-11-25";
+    closed = false;
+    calls: { name: string; args: unknown }[] = [];
+
+    constructor(
+        public tools: Tool[],
+        readonly supportsToolListChanged: boolean,
+        private readonly result: CallToolResult = {
+            content: [{ type: "text", text: "ok" }],
+        },
+    ) {}
+
+    async listTools(): Promise<Tool[]> {
+        return this.tools;
+    }
+
+    async callTool(
+        name: string,
+        args: Record<string, unknown> | undefined,
+    ): Promise<CallToolResult> {
+        this.calls.push({ name, args });
+        return this.result;
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+    }
+}
+
+function session(
+    id: string,
+    reload: () => Promise<void> = async () => {},
+    popup: () => Promise<number> = async () => 0,
+): SessionContext {
+    return {
+        sessionContextId: id,
+        reloadAgentSchema: reload,
+        popupQuestion: popup,
+    } as unknown as SessionContext;
+}
+
+function actionContext(context: SessionContext): ActionContext {
+    return { sessionContext: context } as ActionContext;
+}
+
+async function settle(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function schemaContent(manifest: {
+    schema?: { schemaFile: string | { content: string } };
+}): string {
+    const schemaFile = manifest.schema?.schemaFile;
+    if (schemaFile === undefined || typeof schemaFile === "string") {
+        throw new Error("Expected an inline schema file");
+    }
+    return schemaFile.content;
+}
+
+describe("MCP server provider milestone 5", () => {
+    it("returns failed ActionResults for argument and output validation", async () => {
+        const typed = tool("typed", {
+            inputSchema: {
+                type: "object",
+                required: ["count"],
+                properties: { count: { type: "integer" } },
+            },
+            outputSchema: {
+                type: "object",
+                required: ["ok"],
+                properties: { ok: { type: "boolean" } },
+            },
+        });
+        const connection = new FakeConnection([typed], false, {
+            content: [],
+            structuredContent: { ok: "no" },
+        });
+        const provider = createMcpServerAppAgentProvider(
+            "server",
+            config("server-id"),
+            { name: "test", version: "1" },
+            {
+                credentialStore: new SessionMcpCredentialStore(),
+                policy: defaultMcpPolicy,
+                audit: { async write() {} },
+                connectionFactory: async () => connection,
+            },
+        );
+        const agent = await provider.loadAppAgent("server");
+        const context = actionContext(session("one"));
+
+        const badInput = await agent.executeAction!(
+            {
+                schemaName: "server",
+                actionName: "typed",
+                parameters: { count: "wrong" },
+            },
+            context,
+        );
+        expect(badInput?.error).toContain("rejected its arguments");
+        expect(connection.calls).toHaveLength(0);
+
+        const badOutput = await agent.executeAction!(
+            {
+                schemaName: "server",
+                actionName: "typed",
+                parameters: { count: 1 },
+            },
+            context,
+        );
+        expect(badOutput?.error).toContain("does not match outputSchema");
+        expect(connection.calls).toHaveLength(1);
+        await provider.unloadAppAgent("server");
+    });
+
+    it("isolates approvals and audit identities for same-named tools on different servers", async () => {
+        const audits: McpAuditEvent[] = [];
+        const audit: McpAuditSink = {
+            async write(event) {
+                audits.push(event);
+            },
+        };
+        const mutating = tool("change", {
+            annotations: { readOnlyHint: false },
+        });
+        const makeProvider = (id: string) =>
+            createMcpServerAppAgentProvider(
+                id,
+                config(id),
+                { name: "test", version: "1" },
+                {
+                    credentialStore: new SessionMcpCredentialStore(),
+                    policy: defaultMcpPolicy,
+                    audit,
+                    connectionFactory: async () =>
+                        new FakeConnection([mutating], false),
+                },
+            );
+        const a = makeProvider("a");
+        const b = makeProvider("b");
+        const agentA = await a.loadAppAgent("a");
+        const agentB = await b.loadAppAgent("b");
+        let prompts = 0;
+        const context = actionContext(
+            session(
+                "shared",
+                async () => {},
+                async () => {
+                    prompts++;
+                    return 1;
+                },
+            ),
+        );
+        const action = {
+            schemaName: "mcp",
+            actionName: "change",
+            parameters: {},
+        };
+
+        await agentA.executeAction!(action, context);
+        await agentA.executeAction!(action, context);
+        await agentB.executeAction!(action, context);
+
+        expect(prompts).toBe(2);
+        expect(
+            audits
+                .filter((event) => event.operation === "tool-invocation")
+                .map((event) => event.toolId),
+        ).toEqual([
+            getMcpToolIdentity("a", "change"),
+            getMcpToolIdentity("a", "change"),
+            getMcpToolIdentity("b", "change"),
+        ]);
+        await a.unloadAppAgent("a");
+        await b.unloadAppAgent("b");
+    });
+
+    it("refreshes atomically, coalesces bursts, fans out reload, and audits no-op/rollback", async () => {
+        const scheduler = new ManualScheduler();
+        const audits: McpAuditEvent[] = [];
+        const connection = new FakeConnection([tool("first")], true);
+        let notify:
+            | ((error: Error | null, tools: Tool[] | null) => void)
+            | undefined;
+        const provider = createMcpServerAppAgentProvider(
+            "server",
+            config("server-id"),
+            { name: "test", version: "1" },
+            {
+                credentialStore: new SessionMcpCredentialStore(),
+                policy: defaultMcpPolicy,
+                audit: {
+                    async write(event) {
+                        audits.push(event);
+                    },
+                },
+                refreshScheduler: scheduler,
+                connectionFactory: async (_info, _transport, options) => {
+                    notify = options.toolsChanged;
+                    return connection;
+                },
+            },
+        );
+        const agent = await provider.loadAppAgent("server");
+        let reloadA = 0;
+        let reloadB = 0;
+        await agent.updateAgentContext!(
+            true,
+            session("a", async () => {
+                reloadA++;
+            }),
+            "server",
+        );
+        await agent.updateAgentContext!(
+            true,
+            session("b", async () => {
+                reloadB++;
+                throw new Error("closing");
+            }),
+            "server",
+        );
+        const initialManifest = await provider.getAppAgentManifest("server");
+        expect(Object.isFrozen(initialManifest)).toBe(true);
+        expect(schemaContent(initialManifest)).toContain("first");
+
+        notify!(null, [tool("second")]);
+        notify!(null, [tool("third")]);
+        expect(scheduler.size).toBe(1);
+        scheduler.runAll();
+        await settle();
+
+        const refreshed = await provider.getAppAgentManifest("server");
+        expect(schemaContent(refreshed)).toContain("third");
+        expect(schemaContent(refreshed)).not.toContain("first");
+        expect(schemaContent(initialManifest)).toContain("first");
+        expect(reloadA).toBe(1);
+        expect(reloadB).toBe(1);
+
+        notify!(null, [tool("third")]);
+        scheduler.runAll();
+        await settle();
+        expect(reloadA).toBe(1);
+
+        notify!(new Error("list failed"), null);
+        scheduler.runAll();
+        await settle();
+        notify!(null, []);
+        scheduler.runAll();
+        await settle();
+        const retained = await provider.getAppAgentManifest("server");
+        expect(schemaContent(retained)).toContain("third");
+        expect(
+            audits
+                .filter((event) => event.operation === "catalog-refresh")
+                .map((event) => [event.status, event.decision]),
+        ).toEqual([
+            ["success", "updated"],
+            ["success", "no-op"],
+            ["failure", "rollback"],
+            ["failure", "rollback"],
+        ]);
+        await provider.unloadAppAgent("server");
+    });
+
+    it("does not activate list changes when unadvertised and ignores late notifications after unload", async () => {
+        const scheduler = new ManualScheduler();
+        const connection = new FakeConnection([tool("stable")], false);
+        let notify:
+            | ((error: Error | null, tools: Tool[] | null) => void)
+            | undefined;
+        const provider = createMcpServerAppAgentProvider(
+            "server",
+            config("server-id"),
+            { name: "test", version: "1" },
+            {
+                credentialStore: new SessionMcpCredentialStore(),
+                policy: defaultMcpPolicy,
+                audit: { async write() {} },
+                refreshScheduler: scheduler,
+                connectionFactory: async (_info, _transport, options) => {
+                    if (connection.supportsToolListChanged) {
+                        notify = options.toolsChanged;
+                    }
+                    return connection;
+                },
+            },
+        );
+        await provider.loadAppAgent("server");
+        expect(notify).toBeUndefined();
+        await provider.unloadAppAgent("server");
+        expect(connection.closed).toBe(true);
+
+        const advertised = new FakeConnection([tool("stable")], true);
+        const provider2 = createMcpServerAppAgentProvider(
+            "server2",
+            config("server-2"),
+            { name: "test", version: "1" },
+            {
+                credentialStore: new SessionMcpCredentialStore(),
+                policy: defaultMcpPolicy,
+                audit: { async write() {} },
+                refreshScheduler: scheduler,
+                connectionFactory: async (_info, _transport, options) => {
+                    notify = options.toolsChanged;
+                    return advertised;
+                },
+            },
+        );
+        await provider2.loadAppAgent("server2");
+        await provider2.unloadAppAgent("server2");
+        notify!(null, [tool("late")]);
+        expect(scheduler.size).toBe(0);
+    });
+
+    it("coalesces a notification during refresh into one follow-up pass", async () => {
+        const scheduler = new ManualScheduler();
+        const connection = new FakeConnection([tool("first")], true);
+        let notify:
+            | ((error: Error | null, tools: Tool[] | null) => void)
+            | undefined;
+        let releaseAudit!: () => void;
+        const auditGate = new Promise<void>((resolve) => {
+            releaseAudit = resolve;
+        });
+        let enteredAudit!: () => void;
+        const auditEntered = new Promise<void>((resolve) => {
+            enteredAudit = resolve;
+        });
+        let gateFirstRefresh = true;
+        const provider = createMcpServerAppAgentProvider(
+            "server",
+            config("server-id"),
+            { name: "test", version: "1" },
+            {
+                credentialStore: new SessionMcpCredentialStore(),
+                policy: defaultMcpPolicy,
+                audit: {
+                    async write(event) {
+                        if (
+                            gateFirstRefresh &&
+                            event.operation === "catalog-refresh" &&
+                            event.decision === "updated"
+                        ) {
+                            gateFirstRefresh = false;
+                            enteredAudit();
+                            await auditGate;
+                        }
+                    },
+                },
+                refreshScheduler: scheduler,
+                connectionFactory: async (_info, _transport, options) => {
+                    notify = options.toolsChanged;
+                    return connection;
+                },
+            },
+        );
+        const agent = await provider.loadAppAgent("server");
+        let reloads = 0;
+        await agent.updateAgentContext!(
+            true,
+            session("one", async () => {
+                reloads++;
+            }),
+            "server",
+        );
+
+        notify!(null, [tool("second")]);
+        scheduler.runAll();
+        await auditEntered;
+        notify!(null, [tool("third")]);
+        expect(scheduler.size).toBe(0);
+        releaseAudit();
+        await settle();
+        expect(scheduler.size).toBe(1);
+        scheduler.runAll();
+        await settle();
+
+        expect(
+            schemaContent(await provider.getAppAgentManifest("server")),
+        ).toContain("third");
+        expect(reloads).toBe(2);
+        await provider.unloadAppAgent("server");
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/mcpServerStore.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpServerStore.spec.ts
@@ -16,9 +16,12 @@ function tmpInstanceDir(): string {
 
 function makeConfig(name: string): NormalizedMcpServerConfig {
     return {
+        id: name,
         name,
         scope: "user",
         trust: "trusted",
+        enabled: true,
+        provenance: { source: "test" },
         transport: { kind: "stdio", command: "node", args: ["server.js"] },
     };
 }
@@ -62,6 +65,39 @@ describe("mcpServers.json store", () => {
         const second = openMcpServerStore(dir);
         expect(second.has("beta")).toBe(true);
         expect(second.get("beta")).toEqual(makeConfig("beta"));
+    });
+
+    it("migrates legacy name-keyed records with safe defaults", () => {
+        const dir = tmpInstanceDir();
+        fs.writeFileSync(
+            path.join(dir, "mcpServers.json"),
+            JSON.stringify({
+                servers: {
+                    legacy: {
+                        name: "legacy display",
+                        transport: { kind: "stdio", command: "legacy" },
+                    },
+                },
+            }),
+        );
+
+        const store = openMcpServerStore(dir);
+        expect(store.get("legacy")).toEqual({
+            id: "legacy",
+            name: "legacy display",
+            enabled: true,
+            trust: "untrusted",
+            scope: "user",
+            provenance: {
+                source: "legacy-mcpServers.json",
+                sourceKind: "legacy",
+                ref: "legacy",
+            },
+            transport: { kind: "stdio", command: "legacy" },
+        });
+        expect(readMcpServersJson(dir)?.servers.legacy).toEqual(
+            store.get("legacy"),
+        );
     });
 
     it("drops reserved-name collisions on open", () => {

--- a/ts/packages/defaultAgentProvider/test/mcpToolCatalog.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/mcpToolCatalog.spec.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Tool } from "@modelcontextprotocol/client";
+import {
+    buildMcpToolCatalog,
+    getMcpToolIdentity,
+} from "../src/mcp/mcpToolCatalog.js";
+
+function tool(
+    name: string,
+    inputSchema: Tool["inputSchema"] = {
+        type: "object",
+        properties: {},
+    },
+    outputSchema?: Tool["outputSchema"],
+): Tool {
+    return {
+        name,
+        inputSchema,
+        ...(outputSchema === undefined ? {} : { outputSchema }),
+    };
+}
+
+describe("MCP tool catalog safety", () => {
+    it("uses server config id and tool name as durable identity", () => {
+        const a = buildMcpToolCatalog("server-a", [tool("search")], "Actions");
+        const b = buildMcpToolCatalog("server-b", [tool("search")], "Actions");
+
+        expect([...a.entries.keys()]).toEqual([
+            getMcpToolIdentity("server-a", "search"),
+        ]);
+        expect([...b.entries.keys()]).toEqual([
+            getMcpToolIdentity("server-b", "search"),
+        ]);
+        expect([...a.entries.keys()]).not.toEqual([...b.entries.keys()]);
+    });
+
+    it("produces a stable fingerprint when server ordering changes", () => {
+        const forward = buildMcpToolCatalog(
+            "server",
+            [tool("alpha"), tool("beta")],
+            "Actions",
+        );
+        const reverse = buildMcpToolCatalog(
+            "server",
+            [tool("beta"), tool("alpha")],
+            "Actions",
+        );
+
+        expect(reverse.fingerprint).toBe(forward.fingerprint);
+        expect(reverse.schemaContent).toBe(forward.schemaContent);
+    });
+
+    it("skips external refs and excessive complexity per tool", () => {
+        const deep: Record<string, unknown> = { type: "object" };
+        let cursor = deep;
+        for (let i = 0; i < 45; i++) {
+            const next: Record<string, unknown> = { type: "object" };
+            cursor.properties = { child: next };
+            cursor = next;
+        }
+        const catalog = buildMcpToolCatalog(
+            "server",
+            [
+                tool("good"),
+                tool("external", {
+                    type: "object",
+                    properties: {
+                        value: { $ref: "https://example.com/schema.json" },
+                    },
+                } as Tool["inputSchema"]),
+                tool("deep", deep as Tool["inputSchema"]),
+                tool("composed", {
+                    type: "object",
+                    oneOf: Array.from({ length: 129 }, () => ({
+                        type: "object",
+                    })),
+                } as Tool["inputSchema"]),
+            ],
+            "Actions",
+        );
+
+        expect(
+            [...catalog.entries.values()].map((entry) => entry.name),
+        ).toEqual(["good"]);
+        expect(catalog.skipped).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: getMcpToolIdentity("server", "external"),
+                    reason: expect.stringContaining("external $ref"),
+                }),
+                expect.objectContaining({
+                    id: getMcpToolIdentity("server", "deep"),
+                    reason: expect.stringContaining("maximum depth"),
+                }),
+                expect.objectContaining({
+                    id: getMcpToolIdentity("server", "composed"),
+                    reason: expect.stringContaining("composition branch limit"),
+                }),
+            ]),
+        );
+    });
+
+    it("honors declared dialects and validates arguments and output", () => {
+        const catalog = buildMcpToolCatalog(
+            "server",
+            [
+                tool(
+                    "typed",
+                    {
+                        $schema: "http://json-schema.org/draft-07/schema#",
+                        type: "object",
+                        required: ["count"],
+                        properties: { count: { type: "integer" } },
+                    } as Tool["inputSchema"],
+                    {
+                        $schema: "https://json-schema.org/draft/2020-12/schema",
+                        type: "object",
+                        required: ["ok"],
+                        properties: { ok: { type: "boolean" } },
+                    },
+                ),
+            ],
+            "Actions",
+        );
+        const entry = catalog.entries.get(
+            getMcpToolIdentity("server", "typed"),
+        )!;
+
+        expect(entry.validateArguments({ count: 2 }).valid).toBe(true);
+        expect(entry.validateArguments({ count: "2" }).valid).toBe(false);
+        expect(entry.validateOutput?.({ ok: true }).valid).toBe(true);
+        expect(entry.validateOutput?.({ ok: "yes" }).valid).toBe(false);
+    });
+
+    it("preserves tool metadata in the internal catalog", () => {
+        const source = {
+            ...tool("rich"),
+            title: "Rich tool",
+            description: "Does useful work",
+            annotations: { readOnlyHint: true },
+            icons: [{ src: "data:image/png;base64,AA==" }],
+            outputSchema: { type: "object", properties: {} },
+        } as Tool;
+        const catalog = buildMcpToolCatalog("server", [source], "Actions");
+        const entry = catalog.entries.get(getMcpToolIdentity("server", "rich"));
+
+        expect(entry).toMatchObject({
+            title: "Rich tool",
+            description: "Does useful work",
+            annotations: { readOnlyHint: true },
+            icons: [{ src: "data:image/png;base64,AA==" }],
+            outputSchema: source.outputSchema,
+        });
+    });
+});

--- a/ts/packages/defaultAgentProvider/test/packageAgent.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/packageAgent.spec.ts
@@ -10,6 +10,9 @@ import {
     PACKAGE_AGENT_NAME,
 } from "../src/installSources/packageAgent.js";
 import { CommandHandler } from "@typeagent/agent-sdk/helpers/command";
+import { McpServerSourceApi } from "../src/mcp/mcpAppAgentSource.js";
+import { NormalizedMcpServerConfig } from "../src/mcp/mcpServerConfig.js";
+import { McpInstallCandidate } from "../src/installSources/config.js";
 
 const noopHost: AppAgentProviderSetController = {
     runExclusive: async (callback) => {
@@ -48,6 +51,7 @@ function makeSource(overrides: Partial<InstalledAgentSourceApi> = {}): {
             };
         },
         preview: async () => undefined,
+        resolveMcp: async () => [],
         refresh: async () => {},
         uninstall: async (name) => {
             calls.push({ op: "uninstall", name });
@@ -100,6 +104,120 @@ function notifyCapturingActionContext(agentContext: PackageAgentContext) {
 
 function fakeSessionContext(agentContext: PackageAgentContext) {
     return { agentContext } as any;
+}
+
+function makeMcpSource(initial: NormalizedMcpServerConfig[] = []) {
+    const servers = new Map(initial.map((config) => [config.id, config]));
+    const calls: string[] = [];
+    const api: McpServerSourceApi = {
+        async addServer(config) {
+            calls.push(`add:${config.id}`);
+            servers.set(config.id, config);
+        },
+        async removeServer(id) {
+            calls.push(`remove:${id}`);
+            return servers.delete(id);
+        },
+        listServers: () => [...servers.values()],
+        getServer: (id) => servers.get(id),
+        async setTrust(id, trust) {
+            calls.push(`trust:${id}:${trust}`);
+            const config = servers.get(id)!;
+            const updated = { ...config, trust };
+            servers.set(id, updated);
+            return updated;
+        },
+        async setEnabled(id, enabled) {
+            calls.push(`enabled:${id}:${enabled}`);
+            const config = servers.get(id)!;
+            const updated = { ...config, enabled };
+            servers.set(id, updated);
+            return updated;
+        },
+        async updateServer(id, update) {
+            const config = servers.get(id)!;
+            const updated = { ...config, ...update };
+            servers.set(id, updated);
+            return updated;
+        },
+        async testServer(id, allowUntrusted) {
+            calls.push(`test:${id}:${allowUntrusted}`);
+            return { protocolVersion: "2025-06-18", tools: ["echo"] };
+        },
+    };
+    return { api, calls, servers };
+}
+
+function makeMcpConfig(
+    name: string,
+    overrides: Partial<NormalizedMcpServerConfig> = {},
+): NormalizedMcpServerConfig {
+    return {
+        id: `mcp:local:${name}`,
+        name,
+        transport: { kind: "stdio", command: "node", args: ["server.js"] },
+        enabled: false,
+        trust: "untrusted",
+        scope: "workspace",
+        provenance: {
+            source: "local",
+            sourceKind: "mcp-config",
+            ref: name,
+        },
+        ...overrides,
+    };
+}
+
+function makeMcpCandidate(
+    name: string,
+    overrides: Partial<NormalizedMcpServerConfig> = {},
+): McpInstallCandidate {
+    return {
+        extensionKind: "mcp",
+        source: "local",
+        sourceKind: "mcp-config",
+        ref: name,
+        config: makeMcpConfig(name, overrides),
+    };
+}
+
+function mcpActionContext(agentContext: PackageAgentContext, choice = 0) {
+    const captured: string[] = [];
+    const questions: string[] = [];
+    const context = {
+        sessionContext: {
+            agentContext,
+            notify: () => {},
+            popupQuestion: async (message: string) => {
+                questions.push(message);
+                return choice;
+            },
+        },
+        actionIO: {
+            appendDisplay: (content: any) => {
+                const text =
+                    typeof content === "string"
+                        ? content
+                        : Array.isArray(content?.content)
+                          ? content.content
+                                .map((row: string[]) => row.join(" "))
+                                .join("\n")
+                          : (content?.content ?? JSON.stringify(content));
+                captured.push(
+                    typeof text === "string"
+                        ? text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+                        : text,
+                );
+            },
+            setDisplay: () => {},
+            takeAction: () => {},
+        },
+    } as any;
+    return {
+        context,
+        output: () => captured.join("\n"),
+        questions,
+    };
 }
 
 function capturingActionContext(agentContext: PackageAgentContext) {
@@ -164,6 +282,14 @@ function getHandler(
 ): CommandHandler {
     const table = buildPackageCommandTable(source.sourceCommands());
     return table.commands[name] as CommandHandler;
+}
+
+function getMcpHandler(
+    source: InstalledAgentSourceApi,
+    name: "inspect" | "test" | "trust" | "untrust" | "enable" | "disable",
+): CommandHandler {
+    const table = buildPackageCommandTable(source.sourceCommands());
+    return (table.commands.mcp as any).commands[name] as CommandHandler;
 }
 
 describe("@package agent", () => {
@@ -415,12 +541,36 @@ describe("@package command table", () => {
             "available",
             "install",
             "list",
+            "mcp",
             "source",
             "uninstall",
             "update",
         ]);
         // `@package source` points at the exact host-provided table instance.
         expect(table.commands.source).toBe(sourceTable);
+        expect(
+            (table.commands.install as any).parameters.flags.type,
+        ).toMatchObject({ type: "string", default: "all" });
+        expect(
+            (table.commands.list as any).parameters.flags.type,
+        ).toMatchObject({
+            type: "string",
+            default: "agent",
+        });
+        expect(
+            Object.keys((table.commands.mcp as any).commands).sort(),
+        ).toEqual([
+            "auth",
+            "credentials",
+            "disable",
+            "enable",
+            "inspect",
+            "policy",
+            "status",
+            "test",
+            "trust",
+            "untrust",
+        ]);
         expect(table.defaultSubCommand).toBe("list");
     });
 });
@@ -928,5 +1078,380 @@ describe("@package install one-argument, dry-run, and refresh", () => {
             flags: { refresh: true, source: "path" },
         } as any);
         expect(refreshedWith).toBe("path");
+    });
+});
+
+describe("@package MCP management", () => {
+    it("rejects an implicit install when native and MCP candidates share a name", async () => {
+        const { api } = makeSource({
+            resolveMcp: async () => [makeMcpCandidate("echo")],
+            preview: async () => ({
+                winner: {
+                    source: "feed",
+                    matchKind: "defaultAgentName",
+                    name: "echo",
+                },
+                matches: [
+                    {
+                        source: "feed",
+                        matchKind: "defaultAgentName",
+                        name: "echo",
+                    },
+                ],
+            }),
+        });
+        const { api: mcpSource } = makeMcpSource();
+        const handler = getHandler(api, "install");
+        await expect(
+            handler.run(
+                mcpActionContext({
+                    appAgentProviderSetController: noopHost,
+                    source: api,
+                    mcpSource,
+                }).context,
+                {
+                    args: { target: "echo" },
+                    flags: { type: "all" },
+                } as any,
+            ),
+        ).rejects.toThrow(/matches both a native agent and an MCP server/);
+    });
+
+    it("previews an MCP install without persisting or prompting", async () => {
+        const candidate = makeMcpCandidate("echo", {
+            transport: {
+                kind: "stdio",
+                command: "node",
+                args: ["server.js"],
+                cwd: "C:\\workspace",
+                env: {
+                    TOKEN: { kind: "input", name: "api-token" },
+                    MODE: "safe",
+                },
+            },
+            enabledTools: ["echo"],
+        });
+        const { api } = makeSource({
+            resolveMcp: async () => [candidate],
+        });
+        const mcp = makeMcpSource();
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "install").run(capture.context, {
+            args: { target: "echo" },
+            flags: { type: "mcp", "dry-run": true },
+        } as any);
+        expect(capture.output()).toContain("Command: node server.js");
+        expect(capture.output()).toContain("Cwd: C:\\workspace");
+        expect(capture.output()).toContain(
+            "TOKEN=<credential input:api-token>",
+        );
+        expect(capture.output()).toContain("MODE=<literal>");
+        expect(capture.output()).toContain("Tools: echo");
+        expect(capture.questions).toEqual([]);
+        expect(mcp.calls).toEqual([]);
+    });
+
+    it("requires confirmation and installs disabled, untrusted, without plaintext credentials", async () => {
+        const candidate = makeMcpCandidate("echo", {
+            transport: {
+                kind: "http",
+                url: "https://example.com/mcp",
+                headers: {
+                    Authorization: { kind: "env", name: "MCP_TOKEN" },
+                },
+            },
+        });
+        const { api } = makeSource({
+            resolveMcp: async () => [candidate],
+        });
+        const mcp = makeMcpSource();
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "install").run(capture.context, {
+            args: { target: "echo" },
+            flags: { type: "mcp" },
+        } as any);
+        const stored = mcp.servers.get(candidate.config.id)!;
+        expect(capture.questions).toHaveLength(1);
+        expect(stored).toMatchObject({
+            enabled: false,
+            trust: "untrusted",
+            provenance: {
+                source: "local",
+                sourceKind: "mcp-config",
+                ref: "echo",
+            },
+        });
+        expect(JSON.stringify(stored)).not.toContain("plaintext-secret");
+        expect(JSON.stringify(stored)).toContain('"name":"MCP_TOKEN"');
+    });
+
+    it("cancels an MCP install without persisting", async () => {
+        const { api } = makeSource({
+            resolveMcp: async () => [makeMcpCandidate("echo")],
+        });
+        const mcp = makeMcpSource();
+        const capture = mcpActionContext(
+            {
+                appAgentProviderSetController: noopHost,
+                source: api,
+                mcpSource: mcp.api,
+            },
+            1,
+        );
+        await getHandler(api, "install").run(capture.context, {
+            args: { target: "echo" },
+            flags: { type: "mcp" },
+        } as any);
+        expect(mcp.calls).toEqual([]);
+        expect(capture.output()).toContain("MCP installation cancelled.");
+    });
+
+    it("cleans materialized MCP paths when post-materialization policy rejects", async () => {
+        const candidate = makeMcpCandidate("echo");
+        const materialized = makeMcpConfig("echo", {
+            provenance: {
+                source: "official",
+                sourceKind: "registry",
+                ref: "io.example/echo@1.0.0",
+                npmRegistryUrl: "https://registry.npmjs.org/",
+                ownedPaths: ["owned-root"],
+            },
+        });
+        const cleaned: NormalizedMcpServerConfig[] = [];
+        const { api } = makeSource({
+            resolveMcp: async () => [candidate],
+            materializeMcp: async () => materialized,
+            cleanupMcp: (config) => cleaned.push(config),
+        });
+        const mcp = makeMcpSource();
+        (mcp.api as any).getPolicy = () => ({
+            allowedTransports: ["stdio"],
+            allowPublicNpmRegistry: false,
+        });
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+
+        await expect(
+            getHandler(api, "install").run(capture.context, {
+                args: { target: "echo" },
+                flags: { type: "mcp" },
+            } as any),
+        ).rejects.toThrow(/public npm registry materialization is disabled/);
+
+        expect(cleaned).toEqual([materialized]);
+        expect(mcp.servers.size).toBe(0);
+    });
+
+    it("lists and uninstalls MCP servers through --type mcp", async () => {
+        const config = makeMcpConfig("echo");
+        const { api } = makeSource();
+        const mcp = makeMcpSource([config]);
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "list").run(capture.context, {
+            flags: { type: "mcp" },
+        } as any);
+        expect(capture.output()).toContain("echo node untrusted no local");
+        await getHandler(api, "uninstall").run(capture.context, {
+            args: { name: "echo" },
+            flags: { type: "mcp" },
+        } as any);
+        expect(mcp.calls).toContain(`remove:${config.id}`);
+        expect(mcp.servers.size).toBe(0);
+    });
+
+    it("re-resolves local config updates, previews changes, and preserves state", async () => {
+        const current = makeMcpConfig("echo", {
+            enabled: true,
+            trust: "trusted",
+        });
+        const candidate = makeMcpCandidate("echo", {
+            transport: {
+                kind: "stdio",
+                command: "node",
+                args: ["server-v2.js"],
+            },
+        });
+        const { api } = makeSource({
+            resolveMcp: async (ref, sourceName) => {
+                expect(ref).toBe("echo");
+                expect(sourceName).toBe("local");
+                return [candidate];
+            },
+        });
+        const mcp = makeMcpSource([current]);
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "update").run(capture.context, {
+            args: { name: "echo" },
+            flags: { type: "mcp" },
+        } as any);
+        expect(capture.output()).toContain("Changes: transport");
+        expect(mcp.servers.get(current.id)).toMatchObject({
+            enabled: true,
+            trust: "trusted",
+            transport: { args: ["server-v2.js"] },
+        });
+    });
+
+    it("materializes registry updates before replacement and cleans the superseded root", async () => {
+        const current = makeMcpConfig("echo", {
+            provenance: {
+                source: "official",
+                sourceKind: "registry",
+                ref: "io.example/echo@1.0.0",
+                canonicalServerName: "io.example/echo",
+                serverVersion: "1.0.0",
+                digest: "old",
+                ownedPaths: ["old-root"],
+            },
+        });
+        const candidate = makeMcpCandidate("echo", {
+            provenance: {
+                source: "official",
+                sourceKind: "registry",
+                ref: "io.example/echo@2.0.0",
+                canonicalServerName: "io.example/echo",
+                serverVersion: "2.0.0",
+                digest: "new",
+            },
+        });
+        const cleaned: string[][] = [];
+        const { api } = makeSource({
+            resolveMcp: async (ref, sourceName) => {
+                expect(ref).toBe("io.example/echo@2.0.0");
+                expect(sourceName).toBe("official");
+                return [candidate];
+            },
+            materializeMcp: async () => ({
+                ...candidate.config,
+                provenance: {
+                    ...candidate.config.provenance,
+                    ownedPaths: ["new-root"],
+                },
+            }),
+            cleanupMcp: (config) =>
+                cleaned.push(config.provenance.ownedPaths ?? []),
+        });
+        const mcp = makeMcpSource([current]);
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "update").run(capture.context, {
+            args: { name: "echo", range: "2.0.0" },
+            flags: { type: "mcp" },
+        } as any);
+        expect(mcp.servers.get(current.id)?.provenance).toMatchObject({
+            serverVersion: "2.0.0",
+            ownedPaths: ["new-root"],
+        });
+        expect(cleaned).toEqual([["old-root"]]);
+    });
+
+    it("cleans registry-owned content after a successful MCP uninstall", async () => {
+        const config = makeMcpConfig("echo", {
+            provenance: {
+                source: "official",
+                sourceKind: "registry",
+                ref: "io.example/echo@1.0.0",
+                ownedPaths: ["owned-root"],
+            },
+        });
+        const cleaned: string[][] = [];
+        const { api } = makeSource({
+            cleanupMcp: (removed) =>
+                cleaned.push(removed.provenance.ownedPaths ?? []),
+        });
+        const mcp = makeMcpSource([config]);
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getHandler(api, "uninstall").run(capture.context, {
+            args: { name: "echo" },
+            flags: { type: "mcp" },
+        } as any);
+        expect(cleaned).toEqual([["owned-root"]]);
+    });
+
+    it("supports trust and enable transitions", async () => {
+        const config = makeMcpConfig("echo");
+        const { api } = makeSource();
+        const mcp = makeMcpSource([config]);
+        const context = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        }).context;
+        await getMcpHandler(api, "trust").run(context, {
+            args: { name: "echo" },
+        } as any);
+        await getMcpHandler(api, "enable").run(context, {
+            args: { name: "echo" },
+        } as any);
+        expect(mcp.servers.get(config.id)).toMatchObject({
+            trust: "trusted",
+            enabled: true,
+        });
+    });
+
+    it("confirms an untrusted one-shot test without changing trust", async () => {
+        const config = makeMcpConfig("echo");
+        const { api } = makeSource();
+        const mcp = makeMcpSource([config]);
+        const capture = mcpActionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        await getMcpHandler(api, "test").run(capture.context, {
+            args: { name: "echo" },
+        } as any);
+        expect(mcp.calls).toContain(`test:${config.id}:true`);
+        expect(mcp.servers.get(config.id)?.trust).toBe("untrusted");
+        expect(capture.output()).toContain("Tools: echo");
+    });
+
+    it("completes type flags and MCP names", async () => {
+        const config = makeMcpConfig("echo");
+        const { api } = makeSource();
+        const mcp = makeMcpSource([config]);
+        const session = fakeSessionContext({
+            appAgentProviderSetController: noopHost,
+            source: api,
+            mcpSource: mcp.api,
+        });
+        const install = await getHandler(api, "install").getCompletion!(
+            session,
+            {} as any,
+            ["--type"],
+        );
+        expect(install.groups[0].completions).toEqual(["agent", "mcp", "all"]);
+        const trust = await getMcpHandler(api, "trust").getCompletion!(
+            session,
+            {} as any,
+            ["name"],
+        );
+        expect(trust.groups[0].completions).toEqual(["echo"]);
     });
 });

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
@@ -21,7 +21,6 @@ import {
     type PermissionHandler,
     type PermissionRequest,
     type PermissionRequestResult,
-
     type SessionConfig,
 } from "@github/copilot-sdk";
 import registerDebug from "debug";

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
@@ -16,7 +16,6 @@ import {
     CopilotClient,
     RuntimeConnection,
     defineTool,
-    approveAll,
     type AssistantMessageEvent,
     type CopilotSession,
     type PermissionHandler,

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
@@ -19,6 +19,10 @@ import {
     approveAll,
     type AssistantMessageEvent,
     type CopilotSession,
+    type PermissionHandler,
+    type PermissionRequest,
+    type PermissionRequestResult,
+
     type SessionConfig,
 } from "@github/copilot-sdk";
 import registerDebug from "debug";
@@ -683,6 +687,53 @@ async function copilotSubagentResult(
             error: message,
         };
     }
+}
+
+export function getCopilotPermissionDefault(
+    request: PermissionRequest,
+): PermissionRequestResult | undefined {
+    if (request.kind === "read" && request.requestSandboxBypass !== true) {
+        return { kind: "approve-once" };
+    }
+    if (request.kind === "mcp" && request.readOnly === true) {
+        return { kind: "approve-once" };
+    }
+    if (
+        request.kind === "shell" &&
+        request.requestSandboxBypass !== true &&
+        request.hasWriteFileRedirection === false &&
+        request.commands.length > 0 &&
+        request.commands.every((command) => command.readOnly)
+    ) {
+        return { kind: "approve-once" };
+    }
+    return undefined;
+}
+
+function createCopilotPermissionHandler(
+    context: ActionContext<CommandHandlerContext>,
+): PermissionHandler {
+    return async (request) => {
+        const safe = getCopilotPermissionDefault(request);
+        if (safe !== undefined) {
+            return safe;
+        }
+        const identity =
+            request.kind === "mcp"
+                ? `MCP tool '${request.serverName}/${request.toolName}'`
+                : `Copilot ${request.kind} operation`;
+        const choice = await context.sessionContext.popupQuestion(
+            `${identity} requests sensitive permission. Allow this request once?`,
+            ["Allow once", "Deny"],
+            1,
+        );
+        return choice === 0
+            ? { kind: "approve-once" }
+            : {
+                  kind: "reject",
+                  feedback: "Denied by the TypeAgent host permission policy.",
+              };
+    };
 }
 
 /**
@@ -1513,7 +1564,7 @@ function getCopilotSessionConfig(
             "shell",
         ],
         workingDirectory: getRepoRoot(),
-        onPermissionRequest: approveAll,
+        onPermissionRequest: createCopilotPermissionHandler(context),
         systemMessage: {
             mode: "append" as const,
             content: [

--- a/ts/packages/dispatcher/dispatcher/test/copilotPermission.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/copilotPermission.spec.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getCopilotPermissionDefault } from "../src/reasoning/copilot.js";
+
+describe("Copilot host permission policy", () => {
+    it("approves safe reads and readonly MCP tools", () => {
+        expect(
+            getCopilotPermissionDefault({
+                kind: "read",
+                path: "README.md",
+                intention: "read documentation",
+            }),
+        ).toEqual({ kind: "approve-once" });
+        expect(
+            getCopilotPermissionDefault({
+                kind: "mcp",
+                serverName: "user-server",
+                toolName: "delete",
+                toolTitle: "Delete",
+                readOnly: true,
+            }),
+        ).toEqual({ kind: "approve-once" });
+    });
+
+    it("requires confirmation for unknown or non-readonly MCP tools", () => {
+        expect(
+            getCopilotPermissionDefault({
+                kind: "mcp",
+                serverName: "user-server",
+                toolName: "unknown",
+                toolTitle: "Unknown",
+            } as any),
+        ).toBeUndefined();
+        expect(
+            getCopilotPermissionDefault({
+                kind: "mcp",
+                serverName: "user-server",
+                toolName: "delete",
+                toolTitle: "Delete",
+                readOnly: false,
+            }),
+        ).toBeUndefined();
+    });
+
+    it("requires confirmation for write-capable shell requests", () => {
+        expect(
+            getCopilotPermissionDefault({
+                kind: "shell",
+                intention: "write",
+                fullCommandText: "echo x > file",
+                commands: [{ identifier: "echo", readOnly: false }],
+                possiblePaths: ["file"],
+                possibleUrls: [],
+                hasWriteFileRedirection: true,
+                canOfferSessionApproval: false,
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/ts/packages/shell/src/main/instance.ts
+++ b/ts/packages/shell/src/main/instance.ts
@@ -557,8 +557,7 @@ async function initializeDispatcher(
 
             const [
                 {
-                    getDefaultAppAgentSource,
-                    getMcpAppAgentSource,
+                    getDefaultAppAgentSources,
                     getDefaultAppAgentProviders,
                     getDefaultConstructionProvider,
                     getIndexingServiceRegistry,
@@ -625,10 +624,9 @@ async function initializeDispatcher(
                         browser: browserControl.control,
                     },
                     portRegistrar,
-                    appAgentSources: [
-                        getDefaultAppAgentSource(instanceDir, { configName }),
-                        getMcpAppAgentSource(instanceDir),
-                    ],
+                    appAgentSources: getDefaultAppAgentSources(instanceDir, {
+                        configName,
+                    }),
                     persistSession: true,
                     storageProvider: getFsStorageProvider(),
                     metrics: true,

--- a/ts/tools/docsAutogen/src/commandReference.ts
+++ b/ts/tools/docsAutogen/src/commandReference.ts
@@ -27,8 +27,7 @@ import {
 import { getInstanceDir } from "agent-dispatcher/helpers/data";
 import {
     getDefaultAppAgentProviders,
-    getDefaultAppAgentSource,
-    getMcpAppAgentSource,
+    getDefaultAppAgentSources,
 } from "default-agent-provider";
 import { existsSync } from "node:fs";
 
@@ -77,10 +76,7 @@ export async function generateCommandReferenceMarkdown(
     const appAgentProviders = getDefaultAppAgentProviders(instanceDir);
     // The @package management commands are provided by the install source
     // rather than a static provider; include it so they are documented too.
-    const appAgentSources = [
-        getDefaultAppAgentSource(instanceDir),
-        getMcpAppAgentSource(instanceDir),
-    ];
+    const appAgentSources = getDefaultAppAgentSources(instanceDir);
 
     // Resolve each command's declared action to a fully-qualified name and a
     // link to its schema source. Built from the same providers, so it does not


### PR DESCRIPTION
Complete the MCP v2 integration by making MCP servers fully managed, secure, dynamic TypeAgent extensions.

- unify installed-agent and MCP runtime sources across all hosts
- persist normalized MCP configs with stable identity, provenance, trust, enabled state, tool policy, and credential references
- extend `@package` install, list, update, and uninstall with MCP support, previews, confirmation, ambiguity handling, and management commands
- add local MCP config imports and an MCP Registry v0.1 source with pagination, incremental caching, exact version resolution, remote HTTP, and verified npm package materialization
- safely track and remove owned package paths without deleting shared or unrelated files
- add credential-store and OAuth/PKCE integration points without persisting plaintext secrets
- enforce transport, command, domain, registry, package, and per-tool policies before installation, connection, and invocation
- require confirmation for potentially mutating MCP tools and replace Copilot's unconditional permission approval
- add sanitized, bounded audit logging for MCP lifecycle and tool activity
- validate MCP arguments and structured results using bounded JSON Schema 2020-12 validation with external references disabled
- preserve tool metadata under stable server-config/tool identities
- subscribe to tools/list_changed and atomically refresh schemas across all connected sessions through the dispatcher reload path
- add extensive coverage for installation transactions, registry behavior, security, OAuth, lifecycle fan-out, validation, and catalog refresh

Durable secret persistence and browser-based OAuth interaction remain host-injected interfaces. Default implementations use environment/session credentials and fail explicitly when durable secure storage is unavailable.