### PR TITLE
[OTEL] Introduce RPC metadata envelope

### DIFF
--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -275,6 +275,10 @@ use documented `typeagent.*` instruments instead.
 
 Inject W3C `traceparent` into a dedicated TypeAgent RPC metadata envelope.
 Receivers validate and extract it before handling the operation.
+Outbound injection and inbound extraction are separate explicit channel
+policies. TypeAgent-owned composition roots enable both only for approved
+destinations and trusted transports; a globally configured propagator alone
+does not cause metadata disclosure.
 
 OTel owns the canonical trace ID. Preserve the existing caller value as
 `typeagent.trace.id`. Carry these values on spans and logs:

--- a/ts/packages/agentRpc/README.md
+++ b/ts/packages/agentRpc/README.md
@@ -116,11 +116,11 @@ composition roots must deliberately thread these options to TypeAgent-owned IPC
 channels; adding the envelope type alone does not activate cross-process
 parenting.
 
-Use `invokeWithOptions(name, { signal }, ...args)` when the local caller can
-cancel. Cancellation ends both RPC spans with a stable `cancelled` status.
-It abandons the generic RPC result but does not forcibly interrupt arbitrary
-handler work; application protocols that support execution cancellation must
-still deliver and observe their own cancellation signal.
+Cancellation continues to use each application protocol's existing mechanism.
+For example, agent actions send `cancelAction`, abort the server handler, and
+cause the original invoke to reject with `AbortError`. The RPC SERVER and CLIENT
+spans classify that handler rejection with the stable `cancelled` status; the
+telemetry layer does not introduce a second cancellation wire protocol.
 Malformed, oversized, untrusted, or unsupported metadata is ignored without
 failing the invocation.
 

--- a/ts/packages/agentRpc/README.md
+++ b/ts/packages/agentRpc/README.md
@@ -93,25 +93,41 @@ notifications are not traced. The request may carry a versioned metadata envelop
 with bounded W3C `traceparent`/`tracestate` values and the allowlisted TypeAgent
 `traceId`, `sessionId`, and `activationId` correlation fields.
 
-Remote context is ignored unless the receiving RPC explicitly trusts its channel:
+Outbound metadata and inbound trust are separate opt-ins. Enable each only for an
+approved destination or transport:
 
 ```ts
 createRpc(name, channel, handlers, undefined, {
   tracing: {
+    propagateContext: true,
     trustRemoteContext: true,
-    getCorrelationFields: () => ({
-      sessionId,
-      activationId,
-      traceId,
-    }),
+    getCorrelationFields: ({ method, args }) =>
+      getCorrelationForInvocation(method, args),
   },
 });
 ```
 
+Additive envelope fields retain version 1. Increment the version only for an
+incompatible interpretation; unsupported versions are ignored during rolling
+upgrades.
+
+These are factory-level primitives. Higher-level RPC factories and their
+composition roots must deliberately thread these options to TypeAgent-owned IPC
+channels; adding the envelope type alone does not activate cross-process
+parenting.
+
 Use `invokeWithOptions(name, { signal }, ...args)` when the local caller can
 cancel. Cancellation ends both RPC spans with a stable `cancelled` status.
+It abandons the generic RPC result but does not forcibly interrupt arbitrary
+handler work; application protocols that support execution cancellation must
+still deliver and observe their own cancellation signal.
 Malformed, oversized, untrusted, or unsupported metadata is ignored without
 failing the invocation.
+
+RPC spans use enqueue-time completion: a SERVER span ends after its terminal
+response is handed to `RpcChannel.send`. The callback is optional in the channel
+contract, so later transport-delivery failures are debug diagnostics rather than
+changes to an already-ended span.
 
 ## Trademarks
 

--- a/ts/packages/agentRpc/README.md
+++ b/ts/packages/agentRpc/README.md
@@ -86,6 +86,33 @@ if (rpc) {
   `docs/plans/.../rpc-rebindable-channel-design.md` (where maintained) for the full
   rationale and the per-consumer assessment.
 
+## OpenTelemetry context propagation
+
+Every `invoke` creates one `CLIENT` span and one `SERVER` span. One-way `send`
+notifications are not traced. The request may carry a versioned metadata envelope
+with bounded W3C `traceparent`/`tracestate` values and the allowlisted TypeAgent
+`traceId`, `sessionId`, and `activationId` correlation fields.
+
+Remote context is ignored unless the receiving RPC explicitly trusts its channel:
+
+```ts
+createRpc(name, channel, handlers, undefined, {
+  tracing: {
+    trustRemoteContext: true,
+    getCorrelationFields: () => ({
+      sessionId,
+      activationId,
+      traceId,
+    }),
+  },
+});
+```
+
+Use `invokeWithOptions(name, { signal }, ...args)` when the local caller can
+cancel. Cancellation ends both RPC spans with a stable `cancelled` status.
+Malformed, oversized, untrusted, or unsupported metadata is ignored without
+failing the invocation.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft

--- a/ts/packages/agentRpc/package.json
+++ b/ts/packages/agentRpc/package.json
@@ -29,11 +29,16 @@
     "tsc": "tsc -b"
   },
   "dependencies": {
+    "@opentelemetry/api": "1.9.0",
     "@typeagent/agent-sdk": "workspace:*",
     "@typeagent/common-utils": "workspace:*",
     "debug": "^4.4.0"
   },
   "devDependencies": {
+    "@opentelemetry/context-async-hooks": "2.10.0",
+    "@opentelemetry/core": "2.10.0",
+    "@opentelemetry/sdk-trace-base": "2.10.0",
+    "@opentelemetry/sdk-trace-node": "2.10.0",
     "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.7",
     "jest": "^29.7.0",

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -70,7 +70,18 @@ export type RpcInvokeOptions = {
     signal?: AbortSignal;
 };
 
+export type RpcInvocation = {
+    method: string;
+    args: readonly unknown[];
+};
+
 export type RpcTracingOptions = {
+    /**
+     * Attach the active client span context and allowlisted correlation fields
+     * to outbound invokes. This must only be enabled for an approved
+     * destination because tracestate can contain vendor-specific data.
+     */
+    propagateContext?: boolean;
     /**
      * Accept propagated context and correlation fields from this channel.
      * This must only be enabled for an explicitly trusted transport.
@@ -80,7 +91,9 @@ export type RpcTracingOptions = {
      * Supplies the allowlisted correlation identifiers for an outbound invoke.
      * Invalid or oversized values are omitted.
      */
-    getCorrelationFields?: () => RpcCorrelationFields | undefined;
+    getCorrelationFields?: (
+        invocation: RpcInvocation,
+    ) => RpcCorrelationFields | undefined;
 };
 
 export type RpcOptions = {
@@ -173,6 +186,36 @@ export function createRpc<
         debugOut(message);
         currentChannel.send(message, cbErr);
     };
+    const sendBestEffort = (message: RpcMessage) => {
+        try {
+            out(message, (error) => {
+                if (error !== null) {
+                    debugError(
+                        "Failed to send RPC message",
+                        message.type,
+                        getErrorMessage(error),
+                    );
+                }
+            });
+        } catch (error) {
+            debugError(
+                "Failed to send RPC message",
+                message.type,
+                getErrorMessage(error),
+            );
+        }
+    };
+    const sendResponse = (message: InvokeResult | InvokeError) => {
+        out(message, (error) => {
+            if (error !== null) {
+                debugError(
+                    "Failed to send RPC response",
+                    message.type,
+                    getErrorMessage(error),
+                );
+            }
+        });
+    };
 
     const processInvoke = async (message: InvokeMessage) => {
         const remote = extractRemoteMetadata(
@@ -238,7 +281,7 @@ export function createRpc<
                     }
                     serverInvokes.delete(message.callId);
                     if (result.kind === "result") {
-                        out({
+                        sendResponse({
                             type: "invokeResult",
                             callId: message.callId,
                             result: result.result,
@@ -248,7 +291,7 @@ export function createRpc<
 
                     const cancellationError = isAbortError(result.error);
                     recordServerError(span, cancellationError);
-                    out({
+                    sendResponse({
                         type: "invokeError",
                         callId: message.callId,
                         error: getErrorMessage(result.error),
@@ -302,7 +345,22 @@ export function createRpc<
             }
             return;
         }
-        if (isInvokeMessage(message)) {
+        if (message?.type === "invoke") {
+            if (!isInvokeMessage(message)) {
+                debugError("Invalid invoke message", message);
+                if (isValidCallId(message?.callId)) {
+                    sendBestEffort({
+                        type: "invokeError",
+                        callId: message.callId,
+                        error: "Invalid invoke message",
+                    });
+                }
+                return;
+            }
+            if (serverInvokes.has(message.callId)) {
+                debugError("Duplicate in-flight callId", message.callId);
+                return;
+            }
             void processInvoke(message).catch((error) => {
                 debugError(
                     "Invoke instrumentation failed",
@@ -383,7 +441,14 @@ export function createRpc<
                 attributes: createSpanAttributes(methodName as string),
             },
             async (span) => {
-                const correlation = getOutboundCorrelation(options?.tracing);
+                const invocation = {
+                    method: methodName as string,
+                    args,
+                };
+                const correlation = getOutboundCorrelation(
+                    options?.tracing,
+                    invocation,
+                );
                 setCorrelationAttributes(span, correlation);
                 try {
                     const signal = invokeOptions?.signal;
@@ -391,7 +456,10 @@ export function createRpc<
                         throw createCancellationError(signal.reason);
                     }
 
-                    const metadata = createMetadataEnvelope(correlation);
+                    const metadata =
+                        options?.tracing?.propagateContext === true
+                            ? createMetadataEnvelope(correlation)
+                            : undefined;
                     const message: InvokeMessage = {
                         type: "invoke",
                         callId: nextCallId++,
@@ -428,17 +496,10 @@ export function createRpc<
                                 return;
                             }
                             pending.delete(message.callId);
-                            try {
-                                out({
-                                    type: "invokeCancel",
-                                    callId: message.callId,
-                                });
-                            } catch (error) {
-                                debugError(
-                                    "Failed to send invoke cancellation",
-                                    getErrorMessage(error),
-                                );
-                            }
+                            sendBestEffort({
+                                type: "invokeCancel",
+                                callId: message.callId,
+                            });
                             pendingInvoke.reject(
                                 createCancellationError(signal?.reason),
                             );
@@ -508,6 +569,16 @@ export function createRpc<
             if (!rebindable) {
                 throw new Error("rpc was not created as rebindable");
             }
+            for (const callId of pending.keys()) {
+                sendBestEffort({ type: "invokeCancel", callId });
+            }
+            for (const callId of serverInvokes.keys()) {
+                sendBestEffort({
+                    type: "invokeError",
+                    callId,
+                    error: "Agent channel rebound",
+                });
+            }
             currentChannel.off("message", cb);
             rejectAllPending("Agent channel rebound");
             cancelAllServerInvokes("rebind");
@@ -552,10 +623,14 @@ function setCorrelationAttributes(
 
 function getOutboundCorrelation(
     tracingOptions: RpcTracingOptions | undefined,
+    invocation: RpcInvocation,
 ): RpcCorrelationFields | undefined {
+    if (tracingOptions?.propagateContext !== true) {
+        return undefined;
+    }
     try {
         return validateCorrelationFields(
-            tracingOptions?.getCorrelationFields?.(),
+            tracingOptions.getCorrelationFields?.(invocation),
         );
     } catch {
         return undefined;
@@ -629,14 +704,11 @@ function extractTrustedRemoteMetadata(metadata: unknown): {
     if (!validateTraceparent(traceparent)) {
         return { parentContext: ROOT_CONTEXT, correlation };
     }
-    if (tracestate !== undefined && !validateTracestate(tracestate)) {
-        return { parentContext: ROOT_CONTEXT, correlation };
-    }
 
     const carrier: Record<string, string> = {
         traceparent,
     };
-    if (tracestate !== undefined) {
+    if (validateTracestate(tracestate)) {
         carrier.tracestate = tracestate;
     }
     try {
@@ -698,7 +770,7 @@ function isValidCorrelationValue(value: unknown): value is string {
     return (
         typeof value === "string" &&
         value.length > 0 &&
-        [...value].length <= MAX_CORRELATION_LENGTH &&
+        value.length <= MAX_CORRELATION_LENGTH &&
         CORRELATION_VALUE_PATTERN.test(value)
     );
 }
@@ -821,23 +893,43 @@ function toError(error: unknown): RpcFailure {
 }
 
 function isCallMessage(message: any): message is CallMessage {
-    return message?.type === "call";
+    return (
+        message?.type === "call" &&
+        isValidCallId(message.callId) &&
+        typeof message.name === "string" &&
+        Array.isArray(message.args)
+    );
 }
 
 function isInvokeMessage(message: any): message is InvokeMessage {
-    return message?.type === "invoke";
+    return (
+        message?.type === "invoke" &&
+        isValidCallId(message.callId) &&
+        typeof message.name === "string" &&
+        Array.isArray(message.args)
+    );
 }
 
 function isInvokeCancel(message: any): message is InvokeCancel {
-    return message?.type === "invokeCancel";
+    return message?.type === "invokeCancel" && isValidCallId(message.callId);
 }
 
 function isInvokeResult(message: any): message is InvokeResult {
-    return message?.type === "invokeResult";
+    return message?.type === "invokeResult" && isValidCallId(message.callId);
 }
 
 function isInvokeError(message: any): message is InvokeError {
-    return message?.type === "invokeError";
+    return (
+        message?.type === "invokeError" &&
+        isValidCallId(message.callId) &&
+        typeof message.error === "string"
+    );
+}
+
+function isValidCallId(value: unknown): value is number {
+    return (
+        typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    );
 }
 
 type CallMessage = {

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -1,36 +1,127 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import {
+    context,
+    isSpanContextValid,
+    propagation,
+    ROOT_CONTEXT,
+    SpanKind,
+    SpanStatusCode,
+    trace,
+    type Context,
+    type Span,
+} from "@opentelemetry/api";
 import registerDebug from "debug";
 
 import { RpcChannel } from "./common.js";
-
-type RpcFuncTypes<
-    N extends string,
-    T extends Record<string, (...args: any[]) => any>,
-> = {
-    [K in keyof T as `${N}`]: <K extends string>(
-        name: K,
-        ...args: Parameters<T[K]>
-    ) => ReturnType<T[K]>;
-};
 
 type RpcInvokeFunction = (...args: any[]) => Promise<unknown>;
 type RpcCallFunction = (...args: any[]) => void;
 type RpcInvokeFunctions = Record<string, RpcInvokeFunction>;
 type RpcCallFunctions = Record<string, RpcCallFunction>;
+
+type RpcInvokeMethod<T extends RpcInvokeFunctions> = <
+    K extends keyof T & string,
+>(
+    name: K,
+    ...args: Parameters<T[K]>
+) => ReturnType<T[K]>;
+
+type RpcInvokeWithOptionsMethod<T extends RpcInvokeFunctions> = <
+    K extends keyof T & string,
+>(
+    name: K,
+    options: RpcInvokeOptions,
+    ...args: Parameters<T[K]>
+) => ReturnType<T[K]>;
+
+type RpcSendMethod<T extends RpcCallFunctions> = <K extends keyof T & string>(
+    name: K,
+    ...args: Parameters<T[K]>
+) => void;
+
 type RpcReturn<
     InvokeTargetFunctions extends RpcInvokeFunctions,
     CallTargetFunctions extends RpcCallFunctions,
-> = RpcFuncTypes<"invoke", InvokeTargetFunctions> &
-    RpcFuncTypes<"send", CallTargetFunctions> & {
-        rebind(channel: RpcChannel): void;
-    };
+> = {
+    invoke: RpcInvokeMethod<InvokeTargetFunctions>;
+    invokeWithOptions: RpcInvokeWithOptionsMethod<InvokeTargetFunctions>;
+    send: RpcSendMethod<CallTargetFunctions>;
+    rebind(channel: RpcChannel): void;
+};
+
+export const RPC_METADATA_VERSION = 1;
+
+export type RpcCorrelationFields = {
+    traceId?: string;
+    sessionId?: string;
+    activationId?: string;
+};
+
+export type RpcMetadataEnvelope = {
+    version: typeof RPC_METADATA_VERSION;
+    traceparent?: string;
+    tracestate?: string;
+    typeagent?: RpcCorrelationFields;
+};
+
+export type RpcInvokeOptions = {
+    signal?: AbortSignal;
+};
+
+export type RpcTracingOptions = {
+    /**
+     * Accept propagated context and correlation fields from this channel.
+     * This must only be enabled for an explicitly trusted transport.
+     */
+    trustRemoteContext?: boolean;
+    /**
+     * Supplies the allowlisted correlation identifiers for an outbound invoke.
+     * Invalid or oversized values are omitted.
+     */
+    getCorrelationFields?: () => RpcCorrelationFields | undefined;
+};
 
 export type RpcOptions = {
     // When true, a disconnect rejects in-flight calls but leaves invoke/send
     // intact so the rpc can be reattached to a fresh channel via rebind().
     rebindable?: boolean;
+    tracing?: RpcTracingOptions;
+};
+
+const RPC_SPAN_NAME = "typeagent.rpc.invoke";
+const RPC_INSTRUMENTATION_SCOPE = "@typeagent/agent-rpc";
+const RPC_INSTRUMENTATION_VERSION = "0.0.1";
+const MAX_TRACEPARENT_LENGTH = 512;
+const MAX_TRACESTATE_LENGTH = 512;
+const MAX_CORRELATION_LENGTH = 256;
+const MAX_RPC_METHOD_LENGTH = 256;
+const MAX_TRACESTATE_MEMBERS = 32;
+const CORRELATION_VALUE_PATTERN = /^[A-Za-z0-9._:@/-]+$/;
+const RPC_METHOD_PATTERN = /^[A-Za-z0-9._:/-]+$/;
+const TRACEPARENT_PATTERN =
+    /^([0-9a-f]{2})-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}(.*)$/;
+const SIMPLE_TRACESTATE_KEY_PATTERN = /^[a-z][a-z0-9_*/-]{0,255}$/;
+const MULTITENANT_TRACESTATE_KEY_PATTERN =
+    /^[a-z0-9][a-z0-9_*/-]{0,240}@[a-z][a-z0-9_*/-]{0,13}$/;
+const TRACESTATE_VALUE_PATTERN = /^[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}$/;
+
+type PendingInvoke = {
+    resolve: (result: any) => void;
+    reject: (error: any) => void;
+};
+
+type ServerCancellation = "client" | "disconnect" | "rebind";
+
+type ServerInvoke = {
+    cancel(reason: ServerCancellation): void;
+};
+
+type RpcFailureKind = "remote" | "cancelled";
+
+type RpcFailure = Error & {
+    rpcFailureKind?: RpcFailureKind;
 };
 
 export function createRpc<
@@ -48,13 +139,12 @@ export function createRpc<
     const debugIn = registerDebug(`typeagent:${name}:rpc:in`);
     const debugOut = registerDebug(`typeagent:${name}:rpc:out`);
     const debugError = registerDebug(`typeagent:${name}:rpc:error`);
-    const pending = new Map<
-        number,
-        {
-            resolve: (result: any) => void;
-            reject: (error: any) => void;
-        }
-    >();
+    const tracer = trace.getTracer(
+        RPC_INSTRUMENTATION_SCOPE,
+        RPC_INSTRUMENTATION_VERSION,
+    );
+    const pending = new Map<number, PendingInvoke>();
+    const serverInvokes = new Map<number, ServerInvoke>();
 
     const rebindable = options?.rebindable ?? false;
     let currentChannel: RpcChannel = channel;
@@ -64,19 +154,131 @@ export function createRpc<
         throw new Error("Agent channel disconnected");
     };
     const rejectAllPending = (reason: string) => {
-        for (const r of pending.values()) {
-            r.reject(new Error(reason));
+        for (const pendingInvoke of pending.values()) {
+            pendingInvoke.reject(new Error(reason));
         }
         pending.clear();
+    };
+    const cancelAllServerInvokes = (reason: ServerCancellation) => {
+        for (const serverInvoke of serverInvokes.values()) {
+            serverInvoke.cancel(reason);
+        }
+        serverInvokes.clear();
     };
 
     const out = (
         message: RpcMessage,
-        cbErr: (err: Error | null) => void = (e) => {},
+        cbErr: (err: Error | null) => void = () => {},
     ) => {
         debugOut(message);
         currentChannel.send(message, cbErr);
     };
+
+    const processInvoke = async (message: InvokeMessage) => {
+        const remote = extractRemoteMetadata(
+            message.metadata,
+            options?.tracing?.trustRemoteContext === true,
+        );
+        await tracer.startActiveSpan(
+            RPC_SPAN_NAME,
+            {
+                kind: SpanKind.SERVER,
+                attributes: createSpanAttributes(message.name),
+            },
+            remote.parentContext,
+            async (span) => {
+                setCorrelationAttributes(span, remote.correlation);
+                let cancelServerInvoke:
+                    | ((reason: ServerCancellation) => void)
+                    | undefined;
+                const cancellation = new Promise<{
+                    kind: "cancelled";
+                    reason: ServerCancellation;
+                }>((resolve) => {
+                    cancelServerInvoke = (reason) =>
+                        resolve({ kind: "cancelled", reason });
+                });
+                const serverInvoke: ServerInvoke = {
+                    cancel(reason) {
+                        cancelServerInvoke?.(reason);
+                    },
+                };
+                serverInvokes.set(message.callId, serverInvoke);
+
+                const handler = invokeHandlers?.[message.name];
+                const handlerResult =
+                    handler === undefined
+                        ? Promise.resolve({
+                              kind: "error" as const,
+                              error: new Error(
+                                  `No invoke handler ${message.name}`,
+                              ),
+                          })
+                        : Promise.resolve()
+                              .then(() => handler(...message.args))
+                              .then(
+                                  (result) => ({
+                                      kind: "result" as const,
+                                      result,
+                                  }),
+                                  (error) => ({
+                                      kind: "error" as const,
+                                      error,
+                                  }),
+                              );
+
+                try {
+                    const result = await Promise.race([
+                        handlerResult,
+                        cancellation,
+                    ]);
+                    if (result.kind === "cancelled") {
+                        recordServerCancellation(span, result.reason);
+                        return;
+                    }
+                    serverInvokes.delete(message.callId);
+                    if (result.kind === "result") {
+                        out({
+                            type: "invokeResult",
+                            callId: message.callId,
+                            result: result.result,
+                        });
+                        return;
+                    }
+
+                    const cancellationError = isAbortError(result.error);
+                    recordServerError(span, cancellationError);
+                    out({
+                        type: "invokeError",
+                        callId: message.callId,
+                        error: getErrorMessage(result.error),
+                        ...(cancellationError
+                            ? { cancelled: true }
+                            : undefined),
+                        ...(typeof result.error?.markdown === "string"
+                            ? { errorMarkdown: result.error.markdown }
+                            : undefined),
+                        ...(debugError.enabled &&
+                        typeof result.error?.stack === "string"
+                            ? { stack: result.error.stack }
+                            : undefined),
+                    });
+                } catch (error) {
+                    recordLocalRpcError(span);
+                    debugError(
+                        "Failed to send invoke response",
+                        getErrorMessage(error),
+                    );
+                } finally {
+                    if (serverInvokes.get(message.callId) === serverInvoke) {
+                        serverInvokes.delete(message.callId);
+                    }
+                    span.end();
+                }
+            },
+        );
+    };
+
     const cb = (message: any) => {
         debugIn(message);
         if (isCallMessage(message)) {
@@ -87,10 +289,7 @@ export function createRpc<
             } else {
                 // Call handlers are fire-and-forget (no callId), so any
                 // synchronous throw cannot be reported back to the caller.
-                // Swallow it here to keep the RPC bus alive — otherwise a
-                // single bad notify (e.g. cancelCommand after the remote
-                // dispatcher channel disconnected) would surface as an
-                // uncaught exception in the host process.
+                // Swallow it here to keep the RPC bus alive.
                 try {
                     f(...message.args);
                 } catch (e: any) {
@@ -104,62 +303,46 @@ export function createRpc<
             return;
         }
         if (isInvokeMessage(message)) {
-            const f = invokeHandlers?.[message.name];
-            if (f === undefined) {
-                out({
-                    type: "invokeError",
-                    callId: message.callId,
-                    error: `No invoke handler ${message.name}`,
-                });
-            } else {
-                f(...message.args).then(
-                    (result) => {
-                        out({
-                            type: "invokeResult",
-                            callId: message.callId,
-                            result,
-                        });
-                    },
-                    (error) => {
-                        out({
-                            type: "invokeError",
-                            callId: message.callId,
-                            error: error.message,
-                            errorMarkdown:
-                                typeof error?.markdown === "string"
-                                    ? error.markdown
-                                    : undefined,
-                            stack: debugError.enabled ? error.stack : undefined,
-                        });
-                    },
+            void processInvoke(message).catch((error) => {
+                debugError(
+                    "Invoke instrumentation failed",
+                    getErrorMessage(error),
                 );
-            }
+            });
+            return;
+        }
+        if (isInvokeCancel(message)) {
+            serverInvokes.get(message.callId)?.cancel("client");
             return;
         }
         if (!isInvokeResult(message) && !isInvokeError(message)) {
             return;
         }
-        const r = pending.get(message.callId);
-        if (r === undefined) {
+        const pendingInvoke = pending.get(message.callId);
+        if (pendingInvoke === undefined) {
             debugError("Invalid callId", message);
             return;
         }
         pending.delete(message.callId);
         if (isInvokeResult(message)) {
-            r.resolve(message.result);
+            pendingInvoke.resolve(message.result);
         } else {
             debugError("Invoke error", message.stack);
-            const error: Error & { markdown?: string } = new Error(
-                message.error,
-            );
+            const error = new Error(message.error) as RpcFailure & {
+                markdown?: string;
+            };
+            error.name = message.cancelled === true ? "AbortError" : "Error";
+            error.rpcFailureKind =
+                message.cancelled === true ? "cancelled" : "remote";
             // Only `message` survives structured cloning, so re-attach the
             // rich display the far side asked for.
             if (message.errorMarkdown !== undefined) {
                 error.markdown = message.errorMarkdown;
             }
-            r.reject(error);
+            pendingInvoke.reject(error);
         }
     };
+
     const bindChannel = (newChannel: RpcChannel) => {
         currentChannel = newChannel;
         connected = true;
@@ -174,42 +357,136 @@ export function createRpc<
             newChannel.off("message", cb);
             connected = false;
             rejectAllPending("Agent channel disconnected");
+            cancelAllServerInvokes("disconnect");
             if (!rebindable) {
                 rpc.invoke = errorFunc;
+                rpc.invokeWithOptions = errorFunc;
                 rpc.send = errorFunc;
             }
         });
     };
 
     let nextCallId = 0;
-    const rpc = {
-        invoke: async function (
-            name: keyof InvokeTargetFunctions,
-            ...args: any[]
-        ): Promise<any> {
-            // Fail fast in a rebindable rpc's disconnected window (a poisoned
-            // rpc never reaches here — invoke is replaced outright).
-            if (!connected) {
-                throw new Error("Agent channel disconnected");
-            }
-            const message: InvokeMessage = {
-                type: "invoke",
-                callId: nextCallId++,
-                name: name as string,
-                args,
-            };
+    const invoke = async (
+        methodName: keyof InvokeTargetFunctions,
+        args: any[],
+        invokeOptions?: RpcInvokeOptions,
+    ): Promise<any> => {
+        if (!connected) {
+            throw new Error("Agent channel disconnected");
+        }
 
-            return new Promise<any>((resolve, reject) => {
-                out(message, (err) => {
-                    if (err !== null) {
-                        pending.delete(message.callId);
-                        reject(err);
+        return tracer.startActiveSpan(
+            RPC_SPAN_NAME,
+            {
+                kind: SpanKind.CLIENT,
+                attributes: createSpanAttributes(methodName as string),
+            },
+            async (span) => {
+                const correlation = getOutboundCorrelation(options?.tracing);
+                setCorrelationAttributes(span, correlation);
+                try {
+                    const signal = invokeOptions?.signal;
+                    if (signal?.aborted === true) {
+                        throw createCancellationError(signal.reason);
                     }
-                });
-                pending.set(message.callId, { resolve, reject });
-            });
-        },
-        send: (name: keyof CallTargetFunctions, ...args: any[]) => {
+
+                    const metadata = createMetadataEnvelope(correlation);
+                    const message: InvokeMessage = {
+                        type: "invoke",
+                        callId: nextCallId++,
+                        name: methodName as string,
+                        args,
+                        ...(metadata === undefined ? undefined : { metadata }),
+                    };
+
+                    return await new Promise<any>((resolve, reject) => {
+                        let settled = false;
+                        const cleanup = () => {
+                            signal?.removeEventListener("abort", onAbort);
+                        };
+                        const pendingInvoke: PendingInvoke = {
+                            resolve(result) {
+                                if (settled) {
+                                    return;
+                                }
+                                settled = true;
+                                cleanup();
+                                resolve(result);
+                            },
+                            reject(error) {
+                                if (settled) {
+                                    return;
+                                }
+                                settled = true;
+                                cleanup();
+                                reject(error);
+                            },
+                        };
+                        const onAbort = () => {
+                            if (pending.get(message.callId) !== pendingInvoke) {
+                                return;
+                            }
+                            pending.delete(message.callId);
+                            try {
+                                out({
+                                    type: "invokeCancel",
+                                    callId: message.callId,
+                                });
+                            } catch (error) {
+                                debugError(
+                                    "Failed to send invoke cancellation",
+                                    getErrorMessage(error),
+                                );
+                            }
+                            pendingInvoke.reject(
+                                createCancellationError(signal?.reason),
+                            );
+                        };
+
+                        pending.set(message.callId, pendingInvoke);
+                        signal?.addEventListener("abort", onAbort, {
+                            once: true,
+                        });
+                        if (signal?.aborted === true) {
+                            onAbort();
+                            return;
+                        }
+                        try {
+                            out(message, (error) => {
+                                if (
+                                    error !== null &&
+                                    pending.get(message.callId) ===
+                                        pendingInvoke
+                                ) {
+                                    pending.delete(message.callId);
+                                    pendingInvoke.reject(error);
+                                }
+                            });
+                        } catch (error) {
+                            pending.delete(message.callId);
+                            pendingInvoke.reject(toError(error));
+                        }
+                    });
+                } catch (error) {
+                    recordClientError(span, error);
+                    throw error;
+                } finally {
+                    span.end();
+                }
+            },
+        );
+    };
+
+    const rpc = {
+        invoke: (methodName: keyof InvokeTargetFunctions, ...args: any[]) =>
+            invoke(methodName, args),
+        invokeWithOptions: (
+            methodName: keyof InvokeTargetFunctions,
+            invokeOptions: RpcInvokeOptions,
+            ...args: any[]
+        ) => invoke(methodName, args, invokeOptions),
+        send: (methodName: keyof CallTargetFunctions, ...args: any[]) => {
             if (!connected) {
                 throw new Error("Agent channel disconnected");
             }
@@ -217,12 +494,12 @@ export function createRpc<
                 {
                     type: "call",
                     callId: nextCallId++,
-                    name: name as string,
+                    name: methodName as string,
                     args,
                 },
-                (err) => {
-                    if (err !== null) {
-                        throw err;
+                (error) => {
+                    if (error !== null) {
+                        throw error;
                     }
                 },
             );
@@ -233,6 +510,7 @@ export function createRpc<
             }
             currentChannel.off("message", cb);
             rejectAllPending("Agent channel rebound");
+            cancelAllServerInvokes("rebind");
             bindChannel(newChannel);
         },
     } as RpcReturn<InvokeTargetFunctions, CallTargetFunctions>;
@@ -240,20 +518,326 @@ export function createRpc<
     return rpc;
 }
 
+function createSpanAttributes(methodName: string) {
+    return {
+        "rpc.system": "typeagent",
+        "rpc.method": isValidRpcMethod(methodName)
+            ? methodName
+            : "invalid_method",
+    };
+}
+
+function isValidRpcMethod(value: string): boolean {
+    return (
+        value.length > 0 &&
+        value.length <= MAX_RPC_METHOD_LENGTH &&
+        RPC_METHOD_PATTERN.test(value)
+    );
+}
+
+function setCorrelationAttributes(
+    span: Span,
+    correlation: RpcCorrelationFields | undefined,
+): void {
+    if (correlation?.traceId !== undefined) {
+        span.setAttribute("typeagent.trace.id", correlation.traceId);
+    }
+    if (correlation?.sessionId !== undefined) {
+        span.setAttribute("typeagent.session.id", correlation.sessionId);
+    }
+    if (correlation?.activationId !== undefined) {
+        span.setAttribute("typeagent.activation.id", correlation.activationId);
+    }
+}
+
+function getOutboundCorrelation(
+    tracingOptions: RpcTracingOptions | undefined,
+): RpcCorrelationFields | undefined {
+    try {
+        return validateCorrelationFields(
+            tracingOptions?.getCorrelationFields?.(),
+        );
+    } catch {
+        return undefined;
+    }
+}
+
+function createMetadataEnvelope(
+    correlation: RpcCorrelationFields | undefined,
+): RpcMetadataEnvelope | undefined {
+    const carrier: Record<string, string> = {};
+    try {
+        propagation.inject(context.active(), carrier, {
+            set(target, key, value) {
+                target[key.toLowerCase()] = value;
+            },
+        });
+    } catch {
+        // A host propagator must not be able to fail the RPC operation.
+    }
+
+    const traceparent = validateTraceparent(carrier.traceparent)
+        ? carrier.traceparent
+        : undefined;
+    const tracestate = validateTracestate(carrier.tracestate)
+        ? carrier.tracestate
+        : undefined;
+    if (
+        traceparent === undefined &&
+        tracestate === undefined &&
+        correlation === undefined
+    ) {
+        return undefined;
+    }
+    return {
+        version: RPC_METADATA_VERSION,
+        ...(traceparent === undefined ? undefined : { traceparent }),
+        ...(traceparent === undefined || tracestate === undefined
+            ? undefined
+            : { tracestate }),
+        ...(correlation === undefined ? undefined : { typeagent: correlation }),
+    };
+}
+
+function extractRemoteMetadata(
+    metadata: unknown,
+    trusted: boolean,
+): {
+    parentContext: Context;
+    correlation: RpcCorrelationFields | undefined;
+} {
+    if (!trusted) {
+        return { parentContext: ROOT_CONTEXT, correlation: undefined };
+    }
+    try {
+        return extractTrustedRemoteMetadata(metadata);
+    } catch {
+        return { parentContext: ROOT_CONTEXT, correlation: undefined };
+    }
+}
+
+function extractTrustedRemoteMetadata(metadata: unknown): {
+    parentContext: Context;
+    correlation: RpcCorrelationFields | undefined;
+} {
+    if (!isMetadataEnvelope(metadata)) {
+        return { parentContext: ROOT_CONTEXT, correlation: undefined };
+    }
+    const traceparent = metadata.traceparent;
+    const tracestate = metadata.tracestate;
+    const correlation = validateCorrelationFields(metadata.typeagent);
+    if (!validateTraceparent(traceparent)) {
+        return { parentContext: ROOT_CONTEXT, correlation };
+    }
+    if (tracestate !== undefined && !validateTracestate(tracestate)) {
+        return { parentContext: ROOT_CONTEXT, correlation };
+    }
+
+    const carrier: Record<string, string> = {
+        traceparent,
+    };
+    if (tracestate !== undefined) {
+        carrier.tracestate = tracestate;
+    }
+    try {
+        const extracted = propagation.extract(ROOT_CONTEXT, carrier, {
+            keys(target) {
+                return Object.keys(target);
+            },
+            get(target, key) {
+                return target[key.toLowerCase()];
+            },
+        });
+        const spanContext = trace.getSpanContext(extracted);
+        return {
+            parentContext:
+                spanContext !== undefined && isSpanContextValid(spanContext)
+                    ? extracted
+                    : ROOT_CONTEXT,
+            correlation,
+        };
+    } catch {
+        return { parentContext: ROOT_CONTEXT, correlation };
+    }
+}
+
+function isMetadataEnvelope(value: unknown): value is RpcMetadataEnvelope {
+    if (value === null || typeof value !== "object") {
+        return false;
+    }
+    try {
+        return (
+            (value as { version?: unknown }).version === RPC_METADATA_VERSION
+        );
+    } catch {
+        return false;
+    }
+}
+
+function validateCorrelationFields(
+    value: unknown,
+): RpcCorrelationFields | undefined {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+    const source = value as RpcCorrelationFields;
+    const correlation: RpcCorrelationFields = {};
+    if (isValidCorrelationValue(source.traceId)) {
+        correlation.traceId = source.traceId;
+    }
+    if (isValidCorrelationValue(source.sessionId)) {
+        correlation.sessionId = source.sessionId;
+    }
+    if (isValidCorrelationValue(source.activationId)) {
+        correlation.activationId = source.activationId;
+    }
+    return Object.keys(correlation).length === 0 ? undefined : correlation;
+}
+
+function isValidCorrelationValue(value: unknown): value is string {
+    return (
+        typeof value === "string" &&
+        value.length > 0 &&
+        [...value].length <= MAX_CORRELATION_LENGTH &&
+        CORRELATION_VALUE_PATTERN.test(value)
+    );
+}
+
+function validateTraceparent(value: unknown): value is string {
+    if (typeof value !== "string" || value.length > MAX_TRACEPARENT_LENGTH) {
+        return false;
+    }
+    const match = TRACEPARENT_PATTERN.exec(value);
+    if (match === null || match[1] === "ff") {
+        return false;
+    }
+    return match[1] === "00" ? match[2] === "" : match[2].startsWith("-");
+}
+
+function validateTracestate(value: unknown): value is string {
+    if (
+        typeof value !== "string" ||
+        value.length === 0 ||
+        value.length > MAX_TRACESTATE_LENGTH
+    ) {
+        return false;
+    }
+    const members = value.split(",");
+    if (members.length > MAX_TRACESTATE_MEMBERS) {
+        return false;
+    }
+    const keys = new Set<string>();
+    return members.every((member) => {
+        const trimmed = member.trim();
+        const separator = trimmed.indexOf("=");
+        if (separator <= 0 || separator === trimmed.length - 1) {
+            return false;
+        }
+        const key = trimmed.slice(0, separator);
+        const stateValue = trimmed.slice(separator + 1);
+        const valid =
+            (SIMPLE_TRACESTATE_KEY_PATTERN.test(key) ||
+                MULTITENANT_TRACESTATE_KEY_PATTERN.test(key)) &&
+            TRACESTATE_VALUE_PATTERN.test(stateValue) &&
+            !stateValue.endsWith(" ") &&
+            !keys.has(key);
+        keys.add(key);
+        return valid;
+    });
+}
+
+function recordClientError(span: Span, error: unknown): void {
+    const failureKind = (error as RpcFailure | undefined)?.rpcFailureKind;
+    if (failureKind === "cancelled" || isAbortError(error)) {
+        span.recordException({ name: "AbortError", message: "cancelled" });
+        span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "cancelled",
+        });
+        return;
+    }
+    const message = failureKind === "remote" ? "remote error" : "rpc failed";
+    span.recordException({ name: "RpcClientError", message });
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
+}
+
+function recordServerError(span: Span, cancelled: boolean): void {
+    const name = cancelled ? "AbortError" : "RpcServerError";
+    const message = cancelled ? "cancelled" : "request failed";
+    span.recordException({ name, message });
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
+}
+
+function recordServerCancellation(
+    span: Span,
+    reason: ServerCancellation,
+): void {
+    if (reason === "client") {
+        span.recordException({ name: "AbortError", message: "cancelled" });
+        span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: "cancelled",
+        });
+    } else {
+        recordLocalRpcError(span);
+    }
+}
+
+function recordLocalRpcError(span: Span): void {
+    span.recordException({ name: "RpcServerError", message: "rpc failed" });
+    span.setStatus({ code: SpanStatusCode.ERROR, message: "rpc failed" });
+}
+
+function createCancellationError(reason: unknown): RpcFailure {
+    if (isAbortError(reason)) {
+        return reason as RpcFailure;
+    }
+    const error = new Error("The operation was aborted.") as RpcFailure;
+    error.name = "AbortError";
+    error.rpcFailureKind = "cancelled";
+    return error;
+}
+
+function isAbortError(error: unknown): boolean {
+    return (
+        error !== null &&
+        typeof error === "object" &&
+        (error as { name?: unknown }).name === "AbortError"
+    );
+}
+
+function getErrorMessage(error: unknown): string {
+    return error !== null &&
+        typeof error === "object" &&
+        typeof (error as { message?: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : String(error);
+}
+
+function toError(error: unknown): RpcFailure {
+    return error instanceof Error
+        ? (error as RpcFailure)
+        : (new Error(String(error)) as RpcFailure);
+}
+
 function isCallMessage(message: any): message is CallMessage {
-    return message.type === "call";
+    return message?.type === "call";
 }
 
 function isInvokeMessage(message: any): message is InvokeMessage {
-    return message.type === "invoke";
+    return message?.type === "invoke";
+}
+
+function isInvokeCancel(message: any): message is InvokeCancel {
+    return message?.type === "invokeCancel";
 }
 
 function isInvokeResult(message: any): message is InvokeResult {
-    return message.type === "invokeResult";
+    return message?.type === "invokeResult";
 }
 
 function isInvokeError(message: any): message is InvokeError {
-    return message.type === "invokeError";
+    return message?.type === "invokeError";
 }
 
 type CallMessage = {
@@ -268,6 +852,12 @@ type InvokeMessage = {
     callId: number;
     name: string;
     args: any[];
+    metadata?: RpcMetadataEnvelope;
+};
+
+type InvokeCancel = {
+    type: "invokeCancel";
+    callId: number;
 };
 
 type InvokeResult = {
@@ -280,8 +870,14 @@ type InvokeError = {
     type: "invokeError";
     callId: number;
     error: string;
+    cancelled?: boolean;
     errorMarkdown?: string; // Rich display for hosts that render markdown.
     stack?: string; // Optional stack trace for debugging.
 };
 
-type RpcMessage = CallMessage | InvokeMessage | InvokeResult | InvokeError;
+type RpcMessage =
+    | CallMessage
+    | InvokeMessage
+    | InvokeCancel
+    | InvokeResult
+    | InvokeError;

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -28,14 +28,6 @@ type RpcInvokeMethod<T extends RpcInvokeFunctions> = <
     ...args: Parameters<T[K]>
 ) => ReturnType<T[K]>;
 
-type RpcInvokeWithOptionsMethod<T extends RpcInvokeFunctions> = <
-    K extends keyof T & string,
->(
-    name: K,
-    options: RpcInvokeOptions,
-    ...args: Parameters<T[K]>
-) => ReturnType<T[K]>;
-
 type RpcSendMethod<T extends RpcCallFunctions> = <K extends keyof T & string>(
     name: K,
     ...args: Parameters<T[K]>
@@ -46,7 +38,6 @@ type RpcReturn<
     CallTargetFunctions extends RpcCallFunctions,
 > = {
     invoke: RpcInvokeMethod<InvokeTargetFunctions>;
-    invokeWithOptions: RpcInvokeWithOptionsMethod<InvokeTargetFunctions>;
     send: RpcSendMethod<CallTargetFunctions>;
     rebind(channel: RpcChannel): void;
 };
@@ -64,10 +55,6 @@ export type RpcMetadataEnvelope = {
     traceparent?: string;
     tracestate?: string;
     typeagent?: RpcCorrelationFields;
-};
-
-export type RpcInvokeOptions = {
-    signal?: AbortSignal;
 };
 
 export type RpcInvocation = {
@@ -125,7 +112,7 @@ type PendingInvoke = {
     reject: (error: any) => void;
 };
 
-type ServerCancellation = "client" | "disconnect" | "rebind";
+type ServerCancellation = "disconnect" | "rebind";
 
 type ServerInvoke = {
     cancel(reason: ServerCancellation): void;
@@ -276,7 +263,7 @@ export function createRpc<
                         cancellation,
                     ]);
                     if (result.kind === "cancelled") {
-                        recordServerCancellation(span, result.reason);
+                        recordServerCancellation(span);
                         return;
                     }
                     serverInvokes.delete(message.callId);
@@ -369,10 +356,6 @@ export function createRpc<
             });
             return;
         }
-        if (isInvokeCancel(message)) {
-            serverInvokes.get(message.callId)?.cancel("client");
-            return;
-        }
         if (!isInvokeResult(message) && !isInvokeError(message)) {
             return;
         }
@@ -418,7 +401,6 @@ export function createRpc<
             cancelAllServerInvokes("disconnect");
             if (!rebindable) {
                 rpc.invoke = errorFunc;
-                rpc.invokeWithOptions = errorFunc;
                 rpc.send = errorFunc;
             }
         });
@@ -428,7 +410,6 @@ export function createRpc<
     const invoke = async (
         methodName: keyof InvokeTargetFunctions,
         args: any[],
-        invokeOptions?: RpcInvokeOptions,
     ): Promise<any> => {
         if (!connected) {
             throw new Error("Agent channel disconnected");
@@ -451,11 +432,6 @@ export function createRpc<
                 );
                 setCorrelationAttributes(span, correlation);
                 try {
-                    const signal = invokeOptions?.signal;
-                    if (signal?.aborted === true) {
-                        throw createCancellationError(signal.reason);
-                    }
-
                     const metadata =
                         options?.tracing?.propagateContext === true
                             ? createMetadataEnvelope(correlation)
@@ -469,50 +445,12 @@ export function createRpc<
                     };
 
                     return await new Promise<any>((resolve, reject) => {
-                        let settled = false;
-                        const cleanup = () => {
-                            signal?.removeEventListener("abort", onAbort);
-                        };
                         const pendingInvoke: PendingInvoke = {
-                            resolve(result) {
-                                if (settled) {
-                                    return;
-                                }
-                                settled = true;
-                                cleanup();
-                                resolve(result);
-                            },
-                            reject(error) {
-                                if (settled) {
-                                    return;
-                                }
-                                settled = true;
-                                cleanup();
-                                reject(error);
-                            },
-                        };
-                        const onAbort = () => {
-                            if (pending.get(message.callId) !== pendingInvoke) {
-                                return;
-                            }
-                            pending.delete(message.callId);
-                            sendBestEffort({
-                                type: "invokeCancel",
-                                callId: message.callId,
-                            });
-                            pendingInvoke.reject(
-                                createCancellationError(signal?.reason),
-                            );
+                            resolve,
+                            reject,
                         };
 
                         pending.set(message.callId, pendingInvoke);
-                        signal?.addEventListener("abort", onAbort, {
-                            once: true,
-                        });
-                        if (signal?.aborted === true) {
-                            onAbort();
-                            return;
-                        }
                         try {
                             out(message, (error) => {
                                 if (
@@ -542,11 +480,6 @@ export function createRpc<
     const rpc = {
         invoke: (methodName: keyof InvokeTargetFunctions, ...args: any[]) =>
             invoke(methodName, args),
-        invokeWithOptions: (
-            methodName: keyof InvokeTargetFunctions,
-            invokeOptions: RpcInvokeOptions,
-            ...args: any[]
-        ) => invoke(methodName, args, invokeOptions),
         send: (methodName: keyof CallTargetFunctions, ...args: any[]) => {
             if (!connected) {
                 throw new Error("Agent channel disconnected");
@@ -568,9 +501,6 @@ export function createRpc<
         rebind: (newChannel: RpcChannel) => {
             if (!rebindable) {
                 throw new Error("rpc was not created as rebindable");
-            }
-            for (const callId of pending.keys()) {
-                sendBestEffort({ type: "invokeCancel", callId });
             }
             for (const callId of serverInvokes.keys()) {
                 sendBestEffort({
@@ -840,34 +770,13 @@ function recordServerError(span: Span, cancelled: boolean): void {
     span.setStatus({ code: SpanStatusCode.ERROR, message });
 }
 
-function recordServerCancellation(
-    span: Span,
-    reason: ServerCancellation,
-): void {
-    if (reason === "client") {
-        span.recordException({ name: "AbortError", message: "cancelled" });
-        span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: "cancelled",
-        });
-    } else {
-        recordLocalRpcError(span);
-    }
+function recordServerCancellation(span: Span): void {
+    recordLocalRpcError(span);
 }
 
 function recordLocalRpcError(span: Span): void {
     span.recordException({ name: "RpcServerError", message: "rpc failed" });
     span.setStatus({ code: SpanStatusCode.ERROR, message: "rpc failed" });
-}
-
-function createCancellationError(reason: unknown): RpcFailure {
-    if (isAbortError(reason)) {
-        return reason as RpcFailure;
-    }
-    const error = new Error("The operation was aborted.") as RpcFailure;
-    error.name = "AbortError";
-    error.rpcFailureKind = "cancelled";
-    return error;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -910,10 +819,6 @@ function isInvokeMessage(message: any): message is InvokeMessage {
     );
 }
 
-function isInvokeCancel(message: any): message is InvokeCancel {
-    return message?.type === "invokeCancel" && isValidCallId(message.callId);
-}
-
 function isInvokeResult(message: any): message is InvokeResult {
     return message?.type === "invokeResult" && isValidCallId(message.callId);
 }
@@ -947,11 +852,6 @@ type InvokeMessage = {
     metadata?: RpcMetadataEnvelope;
 };
 
-type InvokeCancel = {
-    type: "invokeCancel";
-    callId: number;
-};
-
 type InvokeResult = {
     type: "invokeResult";
     callId: number;
@@ -967,9 +867,4 @@ type InvokeError = {
     stack?: string; // Optional stack trace for debugging.
 };
 
-type RpcMessage =
-    | CallMessage
-    | InvokeMessage
-    | InvokeCancel
-    | InvokeResult
-    | InvokeError;
+type RpcMessage = CallMessage | InvokeMessage | InvokeResult | InvokeError;

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -719,70 +719,48 @@ describe("createRpc OpenTelemetry propagation", () => {
         });
     });
 
-    it("notifies the old peer when a pending invoke is rebound", async () => {
+    it("marks both spans as cancelled when existing application cancellation aborts the handler", async () => {
+        type Cancel = { cancel: () => void };
         const client = createFakeChannel();
         const server = createFakeChannel();
         connect(client, server);
-        const clientRpc = createRpc<EchoInvoke>(
+        const controller = new AbortController();
+        const clientRpc = createRpc<EchoInvoke, Cancel>(
             "client",
             client,
             undefined,
             undefined,
-            {
-                rebindable: true,
-                tracing: { propagateContext: true },
-            },
+            { tracing: { propagateContext: true } },
         );
-        createRpc<{}, {}, EchoInvoke>(
+        createRpc<{}, {}, EchoInvoke, Cancel>(
             "server",
             server,
             {
-                echo: () => new Promise<number>(() => {}),
+                echo: () =>
+                    new Promise<number>((_resolve, reject) => {
+                        controller.signal.addEventListener(
+                            "abort",
+                            () =>
+                                reject(
+                                    new DOMException(
+                                        "cancelled by caller",
+                                        "AbortError",
+                                    ),
+                                ),
+                            { once: true },
+                        );
+                    }),
             },
-            undefined,
+            {
+                cancel: () => controller.abort(),
+            },
             { tracing: { trustRemoteContext: true } },
         );
 
         const result = clientRpc.invoke("echo", 1);
         await flushMicrotasks();
-        clientRpc.rebind(createFakeChannel());
-        await expect(result).rejects.toThrow("Agent channel rebound");
-        await flushMicrotasks();
-
-        expect(client.sent.map((message) => message.type)).toEqual([
-            "invoke",
-            "invokeCancel",
-        ]);
-        const spans = fixture!.exporter.getFinishedSpans();
-        expect(spans).toHaveLength(2);
-        expect(findSpan(spans, SpanKind.CLIENT).status).toEqual({
-            code: SpanStatusCode.ERROR,
-            message: "rpc failed",
-        });
-        expect(findSpan(spans, SpanKind.SERVER).status).toEqual({
-            code: SpanStatusCode.ERROR,
-            message: "cancelled",
-        });
-    });
-
-    it("marks both spans as cancelled when the client aborts locally", async () => {
-        const handler = () => new Promise<number>(() => {});
-        const { clientRpc } = createTracingPair(
-            { tracing: { trustRemoteContext: true } },
-            { tracing: { propagateContext: true } },
-            handler,
-        );
-        const controller = new AbortController();
-
-        const result = clientRpc.invokeWithOptions(
-            "echo",
-            { signal: controller.signal },
-            1,
-        );
-        await flushMicrotasks();
-        controller.abort();
+        clientRpc.send("cancel");
         await expect(result).rejects.toMatchObject({ name: "AbortError" });
-        await flushMicrotasks();
 
         const spans = fixture!.exporter.getFinishedSpans();
         expect(spans).toHaveLength(2);

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -1,7 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createRpc } from "../src/rpc.js";
+import {
+    context,
+    propagation,
+    SpanKind,
+    SpanStatusCode,
+    trace,
+} from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+import {
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+    type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+import {
+    createRpc,
+    RPC_METADATA_VERSION,
+    type RpcOptions,
+} from "../src/rpc.js";
 import type { RpcChannel } from "../src/common.js";
 
 type FakeChannel = RpcChannel & {
@@ -104,6 +123,48 @@ function createEchoServer(name: string, channel: RpcChannel, offset = 0) {
 
 function flushMicrotasks() {
     return new Promise((r) => queueMicrotask(() => r(undefined)));
+}
+
+type TraceFixture = {
+    exporter: InMemorySpanExporter;
+    provider: NodeTracerProvider;
+};
+
+function installTraceFixture(): TraceFixture {
+    const exporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider({
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register({
+        propagator: new W3CTraceContextPropagator(),
+    });
+    return { exporter, provider };
+}
+
+async function disposeTraceFixture(
+    fixture: TraceFixture | undefined,
+): Promise<void> {
+    if (fixture === undefined) {
+        return;
+    }
+    await fixture.provider.shutdown();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+}
+
+function findSpan(spans: ReadableSpan[], kind: SpanKind): ReadableSpan {
+    const matching = spans.filter((span) => span.kind === kind);
+    if (matching.length !== 1) {
+        throw new Error(
+            `Expected one ${SpanKind[kind]} span, got ${matching.length}`,
+        );
+    }
+    return matching[0]!;
+}
+
+function getParentSpanId(span: ReadableSpan): string | undefined {
+    return span.parentSpanContext?.spanId;
 }
 
 describe("createRpc default (non-rebindable)", () => {
@@ -310,5 +371,303 @@ describe("createRpc rebindable", () => {
             clientRpc.rebind(c);
             await expect(clientRpc.invoke("echo", 10)).resolves.toBe(10 + i);
         }
+    });
+});
+
+describe("createRpc OpenTelemetry propagation", () => {
+    let fixture: TraceFixture | undefined;
+
+    beforeEach(() => {
+        fixture = installTraceFixture();
+    });
+
+    afterEach(async () => {
+        await disposeTraceFixture(fixture);
+        fixture = undefined;
+    });
+
+    function createTracingPair(
+        serverOptions?: RpcOptions,
+        clientOptions?: RpcOptions,
+        handler: (value: number) => Promise<number> = async (value) => value,
+    ) {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+        const clientRpc = createRpc<EchoInvoke>(
+            "client",
+            client,
+            undefined,
+            undefined,
+            clientOptions,
+        );
+        createRpc<{}, {}, EchoInvoke>(
+            "server",
+            server,
+            { echo: handler },
+            undefined,
+            serverOptions,
+        );
+        return { client, server, clientRpc };
+    }
+
+    it("creates one CLIENT span and one parented SERVER span on a trusted channel", async () => {
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            {
+                tracing: {
+                    getCorrelationFields: () => ({
+                        traceId: "legacy-trace",
+                        sessionId: "session-1",
+                        activationId: "activation-1",
+                    }),
+                },
+            },
+        );
+
+        await expect(clientRpc.invoke("echo", 42)).resolves.toBe(42);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        expect(spans).toHaveLength(2);
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBe(
+            clientSpan.spanContext().spanId,
+        );
+        expect(clientSpan.status.code).toBe(SpanStatusCode.UNSET);
+        expect(serverSpan.status.code).toBe(SpanStatusCode.UNSET);
+        expect(serverSpan.attributes).toMatchObject({
+            "typeagent.trace.id": "legacy-trace",
+            "typeagent.session.id": "session-1",
+            "typeagent.activation.id": "activation-1",
+        });
+        expect(client.sent[0].metadata).toMatchObject({
+            version: RPC_METADATA_VERSION,
+            typeagent: {
+                traceId: "legacy-trace",
+                sessionId: "session-1",
+                activationId: "activation-1",
+            },
+        });
+    });
+
+    it("does not extract valid remote context unless the channel opts into trust", async () => {
+        const { clientRpc } = createTracingPair();
+
+        await clientRpc.invoke("echo", 1);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).not.toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBeUndefined();
+    });
+
+    it("ignores malformed propagated context without failing the RPC", async () => {
+        const { client, clientRpc } = createTracingPair({
+            tracing: { trustRemoteContext: true },
+        });
+
+        const result = clientRpc.invoke("echo", 7);
+        client.sent[0].metadata.traceparent = "malformed";
+        await expect(result).resolves.toBe(7);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).not.toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBeUndefined();
+    });
+
+    it("accepts bounded W3C tracestate on a trusted channel", async () => {
+        const { client, clientRpc } = createTracingPair({
+            tracing: { trustRemoteContext: true },
+        });
+
+        const result = clientRpc.invoke("echo", 7);
+        client.sent[0].metadata.tracestate =
+            "vendor=value, tenant@system=other";
+        await expect(result).resolves.toBe(7);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBe(
+            clientSpan.spanContext().spanId,
+        );
+    });
+
+    it.each([
+        [
+            "an unsupported envelope version",
+            (metadata: any) => {
+                metadata.version = RPC_METADATA_VERSION + 1;
+            },
+        ],
+        [
+            "an oversized traceparent",
+            (metadata: any) => {
+                metadata.traceparent = "0".repeat(513);
+            },
+        ],
+        [
+            "an oversized tracestate",
+            (metadata: any) => {
+                metadata.tracestate = `key=${"x".repeat(509)}`;
+            },
+        ],
+    ])("ignores %s without failing the RPC", async (_name, mutateMetadata) => {
+        const { client, clientRpc } = createTracingPair({
+            tracing: { trustRemoteContext: true },
+        });
+
+        const result = clientRpc.invoke("echo", 7);
+        mutateMetadata(client.sent[0].metadata);
+        await expect(result).resolves.toBe(7);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).not.toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBeUndefined();
+    });
+
+    it("omits unknown, malformed, and oversized correlation fields", async () => {
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            {
+                tracing: {
+                    getCorrelationFields: () =>
+                        ({
+                            sessionId: "session-valid",
+                            traceId: "contains spaces",
+                            activationId: "x".repeat(257),
+                            userText: "must-not-propagate",
+                        }) as any,
+                },
+            },
+        );
+
+        await clientRpc.invoke("echo", 1);
+
+        expect(client.sent[0].metadata.typeagent).toEqual({
+            sessionId: "session-valid",
+        });
+        const serverSpan = findSpan(
+            fixture!.exporter.getFinishedSpans(),
+            SpanKind.SERVER,
+        );
+        expect(serverSpan.attributes["typeagent.session.id"]).toBe(
+            "session-valid",
+        );
+        expect(serverSpan.attributes["typeagent.trace.id"]).toBeUndefined();
+        expect(
+            serverSpan.attributes["typeagent.activation.id"],
+        ).toBeUndefined();
+    });
+
+    it("does not create spans for one-way notifications", async () => {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+        const clientRpc = createRpc<{}, Notify>("client", client);
+        createRpc<{}, {}, {}, Notify>("server", server, undefined, {
+            notify: () => {},
+        });
+
+        clientRpc.send("notify", 1);
+        await flushMicrotasks();
+
+        expect(fixture!.exporter.getFinishedSpans()).toHaveLength(0);
+    });
+
+    it("marks both spans as cancelled when the client aborts locally", async () => {
+        const handler = () => new Promise<number>(() => {});
+        const { clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            undefined,
+            handler,
+        );
+        const controller = new AbortController();
+
+        const result = clientRpc.invokeWithOptions(
+            "echo",
+            { signal: controller.signal },
+            1,
+        );
+        await flushMicrotasks();
+        controller.abort();
+        await expect(result).rejects.toMatchObject({ name: "AbortError" });
+        await flushMicrotasks();
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        expect(spans).toHaveLength(2);
+        for (const span of spans) {
+            expect(span.status).toEqual({
+                code: SpanStatusCode.ERROR,
+                message: "cancelled",
+            });
+        }
+    });
+
+    it("preserves server cancellation and ends both spans", async () => {
+        const { clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            undefined,
+            async () => {
+                throw new DOMException("cancelled by server", "AbortError");
+            },
+        );
+
+        await expect(clientRpc.invoke("echo", 1)).rejects.toMatchObject({
+            name: "AbortError",
+        });
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        expect(spans).toHaveLength(2);
+        for (const span of spans) {
+            expect(span.status).toEqual({
+                code: SpanStatusCode.ERROR,
+                message: "cancelled",
+            });
+        }
+    });
+
+    it("records stable statuses for remote errors and ends both spans", async () => {
+        const { clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            undefined,
+            async () => {
+                throw new Error("private server detail");
+            },
+        );
+
+        await expect(clientRpc.invoke("echo", 1)).rejects.toThrow(
+            "private server detail",
+        );
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(clientSpan.status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "remote error",
+        });
+        expect(serverSpan.status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "request failed",
+        });
     });
 });

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -416,6 +416,7 @@ describe("createRpc OpenTelemetry propagation", () => {
             { tracing: { trustRemoteContext: true } },
             {
                 tracing: {
+                    propagateContext: true,
                     getCorrelationFields: () => ({
                         traceId: "legacy-trace",
                         sessionId: "session-1",
@@ -455,7 +456,9 @@ describe("createRpc OpenTelemetry propagation", () => {
     });
 
     it("does not extract valid remote context unless the channel opts into trust", async () => {
-        const { clientRpc } = createTracingPair();
+        const { clientRpc } = createTracingPair(undefined, {
+            tracing: { propagateContext: true },
+        });
 
         await clientRpc.invoke("echo", 1);
 
@@ -468,10 +471,35 @@ describe("createRpc OpenTelemetry propagation", () => {
         expect(getParentSpanId(serverSpan)).toBeUndefined();
     });
 
+    it("does not disclose propagation metadata without outbound opt-in", async () => {
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            {
+                tracing: {
+                    getCorrelationFields: () => ({
+                        sessionId: "must-not-leave",
+                    }),
+                },
+            },
+        );
+
+        await clientRpc.invoke("echo", 1);
+
+        expect(client.sent[0].metadata).toBeUndefined();
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).not.toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(clientSpan.attributes["typeagent.session.id"]).toBeUndefined();
+    });
+
     it("ignores malformed propagated context without failing the RPC", async () => {
-        const { client, clientRpc } = createTracingPair({
-            tracing: { trustRemoteContext: true },
-        });
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            { tracing: { propagateContext: true } },
+        );
 
         const result = clientRpc.invoke("echo", 7);
         client.sent[0].metadata.traceparent = "malformed";
@@ -487,9 +515,10 @@ describe("createRpc OpenTelemetry propagation", () => {
     });
 
     it("accepts bounded W3C tracestate on a trusted channel", async () => {
-        const { client, clientRpc } = createTracingPair({
-            tracing: { trustRemoteContext: true },
-        });
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            { tracing: { propagateContext: true } },
+        );
 
         const result = clientRpc.invoke("echo", 7);
         client.sent[0].metadata.tracestate =
@@ -520,16 +549,11 @@ describe("createRpc OpenTelemetry propagation", () => {
                 metadata.traceparent = "0".repeat(513);
             },
         ],
-        [
-            "an oversized tracestate",
-            (metadata: any) => {
-                metadata.tracestate = `key=${"x".repeat(509)}`;
-            },
-        ],
     ])("ignores %s without failing the RPC", async (_name, mutateMetadata) => {
-        const { client, clientRpc } = createTracingPair({
-            tracing: { trustRemoteContext: true },
-        });
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            { tracing: { propagateContext: true } },
+        );
 
         const result = clientRpc.invoke("echo", 7);
         mutateMetadata(client.sent[0].metadata);
@@ -544,11 +568,33 @@ describe("createRpc OpenTelemetry propagation", () => {
         expect(getParentSpanId(serverSpan)).toBeUndefined();
     });
 
+    it("drops malformed tracestate without discarding a valid traceparent", async () => {
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            { tracing: { propagateContext: true } },
+        );
+
+        const result = clientRpc.invoke("echo", 7);
+        client.sent[0].metadata.tracestate = `key=${"x".repeat(509)}`;
+        await expect(result).resolves.toBe(7);
+
+        const spans = fixture!.exporter.getFinishedSpans();
+        const clientSpan = findSpan(spans, SpanKind.CLIENT);
+        const serverSpan = findSpan(spans, SpanKind.SERVER);
+        expect(serverSpan.spanContext().traceId).toBe(
+            clientSpan.spanContext().traceId,
+        );
+        expect(getParentSpanId(serverSpan)).toBe(
+            clientSpan.spanContext().spanId,
+        );
+    });
+
     it("omits unknown, malformed, and oversized correlation fields", async () => {
         const { client, clientRpc } = createTracingPair(
             { tracing: { trustRemoteContext: true } },
             {
                 tracing: {
+                    propagateContext: true,
                     getCorrelationFields: () =>
                         ({
                             sessionId: "session-valid",
@@ -578,6 +624,32 @@ describe("createRpc OpenTelemetry propagation", () => {
         ).toBeUndefined();
     });
 
+    it("resolves correlation fields from each invocation", async () => {
+        const invocations: { method: string; args: readonly unknown[] }[] = [];
+        const { client, clientRpc } = createTracingPair(
+            { tracing: { trustRemoteContext: true } },
+            {
+                tracing: {
+                    propagateContext: true,
+                    getCorrelationFields: (invocation) => {
+                        invocations.push(invocation);
+                        return { sessionId: `session-${invocation.args[0]}` };
+                    },
+                },
+            },
+        );
+
+        await clientRpc.invoke("echo", 3);
+        await clientRpc.invoke("echo", 4);
+
+        expect(invocations).toEqual([
+            { method: "echo", args: [3] },
+            { method: "echo", args: [4] },
+        ]);
+        expect(client.sent[0].metadata.typeagent.sessionId).toBe("session-3");
+        expect(client.sent[1].metadata.typeagent.sessionId).toBe("session-4");
+    });
+
     it("does not create spans for one-way notifications", async () => {
         const client = createFakeChannel();
         const server = createFakeChannel();
@@ -593,11 +665,111 @@ describe("createRpc OpenTelemetry propagation", () => {
         expect(fixture!.exporter.getFinishedSpans()).toHaveLength(0);
     });
 
+    it("rejects malformed invoke messages with a usable callId", async () => {
+        const server = createFakeChannel();
+        createRpc<{}, {}, EchoInvoke>("server", server, {
+            echo: async (value) => value,
+        });
+
+        server.deliver({
+            type: "invoke",
+            callId: 17,
+            name: null,
+            args: [1],
+        });
+        await flushMicrotasks();
+
+        expect(server.sent).toEqual([
+            {
+                type: "invokeError",
+                callId: 17,
+                error: "Invalid invoke message",
+            },
+        ]);
+        expect(fixture!.exporter.getFinishedSpans()).toHaveLength(0);
+    });
+
+    it("does not orphan an active span when a callId is duplicated", async () => {
+        const server = createFakeChannel();
+        createRpc<{}, {}, EchoInvoke>("server", server, {
+            echo: () => new Promise<number>(() => {}),
+        });
+        const message = {
+            type: "invoke",
+            callId: 5,
+            name: "echo",
+            args: [1],
+        };
+
+        server.deliver(message);
+        server.deliver({ ...message, args: [2] });
+        await flushMicrotasks();
+        expect(fixture!.exporter.getFinishedSpans()).toHaveLength(0);
+
+        server.fireDisconnect();
+        await flushMicrotasks();
+
+        const serverSpans = fixture!.exporter
+            .getFinishedSpans()
+            .filter((span) => span.kind === SpanKind.SERVER);
+        expect(serverSpans).toHaveLength(1);
+        expect(serverSpans[0]!.status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "rpc failed",
+        });
+    });
+
+    it("notifies the old peer when a pending invoke is rebound", async () => {
+        const client = createFakeChannel();
+        const server = createFakeChannel();
+        connect(client, server);
+        const clientRpc = createRpc<EchoInvoke>(
+            "client",
+            client,
+            undefined,
+            undefined,
+            {
+                rebindable: true,
+                tracing: { propagateContext: true },
+            },
+        );
+        createRpc<{}, {}, EchoInvoke>(
+            "server",
+            server,
+            {
+                echo: () => new Promise<number>(() => {}),
+            },
+            undefined,
+            { tracing: { trustRemoteContext: true } },
+        );
+
+        const result = clientRpc.invoke("echo", 1);
+        await flushMicrotasks();
+        clientRpc.rebind(createFakeChannel());
+        await expect(result).rejects.toThrow("Agent channel rebound");
+        await flushMicrotasks();
+
+        expect(client.sent.map((message) => message.type)).toEqual([
+            "invoke",
+            "invokeCancel",
+        ]);
+        const spans = fixture!.exporter.getFinishedSpans();
+        expect(spans).toHaveLength(2);
+        expect(findSpan(spans, SpanKind.CLIENT).status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "rpc failed",
+        });
+        expect(findSpan(spans, SpanKind.SERVER).status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "cancelled",
+        });
+    });
+
     it("marks both spans as cancelled when the client aborts locally", async () => {
         const handler = () => new Promise<number>(() => {});
         const { clientRpc } = createTracingPair(
             { tracing: { trustRemoteContext: true } },
-            undefined,
+            { tracing: { propagateContext: true } },
             handler,
         );
         const controller = new AbortController();
@@ -625,7 +797,7 @@ describe("createRpc OpenTelemetry propagation", () => {
     it("preserves server cancellation and ends both spans", async () => {
         const { clientRpc } = createTracingPair(
             { tracing: { trustRemoteContext: true } },
-            undefined,
+            { tracing: { propagateContext: true } },
             async () => {
                 throw new DOMException("cancelled by server", "AbortError");
             },
@@ -648,7 +820,7 @@ describe("createRpc OpenTelemetry propagation", () => {
     it("records stable statuses for remote errors and ends both spans", async () => {
         const { clientRpc } = createTracingPair(
             { tracing: { trustRemoteContext: true } },
-            undefined,
+            { tracing: { propagateContext: true } },
             async () => {
                 throw new Error("private server detail");
             },

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1458,6 +1458,9 @@ importers:
 
   packages/agentRpc:
     dependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
       '@typeagent/agent-sdk':
         specifier: workspace:*
         version: link:../agentSdk
@@ -1468,6 +1471,18 @@ importers:
         specifier: ^4.4.0
         version: 4.4.1(supports-color@8.1.1)
     devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.0)
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12


### PR DESCRIPTION
**Summary**

• Add an optional, versioned metadata envelope to RPC  invoke  requests.
• Propagate validated W3C trace context and allowlisted TypeAgent correlation fields.
• Create one CLIENT and one SERVER span per invoke; notifications remain untraced.
• Require explicit opt-in for outbound propagation and inbound trust.
• Handle errors, cancellation, disconnects, and malformed metadata safely.
• Add in-memory coverage for parenting, trust, validation, and span lifecycle.