### PR TITLE
Add agent-guided execution and rollout controls for macros

### DIFF
--- a/ts/packages/agentServer/client/src/agentServerClient.ts
+++ b/ts/packages/agentServer/client/src/agentServerClient.ts
@@ -54,6 +54,7 @@ import {
     RunMacroRequest,
     RunMacroResponse,
     SearchMacrosRequest,
+    SubmitMacroCandidateRequest,
     TraceSummary,
     ValidateMacroRequest,
     getDispatcherChannelName,
@@ -160,6 +161,9 @@ export type AgentServerConnection = {
     disableMacro(request: DisableMacroRequest): Promise<MacroVersionRef>;
     deleteMacro(request: DeleteMacroRequest): Promise<void>;
     runMacro(request: RunMacroRequest): Promise<RunMacroResponse>;
+    submitMacroCandidate(
+        request: SubmitMacroCandidateRequest,
+    ): Promise<MacroVersionRef>;
     cancelMacroRun(runId: string): Promise<void>;
     getMacroRun(runId: string): Promise<MacroRunRecord>;
 
@@ -394,6 +398,12 @@ export function createAgentServerConnection(
 
         async runMacro(request: RunMacroRequest): Promise<RunMacroResponse> {
             return rpc.invoke("runMacro", request);
+        },
+
+        async submitMacroCandidate(
+            request: SubmitMacroCandidateRequest,
+        ): Promise<MacroVersionRef> {
+            return rpc.invoke("submitMacroCandidate", request);
         },
 
         async cancelMacroRun(runId: string): Promise<void> {

--- a/ts/packages/agentServer/client/test/conversation-stubConnection.ts
+++ b/ts/packages/agentServer/client/test/conversation-stubConnection.ts
@@ -160,6 +160,9 @@ export function makeStubConnection(
         async runMacro() {
             throw new Error("Not implemented by conversation test stub");
         },
+        async submitMacroCandidate() {
+            throw new Error("Not implemented by conversation test stub");
+        },
         async cancelMacroRun() {},
         async getMacroRun() {
             throw new Error("Not implemented by conversation test stub");

--- a/ts/packages/agentServer/protocol/src/index.ts
+++ b/ts/packages/agentServer/protocol/src/index.ts
@@ -48,6 +48,7 @@ export {
     RunMacroRequest,
     RunMacroResponse,
     SearchMacrosRequest,
+    SubmitMacroCandidateRequest,
     TraceSummary,
     ValidateMacroRequest,
     getDispatcherChannelName,

--- a/ts/packages/agentServer/protocol/src/protocol.ts
+++ b/ts/packages/agentServer/protocol/src/protocol.ts
@@ -27,6 +27,7 @@ import type {
     RunMacroRequest,
     RunMacroResponse,
     SearchMacrosRequest,
+    SubmitMacroCandidateRequest,
     TraceSummary,
     ValidateMacroRequest,
 } from "@typeagent/copilot-macros";
@@ -55,6 +56,7 @@ export type {
     RunMacroRequest,
     RunMacroResponse,
     SearchMacrosRequest,
+    SubmitMacroCandidateRequest,
     TraceSummary,
     ValidateMacroRequest,
 } from "@typeagent/copilot-macros";
@@ -213,6 +215,9 @@ export type AgentServerInvokeFunctions = {
     disableMacro: (request: DisableMacroRequest) => Promise<MacroVersionRef>;
     deleteMacro: (request: DeleteMacroRequest) => Promise<void>;
     runMacro: (request: RunMacroRequest) => Promise<RunMacroResponse>;
+    submitMacroCandidate: (
+        request: SubmitMacroCandidateRequest,
+    ) => Promise<MacroVersionRef>;
     cancelMacroRun: (runId: string) => Promise<void>;
     getMacroRun: (runId: string) => Promise<MacroRunRecord>;
 

--- a/ts/packages/agentServer/server/src/connectionHandler.ts
+++ b/ts/packages/agentServer/server/src/connectionHandler.ts
@@ -284,6 +284,8 @@ export function createAgentServerConnectionHandler(
             disableMacro: async (request) => macroManager.disableMacro(request),
             deleteMacro: async (request) => macroManager.deleteMacro(request),
             runMacro: async (request) => macroManager.runMacro(request),
+            submitMacroCandidate: async (request) =>
+                macroManager.submitMacroCandidate(request),
             cancelMacroRun: async (runId) => macroManager.cancelMacroRun(runId),
             getMacroRun: async (runId) => macroManager.getMacroRun(runId),
 

--- a/ts/packages/agentServer/server/test/macroRecordingRpc.spec.ts
+++ b/ts/packages/agentServer/server/test/macroRecordingRpc.spec.ts
@@ -124,7 +124,41 @@ describe("macro recording RPC", () => {
             status: "completed",
             macroId: approved.macroId,
         });
-
+        const approvedMacro = await connection.inspectMacro(approved);
+        await expect(
+            connection.runMacro({
+                runId: "agent-run-1",
+                macroId: approved.macroId,
+                version: approved.version,
+                preference: "agent",
+            }),
+        ).resolves.toMatchObject({
+            status: "agentRequired",
+            launch: {
+                agent: "typeagent-macro-runner",
+                candidate: { handoffRunId: "agent-run-1" },
+            },
+        });
+        const candidate = await connection.submitMacroCandidate({
+            sourceMacroId: approved.macroId,
+            sourceVersion: approved.version,
+            handoffRunId: "agent-run-1",
+            reason: "Adapted during agent-guided execution.",
+            inputs: approvedMacro.inputs,
+            steps: approvedMacro.steps,
+            executionEvidence: {
+                outcome: "completed",
+                toolCalls: 1,
+                retries: 0,
+                durationMs: 100,
+                tokensUsed: 100,
+                steps: [{ stepId: "step-1", status: "completed" }],
+            },
+        });
+        expect(candidate).toMatchObject({ version: 3, state: "draft" });
+        await expect(connection.inspectMacro(approved)).resolves.toMatchObject({
+            state: "approved",
+        });
         await connection.close();
     });
 });

--- a/ts/packages/agents/browserExtension/src/extension/serviceWorker/dispatcherConnection.ts
+++ b/ts/packages/agents/browserExtension/src/extension/serviceWorker/dispatcherConnection.ts
@@ -570,6 +570,7 @@ function makeConnectionAdapter(): AgentServerConnection {
         disableMacro: () => notSupported("disableMacro"),
         deleteMacro: () => notSupported("deleteMacro"),
         runMacro: () => notSupported("runMacro"),
+        submitMacroCandidate: () => notSupported("submitMacroCandidate"),
         cancelMacroRun: () => notSupported("cancelMacroRun"),
         getMacroRun: () => notSupported("getMacroRun"),
 

--- a/ts/packages/copilot-macros/src/contracts.ts
+++ b/ts/packages/copilot-macros/src/contracts.ts
@@ -99,6 +99,15 @@ export interface CopilotToolMacro {
     sourceTraceId: string;
     createdAt: string;
     warnings: string[];
+    candidateProvenance?: MacroCandidateProvenance;
+}
+
+export interface MacroCandidateProvenance {
+    sourceMacroId: string;
+    sourceVersion: number;
+    handoffRunId: string;
+    reason: string;
+    submittedAt: string;
 }
 
 export interface MacroSummary {
@@ -199,6 +208,50 @@ export interface RunMacroRequest extends InspectMacroRequest {
     dryRun?: boolean;
 }
 
+export interface AgentRunnerLaunchPayload {
+    agent: "typeagent-macro-runner";
+    macro: CopilotToolMacro;
+    inputs: Record<string, unknown>;
+    reason: {
+        code: "agentRequested" | "agentRequired";
+        message: string;
+        stepIds: string[];
+    };
+    budgets: {
+        maxToolCalls: number;
+        maxRetries: number;
+        timeoutMs: number;
+        maxTokens: number;
+    };
+    candidate: {
+        sourceMacroId: string;
+        sourceVersion: number;
+        handoffRunId: string;
+    };
+}
+
+export interface SubmitMacroCandidateRequest {
+    sourceMacroId: string;
+    sourceVersion: number;
+    handoffRunId: string;
+    reason: string;
+    name?: string;
+    description?: string;
+    inputs: MacroInput[];
+    steps: MacroStep[];
+    executionEvidence: {
+        outcome: "completed";
+        toolCalls: number;
+        retries: number;
+        durationMs: number;
+        tokensUsed: number;
+        steps: Array<{
+            stepId: string;
+            status: "completed" | "failed" | "denied" | "cancelled";
+        }>;
+    };
+}
+
 export interface MacroRunStep {
     stepId: string;
     toolName: string;
@@ -239,6 +292,7 @@ export type RunMacroResponse =
           macroId: string;
           version: number;
           reason: string;
+          launch: AgentRunnerLaunchPayload;
       };
 
 export interface ReplayToolDescriptor {

--- a/ts/packages/copilot-macros/src/macroManager.ts
+++ b/ts/packages/copilot-macros/src/macroManager.ts
@@ -3,7 +3,14 @@
 
 import { randomUUID } from "node:crypto";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+    appendFile,
+    mkdir,
+    readFile,
+    rename,
+    rm,
+    writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import type {
     ApproveMacroRequest,
@@ -31,6 +38,7 @@ import type {
     RunMacroRequest,
     RunMacroResponse,
     ValidateMacroRequest,
+    SubmitMacroCandidateRequest,
 } from "./contracts.js";
 import {
     inspectReplayTools,
@@ -44,6 +52,21 @@ import { redactTraceValue } from "./redaction.js";
 const defaultRecordingTtlMs = 10 * 60 * 1000;
 const maxPersistedRunValueBytes = 256 * 1024;
 const maxPersistedRunPreviewCharacters = 16 * 1024;
+const maxCandidateBytes = 256 * 1024;
+const maxCandidateItems = 100;
+
+interface AgentHandoffRecord {
+    runId: string;
+    macroId: string;
+    version: number;
+    createdAt: string;
+    budgets: {
+        maxToolCalls: number;
+        maxRetries: number;
+        timeoutMs: number;
+        maxTokens: number;
+    };
+}
 
 function sanitizeRunValue(value: unknown): unknown {
     const redacted = redactTraceValue(value);
@@ -378,6 +401,133 @@ export class MacroManager {
         });
     }
 
+    async submitMacroCandidate(
+        request: SubmitMacroCandidateRequest,
+    ): Promise<MacroVersionRef> {
+        if (!request.reason.trim() || request.reason.length > 2_000) {
+            throw new Error("A bounded candidate reason is required.");
+        }
+        this.validateMacroId(request.handoffRunId);
+        if (
+            request.inputs.length > maxCandidateItems ||
+            request.steps.length === 0 ||
+            request.steps.length > maxCandidateItems ||
+            Buffer.byteLength(JSON.stringify(request)) > maxCandidateBytes
+        ) {
+            throw new Error("Macro candidate exceeds submission limits.");
+        }
+        if (
+            request.steps.some(
+                (step) =>
+                    (step.executionClass !== "replayable" &&
+                        step.executionClass !== "agentRequired") ||
+                    !step.id.trim() ||
+                    !step.toolName.trim() ||
+                    !step.sourceToolCallId.trim(),
+            )
+        ) {
+            throw new Error("Macro candidate contains an invalid step.");
+        }
+        return this.mutateCatalog(async () => {
+            const source = await this.inspectMacro({
+                macroId: request.sourceMacroId,
+                version: request.sourceVersion,
+            });
+            if (source.state !== "approved") {
+                throw new Error(
+                    "Macro candidates must derive from an approved version.",
+                );
+            }
+            const handoff = await this.readJson<AgentHandoffRecord>(
+                this.handoffPath(request.handoffRunId),
+                `Agent handoff not found: ${request.handoffRunId}`,
+            );
+            if (
+                handoff.macroId !== source.macroId ||
+                handoff.version !== source.version
+            ) {
+                throw new Error(
+                    "Macro candidate provenance does not match its agent handoff.",
+                );
+            }
+            if (
+                request.executionEvidence.outcome !== "completed" ||
+                request.executionEvidence.toolCalls < 0 ||
+                request.executionEvidence.toolCalls >
+                    handoff.budgets.maxToolCalls ||
+                request.executionEvidence.retries < 0 ||
+                request.executionEvidence.retries >
+                    handoff.budgets.maxRetries ||
+                request.executionEvidence.durationMs < 0 ||
+                request.executionEvidence.durationMs >
+                    handoff.budgets.timeoutMs ||
+                request.executionEvidence.tokensUsed < 0 ||
+                request.executionEvidence.tokensUsed >
+                    handoff.budgets.maxTokens ||
+                request.executionEvidence.steps.length !==
+                    request.steps.length ||
+                request.executionEvidence.steps.some(
+                    (step) => step.status !== "completed",
+                ) ||
+                request.steps.some(
+                    (step) =>
+                        !request.executionEvidence.steps.some(
+                            (evidence) => evidence.stepId === step.id,
+                        ),
+                )
+            ) {
+                throw new Error(
+                    "Macro candidate execution evidence exceeds its handoff budget.",
+                );
+            }
+            const latest = await this.getLatestSummary(source.macroId);
+            const createdAt = new Date().toISOString();
+            const candidate: CopilotToolMacro = {
+                ...source,
+                version: latest.version + 1,
+                name: request.name?.trim() || source.name,
+                description: request.description?.trim() || source.description,
+                state: "draft",
+                executionClass: request.steps.every(
+                    (step) => step.executionClass === "replayable",
+                )
+                    ? "replayable"
+                    : "agentRequired",
+                inputs: request.inputs,
+                steps: request.steps,
+                createdAt,
+                warnings: [
+                    ...source.warnings,
+                    "Agent-guided adaptation requires explicit review and approval.",
+                ],
+                candidateProvenance: {
+                    sourceMacroId: source.macroId,
+                    sourceVersion: source.version,
+                    handoffRunId: request.handoffRunId,
+                    reason: request.reason.trim(),
+                    submittedAt: createdAt,
+                },
+            };
+            const report = validateMacro(
+                candidate,
+                await this.readTrace(source.sourceTraceId),
+            );
+            if (!report.valid) {
+                throw new Error(
+                    `Macro candidate validation failed: ${report.issues
+                        .filter((issue) => issue.severity === "error")
+                        .map((issue) => issue.message)
+                        .join("; ")}`,
+                );
+            }
+            await this.writeVersion(candidate);
+            await this.upsertSummary(candidate);
+            await this.recordMetric("candidate", "submitted");
+            await rm(this.handoffPath(request.handoffRunId), { force: true });
+            return this.versionRef(candidate);
+        });
+    }
+
     async runMacro(request: RunMacroRequest): Promise<RunMacroResponse> {
         this.validateMacroId(request.runId);
         if (this.activeRuns.has(request.runId)) {
@@ -395,15 +545,55 @@ export class MacroManager {
             if (preference === "replay") {
                 throw new Error("This macro requires agent-guided execution.");
             }
+            const agentStepIds = macro.steps
+                .filter((step) => step.executionClass === "agentRequired")
+                .map((step) => step.id);
+            const reason =
+                preference === "agent"
+                    ? "Agent-guided execution was requested."
+                    : "The macro contains steps that are not replayable.";
+            const budgets = {
+                maxToolCalls: Math.max(macro.steps.length * 2, 10),
+                maxRetries: 1,
+                timeoutMs: Math.min(
+                    Math.max(request.timeoutMs ?? 10 * 60_000, 1),
+                    10 * 60_000,
+                ),
+                maxTokens: 16_000,
+            };
+            await this.writeAgentHandoff({
+                runId: request.runId,
+                macroId: macro.macroId,
+                version: macro.version,
+                createdAt: new Date().toISOString(),
+                budgets,
+            });
+            await this.recordMetric("agentHandoff", "required");
             return {
                 status: "agentRequired",
                 runId: request.runId,
                 macroId: macro.macroId,
                 version: macro.version,
-                reason:
-                    preference === "agent"
-                        ? "Agent-guided execution was requested."
-                        : "The macro contains steps that are not replayable.",
+                reason,
+                launch: {
+                    agent: "typeagent-macro-runner",
+                    macro,
+                    inputs: request.inputs ?? {},
+                    reason: {
+                        code:
+                            preference === "agent"
+                                ? "agentRequested"
+                                : "agentRequired",
+                        message: reason,
+                        stepIds: agentStepIds,
+                    },
+                    budgets,
+                    candidate: {
+                        sourceMacroId: macro.macroId,
+                        sourceVersion: macro.version,
+                        handoffRunId: request.runId,
+                    },
+                },
             };
         }
         if (!this.replayHost) {
@@ -485,6 +675,7 @@ export class MacroManager {
             };
         }
         run = await this.writeRun(run, macro);
+        await this.recordMetric("replay", run.status);
         return { status: run.status, run } as RunMacroResponse;
     }
 
@@ -630,6 +821,34 @@ export class MacroManager {
 
     private runPath(runId: string): string {
         return path.join(this.rootDir, "runs", `${runId}.json`);
+    }
+
+    private handoffPath(runId: string): string {
+        return path.join(this.rootDir, "handoffs", `${runId}.json`);
+    }
+
+    private async writeAgentHandoff(
+        handoff: AgentHandoffRecord,
+    ): Promise<void> {
+        const destination = this.handoffPath(handoff.runId);
+        await mkdir(path.dirname(destination), { recursive: true });
+        await writeFile(destination, JSON.stringify(handoff, undefined, 2), {
+            encoding: "utf8",
+            flag: "wx",
+        });
+    }
+
+    private async recordMetric(
+        operation: "replay" | "agentHandoff" | "candidate",
+        outcome: string,
+    ): Promise<void> {
+        const destination = path.join(this.rootDir, "metrics.jsonl");
+        await mkdir(path.dirname(destination), { recursive: true });
+        await appendFile(
+            destination,
+            `${JSON.stringify({ timestamp: new Date().toISOString(), operation, outcome })}\n`,
+            "utf8",
+        ).catch(() => undefined);
     }
 
     private async writeRun(

--- a/ts/packages/copilot-macros/test/macroCatalog.spec.ts
+++ b/ts/packages/copilot-macros/test/macroCatalog.spec.ts
@@ -162,6 +162,96 @@ describe("MacroManager draft catalog", () => {
             version: 2,
             state: "approved",
         });
+        const handoff = await manager.runMacro({
+            runId: "agent-run-1",
+            macroId: agentDraft.macroId,
+        });
+        expect(handoff).toMatchObject({
+            status: "agentRequired",
+            launch: {
+                agent: "typeagent-macro-runner",
+                macro: { macroId: agentDraft.macroId, version: 2 },
+                reason: { stepIds: ["step-1"] },
+                candidate: { handoffRunId: "agent-run-1" },
+            },
+        });
+        const approved = await manager.inspectMacro({
+            macroId: agentDraft.macroId,
+            version: 2,
+        });
+        await expect(
+            manager.submitMacroCandidate({
+                sourceMacroId: approved.macroId,
+                sourceVersion: approved.version,
+                handoffRunId: "agent-run-1",
+                reason: "Permission was denied.",
+                inputs: approved.inputs,
+                steps: approved.steps,
+                executionEvidence: {
+                    outcome: "completed",
+                    toolCalls: 1,
+                    retries: 0,
+                    durationMs: 100,
+                    tokensUsed: 100,
+                    steps: [{ stepId: "step-1", status: "denied" }],
+                },
+            }),
+        ).rejects.toThrow("execution evidence");
+        const candidate = await manager.submitMacroCandidate({
+            sourceMacroId: approved.macroId,
+            sourceVersion: approved.version,
+            handoffRunId: "agent-run-1",
+            reason: "Adapted the native tool arguments.",
+            inputs: approved.inputs,
+            steps: approved.steps,
+            executionEvidence: {
+                outcome: "completed",
+                toolCalls: 1,
+                retries: 0,
+                durationMs: 100,
+                tokensUsed: 100,
+                steps: [{ stepId: "step-1", status: "completed" }],
+            },
+        });
+        expect(candidate).toMatchObject({ version: 3, state: "draft" });
+        await expect(
+            manager.inspectMacro({
+                macroId: approved.macroId,
+                version: approved.version,
+            }),
+        ).resolves.toMatchObject({ state: "approved" });
+        await expect(manager.inspectMacro(candidate)).resolves.toMatchObject({
+            state: "draft",
+            candidateProvenance: {
+                sourceVersion: 2,
+                handoffRunId: "agent-run-1",
+            },
+        });
+        await expect(
+            manager.submitMacroCandidate({
+                sourceMacroId: approved.macroId,
+                sourceVersion: approved.version,
+                handoffRunId: "unknown-run",
+                reason: "This content must not become telemetry.",
+                inputs: approved.inputs,
+                steps: approved.steps,
+                executionEvidence: {
+                    outcome: "completed",
+                    toolCalls: 1,
+                    retries: 0,
+                    durationMs: 100,
+                    tokensUsed: 100,
+                    steps: [{ stepId: "step-1", status: "completed" }],
+                },
+            }),
+        ).rejects.toThrow("Agent handoff not found");
+        const metrics = await readFile(
+            path.join(instanceDir, "copilot-macros", "metrics.jsonl"),
+            "utf8",
+        );
+        expect(metrics).toContain('"operation":"agentHandoff"');
+        expect(metrics).toContain('"operation":"candidate"');
+        expect(metrics).not.toContain("Adapted the native tool arguments");
         await expect(
             manager.inspectMacro({ macroId: agentDraft.macroId }),
         ).resolves.toMatchObject({

--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -169,6 +169,47 @@ Check that the plugin loaded:
 
 Should show `typeagent` under the plugins section.
 
+## Tool-Composed Macros
+
+The plugin includes the `typeagent-macros` MCP server, the TypeAgent Macro
+Runner agent, and the `typeagent-macros` skill. Approved replayable macros run
+deterministically. If `run_macro` returns `agentRequired`, the skill hands the
+complete launch payload to the runner, which executes the whole macro through
+Copilot's live tool and permission surface.
+
+Agent-guided adaptations may be saved only through
+`submit_macro_candidate`. The server validates handoff provenance, execution
+budgets, and macro structure, then creates a new draft. It never mutates or
+promotes the approved version.
+
+### Rollout Controls
+
+Each macro boundary is enabled by default and can be disabled independently:
+
+| Environment variable                    | Boundary                   |
+| --------------------------------------- | -------------------------- |
+| `TYPEAGENT_MACRO_RECORDING_ENABLED`     | Explicit trace recording   |
+| `TYPEAGENT_MACRO_INDUCTION_ENABLED`     | Draft creation from traces |
+| `TYPEAGENT_MACRO_REPLAY_ENABLED`        | Deterministic replay       |
+| `TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED` | Agent-runner handoff       |
+
+Set a variable to `0`, `false`, or `off` before starting Copilot to disable
+that boundary. `@typeagent status` reports the effective settings. These flags
+do not change direct, MCP, dev, or PowerShell mode selection.
+
+### Recovery And Rollback
+
+Macro data is stored under the agent-server instance directory in
+`copilot-macros/`. Back up that directory before schema or deployment changes.
+Run records, handoffs, and immutable macro versions are separate files;
+`metrics.jsonl` contains only timestamp, operation, and outcome.
+
+To stop a rollout, disable the affected boundary and restart Copilot. Existing
+approved versions and drafts remain intact. Restore the backed-up
+`copilot-macros/` directory only while agent-server is stopped. To roll back the
+plugin, reinstall the previous plugin snapshot and leave the newer boundary
+disabled until compatibility is confirmed.
+
 ---
 
 ## Install Globally (available in every `copilot` session)

--- a/ts/packages/copilot-plugin/agents/typeagent-macro-runner.agent.md
+++ b/ts/packages/copilot-plugin/agents/typeagent-macro-runner.agent.md
@@ -1,0 +1,46 @@
+---
+name: typeagent-macro-runner
+description: "Runs an approved TypeAgent macro from a structured agentRequired handoff using live Copilot tools and permissions. Use when run_macro returns a typeagent-macro-runner launch payload."
+tools:
+  - read
+  - search
+  - edit
+  - execute
+  - typeagent-workspace/*
+  - typeagent-macros/inspect_macro
+  - typeagent-macros/submit_macro_candidate
+user-invocable: false
+---
+
+Execute exactly one approved TypeAgent macro from the supplied structured
+launch payload.
+
+## Required Input
+
+Require the complete `launch` object returned by `run_macro`. Reject requests
+that provide only a macro name or free-form procedure.
+
+## Procedure
+
+1. Call `inspect_macro` with `launch.macro.macroId` and
+   `launch.macro.version`. Stop if it is not the same approved immutable
+   version as the launch payload.
+2. Execute the whole macro in step order using the supplied inputs and prior
+   step results. Do not split execution between deterministic replay and this
+   runner.
+3. Use Copilot's live tool permissions. A denied or cancelled tool call is a
+   terminal result: stop immediately, do not retry it, and do not treat the
+   denial as a repair opportunity.
+4. Stay within `launch.budgets.maxToolCalls`, `maxRetries`, `timeoutMs`, and
+   `maxTokens`. Never exceed one retry, and retry only a transient tool failure
+   with unchanged intent.
+5. Return concise evidence for each attempted step and the final outcome. Do
+   not include secret input values in the response.
+6. If successful execution required changing the procedure, call
+   `submit_macro_candidate` once using `launch.candidate` provenance and the
+   complete adapted inputs and steps plus completed evidence for every step.
+   The result must remain a draft for explicit review. Never approve, promote,
+   or mutate the approved version.
+
+Do not call `run_macro` recursively. Do not submit a candidate after permission
+denial, cancellation, timeout, or an unsuccessful adaptation.

--- a/ts/packages/copilot-plugin/skills/typeagent-macros/SKILL.md
+++ b/ts/packages/copilot-plugin/skills/typeagent-macros/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: typeagent-macros
+description: "Discover, inspect, validate, and run TypeAgent tool-composed macros. Use when a user asks to repeat a recorded workflow or run, adapt, repair, or manage a TypeAgent macro."
+---
+
+# TypeAgent Macros
+
+Use the `typeagent-macros` MCP server for macro catalog and lifecycle work.
+
+## Run A Macro
+
+1. Use `search_macros` or `list_macros` to find the macro.
+2. Use `inspect_macro` and `get_macro_requirements` before execution. Collect
+   all required inputs without exposing secret values in chat.
+3. Call `run_macro` with `preference: "auto"`.
+4. For `completed`, report the sanitized result. For `failed` or `cancelled`,
+   report the structured failure without inventing a repair.
+5. For `agentRequired`, invoke the `TypeAgent Macro Runner` agent with the
+   complete returned `launch` object. Do not manually paraphrase or reconstruct
+   the launch payload.
+
+Deterministic replay and agent-guided execution are whole-macro choices. Never
+replay a prefix before handing the remaining steps to the runner.
+
+## Adaptation
+
+The runner may submit a changed successful procedure through
+`submit_macro_candidate`. Candidate submission creates a separately reviewable
+draft. It never changes or approves the source version. Permission denial,
+cancellation, and timeout are terminal outcomes, not adaptation signals.
+
+## Lifecycle
+
+- Create drafts only from explicitly captured traces.
+- Validate drafts before asking the user to approve them.
+- Approval is always an explicit user action.
+- Use `get_macro_run` only for sanitized persisted deterministic run evidence.

--- a/ts/packages/copilot-plugin/src/hooks/hook-router.ts
+++ b/ts/packages/copilot-plugin/src/hooks/hook-router.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import type { HookInput, HookOutput } from "./types.js";
 import { connectToAgentServer } from "../shared/typeagent-client.js";
 import { redactTraceValue } from "@typeagent/copilot-macros";
+import { getMacroFeatures } from "../shared/macro-features.js";
 import {
     getConfigPath,
     getMode,
@@ -296,6 +297,7 @@ export async function routePrompt(
 }
 
 async function claimMacroRecording(input: HookInput): Promise<boolean> {
+    if (!getMacroFeatures().recording) return false;
     let connection;
     try {
         connection = await connectToAgentServer();

--- a/ts/packages/copilot-plugin/src/mcp/macroServer.ts
+++ b/ts/packages/copilot-plugin/src/mcp/macroServer.ts
@@ -7,17 +7,27 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { AgentServerConnection } from "@typeagent/agent-server-client";
+import type {
+    SubmitMacroCandidateRequest,
+    ValueExpression,
+} from "@typeagent/copilot-macros";
 import { connectToAgentServer } from "../shared/typeagent-client.js";
 import { getMode, type Mode } from "../shared/plugin-config.js";
+import {
+    getMacroFeatures,
+    type MacroFeatures,
+} from "../shared/macro-features.js";
 
 export interface MacroServerDependencies {
     connect: () => Promise<AgentServerConnection>;
     getMode: () => Mode;
+    getFeatures?: () => MacroFeatures;
 }
 
 const defaultDependencies: MacroServerDependencies = {
     connect: connectToAgentServer,
     getMode,
+    getFeatures: getMacroFeatures,
 };
 
 function result(value: unknown): CallToolResult {
@@ -96,6 +106,11 @@ export class MacroCatalogAdapter {
         name: string;
         description?: string | undefined;
     }) {
+        if (!this.features().induction) {
+            return Promise.resolve(
+                errorResult("Macro induction is disabled by configuration."),
+            );
+        }
         return this.call((connection) =>
             connection.createMacroFromTrace({
                 traceId: request.traceId,
@@ -134,6 +149,12 @@ export class MacroCatalogAdapter {
         return this.call((connection) => connection.getMacroRun(request.runId));
     }
 
+    submitMacroCandidate(request: SubmitMacroCandidateRequest) {
+        return this.call((connection) =>
+            connection.submitMacroCandidate(request),
+        );
+    }
+
     async runMacro(
         request: {
             macroId: string;
@@ -156,6 +177,26 @@ export class MacroCatalogAdapter {
         try {
             connection = await this.dependencies.connect();
             const activeConnection = connection;
+            const features = this.features();
+            if (!features.replay || !features.agentHandoff) {
+                const requirements = await connection.getMacroRequirements(
+                    this.macroRef(request),
+                );
+                const usesAgent =
+                    request.preference === "agent" ||
+                    (request.preference !== "replay" &&
+                        requirements.executionClass === "agentRequired");
+                if (usesAgent && !features.agentHandoff) {
+                    return errorResult(
+                        "Macro agent-runner handoff is disabled by configuration.",
+                    );
+                }
+                if (!usesAgent && !features.replay) {
+                    return errorResult(
+                        "Deterministic macro replay is disabled by configuration.",
+                    );
+                }
+            }
             if (signal) {
                 const cancel = () => {
                     void activeConnection.cancelMacroRun(runId);
@@ -204,6 +245,10 @@ export class MacroCatalogAdapter {
         };
     }
 
+    private features(): MacroFeatures {
+        return this.dependencies.getFeatures?.() ?? getMacroFeatures();
+    }
+
     private async call(
         operation: (connection: AgentServerConnection) => Promise<unknown>,
     ): Promise<CallToolResult> {
@@ -228,6 +273,33 @@ const macroRefSchema = {
     macroId: z.string().min(1),
     version: z.number().int().positive().optional(),
 };
+
+const valueExpressionSchema = z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("literal"), value: z.unknown() }),
+    z.object({ kind: z.literal("input"), name: z.string().min(1) }),
+    z.object({
+        kind: z.literal("stepResult"),
+        stepId: z.string().min(1),
+        path: z.array(z.string()).optional(),
+    }),
+]);
+
+const macroInputSchema = z.object({
+    name: z.string().min(1),
+    description: z.string(),
+    required: z.boolean(),
+    secret: z.boolean(),
+});
+
+const macroStepSchema = z.object({
+    id: z.string().min(1),
+    toolName: z.string().min(1),
+    mcpServerName: z.string().min(1).optional(),
+    arguments: valueExpressionSchema,
+    executionClass: z.enum(["replayable", "agentRequired"]),
+    sourceToolCallId: z.string().min(1),
+    schemaFingerprint: z.string().optional(),
+});
 
 export class TypeAgentMacroMcpServer {
     private readonly server = new McpServer({
@@ -318,6 +390,69 @@ export class TypeAgentMacroMcpServer {
             "Inspect a sanitized macro run record.",
             { runId: z.string().min(1) },
             (request) => adapter.getMacroRun(request),
+        );
+        this.server.tool(
+            "submit_macro_candidate",
+            "Save an agent-guided adaptation as a validated draft version for explicit review.",
+            {
+                sourceMacroId: z.string().min(1),
+                sourceVersion: z.number().int().positive(),
+                handoffRunId: z.string().min(1),
+                reason: z.string().min(1).max(2_000),
+                name: z.string().min(1).optional(),
+                description: z.string().optional(),
+                inputs: z.array(macroInputSchema).max(100),
+                steps: z.array(macroStepSchema).min(1).max(100),
+                executionEvidence: z.object({
+                    outcome: z.literal("completed"),
+                    toolCalls: z.number().int().nonnegative(),
+                    retries: z.number().int().nonnegative(),
+                    durationMs: z.number().nonnegative(),
+                    tokensUsed: z.number().int().nonnegative(),
+                    steps: z
+                        .array(
+                            z.object({
+                                stepId: z.string().min(1),
+                                status: z.enum([
+                                    "completed",
+                                    "failed",
+                                    "denied",
+                                    "cancelled",
+                                ]),
+                            }),
+                        )
+                        .min(1)
+                        .max(100),
+                }),
+            },
+            (request) =>
+                adapter.submitMacroCandidate({
+                    sourceMacroId: request.sourceMacroId,
+                    sourceVersion: request.sourceVersion,
+                    handoffRunId: request.handoffRunId,
+                    reason: request.reason,
+                    inputs: request.inputs,
+                    executionEvidence: request.executionEvidence,
+                    steps: request.steps.map((step) => ({
+                        id: step.id,
+                        toolName: step.toolName,
+                        ...(step.mcpServerName !== undefined
+                            ? { mcpServerName: step.mcpServerName }
+                            : {}),
+                        arguments: step.arguments as ValueExpression,
+                        executionClass: step.executionClass,
+                        sourceToolCallId: step.sourceToolCallId,
+                        ...(step.schemaFingerprint !== undefined
+                            ? { schemaFingerprint: step.schemaFingerprint }
+                            : {}),
+                    })),
+                    ...(request.name !== undefined
+                        ? { name: request.name }
+                        : {}),
+                    ...(request.description !== undefined
+                        ? { description: request.description }
+                        : {}),
+                }),
         );
     }
 

--- a/ts/packages/copilot-plugin/src/mcp/serverSelector.ts
+++ b/ts/packages/copilot-plugin/src/mcp/serverSelector.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export type McpServerKind = "agent" | "workspace" | "macros";
+
+export function selectMcpServer(args: readonly string[]): McpServerKind {
+    const selectors = ["--workspace", "--macros"].filter((selector) =>
+        args.includes(selector),
+    );
+    if (selectors.length > 1) {
+        throw new Error(
+            `Conflicting MCP server selectors: ${selectors.join(", ")}`,
+        );
+    }
+    if (args.includes("--workspace")) return "workspace";
+    if (args.includes("--macros")) return "macros";
+    return "agent";
+}

--- a/ts/packages/copilot-plugin/src/shared/macro-features.ts
+++ b/ts/packages/copilot-plugin/src/shared/macro-features.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface MacroFeatures {
+    recording: boolean;
+    induction: boolean;
+    replay: boolean;
+    agentHandoff: boolean;
+}
+
+function enabled(name: string): boolean {
+    const value = process.env[name]?.trim().toLowerCase();
+    return value !== "0" && value !== "false" && value !== "off";
+}
+
+export function getMacroFeatures(): MacroFeatures {
+    return {
+        recording: enabled("TYPEAGENT_MACRO_RECORDING_ENABLED"),
+        induction: enabled("TYPEAGENT_MACRO_INDUCTION_ENABLED"),
+        replay: enabled("TYPEAGENT_MACRO_REPLAY_ENABLED"),
+        agentHandoff: enabled("TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED"),
+    };
+}

--- a/ts/packages/copilot-plugin/test/macroFeatures.spec.ts
+++ b/ts/packages/copilot-plugin/test/macroFeatures.spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getMacroFeatures } from "../src/shared/macro-features.js";
+
+const names = [
+    "TYPEAGENT_MACRO_RECORDING_ENABLED",
+    "TYPEAGENT_MACRO_INDUCTION_ENABLED",
+    "TYPEAGENT_MACRO_REPLAY_ENABLED",
+    "TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED",
+] as const;
+
+describe("macro feature flags", () => {
+    const original = Object.fromEntries(
+        names.map((name) => [name, process.env[name]]),
+    );
+
+    afterEach(() => {
+        for (const name of names) {
+            const value = original[name];
+            if (value === undefined) delete process.env[name];
+            else process.env[name] = value;
+        }
+    });
+
+    it("enables every boundary by default", () => {
+        for (const name of names) delete process.env[name];
+
+        expect(getMacroFeatures()).toEqual({
+            recording: true,
+            induction: true,
+            replay: true,
+            agentHandoff: true,
+        });
+    });
+
+    it.each(["0", "false", "off"])("recognizes %s as disabled", (value) => {
+        for (const name of names) process.env[name] = value;
+
+        expect(getMacroFeatures()).toEqual({
+            recording: false,
+            induction: false,
+            replay: false,
+            agentHandoff: false,
+        });
+    });
+});

--- a/ts/packages/copilot-plugin/test/macroServer.spec.ts
+++ b/ts/packages/copilot-plugin/test/macroServer.spec.ts
@@ -6,6 +6,7 @@ import type { AgentServerConnection } from "@typeagent/agent-server-client";
 import type {
     RunMacroRequest,
     RunMacroResponse,
+    SubmitMacroCandidateRequest,
 } from "@typeagent/copilot-macros";
 import { MacroCatalogAdapter } from "../src/mcp/macroServer.js";
 
@@ -66,6 +67,109 @@ describe("macro MCP catalog adapter", () => {
         expect(connect).not.toHaveBeenCalled();
     });
 
+    it("can disable replay without disabling agent handoff", async () => {
+        const runMacro = jest.fn(async (request: RunMacroRequest) => ({
+            status: "agentRequired" as const,
+            runId: request.runId,
+            macroId: request.macroId,
+            version: 2,
+            reason: "Agent required",
+            launch: {
+                agent: "typeagent-macro-runner" as const,
+                macro: {
+                    schemaVersion: 1 as const,
+                    macroId: request.macroId,
+                    version: 2,
+                    name: "Native operation",
+                    description: "Native operation",
+                    state: "approved" as const,
+                    executionClass: "agentRequired" as const,
+                    inputs: [],
+                    steps: [],
+                    sourceTraceId: "trace-1",
+                    createdAt: "2026-08-14T10:00:00.000Z",
+                    warnings: [],
+                },
+                inputs: {},
+                reason: {
+                    code: "agentRequired" as const,
+                    message: "Agent required",
+                    stepIds: [],
+                },
+                budgets: {
+                    maxToolCalls: 10,
+                    maxRetries: 1,
+                    timeoutMs: 600_000,
+                    maxTokens: 16_000,
+                },
+                candidate: {
+                    sourceMacroId: request.macroId,
+                    sourceVersion: 2,
+                    handoffRunId: request.runId,
+                },
+            },
+        }));
+        const client = connection({
+            getMacroRequirements: jest.fn(async () => ({
+                macroId: "macro-1",
+                version: 2,
+                executionClass: "agentRequired" as const,
+                inputs: [],
+                tools: [],
+            })),
+            runMacro,
+        });
+        const adapter = new MacroCatalogAdapter({
+            connect: jest.fn(async () => client),
+            getMode: () => "dev",
+            getFeatures: () => ({
+                recording: true,
+                induction: true,
+                replay: false,
+                agentHandoff: true,
+            }),
+        });
+
+        const response = await adapter.runMacro({ macroId: "macro-1" });
+
+        expect(response.isError).toBeUndefined();
+        expect(runMacro).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks agent handoff independently of replay", async () => {
+        const runMacro = jest.fn(
+            async (_request: RunMacroRequest): Promise<RunMacroResponse> => {
+                throw new Error("runMacro must not be called");
+            },
+        );
+        const client = connection({
+            getMacroRequirements: jest.fn(async () => ({
+                macroId: "macro-1",
+                version: 2,
+                executionClass: "agentRequired" as const,
+                inputs: [],
+                tools: [],
+            })),
+            runMacro,
+        });
+        const adapter = new MacroCatalogAdapter({
+            connect: jest.fn(async () => client),
+            getMode: () => "dev",
+            getFeatures: () => ({
+                recording: true,
+                induction: true,
+                replay: true,
+                agentHandoff: false,
+            }),
+        });
+
+        await expect(
+            adapter.runMacro({ macroId: "macro-1" }),
+        ).resolves.toMatchObject({ isError: true });
+        expect(runMacro).not.toHaveBeenCalled();
+        expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
     it("runs a macro with a preallocated run ID", async () => {
         const runMacro = jest.fn(async (request: RunMacroRequest) => ({
             status: "completed" as const,
@@ -124,6 +228,55 @@ describe("macro MCP catalog adapter", () => {
         expect(response.content[0]).toMatchObject({
             type: "text",
             text: expect.stringContaining("run-1"),
+        });
+        expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits an agent-guided adaptation as a draft candidate", async () => {
+        const submitMacroCandidate = jest.fn(
+            async (_request: SubmitMacroCandidateRequest) => ({
+                macroId: "macro-1",
+                version: 3,
+                state: "draft" as const,
+            }),
+        );
+        const client = connection({ submitMacroCandidate });
+        const adapter = new MacroCatalogAdapter({
+            connect: jest.fn(async () => client),
+            getMode: () => "dev",
+        });
+        const request: SubmitMacroCandidateRequest = {
+            sourceMacroId: "macro-1",
+            sourceVersion: 2,
+            handoffRunId: "run-1",
+            reason: "Adapted the native step.",
+            inputs: [],
+            steps: [
+                {
+                    id: "step-1",
+                    toolName: "native-tool",
+                    arguments: { kind: "literal", value: {} },
+                    executionClass: "agentRequired",
+                    sourceToolCallId: "call-1",
+                },
+            ],
+            executionEvidence: {
+                outcome: "completed",
+                toolCalls: 1,
+                retries: 0,
+                durationMs: 100,
+                tokensUsed: 100,
+                steps: [{ stepId: "step-1", status: "completed" }],
+            },
+        };
+
+        const response = await adapter.submitMacroCandidate(request);
+
+        expect(response.isError).toBeUndefined();
+        expect(submitMacroCandidate).toHaveBeenCalledWith(request);
+        expect(response.content[0]).toMatchObject({
+            type: "text",
+            text: expect.stringContaining('"state": "draft"'),
         });
         expect(client.close).toHaveBeenCalledTimes(1);
     });

--- a/ts/packages/copilot-plugin/test/serverSelector.spec.ts
+++ b/ts/packages/copilot-plugin/test/serverSelector.spec.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { selectMcpServer } from "../src/mcp/serverSelector.js";
+
+describe("MCP server selection", () => {
+    it.each([
+        [[], "agent"],
+        [["--workspace"], "workspace"],
+        [["--macros"], "macros"],
+    ] as const)("selects %s as %s", (args, expected) => {
+        expect(selectMcpServer(args)).toBe(expected);
+    });
+
+    it("rejects conflicting logical server selectors", () => {
+        expect(() => selectMcpServer(["--workspace", "--macros"])).toThrow(
+            "Conflicting MCP server selectors",
+        );
+    });
+});


### PR DESCRIPTION
- Adds structured handoff to a dedicated Copilot macro runner for agent-required macros.
- Enforces execution budgets and validates completion evidence.
- Saves adaptations as immutable draft candidates without modifying approved versions.
- Wires candidate submission through RPC and MCP.
- Adds independent flags for recording, induction, replay, and agent handoff.
- Adds content-free lifecycle metrics, recovery documentation, and focused tests.