### PR TITLE
test: stabilize timing-sensitive tests causing build-ts CI flakiness

### DIFF
--- a/ts/packages/defaultAgentProvider/test/basic.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/basic.spec.ts
@@ -36,6 +36,9 @@ describe("AppAgentProvider", () => {
                 agents: enabledAgentNames,
             });
             await dispatcher.close();
-        }, 120000); // take longer time to start up on CI's small machines.
+            // Startup + shutdown of every default agent can occasionally spike
+            // past the old 2-minute limit on CI's small, contended machines, so
+            // allow some headroom rather than fail flakily on a slow run.
+        }, 180000);
     });
 });

--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -114,7 +114,7 @@ describe("selectFromPartitions", () => {
 
     test("all partitions run in parallel", async () => {
         const startTimes: number[] = [];
-        const delayMs = 100;
+        const delayMs = 200;
         const makeTimedTranslator = (
             result: Result<AssistantSelection>,
             delay: number,
@@ -146,16 +146,20 @@ describe("selectFromPartitions", () => {
         await selectFromPartitions(partitions, "test");
         const elapsed = Date.now() - before;
 
-        // All three started nearly simultaneously (within 10ms of each other)
+        // selectFromPartitions dispatches every translator synchronously before
+        // awaiting any, so parallel start times cluster near 0, while a
+        // sequential rewrite would space them ~delayMs apart (spread ~2*delayMs).
+        // The threshold sits in that gap with wide margin for CI scheduling
+        // jitter: a single GC pause between the synchronous dispatch calls used
+        // to break the old 10ms bound.
         expect(startTimes).toHaveLength(3);
         const spread = Math.max(...startTimes) - Math.min(...startTimes);
-        expect(spread).toBeLessThan(10);
+        expect(spread).toBeLessThan(delayMs);
 
-        // Parallel: total time should be well under sequential (3 × delayMs).
-        // The 2.5× threshold gives ~150ms of headroom for CI timer jitter
-        // while still catching any accidental sequential execution (which
-        // would take ~300ms and clearly exceed the limit).
-        expect(elapsed).toBeLessThan(delayMs * 2.5);
+        // Parallel total is ~delayMs; a sequential rewrite would take ~3*delayMs.
+        // The 2x bound leaves ~delayMs of headroom for late timers under CI load
+        // while still catching any accidental sequential execution.
+        expect(elapsed).toBeLessThan(delayMs * 2);
     });
 
     test("error from a partition is propagated in order", async () => {

--- a/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
@@ -172,18 +172,23 @@ test("StudioServiceClient presents the capability token as a Bearer header", asy
 test("heartbeat keeps a healthy connection alive (no false positives)", async () => {
     const stub = await startStubServer();
     let closed = false;
-    // Short period so several beats elapse quickly; the ws server auto-pongs,
-    // so the watchdog must NOT terminate a healthy socket.
+    // The ws server auto-pongs, so the watchdog must NOT terminate a healthy
+    // socket. This asserts a negative (no termination), so the interval must
+    // sit well above CI event-loop scheduling jitter: a false termination needs
+    // the loop stalled for a full interval right after a ping. A 25ms period
+    // made that easy to hit under parallel-jest CPU contention (the flaky
+    // "true !== false" / "WebSocket CLOSING" failures), so use a comfortably
+    // larger interval that still exercises several ping/pong sweeps.
     const client = await StudioServiceClient.connect({
         endpoint: stub.endpoint,
-        heartbeatMs: 25,
+        heartbeatMs: 250,
         onClose: () => {
             closed = true;
         },
     });
     assert.ok(client);
     try {
-        await new Promise((r) => setTimeout(r, 200)); // ~8 beats
+        await new Promise((r) => setTimeout(r, 1250)); // ~5 beats
         assert.equal(closed, false, "healthy connection must stay open");
         const info = await client!.getStudioInfo();
         assert.equal(info.repoRootInfo.repoRoot, "/repo/ts");

--- a/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
@@ -9,6 +9,13 @@ import { attachHeartbeat } from "../src/heartbeat.js";
 // peer is reaped in `intervalMs`..`2 * intervalMs`.
 const INTERVAL_MS = 40;
 
+// The "healthy peer stays connected" case asserts a negative (the watchdog does
+// NOT reap a responsive socket), so it must tolerate CI event-loop stalls: a
+// false reap needs the loop blocked for a full interval right after a ping. The
+// 40ms sweep is small enough that parallel-jest CPU contention tripped it, so
+// the healthy-path assertion uses a comfortably larger interval.
+const HEALTHY_INTERVAL_MS = 250;
+
 const openServers: WebSocketServer[] = [];
 const openClients: WebSocket[] = [];
 const stops: Array<() => void> = [];
@@ -102,12 +109,12 @@ describe("attachHeartbeat", () => {
 
     it("keeps a responsive client connected across many sweeps", async () => {
         const { wss, url } = await startServer();
-        stops.push(attachHeartbeat(wss, { intervalMs: INTERVAL_MS }));
+        stops.push(attachHeartbeat(wss, { intervalMs: HEALTHY_INTERVAL_MS }));
 
         const client = connect(url); // default autoPong:true
         await waitForOpen(client);
 
-        await delay(INTERVAL_MS * 6);
+        await delay(HEALTHY_INTERVAL_MS * 4);
         expect(client.readyState).toBe(WebSocket.OPEN);
         expect(wss.clients.size).toBe(1);
     });


### PR DESCRIPTION
## Problem

The merge queue (and CI generally) has been flaky, failing 1–3 attempts. Investigation shows the **`build-ts`** workflow is the sole failing check, always in the **Test** step (`test:local`), on both Windows and macOS runners. It is not queue-specific:

| Trigger | `build-ts` failure rate |
|---|---|
| `main` (post-merge push) | ~26% (22/84) |
| PR branches | ~43% (26/60) |
| merge queue | ~28% (23/81) |

Across 9 failed queue runs the failures cluster into a handful of **timing-sensitive tests** that false-fail under parallel-jest CPU contention on CI runners. Product code is unaffected (e.g. the heartbeat default is 30s in prod, not 25ms).

| Test | Hits | Root cause |
|---|---|---|
| `typeagent-studio` › heartbeat keeps a healthy connection alive | 5/9 | 25ms watchdog reaps a *healthy* in-process socket when an event-loop stall spans one interval → `true !== false` / `WebSocket CLOSING` |
| `dispatcher/unknownSwitcher` › all partitions run in parallel | 2 | `spread < 10ms` / `elapsed < 2.5×` too tight; a single GC pause breaks it |
| `webSocketChannelServer/heartbeat` › responsive client stays connected | 1 | same false-reap class at 40ms |
| `defaultAgentProvider/basic` › startup and shutdown | 1 | occasionally exceeds the 120s timeout |

## Fixes

All are **monotonic relaxations** of timing tolerances — they cannot make a currently-passing test fail, and thresholds stay well inside the parallel-vs-sequential gap so real regressions still fail:

- **studio heartbeat**: `heartbeatMs 25 → 250`, observation window `200 → 1250ms`
- **server heartbeat**: dedicated `HEALTHY_INTERVAL_MS = 250` for the healthy-stays-open case (dead-peer tests unchanged)
- **unknownSwitcher**: `delayMs 100 → 200`; `spread < delayMs`, `elapsed < 2×delayMs`
- **defaultAgentProvider**: smoke-test timeout `120s → 180s`

## Validation

Prettier passes; `webSocketChannelServer` compiles with the change. These are CI-contention flakes (they pass locally almost always), so the real proof is CI/merge-queue stability on this PR.
