### PR TITLE
[CICD] Add Test Retry logic

### DIFF
--- a/.github/workflows/build-ts.yml
+++ b/.github/workflows/build-ts.yml
@@ -141,6 +141,10 @@ jobs:
         working-directory: ts
         run: |
           pnpm run postinstall:better-sqlite3-node-restore
+      # Runs the unit suite once, then reruns only the packages that owned a
+      # failing test (serially) to tell flaky failures from real ones.  Flaky
+      # tests (passed on retry) are reported as annotations / a step summary but
+      # do not fail the build; a test that fails twice does.
       - name: Test
         if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ts != 'false' }}
         working-directory: ts

--- a/.github/workflows/build-ts.yml
+++ b/.github/workflows/build-ts.yml
@@ -144,7 +144,7 @@ jobs:
       # Runs the unit suite once, then reruns only the packages that owned a
       # failing test (serially) to tell flaky failures from real ones.  Flaky
       # tests (passed on retry) are reported as annotations / a step summary but
-      # do not fail the build; a test that fails twice does.
+      # do not fail the build; the retry package suite must otherwise pass.
       - name: Test
         if: ${{ github.event_name != 'pull_request' || steps.filter.outputs.ts != 'false' }}
         working-directory: ts

--- a/ts/packages/defaultAgentProvider/test/basic.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/basic.spec.ts
@@ -36,6 +36,9 @@ describe("AppAgentProvider", () => {
                 agents: enabledAgentNames,
             });
             await dispatcher.close();
-        }, 120000); // take longer time to start up on CI's small machines.
+            // Startup + shutdown of every default agent can occasionally spike
+            // past the old 2-minute limit on CI's small, contended machines, so
+            // allow some headroom rather than fail flakily on a slow run.
+        }, 180000);
     });
 });

--- a/ts/packages/defaultAgentProvider/test/basic.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/basic.spec.ts
@@ -36,9 +36,6 @@ describe("AppAgentProvider", () => {
                 agents: enabledAgentNames,
             });
             await dispatcher.close();
-            // Startup + shutdown of every default agent can occasionally spike
-            // past the old 2-minute limit on CI's small, contended machines, so
-            // allow some headroom rather than fail flakily on a slow run.
-        }, 180000);
+        }, 120000); // Startup is slower on small CI machines.
     });
 });

--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -114,7 +114,7 @@ describe("selectFromPartitions", () => {
 
     test("all partitions run in parallel", async () => {
         const startTimes: number[] = [];
-        const delayMs = 100;
+        const delayMs = 200;
         const makeTimedTranslator = (
             result: Result<AssistantSelection>,
             delay: number,
@@ -146,16 +146,20 @@ describe("selectFromPartitions", () => {
         await selectFromPartitions(partitions, "test");
         const elapsed = Date.now() - before;
 
-        // All three started nearly simultaneously (within 10ms of each other)
+        // selectFromPartitions dispatches every translator synchronously before
+        // awaiting any, so parallel start times cluster near 0, while a
+        // sequential rewrite would space them ~delayMs apart (spread ~2*delayMs).
+        // The threshold sits in that gap with wide margin for CI scheduling
+        // jitter: a single GC pause between the synchronous dispatch calls used
+        // to break the old 10ms bound.
         expect(startTimes).toHaveLength(3);
         const spread = Math.max(...startTimes) - Math.min(...startTimes);
-        expect(spread).toBeLessThan(10);
+        expect(spread).toBeLessThan(delayMs);
 
-        // Parallel: total time should be well under sequential (3 × delayMs).
-        // The 2.5× threshold gives ~150ms of headroom for CI timer jitter
-        // while still catching any accidental sequential execution (which
-        // would take ~300ms and clearly exceed the limit).
-        expect(elapsed).toBeLessThan(delayMs * 2.5);
+        // Parallel total is ~delayMs; a sequential rewrite would take ~3*delayMs.
+        // The 2x bound leaves ~delayMs of headroom for late timers under CI load
+        // while still catching any accidental sequential execution.
+        expect(elapsed).toBeLessThan(delayMs * 2);
     });
 
     test("error from a partition is propagated in order", async () => {

--- a/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/unknownSwitcher.spec.ts
@@ -113,53 +113,44 @@ describe("selectFromPartitions", () => {
     });
 
     test("all partitions run in parallel", async () => {
-        const startTimes: number[] = [];
-        const delayMs = 200;
-        const makeTimedTranslator = (
+        const started: string[] = [];
+        const pending: Array<() => void> = [];
+        const makeDeferredTranslator = (
+            name: string,
             result: Result<AssistantSelection>,
-            delay: number,
         ) => ({
             translate: (_request: string) => {
-                startTimes.push(Date.now());
-                return new Promise<Result<AssistantSelection>>((resolve) =>
-                    setTimeout(() => resolve(result), delay),
-                );
+                started.push(name);
+                return new Promise<Result<AssistantSelection>>((resolve) => {
+                    pending.push(() => resolve(result));
+                });
             },
         });
 
         const partitions = [
             {
                 names: ["a"],
-                translator: makeTimedTranslator(unknownResult, delayMs),
+                translator: makeDeferredTranslator("a", unknownResult),
             },
             {
                 names: ["b"],
-                translator: makeTimedTranslator(unknownResult, delayMs),
+                translator: makeDeferredTranslator("b", unknownResult),
             },
             {
                 names: ["c"],
-                translator: makeTimedTranslator(unknownResult, delayMs),
+                translator: makeDeferredTranslator("c", unknownResult),
             },
         ];
 
-        const before = Date.now();
-        await selectFromPartitions(partitions, "test");
-        const elapsed = Date.now() - before;
+        const selection = selectFromPartitions(partitions, "test");
 
-        // selectFromPartitions dispatches every translator synchronously before
-        // awaiting any, so parallel start times cluster near 0, while a
-        // sequential rewrite would space them ~delayMs apart (spread ~2*delayMs).
-        // The threshold sits in that gap with wide margin for CI scheduling
-        // jitter: a single GC pause between the synchronous dispatch calls used
-        // to break the old 10ms bound.
-        expect(startTimes).toHaveLength(3);
-        const spread = Math.max(...startTimes) - Math.min(...startTimes);
-        expect(spread).toBeLessThan(delayMs);
-
-        // Parallel total is ~delayMs; a sequential rewrite would take ~3*delayMs.
-        // The 2x bound leaves ~delayMs of headroom for late timers under CI load
-        // while still catching any accidental sequential execution.
-        expect(elapsed).toBeLessThan(delayMs * 2);
+        // Every translator must be invoked before any result is allowed to
+        // resolve. A sequential implementation would only have started "a".
+        expect(started).toEqual(["a", "b", "c"]);
+        for (const resolve of pending) {
+            resolve();
+        }
+        await selection;
     });
 
     test("error from a partition is propagated in order", async () => {

--- a/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
@@ -34,13 +34,16 @@ const STUB_INFO: StudioInfo = {
  * handlers, so the client is exercised over an actual socket. Returns the bound
  * `ws://` endpoint and a close fn.
  */
-async function startStubServer(): Promise<{
+async function startStubServer(onPing?: () => void): Promise<{
     endpoint: string;
     close: () => Promise<void>;
 }> {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     await new Promise<void>((resolve) => server.once("listening", resolve));
     server.on("connection", (socket) => {
+        if (onPing !== undefined) {
+            socket.on("ping", onPing);
+        }
         let push: (e: StudioEvent) => void = () => {};
         const handlers = stubInvokeHandlers({
             getStudioInfo: async () => STUB_INFO,
@@ -71,6 +74,49 @@ async function startStubServer(): Promise<{
                 for (const c of server.clients) c.terminate();
                 server.close(() => resolve());
             }),
+    };
+}
+
+function createSignalCounter(
+    target: number,
+    timeoutMs: number,
+    timeoutMessage: string,
+): {
+    promise: Promise<void>;
+    signal: () => void;
+    reject: (error: Error) => void;
+} {
+    let count = 0;
+    let resolvePromise!: () => void;
+    let rejectPromise!: (error: Error) => void;
+    let settled = false;
+    const promise = new Promise<void>((resolve, reject) => {
+        resolvePromise = resolve;
+        rejectPromise = reject;
+    });
+    const timer = setTimeout(() => {
+        settled = true;
+        rejectPromise(new Error(timeoutMessage));
+    }, timeoutMs);
+    timer.unref?.();
+
+    const settle = (complete: () => void) => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        complete();
+    };
+    return {
+        promise,
+        signal: () => {
+            count++;
+            if (count >= target) {
+                settle(resolvePromise);
+            }
+        },
+        reject: (error) => settle(() => rejectPromise(error)),
     };
 }
 
@@ -170,7 +216,12 @@ test("StudioServiceClient presents the capability token as a Bearer header", asy
 });
 
 test("heartbeat keeps a healthy connection alive (no false positives)", async () => {
-    const stub = await startStubServer();
+    const heartbeatSweeps = createSignalCounter(
+        3,
+        3000,
+        "healthy connection did not complete three heartbeat sweeps",
+    );
+    const stub = await startStubServer(heartbeatSweeps.signal);
     let closed = false;
     // The ws server auto-pongs, so the watchdog must NOT terminate a healthy
     // socket. This asserts a negative (no termination), so the interval must
@@ -184,11 +235,14 @@ test("heartbeat keeps a healthy connection alive (no false positives)", async ()
         heartbeatMs: 250,
         onClose: () => {
             closed = true;
+            heartbeatSweeps.reject(
+                new Error("healthy connection closed during heartbeat sweeps"),
+            );
         },
     });
     assert.ok(client);
     try {
-        await new Promise((r) => setTimeout(r, 1250)); // ~5 beats
+        await heartbeatSweeps.promise;
         assert.equal(closed, false, "healthy connection must stay open");
         const info = await client!.getStudioInfo();
         assert.equal(info.repoRootInfo.repoRoot, "/repo/ts");

--- a/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
+++ b/ts/packages/typeagent-studio/src/test/studioServiceClient.spec.ts
@@ -172,18 +172,23 @@ test("StudioServiceClient presents the capability token as a Bearer header", asy
 test("heartbeat keeps a healthy connection alive (no false positives)", async () => {
     const stub = await startStubServer();
     let closed = false;
-    // Short period so several beats elapse quickly; the ws server auto-pongs,
-    // so the watchdog must NOT terminate a healthy socket.
+    // The ws server auto-pongs, so the watchdog must NOT terminate a healthy
+    // socket. This asserts a negative (no termination), so the interval must
+    // sit well above CI event-loop scheduling jitter: a false termination needs
+    // the loop stalled for a full interval right after a ping. A 25ms period
+    // made that easy to hit under parallel-jest CPU contention (the flaky
+    // "true !== false" / "WebSocket CLOSING" failures), so use a comfortably
+    // larger interval that still exercises several ping/pong sweeps.
     const client = await StudioServiceClient.connect({
         endpoint: stub.endpoint,
-        heartbeatMs: 25,
+        heartbeatMs: 250,
         onClose: () => {
             closed = true;
         },
     });
     assert.ok(client);
     try {
-        await new Promise((r) => setTimeout(r, 200)); // ~8 beats
+        await new Promise((r) => setTimeout(r, 1250)); // ~5 beats
         assert.equal(closed, false, "healthy connection must stay open");
         const info = await client!.getStudioInfo();
         assert.equal(info.repoRootInfo.repoRoot, "/repo/ts");

--- a/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
@@ -57,6 +57,38 @@ function waitForClose(ws: WebSocket, timeoutMs: number): Promise<void> {
     });
 }
 
+function waitForPings(
+    ws: WebSocket,
+    target: number,
+    timeoutMs: number,
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        let count = 0;
+        const cleanup = () => {
+            clearTimeout(timer);
+            ws.off("ping", onPing);
+            ws.off("close", onClose);
+        };
+        const onPing = () => {
+            count++;
+            if (count >= target) {
+                cleanup();
+                resolve();
+            }
+        };
+        const onClose = () => {
+            cleanup();
+            reject(new Error("responsive client closed during heartbeat test"));
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error("heartbeat pings did not arrive in time"));
+        }, timeoutMs);
+        ws.on("ping", onPing);
+        ws.once("close", onClose);
+    });
+}
+
 function delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -114,7 +146,7 @@ describe("attachHeartbeat", () => {
         const client = connect(url); // default autoPong:true
         await waitForOpen(client);
 
-        await delay(HEALTHY_INTERVAL_MS * 4);
+        await waitForPings(client, 3, HEALTHY_INTERVAL_MS * 10);
         expect(client.readyState).toBe(WebSocket.OPEN);
         expect(wss.clients.size).toBe(1);
     });

--- a/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/heartbeat.spec.ts
@@ -9,6 +9,13 @@ import { attachHeartbeat } from "../src/heartbeat.js";
 // peer is reaped in `intervalMs`..`2 * intervalMs`.
 const INTERVAL_MS = 40;
 
+// The "healthy peer stays connected" case asserts a negative (the watchdog does
+// NOT reap a responsive socket), so it must tolerate CI event-loop stalls: a
+// false reap needs the loop blocked for a full interval right after a ping. The
+// 40ms sweep is small enough that parallel-jest CPU contention tripped it, so
+// the healthy-path assertion uses a comfortably larger interval.
+const HEALTHY_INTERVAL_MS = 250;
+
 const openServers: WebSocketServer[] = [];
 const openClients: WebSocket[] = [];
 const stops: Array<() => void> = [];
@@ -102,12 +109,12 @@ describe("attachHeartbeat", () => {
 
     it("keeps a responsive client connected across many sweeps", async () => {
         const { wss, url } = await startServer();
-        stops.push(attachHeartbeat(wss, { intervalMs: INTERVAL_MS }));
+        stops.push(attachHeartbeat(wss, { intervalMs: HEALTHY_INTERVAL_MS }));
 
         const client = connect(url); // default autoPong:true
         await waitForOpen(client);
 
-        await delay(INTERVAL_MS * 6);
+        await delay(HEALTHY_INTERVAL_MS * 4);
         expect(client.readyState).toBe(WebSocket.OPEN);
         expect(wss.clients.size).toBe(1);
     });

--- a/ts/tools/scripts/lib/testRetry.mjs
+++ b/ts/tools/scripts/lib/testRetry.mjs
@@ -93,26 +93,38 @@ export function findPackageDir(testFilePath, workspaceRoot, isPackageDir) {
 // Compare the two rounds and bucket every failure.
 //   confirmed      - failed round 1 and again on the isolated retry (real bug)
 //   flakyRecovered - failed round 1, passed on retry (flaky, not fatal)
-//   newOnRetry     - passed round 1, failed on retry (unstable, not fatal)
+//   newOnRetry     - passed round 1, failed on retry (unstable and fatal)
 //   unretriable    - round 1 failure with no owning package to rerun (fatal)
 // first entries carry a `package` field (string) or undefined when unretriable.
 // retryTrusted is false when the retry process itself crashed without emitting
 // results; in that case round 1 failures cannot be cleared as flaky.
-export function classifyRetryResults({ first, second, retryTrusted = true }) {
-    const secondKeys = new Set(second.map((failure) => failure.key));
+export function classifyRetryResults({
+    first,
+    second,
+    retryTrusted = true,
+    retryFailed = false,
+}) {
+    const secondByKey = new Map(
+        second.map((failure) => [failure.key, failure]),
+    );
+    const secondKeys = new Set(secondByKey.keys());
     const firstKeys = new Set(first.map((failure) => failure.key));
 
     const unretriable = first.filter(
         (failure) => failure.package === undefined,
     );
-    const retriable = first.filter(
-        (failure) => failure.package !== undefined,
-    );
+    const retriable = first.filter((failure) => failure.package !== undefined);
 
     let confirmed;
     let flakyRecovered;
     if (retryTrusted) {
-        confirmed = retriable.filter((failure) => secondKeys.has(failure.key));
+        confirmed = retriable
+            .filter((failure) => secondKeys.has(failure.key))
+            .map((failure) => ({
+                ...secondByKey.get(failure.key),
+                key: failure.key,
+                package: failure.package,
+            }));
         flakyRecovered = retriable.filter(
             (failure) => !secondKeys.has(failure.key),
         );
@@ -124,12 +136,20 @@ export function classifyRetryResults({ first, second, retryTrusted = true }) {
 
     const newOnRetry = second.filter((failure) => !firstKeys.has(failure.key));
 
-    return { confirmed, flakyRecovered, newOnRetry, unretriable };
+    return {
+        confirmed,
+        flakyRecovered,
+        newOnRetry,
+        unretriable,
+        retryFailed,
+    };
 }
 
 export function hasHardFailures(classification) {
     return (
+        classification.retryFailed ||
         classification.confirmed.length > 0 ||
+        classification.newOnRetry.length > 0 ||
         classification.unretriable.length > 0
     );
 }
@@ -178,34 +198,37 @@ export function buildSummaryLines(classification) {
         classification;
     const lines = [];
 
-    if (flakyRecovered.length > 0 || newOnRetry.length > 0) {
-        const flakyCount = flakyRecovered.length + newOnRetry.length;
+    if (flakyRecovered.length > 0) {
         lines.push(
-            `\n${RULE}\nFLAKY TESTS (${flakyCount}) - passed on retry, not failing the build\n${RULE}`,
+            `\n${RULE}\nFLAKY TESTS (${flakyRecovered.length}) - failed initially, passed on retry\n${RULE}`,
         );
         for (const failure of flakyRecovered) {
             lines.push(...formatFailure(failure));
         }
-        for (const failure of newOnRetry) {
-            lines.push(
-                `\nFLAKY ${normalizeTestFilePath(failure.testFilePath)}`,
-                `  ${failure.fullName}`,
-                indent(
-                    "Passed on the first run but failed when the package was retried.",
-                    4,
-                ),
-            );
-        }
         lines.push(`\n${RULE}`);
     }
 
-    if (confirmed.length > 0 || unretriable.length > 0) {
-        const failCount = confirmed.length + unretriable.length;
+    if (
+        confirmed.length > 0 ||
+        newOnRetry.length > 0 ||
+        unretriable.length > 0
+    ) {
+        const failCount =
+            confirmed.length + newOnRetry.length + unretriable.length;
         lines.push(
-            `\n${RULE}\nFAILED TESTS (${failCount}) - failed on retry\n${RULE}`,
+            `\n${RULE}\nBUILD-BLOCKING TEST FAILURES (${failCount})\n${RULE}`,
         );
         for (const failure of confirmed) {
             lines.push(...formatFailure(failure));
+        }
+        for (const failure of newOnRetry) {
+            lines.push(...formatFailure(failure));
+            lines.push(
+                indent(
+                    "(passed initially but failed when the package was retried)",
+                    2,
+                ),
+            );
         }
         for (const failure of unretriable) {
             lines.push(...formatFailure(failure));
@@ -217,6 +240,11 @@ export function buildSummaryLines(classification) {
             );
         }
         lines.push(`\n${RULE}`);
+    }
+    if (classification.retryFailed) {
+        lines.push(
+            "\nThe retry command exited unsuccessfully; the build remains failed.",
+        );
     }
 
     return lines;
@@ -233,10 +261,7 @@ function githubEscape(value) {
 // annotations in the PR checks UI (tracked, not silently masked).
 export function buildGithubAnnotations(classification) {
     const annotations = [];
-    for (const failure of [
-        ...classification.flakyRecovered,
-        ...classification.newOnRetry,
-    ]) {
+    for (const failure of classification.flakyRecovered) {
         annotations.push(
             `::warning title=Flaky test::${githubEscape(
                 `${failure.fullName} (${normalizeTestFilePath(failure.testFilePath)}) passed only after a retry`,
@@ -245,12 +270,18 @@ export function buildGithubAnnotations(classification) {
     }
     for (const failure of [
         ...classification.confirmed,
+        ...classification.newOnRetry,
         ...classification.unretriable,
     ]) {
         annotations.push(
             `::error title=Test failed::${githubEscape(
                 `${failure.fullName} (${normalizeTestFilePath(failure.testFilePath)})`,
             )}`,
+        );
+    }
+    if (classification.retryFailed) {
+        annotations.push(
+            "::error title=Test retry failed::The retry command exited unsuccessfully.",
         );
     }
     return annotations;
@@ -264,7 +295,8 @@ export function buildStepSummaryMarkdown(classification) {
         confirmed.length === 0 &&
         unretriable.length === 0 &&
         flakyRecovered.length === 0 &&
-        newOnRetry.length === 0
+        newOnRetry.length === 0 &&
+        !classification.retryFailed
     ) {
         return "";
     }
@@ -280,7 +312,10 @@ export function buildStepSummaryMarkdown(classification) {
     addRows(confirmed, "❌ Failed on retry");
     addRows(unretriable, "❌ Failed (no retry)");
     addRows(flakyRecovered, "⚠️ Flaky (recovered)");
-    addRows(newOnRetry, "⚠️ Flaky (new on retry)");
+    addRows(newOnRetry, "❌ Failed only on retry");
+    if (classification.retryFailed) {
+        rows.push("| ❌ Retry command failed | - | See the test log |");
+    }
 
     return [
         "### Test retry summary",

--- a/ts/tools/scripts/lib/testRetry.mjs
+++ b/ts/tools/scripts/lib/testRetry.mjs
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Pure helpers for the flaky-test retry harness (runTestLocalWithSummary.mjs).
+// Kept side-effect free so they can be unit tested with node:test.
+
+import path from "node:path";
+
+// Convert a possibly-file:// path into a plain filesystem path. Done manually
+// (rather than url.fileURLToPath) because on Windows fileURLToPath throws for a
+// driveless URL like file:///repo/..., and reporters run on all three OSes.
+export function toFsPath(filePath) {
+    if (typeof filePath !== "string" || !filePath.startsWith("file://")) {
+        return filePath;
+    }
+    let decoded;
+    try {
+        decoded = decodeURIComponent(filePath.slice("file://".length));
+    } catch {
+        decoded = filePath.slice("file://".length);
+    }
+    // Strip the leading slash before a Windows drive letter (/C:/x -> C:/x).
+    return /^\/[A-Za-z]:/.test(decoded) ? decoded.slice(1) : decoded;
+}
+
+// Turn a reporter-provided test file path into a stable, comparable string.
+// Reporters emit absolute paths (jest) or file:// URLs / source paths (node
+// --test). We normalize to a forward-slash path relative to the workspace so
+// the same test produces the same key across both retry rounds.
+export function normalizeTestFilePath(filePath, cwd = process.cwd()) {
+    if (typeof filePath !== "string" || filePath.length === 0) {
+        return String(filePath);
+    }
+    const resolved = toFsPath(filePath);
+    const absolute = path.isAbsolute(resolved)
+        ? resolved
+        : path.resolve(cwd, resolved);
+    const relative = path.relative(cwd, absolute);
+    const chosen =
+        relative.startsWith("..") || path.isAbsolute(relative)
+            ? absolute
+            : relative;
+    return chosen.replaceAll("\\", "/");
+}
+
+// Identity of a failing test: file + full test name. Ignores the failure
+// message so the same test matches across rounds even if the message differs.
+export function failureKey(failure, cwd = process.cwd()) {
+    return `${normalizeTestFilePath(failure.testFilePath, cwd)}\n${failure.fullName}`;
+}
+
+// Collapse duplicate reports of the same test (a reporter can emit the same
+// failure more than once) to one entry, keeping the first message seen and
+// attaching the computed key.
+export function dedupeFailures(failures, cwd = process.cwd()) {
+    const byKey = new Map();
+    for (const failure of failures) {
+        const key = failureKey(failure, cwd);
+        if (!byKey.has(key)) {
+            byKey.set(key, { ...failure, key });
+        }
+    }
+    return [...byKey.values()];
+}
+
+// Walk up from a test file to the nearest package directory, without escaping
+// the workspace root. isPackageDir(dir) reports whether dir holds a
+// package.json; injecting it keeps this testable without touching the fs.
+export function findPackageDir(testFilePath, workspaceRoot, isPackageDir) {
+    const root = path.resolve(workspaceRoot);
+    let dir = path.dirname(path.resolve(testFilePath));
+    const relativeToRoot = path.relative(root, dir);
+    if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) {
+        return undefined;
+    }
+    while (true) {
+        // Stop before the workspace root so we never treat the root package as
+        // the owner of a test (its script reruns the whole suite).
+        if (path.resolve(dir) === root) {
+            return undefined;
+        }
+        if (isPackageDir(dir)) {
+            return dir;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return undefined;
+        }
+        dir = parent;
+    }
+}
+
+// Compare the two rounds and bucket every failure.
+//   confirmed      - failed round 1 and again on the isolated retry (real bug)
+//   flakyRecovered - failed round 1, passed on retry (flaky, not fatal)
+//   newOnRetry     - passed round 1, failed on retry (unstable, not fatal)
+//   unretriable    - round 1 failure with no owning package to rerun (fatal)
+// first entries carry a `package` field (string) or undefined when unretriable.
+// retryTrusted is false when the retry process itself crashed without emitting
+// results; in that case round 1 failures cannot be cleared as flaky.
+export function classifyRetryResults({ first, second, retryTrusted = true }) {
+    const secondKeys = new Set(second.map((failure) => failure.key));
+    const firstKeys = new Set(first.map((failure) => failure.key));
+
+    const unretriable = first.filter(
+        (failure) => failure.package === undefined,
+    );
+    const retriable = first.filter(
+        (failure) => failure.package !== undefined,
+    );
+
+    let confirmed;
+    let flakyRecovered;
+    if (retryTrusted) {
+        confirmed = retriable.filter((failure) => secondKeys.has(failure.key));
+        flakyRecovered = retriable.filter(
+            (failure) => !secondKeys.has(failure.key),
+        );
+    } else {
+        // The retry gave us nothing to trust, so keep the original failures.
+        confirmed = retriable;
+        flakyRecovered = [];
+    }
+
+    const newOnRetry = second.filter((failure) => !firstKeys.has(failure.key));
+
+    return { confirmed, flakyRecovered, newOnRetry, unretriable };
+}
+
+export function hasHardFailures(classification) {
+    return (
+        classification.confirmed.length > 0 ||
+        classification.unretriable.length > 0
+    );
+}
+
+export function hasFlakyResults(classification) {
+    return (
+        classification.flakyRecovered.length > 0 ||
+        classification.newOnRetry.length > 0
+    );
+}
+
+const RULE = "=".repeat(80);
+
+export function stripAnsi(value) {
+    return value.replace(
+        /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*)?\u0007)|(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g,
+        "",
+    );
+}
+
+function indent(value, spaces) {
+    const prefix = " ".repeat(spaces);
+    return value
+        .trimEnd()
+        .split(/\r?\n/u)
+        .map((line) => `${prefix}${line}`)
+        .join("\n");
+}
+
+function formatFailure(failure, { includeMessages = true } = {}) {
+    const lines = [
+        `\nFAIL ${normalizeTestFilePath(failure.testFilePath)}`,
+        `  ${failure.fullName}`,
+    ];
+    if (includeMessages) {
+        for (const message of failure.failureMessages ?? []) {
+            lines.push(indent(stripAnsi(String(message)), 4));
+        }
+    }
+    return lines;
+}
+
+// Build the human-readable summary printed at the end of the test step.
+export function buildSummaryLines(classification) {
+    const { confirmed, flakyRecovered, newOnRetry, unretriable } =
+        classification;
+    const lines = [];
+
+    if (flakyRecovered.length > 0 || newOnRetry.length > 0) {
+        const flakyCount = flakyRecovered.length + newOnRetry.length;
+        lines.push(
+            `\n${RULE}\nFLAKY TESTS (${flakyCount}) - passed on retry, not failing the build\n${RULE}`,
+        );
+        for (const failure of flakyRecovered) {
+            lines.push(...formatFailure(failure));
+        }
+        for (const failure of newOnRetry) {
+            lines.push(
+                `\nFLAKY ${normalizeTestFilePath(failure.testFilePath)}`,
+                `  ${failure.fullName}`,
+                indent(
+                    "Passed on the first run but failed when the package was retried.",
+                    4,
+                ),
+            );
+        }
+        lines.push(`\n${RULE}`);
+    }
+
+    if (confirmed.length > 0 || unretriable.length > 0) {
+        const failCount = confirmed.length + unretriable.length;
+        lines.push(
+            `\n${RULE}\nFAILED TESTS (${failCount}) - failed on retry\n${RULE}`,
+        );
+        for (const failure of confirmed) {
+            lines.push(...formatFailure(failure));
+        }
+        for (const failure of unretriable) {
+            lines.push(...formatFailure(failure));
+            lines.push(
+                indent(
+                    "(could not be isolated to a package for retry; treated as a failure)",
+                    2,
+                ),
+            );
+        }
+        lines.push(`\n${RULE}`);
+    }
+
+    return lines;
+}
+
+function githubEscape(value) {
+    return String(value)
+        .replaceAll("%", "%25")
+        .replaceAll("\r", "%0D")
+        .replaceAll("\n", "%0A");
+}
+
+// GitHub Actions workflow commands so flaky/failed tests surface as
+// annotations in the PR checks UI (tracked, not silently masked).
+export function buildGithubAnnotations(classification) {
+    const annotations = [];
+    for (const failure of [
+        ...classification.flakyRecovered,
+        ...classification.newOnRetry,
+    ]) {
+        annotations.push(
+            `::warning title=Flaky test::${githubEscape(
+                `${failure.fullName} (${normalizeTestFilePath(failure.testFilePath)}) passed only after a retry`,
+            )}`,
+        );
+    }
+    for (const failure of [
+        ...classification.confirmed,
+        ...classification.unretriable,
+    ]) {
+        annotations.push(
+            `::error title=Test failed::${githubEscape(
+                `${failure.fullName} (${normalizeTestFilePath(failure.testFilePath)})`,
+            )}`,
+        );
+    }
+    return annotations;
+}
+
+// Markdown appended to $GITHUB_STEP_SUMMARY for an at-a-glance flaky report.
+export function buildStepSummaryMarkdown(classification) {
+    const { confirmed, flakyRecovered, newOnRetry, unretriable } =
+        classification;
+    if (
+        confirmed.length === 0 &&
+        unretriable.length === 0 &&
+        flakyRecovered.length === 0 &&
+        newOnRetry.length === 0
+    ) {
+        return "";
+    }
+
+    const rows = [];
+    const addRows = (failures, status) => {
+        for (const failure of failures) {
+            const file = normalizeTestFilePath(failure.testFilePath);
+            const name = String(failure.fullName).replaceAll("|", "\\|");
+            rows.push(`| ${status} | \`${file}\` | ${name} |`);
+        }
+    };
+    addRows(confirmed, "❌ Failed on retry");
+    addRows(unretriable, "❌ Failed (no retry)");
+    addRows(flakyRecovered, "⚠️ Flaky (recovered)");
+    addRows(newOnRetry, "⚠️ Flaky (new on retry)");
+
+    return [
+        "### Test retry summary",
+        "",
+        "| Result | File | Test |",
+        "| --- | --- | --- |",
+        ...rows,
+        "",
+    ].join("\n");
+}

--- a/ts/tools/scripts/runTestLocalWithSummary.mjs
+++ b/ts/tools/scripts/runTestLocalWithSummary.mjs
@@ -1,75 +1,172 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Runs the local unit-test suite (`test:local`) with flaky-test mitigation:
+//
+//  1. Run the whole suite once, capturing individual failures via the reporter
+//     that writes to TYPEAGENT_TEST_FAILURES_DIR.
+//  2. If anything failed, rerun ONLY the packages that owned a failing test,
+//     serially, into a fresh failures directory (option #2, "rerun-only-
+//     failed").
+//  3. Classify each round-1 failure as flaky (passed on retry) or confirmed
+//     (failed again), print a summary, and emit GitHub annotations / a step
+//     summary so flaky tests are tracked instead of silently masked (option
+//     #3). The build only fails on confirmed failures.
+
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-const failureDirectory = fs.mkdtempSync(
-    path.join(os.tmpdir(), "typeagent-test-failures-"),
-);
-const [testCommand, testArguments] =
-    process.platform === "win32"
-        ? [
-              process.env.ComSpec ?? "cmd.exe",
-              ["/d", "/s", "/c", "pnpm run test:local"],
-          ]
-        : ["pnpm", ["run", "test:local"]];
+import {
+    dedupeFailures,
+    findPackageDir,
+    classifyRetryResults,
+    hasHardFailures,
+    buildSummaryLines,
+    buildGithubAnnotations,
+    buildStepSummaryMarkdown,
+    toFsPath,
+} from "./lib/testRetry.mjs";
 
-const result = spawnSync(testCommand, testArguments, {
-    env: {
-        ...process.env,
-        TYPEAGENT_TEST_FAILURES_DIR: failureDirectory,
-    },
-    stdio: "inherit",
-});
+// build-ts runs this from the `ts` directory, which is the pnpm workspace root.
+const workspaceRoot = process.cwd();
+const isWindows = process.platform === "win32";
+const inGithubActions = process.env.GITHUB_ACTIONS === "true";
 
+const firstDirectory = makeFailuresDirectory("run1");
+let secondDirectory;
 try {
-    printFailureSummary(failureDirectory, result.status);
-} finally {
-    fs.rmSync(failureDirectory, { recursive: true, force: true });
-}
+    const firstResult = runPnpm(["run", "test:local"], firstDirectory);
 
-if (result.error !== undefined) {
-    throw result.error;
-}
-if (result.signal !== null) {
-    process.kill(process.pid, result.signal);
-}
-process.exitCode = result.status ?? 1;
+    // A spawn error or a killing signal is an infrastructure failure, not a
+    // test failure we can retry; surface it exactly like before.
+    if (firstResult.error !== undefined) {
+        throw firstResult.error;
+    }
+    if (firstResult.signal !== null) {
+        process.kill(process.pid, firstResult.signal);
+    }
 
-function printFailureSummary(directory, exitCode) {
-    const failures = fs
-        .readdirSync(directory)
-        .filter((fileName) => fileName.endsWith(".json"))
-        .flatMap((fileName) => readFailureArtifact(directory, fileName));
-    const uniqueFailures = [
-        ...new Map(
-            failures.map((failure) => [JSON.stringify(failure), failure]),
-        ).values(),
-    ];
+    const firstFailures = dedupeFailures(
+        readFailures(firstDirectory),
+        workspaceRoot,
+    );
 
-    if (uniqueFailures.length === 0) {
-        if (exitCode !== 0) {
+    if (firstFailures.length === 0) {
+        if ((firstResult.status ?? 1) !== 0) {
             console.error(
                 "\nFAILED TEST SUMMARY\nNo individual test failures were captured. See the test output above.",
             );
         }
-        return;
+        process.exitCode = firstResult.status ?? 0;
+    } else {
+        process.exitCode = handleFailures(firstFailures);
+    }
+} finally {
+    fs.rmSync(firstDirectory, { recursive: true, force: true });
+    if (secondDirectory !== undefined) {
+        fs.rmSync(secondDirectory, { recursive: true, force: true });
+    }
+}
+
+function handleFailures(firstFailures) {
+    // Attach the owning package (for the retry) to each round-1 failure.
+    const annotated = firstFailures.map((failure) => ({
+        ...failure,
+        package: resolvePackageName(failure.testFilePath),
+    }));
+
+    const packages = [
+        ...new Set(
+            annotated
+                .map((failure) => failure.package)
+                .filter((name) => name !== undefined),
+        ),
+    ];
+
+    let second = [];
+    let retryTrusted = true;
+    if (packages.length > 0) {
+        const retriableCount = annotated.filter(
+            (failure) => failure.package !== undefined,
+        ).length;
+        console.error(
+            `\n${"=".repeat(80)}\nRETRYING ${retriableCount} failed test(s) across ${packages.length} package(s) to detect flakiness\n${"=".repeat(80)}`,
+        );
+
+        secondDirectory = makeFailuresDirectory("run2");
+        const retryResult = runPnpm(
+            [
+                ...packages.flatMap((name) => ["--filter", name]),
+                // Serial rerun of only the affected packages: isolates genuine
+                // failures from parallelism/resource-contention flakiness.
+                "--workspace-concurrency=1",
+                "--no-sort",
+                "--stream",
+                "--no-bail",
+                "run",
+                "test:local",
+            ],
+            secondDirectory,
+        );
+
+        second = dedupeFailures(readFailures(secondDirectory), workspaceRoot);
+
+        // If the retry itself crashed without producing any results, we cannot
+        // trust an empty second round as "everything recovered".
+        const retryCrashed =
+            retryResult.error !== undefined ||
+            retryResult.signal !== null ||
+            ((retryResult.status ?? 1) !== 0 && second.length === 0);
+        retryTrusted = !retryCrashed;
     }
 
-    console.error(
-        `\n${"=".repeat(80)}\nFAILED TEST SUMMARY (${uniqueFailures.length})\n${"=".repeat(80)}`,
-    );
-    for (const failure of uniqueFailures) {
-        console.error(`\nFAIL ${normalizePath(failure.testFilePath)}`);
-        console.error(`  ${failure.fullName}`);
-        for (const message of failure.failureMessages) {
-            console.error(indent(stripAnsi(message), 4));
-        }
+    const classification = classifyRetryResults({
+        first: annotated,
+        second,
+        retryTrusted,
+    });
+
+    for (const line of buildSummaryLines(classification)) {
+        console.error(line);
     }
-    console.error(`\n${"=".repeat(80)}`);
+
+    if (inGithubActions) {
+        emitGithubReport(classification);
+    }
+
+    return hasHardFailures(classification) ? 1 : 0;
+}
+
+function makeFailuresDirectory(label) {
+    return fs.mkdtempSync(
+        path.join(os.tmpdir(), `typeagent-test-failures-${label}-`),
+    );
+}
+
+function runPnpm(pnpmArguments, failuresDirectory) {
+    const [command, commandArguments] = isWindows
+        ? [
+              process.env.ComSpec ?? "cmd.exe",
+              ["/d", "/s", "/c", ["pnpm", ...pnpmArguments].join(" ")],
+          ]
+        : ["pnpm", pnpmArguments];
+
+    return spawnSync(command, commandArguments, {
+        env: {
+            ...process.env,
+            TYPEAGENT_TEST_FAILURES_DIR: failuresDirectory,
+        },
+        stdio: "inherit",
+    });
+}
+
+function readFailures(directory) {
+    return fs
+        .readdirSync(directory)
+        .filter((fileName) => fileName.endsWith(".json"))
+        .flatMap((fileName) => readFailureArtifact(directory, fileName));
 }
 
 function readFailureArtifact(directory, fileName) {
@@ -85,26 +182,50 @@ function readFailureArtifact(directory, fileName) {
     }
 }
 
-function normalizePath(filePath) {
-    return (
-        path.isAbsolute(filePath)
-            ? path.relative(process.cwd(), filePath)
-            : filePath
-    ).replaceAll("\\", "/");
-}
-
-function stripAnsi(value) {
-    return value.replace(
-        /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*)?\u0007)|(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g,
-        "",
+function resolvePackageName(testFilePath) {
+    const packageDir = findPackageDir(
+        toAbsolutePath(testFilePath),
+        workspaceRoot,
+        (directory) => fs.existsSync(path.join(directory, "package.json")),
     );
+    if (packageDir === undefined) {
+        return undefined;
+    }
+    try {
+        const manifest = JSON.parse(
+            fs.readFileSync(path.join(packageDir, "package.json"), "utf8"),
+        );
+        return typeof manifest.name === "string" && manifest.name.length > 0
+            ? manifest.name
+            : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
-function indent(value, spaces) {
-    const prefix = " ".repeat(spaces);
-    return value
-        .trimEnd()
-        .split(/\r?\n/u)
-        .map((line) => `${prefix}${line}`)
-        .join("\n");
+function toAbsolutePath(testFilePath) {
+    if (typeof testFilePath !== "string" || testFilePath.length === 0) {
+        return workspaceRoot;
+    }
+    const resolved = toFsPath(testFilePath);
+    return path.isAbsolute(resolved)
+        ? resolved
+        : path.resolve(workspaceRoot, resolved);
+}
+
+function emitGithubReport(classification) {
+    for (const annotation of buildGithubAnnotations(classification)) {
+        console.log(annotation);
+    }
+    const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+    const markdown = buildStepSummaryMarkdown(classification);
+    if (summaryFile !== undefined && markdown.length > 0) {
+        try {
+            fs.appendFileSync(summaryFile, `${markdown}\n`);
+        } catch (error) {
+            console.error(
+                `Unable to write GitHub step summary: ${error.message}`,
+            );
+        }
+    }
 }

--- a/ts/tools/scripts/runTestLocalWithSummary.mjs
+++ b/ts/tools/scripts/runTestLocalWithSummary.mjs
@@ -11,7 +11,7 @@
 //  3. Classify each round-1 failure as flaky (passed on retry) or confirmed
 //     (failed again), print a summary, and emit GitHub annotations / a step
 //     summary so flaky tests are tracked instead of silently masked (option
-//     #3). The build only fails on confirmed failures.
+//     #3). The build fails unless the retry command completes successfully.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -87,6 +87,7 @@ function handleFailures(firstFailures) {
 
     let second = [];
     let retryTrusted = true;
+    let retryFailed = false;
     if (packages.length > 0) {
         const retriableCount = annotated.filter(
             (failure) => failure.package !== undefined,
@@ -112,6 +113,10 @@ function handleFailures(firstFailures) {
         );
 
         second = dedupeFailures(readFailures(secondDirectory), workspaceRoot);
+        retryFailed =
+            retryResult.error !== undefined ||
+            retryResult.signal !== null ||
+            (retryResult.status ?? 1) !== 0;
 
         // If the retry itself crashed without producing any results, we cannot
         // trust an empty second round as "everything recovered".
@@ -126,6 +131,7 @@ function handleFailures(firstFailures) {
         first: annotated,
         second,
         retryTrusted,
+        retryFailed,
     });
 
     for (const line of buildSummaryLines(classification)) {

--- a/ts/tools/scripts/test/testRetry.spec.mjs
+++ b/ts/tools/scripts/test/testRetry.spec.mjs
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+
+import {
+    normalizeTestFilePath,
+    failureKey,
+    dedupeFailures,
+    findPackageDir,
+    classifyRetryResults,
+    hasHardFailures,
+    hasFlakyResults,
+    buildSummaryLines,
+    buildGithubAnnotations,
+    buildStepSummaryMarkdown,
+} from "../lib/testRetry.mjs";
+
+const cwd = "/repo/ts";
+
+function failure(file, name, message = "boom") {
+    return {
+        testFilePath: file,
+        fullName: name,
+        failureMessages: [message],
+    };
+}
+
+// Attach a `key` (as dedupeFailures would) plus an owning package.
+function withKey(file, name, pkg) {
+    return {
+        ...failure(file, name),
+        key: failureKey(failure(file, name), cwd),
+        package: pkg,
+    };
+}
+
+test("normalizeTestFilePath makes paths workspace-relative with forward slashes", () => {
+    assert.equal(
+        normalizeTestFilePath("/repo/ts/packages/a/dist/test/x.spec.js", cwd),
+        "packages/a/dist/test/x.spec.js",
+    );
+    // file:// URLs are decoded.
+    assert.equal(
+        normalizeTestFilePath("file:///repo/ts/packages/a/test/y.spec.ts", cwd),
+        "packages/a/test/y.spec.ts",
+    );
+});
+
+test("failureKey is identical across rounds and ignores the message", () => {
+    const first = failure("/repo/ts/packages/a/dist/test/x.spec.js", "does X");
+    const second = failure(
+        "/repo/ts/packages/a/dist/test/x.spec.js",
+        "does X",
+        "a different message",
+    );
+    assert.equal(failureKey(first, cwd), failureKey(second, cwd));
+});
+
+test("dedupeFailures collapses repeated reports and attaches a key", () => {
+    const deduped = dedupeFailures(
+        [
+            failure("/repo/ts/packages/a/dist/test/x.spec.js", "does X"),
+            failure("/repo/ts/packages/a/dist/test/x.spec.js", "does X"),
+            failure("/repo/ts/packages/a/dist/test/x.spec.js", "does Y"),
+        ],
+        cwd,
+    );
+    assert.equal(deduped.length, 2);
+    assert.ok(deduped.every((entry) => typeof entry.key === "string"));
+});
+
+test("findPackageDir walks up to the nearest package, not the workspace root", () => {
+    const root = path.resolve("/repo/ts");
+    const packageA = path.join(root, "packages", "a");
+    const testFile = path.join(packageA, "dist", "test", "x.spec.js");
+    const isPackageDir = (dir) => {
+        const resolved = path.resolve(dir);
+        return resolved === packageA || resolved === root;
+    };
+    const found = findPackageDir(testFile, root, isPackageDir);
+    assert.equal(path.resolve(found), packageA);
+});
+
+test("findPackageDir returns undefined for files outside the workspace", () => {
+    assert.equal(
+        findPackageDir("/somewhere/else/x.spec.js", "/repo/ts", () => true),
+        undefined,
+    );
+});
+
+test("findPackageDir returns undefined when only the root owns the file", () => {
+    const isPackageDir = (dir) => dir.replaceAll("\\", "/") === "/repo/ts";
+    assert.equal(
+        findPackageDir("/repo/ts/scripts/x.spec.js", "/repo/ts", isPackageDir),
+        undefined,
+    );
+});
+
+test("classify: a failure that passes on retry is flaky, not fatal", () => {
+    const first = [withKey("/repo/ts/packages/a/test/x.spec.js", "flaky", "a")];
+    const classification = classifyRetryResults({ first, second: [] });
+    assert.equal(classification.flakyRecovered.length, 1);
+    assert.equal(classification.confirmed.length, 0);
+    assert.equal(hasHardFailures(classification), false);
+    assert.equal(hasFlakyResults(classification), true);
+});
+
+test("classify: a failure that fails again on retry is confirmed and fatal", () => {
+    const first = [
+        withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+    ];
+    const second = [
+        { ...failure("/repo/ts/packages/a/test/x.spec.js", "broken") },
+    ].map((f) => ({ ...f, key: failureKey(f, cwd) }));
+    const classification = classifyRetryResults({ first, second });
+    assert.equal(classification.confirmed.length, 1);
+    assert.equal(classification.flakyRecovered.length, 0);
+    assert.equal(hasHardFailures(classification), true);
+});
+
+test("classify: a failure with no owning package is unretriable and fatal", () => {
+    const first = [withKey("<Jest run>", "jest crashed", undefined)];
+    const classification = classifyRetryResults({ first, second: [] });
+    assert.equal(classification.unretriable.length, 1);
+    assert.equal(hasHardFailures(classification), true);
+});
+
+test("classify: a test that only fails on retry is reported flaky, not fatal", () => {
+    const first = [
+        withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+    ];
+    const newFail = failure(
+        "/repo/ts/packages/a/test/x.spec.js",
+        "was passing",
+    );
+    const second = [
+        { ...failure("/repo/ts/packages/a/test/x.spec.js", "broken") },
+        newFail,
+    ].map((f) => ({ ...f, key: failureKey(f, cwd) }));
+    const classification = classifyRetryResults({ first, second });
+    assert.equal(classification.confirmed.length, 1);
+    assert.equal(classification.newOnRetry.length, 1);
+    assert.equal(classification.newOnRetry[0].fullName, "was passing");
+});
+
+test("classify: an untrusted (crashed) retry keeps round-1 failures as confirmed", () => {
+    const first = [
+        withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+    ];
+    const classification = classifyRetryResults({
+        first,
+        second: [],
+        retryTrusted: false,
+    });
+    assert.equal(classification.confirmed.length, 1);
+    assert.equal(classification.flakyRecovered.length, 0);
+    assert.equal(hasHardFailures(classification), true);
+});
+
+test("buildSummaryLines separates flaky from failed sections", () => {
+    const classification = {
+        confirmed: [
+            withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+        ],
+        flakyRecovered: [
+            withKey("/repo/ts/packages/b/test/y.spec.js", "flaky", "b"),
+        ],
+        newOnRetry: [],
+        unretriable: [],
+    };
+    const text = buildSummaryLines(classification).join("\n");
+    assert.match(text, /FLAKY TESTS \(1\)/);
+    assert.match(text, /FAILED TESTS \(1\)/);
+    assert.match(text, /broken/);
+    assert.match(text, /flaky/);
+});
+
+test("buildGithubAnnotations emits warnings for flaky and errors for failed", () => {
+    const classification = {
+        confirmed: [
+            withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+        ],
+        flakyRecovered: [
+            withKey("/repo/ts/packages/b/test/y.spec.js", "flaky", "b"),
+        ],
+        newOnRetry: [],
+        unretriable: [],
+    };
+    const annotations = buildGithubAnnotations(classification);
+    assert.ok(annotations.some((line) => line.startsWith("::warning ")));
+    assert.ok(annotations.some((line) => line.startsWith("::error ")));
+});
+
+test("buildStepSummaryMarkdown is empty when there is nothing to report", () => {
+    assert.equal(
+        buildStepSummaryMarkdown({
+            confirmed: [],
+            flakyRecovered: [],
+            newOnRetry: [],
+            unretriable: [],
+        }),
+        "",
+    );
+});
+
+test("buildStepSummaryMarkdown renders a table when there are results", () => {
+    const markdown = buildStepSummaryMarkdown({
+        confirmed: [
+            withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
+        ],
+        flakyRecovered: [],
+        newOnRetry: [],
+        unretriable: [],
+    });
+    assert.match(markdown, /### Test retry summary/);
+    assert.match(markdown, /Failed on retry/);
+    assert.match(markdown, /packages\/a\/test\/x\.spec\.js/);
+});
+
+// Guard against a regression in the path math the resolver relies on.
+test("path.relative stays inside the workspace for a real sub-package layout", () => {
+    const rel = path.relative(cwd, "/repo/ts/packages/a/dist/test/x.spec.js");
+    assert.ok(!rel.startsWith(".."));
+});

--- a/ts/tools/scripts/test/testRetry.spec.mjs
+++ b/ts/tools/scripts/test/testRetry.spec.mjs
@@ -113,10 +113,19 @@ test("classify: a failure that fails again on retry is confirmed and fatal", () 
         withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
     ];
     const second = [
-        { ...failure("/repo/ts/packages/a/test/x.spec.js", "broken") },
+        {
+            ...failure(
+                "/repo/ts/packages/a/test/x.spec.js",
+                "broken",
+                "retry failure",
+            ),
+        },
     ].map((f) => ({ ...f, key: failureKey(f, cwd) }));
     const classification = classifyRetryResults({ first, second });
     assert.equal(classification.confirmed.length, 1);
+    assert.deepEqual(classification.confirmed[0].failureMessages, [
+        "retry failure",
+    ]);
     assert.equal(classification.flakyRecovered.length, 0);
     assert.equal(hasHardFailures(classification), true);
 });
@@ -128,7 +137,7 @@ test("classify: a failure with no owning package is unretriable and fatal", () =
     assert.equal(hasHardFailures(classification), true);
 });
 
-test("classify: a test that only fails on retry is reported flaky, not fatal", () => {
+test("classify: a test that only fails on retry is fatal", () => {
     const first = [
         withKey("/repo/ts/packages/a/test/x.spec.js", "broken", "a"),
     ];
@@ -144,6 +153,7 @@ test("classify: a test that only fails on retry is reported flaky, not fatal", (
     assert.equal(classification.confirmed.length, 1);
     assert.equal(classification.newOnRetry.length, 1);
     assert.equal(classification.newOnRetry[0].fullName, "was passing");
+    assert.equal(hasHardFailures(classification), true);
 });
 
 test("classify: an untrusted (crashed) retry keeps round-1 failures as confirmed", () => {
@@ -160,6 +170,17 @@ test("classify: an untrusted (crashed) retry keeps round-1 failures as confirmed
     assert.equal(hasHardFailures(classification), true);
 });
 
+test("classify: a nonzero retry remains fatal even when failures were captured", () => {
+    const first = [withKey("/repo/ts/packages/a/test/x.spec.js", "flaky", "a")];
+    const classification = classifyRetryResults({
+        first,
+        second: [],
+        retryFailed: true,
+    });
+    assert.equal(classification.flakyRecovered.length, 1);
+    assert.equal(hasHardFailures(classification), true);
+});
+
 test("buildSummaryLines separates flaky from failed sections", () => {
     const classification = {
         confirmed: [
@@ -173,9 +194,36 @@ test("buildSummaryLines separates flaky from failed sections", () => {
     };
     const text = buildSummaryLines(classification).join("\n");
     assert.match(text, /FLAKY TESTS \(1\)/);
-    assert.match(text, /FAILED TESTS \(1\)/);
+    assert.match(text, /BUILD-BLOCKING TEST FAILURES \(1\)/);
     assert.match(text, /broken/);
     assert.match(text, /flaky/);
+});
+
+test("buildSummaryLines lists each flaky and confirmed test by name", () => {
+    const classification = {
+        confirmed: [
+            withKey(
+                "/repo/ts/packages/a/test/x.spec.js",
+                "confirmed failure",
+                "a",
+            ),
+        ],
+        flakyRecovered: [
+            withKey(
+                "/repo/ts/packages/b/test/y.spec.js",
+                "recovered flaky test",
+                "b",
+            ),
+        ],
+        newOnRetry: [],
+        unretriable: [],
+        retryFailed: true,
+    };
+    const text = buildSummaryLines(classification).join("\n");
+    assert.match(
+        text,
+        /FLAKY TESTS[\s\S]*recovered flaky test[\s\S]*BUILD-BLOCKING TEST FAILURES[\s\S]*confirmed failure/,
+    );
 });
 
 test("buildGithubAnnotations emits warnings for flaky and errors for failed", () => {
@@ -192,6 +240,27 @@ test("buildGithubAnnotations emits warnings for flaky and errors for failed", ()
     const annotations = buildGithubAnnotations(classification);
     assert.ok(annotations.some((line) => line.startsWith("::warning ")));
     assert.ok(annotations.some((line) => line.startsWith("::error ")));
+});
+
+test("buildGithubAnnotations reports new-on-retry failures as errors", () => {
+    const classification = {
+        confirmed: [],
+        flakyRecovered: [],
+        newOnRetry: [
+            withKey("/repo/ts/packages/a/test/x.spec.js", "new failure", "a"),
+        ],
+        unretriable: [],
+        retryFailed: true,
+    };
+    const annotations = buildGithubAnnotations(classification);
+    assert.ok(
+        annotations.some(
+            (line) =>
+                line.startsWith("::error title=Test failed::") &&
+                line.includes("new failure"),
+        ),
+    );
+    assert.ok(annotations.every((line) => !line.includes("passed only after")));
 });
 
 test("buildStepSummaryMarkdown is empty when there is nothing to report", () => {


### PR DESCRIPTION
Summary

• Add targeted retry handling to  build-ts : rerun only packages containing failed tests, serially.
• Emit console summaries, GitHub annotations, and step-summary tables.
• Replace timing-sensitive concurrency assertions with deterministic deferred promises
• Make heartbeat tests wait for observed ping cycles rather than fixed sleeps, while retaining CI-safe intervals (to test the actual protocol behavior rather than assuming based on elapsed time)

**Classify and report tests as:**
 - **Flaky**: failed initially, passed on retry.
 - **Build-blocking**: failed again, failed only on retry, could not be retried, or retry execution failed.
