### PR TITLE
Register macro MCP server

### DIFF
--- a/ts/packages/copilot-macros/src/contracts.ts
+++ b/ts/packages/copilot-macros/src/contracts.ts
@@ -67,14 +67,35 @@ export type MacroVersionState = "draft" | "approved" | "disabled";
 export type ValueExpression =
     | { kind: "literal"; value: unknown }
     | { kind: "input"; name: string }
-    | { kind: "stepResult"; stepId: string; path?: string[] };
+    | { kind: "stepResult"; stepId: string; path?: string[] }
+    | {
+          kind: "template";
+          value: unknown;
+          bindings: Array<{
+              path: string[];
+              expression: Exclude<ValueExpression, { kind: "template" }>;
+          }>;
+      };
+
+export type MacroValueType =
+    | "null"
+    | "array"
+    | "object"
+    | "string"
+    | "number"
+    | "boolean";
 
 export interface MacroInput {
     name: string;
     description: string;
     required: boolean;
     secret: boolean;
+    valueType?: MacroValueType;
 }
+
+export type MacroPostcondition =
+    | { kind: "resultType"; valueType: MacroValueType }
+    | { kind: "resultPathExists"; path: string[] };
 
 export interface MacroStep {
     id: string;
@@ -84,6 +105,7 @@ export interface MacroStep {
     executionClass: MacroExecutionClass;
     sourceToolCallId: string;
     schemaFingerprint?: string;
+    postconditions?: MacroPostcondition[];
 }
 
 export interface CopilotToolMacro {

--- a/ts/packages/copilot-macros/src/deterministicReplay.ts
+++ b/ts/packages/copilot-macros/src/deterministicReplay.ts
@@ -8,6 +8,7 @@ import type {
     ReplayToolDescriptor,
     ReplayToolContext,
     ReplayToolHost,
+    MacroValueType,
     ValueExpression,
 } from "./contracts.js";
 
@@ -26,6 +27,28 @@ function resolveExpression(
     results: ReadonlyMap<string, unknown>,
 ): unknown {
     if (expression.kind === "literal") return expression.value;
+    if (expression.kind === "template") {
+        const value = structuredClone(expression.value);
+        for (const binding of expression.bindings) {
+            let parent = value as Record<string, unknown>;
+            for (const segment of binding.path.slice(0, -1)) {
+                const child = parent[segment];
+                if (child === null || typeof child !== "object") {
+                    throw new ReplayValidationError(
+                        "invalidTemplatePath",
+                        `Template path is unavailable: ${binding.path.join(".")}`,
+                    );
+                }
+                parent = child as Record<string, unknown>;
+            }
+            parent[binding.path.at(-1)!] = resolveExpression(
+                binding.expression,
+                inputs,
+                results,
+            );
+        }
+        return value;
+    }
     if (expression.kind === "input") {
         if (!Object.prototype.hasOwnProperty.call(inputs, expression.name)) {
             throw new ReplayValidationError(
@@ -59,6 +82,52 @@ function resolveExpression(
         value = record[segment];
     }
     return value;
+}
+
+function getValueType(value: unknown): MacroValueType {
+    if (value === null) return "null";
+    if (Array.isArray(value)) return "array";
+    return typeof value as Exclude<MacroValueType, "null" | "array">;
+}
+
+function referencedInputs(expression: ValueExpression): string[] {
+    if (expression.kind === "input") return [expression.name];
+    if (expression.kind !== "template") return [];
+    return expression.bindings.flatMap((binding) =>
+        referencedInputs(binding.expression),
+    );
+}
+
+function validatePostconditions(
+    stepId: string,
+    result: unknown,
+    postconditions: CopilotToolMacro["steps"][number]["postconditions"] = [],
+): void {
+    for (const postcondition of postconditions) {
+        if (postcondition.kind === "resultType") {
+            if (getValueType(result) !== postcondition.valueType) {
+                throw new ReplayValidationError(
+                    "postconditionFailed",
+                    `${stepId} returned ${getValueType(result)}; expected ${postcondition.valueType}.`,
+                );
+            }
+            continue;
+        }
+        let value = result;
+        for (const segment of postcondition.path) {
+            if (
+                value === null ||
+                typeof value !== "object" ||
+                !Object.prototype.hasOwnProperty.call(value, segment)
+            ) {
+                throw new ReplayValidationError(
+                    "postconditionFailed",
+                    `${stepId} result is missing required path ${postcondition.path.join(".")}.`,
+                );
+            }
+            value = (value as Record<string, unknown>)[segment];
+        }
+    }
 }
 
 function isAbort(error: unknown, signal: AbortSignal): boolean {
@@ -96,6 +165,16 @@ export async function inspectReplayTools(
                 `Required macro input is missing: ${input.name}`,
             );
         }
+        if (
+            Object.prototype.hasOwnProperty.call(inputs, input.name) &&
+            input.valueType !== undefined &&
+            getValueType(inputs[input.name]) !== input.valueType
+        ) {
+            throw new ReplayValidationError(
+                "invalidInputType",
+                `Macro input '${input.name}' must be ${input.valueType}.`,
+            );
+        }
     }
     const descriptors = new Map<string, ReplayToolDescriptor>();
     for (const step of macro.steps) {
@@ -105,14 +184,13 @@ export async function inspectReplayTools(
                 `Step requires agent-guided execution: ${step.id}`,
             );
         }
-        if (
-            step.arguments.kind === "input" &&
-            !Object.prototype.hasOwnProperty.call(inputs, step.arguments.name)
-        ) {
-            throw new ReplayValidationError(
-                "missingInput",
-                `Required macro input is missing: ${step.arguments.name}`,
-            );
+        for (const inputName of referencedInputs(step.arguments)) {
+            if (!Object.prototype.hasOwnProperty.call(inputs, inputName)) {
+                throw new ReplayValidationError(
+                    "missingInput",
+                    `Required macro input is missing: ${inputName}`,
+                );
+            }
         }
         const descriptor = await host.inspectTool(
             step.mcpServerName,
@@ -168,6 +246,7 @@ export async function replayMacro(
                 signal,
                 context,
             );
+            validatePostconditions(step.id, result, step.postconditions);
             results.set(step.id, result);
             steps.push({
                 stepId: step.id,

--- a/ts/packages/copilot-macros/src/deterministicReplay.ts
+++ b/ts/packages/copilot-macros/src/deterministicReplay.ts
@@ -33,7 +33,11 @@ function resolveExpression(
             let parent = value as Record<string, unknown>;
             for (const segment of binding.path.slice(0, -1)) {
                 const child = parent[segment];
-                if (child === null || typeof child !== "object") {
+                if (
+                    !Object.prototype.hasOwnProperty.call(parent, segment) ||
+                    child === null ||
+                    typeof child !== "object"
+                ) {
                     throw new ReplayValidationError(
                         "invalidTemplatePath",
                         `Template path is unavailable: ${binding.path.join(".")}`,
@@ -41,11 +45,12 @@ function resolveExpression(
                 }
                 parent = child as Record<string, unknown>;
             }
-            parent[binding.path.at(-1)!] = resolveExpression(
-                binding.expression,
-                inputs,
-                results,
-            );
+            Object.defineProperty(parent, binding.path.at(-1)!, {
+                value: resolveExpression(binding.expression, inputs, results),
+                configurable: true,
+                enumerable: true,
+                writable: true,
+            });
         }
         return value;
     }

--- a/ts/packages/copilot-macros/src/macroDefinition.ts
+++ b/ts/packages/copilot-macros/src/macroDefinition.ts
@@ -66,6 +66,62 @@ function inferPostconditions(result: unknown): MacroPostcondition[] {
     return postconditions;
 }
 
+type BoundValueExpression = Exclude<ValueExpression, { kind: "template" }>;
+
+function findPriorResultExpression(
+    leaf: unknown,
+    priorSteps: MacroStep[],
+    priorCalls: RecordedInteractionTrace["toolCalls"],
+): BoundValueExpression | undefined {
+    if (typeof leaf !== "string" || leaf === "[REDACTED]" || leaf.length < 3) {
+        return undefined;
+    }
+    for (let index = priorCalls.length - 1; index >= 0; index--) {
+        const resultPath = findValuePath(priorCalls[index].result, leaf);
+        if (resultPath !== undefined) {
+            return {
+                kind: "stepResult",
+                stepId: priorSteps[index].id,
+                ...(resultPath.length > 0 ? { path: resultPath } : {}),
+            };
+        }
+    }
+    return undefined;
+}
+
+function createInputExpression(
+    leaf: unknown,
+    stepId: string,
+    path: string[],
+    prompt: string,
+    inputs: MacroInput[],
+    warnings: string[],
+): BoundValueExpression | undefined {
+    const redacted = leaf === "[REDACTED]";
+    const mentionedInPrompt =
+        typeof leaf === "string" &&
+        leaf.length >= 3 &&
+        prompt.toLowerCase().includes(leaf.toLowerCase());
+    if (!redacted && !mentionedInPrompt) return undefined;
+
+    const name = getInputName(stepId, path);
+    inputs.push({
+        name,
+        description: redacted
+            ? `Secret value required by ${stepId} at ${path.join(".") || "arguments"}`
+            : `Value captured from the request for ${stepId} at ${path.join(".") || "arguments"}`,
+        required: true,
+        secret: redacted,
+        ...(redacted ? {} : { valueType: getValueType(leaf) }),
+    });
+    if (redacted) {
+        warnings.push(
+            `${stepId} contains a redacted value and requires review of the generated secret input.`,
+        );
+    }
+    return { kind: "input", name };
+}
+
 function convertArguments(
     value: unknown,
     stepId: string,
@@ -85,52 +141,9 @@ function convertArguments(
         for (const segment of path) {
             leaf = (leaf as Record<string, unknown>)[segment];
         }
-        let expression:
-            | Exclude<ValueExpression, { kind: "template" }>
-            | undefined;
-        if (
-            typeof leaf === "string" &&
-            leaf !== "[REDACTED]" &&
-            leaf.length >= 3
-        ) {
-            for (let index = priorCalls.length - 1; index >= 0; index--) {
-                const resultPath = findValuePath(
-                    priorCalls[index].result,
-                    leaf,
-                );
-                if (resultPath !== undefined) {
-                    expression = {
-                        kind: "stepResult",
-                        stepId: priorSteps[index].id,
-                        ...(resultPath.length > 0 ? { path: resultPath } : {}),
-                    };
-                    break;
-                }
-            }
-        }
-        const redacted = leaf === "[REDACTED]";
-        const mentionedInPrompt =
-            typeof leaf === "string" &&
-            leaf.length >= 3 &&
-            prompt.toLowerCase().includes(leaf.toLowerCase());
-        if (!expression && (redacted || mentionedInPrompt)) {
-            const name = getInputName(stepId, path);
-            inputs.push({
-                name,
-                description: redacted
-                    ? `Secret value required by ${stepId} at ${path.join(".") || "arguments"}`
-                    : `Value captured from the request for ${stepId} at ${path.join(".") || "arguments"}`,
-                required: true,
-                secret: redacted,
-                ...(redacted ? {} : { valueType: getValueType(leaf) }),
-            });
-            expression = { kind: "input", name };
-            if (redacted) {
-                warnings.push(
-                    `${stepId} contains a redacted value and requires review of the generated secret input.`,
-                );
-            }
-        }
+        const expression =
+            findPriorResultExpression(leaf, priorSteps, priorCalls) ??
+            createInputExpression(leaf, stepId, path, prompt, inputs, warnings);
         if (expression) bindings.push({ path, expression });
     }
     return bindings.length === 0

--- a/ts/packages/copilot-macros/src/macroDefinition.ts
+++ b/ts/packages/copilot-macros/src/macroDefinition.ts
@@ -5,7 +5,9 @@ import type {
     CopilotToolMacro,
     MacroExecutionClass,
     MacroInput,
+    MacroPostcondition,
     MacroStep,
+    MacroValueType,
     MacroValidationIssue,
     MacroValidationReport,
     RecordedInteractionTrace,
@@ -19,30 +21,121 @@ function classifyTool(
     return mcpServerName ? "replayable" : "agentRequired";
 }
 
+function getValueType(value: unknown): MacroValueType {
+    if (value === null) return "null";
+    if (Array.isArray(value)) return "array";
+    return typeof value as Exclude<MacroValueType, "null" | "array">;
+}
+
+function getInputName(stepId: string, path: string[]): string {
+    const suffix = path
+        .map((segment) => segment.replace(/[^a-zA-Z0-9]+/g, "_"))
+        .filter(Boolean)
+        .join("_");
+    return `${stepId.replace(/-/g, "_")}_${suffix || "value"}`;
+}
+
+function findValuePath(root: unknown, target: unknown): string[] | undefined {
+    if (Object.is(root, target)) return [];
+    if (root === null || typeof root !== "object") return undefined;
+    for (const [key, child] of Object.entries(root)) {
+        const nested = findValuePath(child, target);
+        if (nested !== undefined) return [key, ...nested];
+    }
+    return undefined;
+}
+
+function collectLeafPaths(value: unknown, path: string[] = []): string[][] {
+    if (value === null || typeof value !== "object") return [path];
+    return Object.entries(value).flatMap(([key, child]) =>
+        collectLeafPaths(child, [...path, key]),
+    );
+}
+
+function inferPostconditions(result: unknown): MacroPostcondition[] {
+    const postconditions: MacroPostcondition[] = [
+        { kind: "resultType", valueType: getValueType(result) },
+    ];
+    if (result !== null && typeof result === "object") {
+        for (const path of collectLeafPaths(result).slice(0, 50)) {
+            if (path.length > 0) {
+                postconditions.push({ kind: "resultPathExists", path });
+            }
+        }
+    }
+    return postconditions;
+}
+
 function convertArguments(
     value: unknown,
     stepId: string,
+    prompt: string,
+    priorSteps: MacroStep[],
+    priorCalls: RecordedInteractionTrace["toolCalls"],
     inputs: MacroInput[],
     warnings: string[],
 ): ValueExpression {
     if (value === undefined) {
         return { kind: "literal", value: {} };
     }
-    const serialized = JSON.stringify(value);
-    if (serialized?.includes("[REDACTED]")) {
-        const inputName = `${stepId}_secret`;
-        inputs.push({
-            name: inputName,
-            description: `Secret value required by ${stepId}`,
-            required: true,
-            secret: true,
-        });
-        warnings.push(
-            `${stepId} contains a redacted value and requires review of the generated secret input.`,
-        );
-        return { kind: "input", name: inputName };
+    const bindings: Extract<ValueExpression, { kind: "template" }>["bindings"] =
+        [];
+    for (const path of collectLeafPaths(value)) {
+        let leaf: unknown = value;
+        for (const segment of path) {
+            leaf = (leaf as Record<string, unknown>)[segment];
+        }
+        let expression:
+            | Exclude<ValueExpression, { kind: "template" }>
+            | undefined;
+        if (
+            typeof leaf === "string" &&
+            leaf !== "[REDACTED]" &&
+            leaf.length >= 3
+        ) {
+            for (let index = priorCalls.length - 1; index >= 0; index--) {
+                const resultPath = findValuePath(
+                    priorCalls[index].result,
+                    leaf,
+                );
+                if (resultPath !== undefined) {
+                    expression = {
+                        kind: "stepResult",
+                        stepId: priorSteps[index].id,
+                        ...(resultPath.length > 0 ? { path: resultPath } : {}),
+                    };
+                    break;
+                }
+            }
+        }
+        const redacted = leaf === "[REDACTED]";
+        const mentionedInPrompt =
+            typeof leaf === "string" &&
+            leaf.length >= 3 &&
+            prompt.toLowerCase().includes(leaf.toLowerCase());
+        if (!expression && (redacted || mentionedInPrompt)) {
+            const name = getInputName(stepId, path);
+            inputs.push({
+                name,
+                description: redacted
+                    ? `Secret value required by ${stepId} at ${path.join(".") || "arguments"}`
+                    : `Value captured from the request for ${stepId} at ${path.join(".") || "arguments"}`,
+                required: true,
+                secret: redacted,
+                ...(redacted ? {} : { valueType: getValueType(leaf) }),
+            });
+            expression = { kind: "input", name };
+            if (redacted) {
+                warnings.push(
+                    `${stepId} contains a redacted value and requires review of the generated secret input.`,
+                );
+            }
+        }
+        if (expression) bindings.push({ path, expression });
     }
-    return { kind: "literal", value };
+    return bindings.length === 0
+        ? { kind: "literal", value }
+        : { kind: "template", value, bindings };
 }
 
 export function induceMacroFromTrace(
@@ -55,7 +148,8 @@ export function induceMacroFromTrace(
 ): CopilotToolMacro {
     const warnings: string[] = [];
     const inputs: MacroInput[] = [];
-    const steps: MacroStep[] = trace.toolCalls.map((call, index) => {
+    const steps: MacroStep[] = [];
+    trace.toolCalls.forEach((call, index) => {
         const id = `step-${index + 1}`;
         const executionClass = classifyTool(call.name, call.mcpServerName);
         if (executionClass === "agentRequired") {
@@ -68,16 +162,27 @@ export function induceMacroFromTrace(
                 `${id} was captured with status ${call.status} and requires review.`,
             );
         }
-        return {
+        steps.push({
             id,
             toolName: call.name,
             ...(call.mcpServerName
                 ? { mcpServerName: call.mcpServerName }
                 : {}),
-            arguments: convertArguments(call.arguments, id, inputs, warnings),
+            arguments: convertArguments(
+                call.arguments,
+                id,
+                trace.prompt,
+                steps,
+                trace.toolCalls.slice(0, index),
+                inputs,
+                warnings,
+            ),
             executionClass,
             sourceToolCallId: call.toolCallId,
-        };
+            ...(call.result === undefined
+                ? {}
+                : { postconditions: inferPostconditions(call.result) }),
+        });
     });
 
     return {
@@ -105,6 +210,34 @@ function validateExpression(
     macro: CopilotToolMacro,
     stepIndex: number,
 ): string | undefined {
+    if (expression.kind === "template") {
+        if (expression.bindings.length === 0) {
+            return "A template expression requires at least one binding.";
+        }
+        for (const binding of expression.bindings) {
+            if (binding.path.length === 0) {
+                return "A template binding requires a non-empty path.";
+            }
+            let target = expression.value;
+            for (const segment of binding.path) {
+                if (
+                    target === null ||
+                    typeof target !== "object" ||
+                    !Object.prototype.hasOwnProperty.call(target, segment)
+                ) {
+                    return `Template binding path is unavailable: ${binding.path.join(".")}`;
+                }
+                target = (target as Record<string, unknown>)[segment];
+            }
+            const error = validateExpression(
+                binding.expression,
+                macro,
+                stepIndex,
+            );
+            if (error) return error;
+        }
+        return undefined;
+    }
     if (expression.kind === "input") {
         return macro.inputs.some((input) => input.name === expression.name)
             ? undefined
@@ -162,6 +295,21 @@ export function validateMacro(
                 severity: "error",
                 code: "invalidExpression",
                 message: expressionError,
+                stepId: step.id,
+            });
+        }
+        if (
+            step.postconditions?.some(
+                (condition) =>
+                    condition.kind === "resultPathExists" &&
+                    condition.path.length === 0,
+            )
+        ) {
+            issues.push({
+                severity: "error",
+                code: "invalidPostcondition",
+                message:
+                    "A result path postcondition requires a non-empty path.",
                 stepId: step.id,
             });
         }

--- a/ts/packages/copilot-macros/test/deterministicReplay.spec.ts
+++ b/ts/packages/copilot-macros/test/deterministicReplay.spec.ts
@@ -108,6 +108,50 @@ describe("deterministic macro replay", () => {
         ]);
     });
 
+    it("treats __proto__ template paths as own data properties", async () => {
+        const source = macro();
+        source.inputs[0].valueType = "object";
+        source.steps = [
+            {
+                ...source.steps[0],
+                arguments: {
+                    kind: "template",
+                    value: JSON.parse('{"__proto__":"captured"}'),
+                    bindings: [
+                        {
+                            path: ["__proto__"],
+                            expression: { kind: "input", name: "path" },
+                        },
+                    ],
+                },
+                postconditions: [],
+            },
+        ];
+        const replayHost = host();
+        const injectedPrototype = { polluted: true };
+
+        const run = await replayMacro(
+            source,
+            "run-1",
+            { path: injectedPrototype },
+            replayHost.value,
+            new AbortController().signal,
+        );
+
+        const argumentsValue = replayHost.calls[0].argumentsValue as Record<
+            string,
+            unknown
+        >;
+        expect(run.status).toBe("completed");
+        expect(Object.getPrototypeOf(argumentsValue)).not.toBe(
+            injectedPrototype,
+        );
+        expect(
+            Object.prototype.hasOwnProperty.call(argumentsValue, "__proto__"),
+        ).toBe(true);
+        expect(argumentsValue["__proto__"]).toBe(injectedPrototype);
+    });
+
     it("preflights every tool before executing step one", async () => {
         const replayHost = host({
             inspectTool: async (_server, toolName) =>

--- a/ts/packages/copilot-macros/test/deterministicReplay.spec.ts
+++ b/ts/packages/copilot-macros/test/deterministicReplay.spec.ts
@@ -16,15 +16,36 @@ function macro(): CopilotToolMacro {
         description: "",
         state: "approved",
         executionClass: "replayable",
-        inputs: [],
+        inputs: [
+            {
+                name: "path",
+                description: "File to read",
+                required: true,
+                secret: false,
+                valueType: "string",
+            },
+        ],
         steps: [
             {
                 id: "step-1",
                 toolName: "read",
                 mcpServerName: "typeagent-workspace",
-                arguments: { kind: "input", name: "path" },
+                arguments: {
+                    kind: "template",
+                    value: { path: "captured.json", encoding: "utf8" },
+                    bindings: [
+                        {
+                            path: ["path"],
+                            expression: { kind: "input", name: "path" },
+                        },
+                    ],
+                },
                 executionClass: "replayable",
                 sourceToolCallId: "call-1",
+                postconditions: [
+                    { kind: "resultType", valueType: "object" },
+                    { kind: "resultPathExists", path: ["query"] },
+                ],
             },
             {
                 id: "step-2",
@@ -76,7 +97,13 @@ describe("deterministic macro replay", () => {
         expect(run.status).toBe("completed");
         expect(run.result).toEqual({ matches: 1 });
         expect(replayHost.calls).toEqual([
-            { toolName: "read", argumentsValue: "package.json" },
+            {
+                toolName: "read",
+                argumentsValue: {
+                    path: "package.json",
+                    encoding: "utf8",
+                },
+            },
             { toolName: "grep", argumentsValue: "needle" },
         ]);
     });
@@ -117,6 +144,41 @@ describe("deterministic macro replay", () => {
             ),
         ).rejects.toMatchObject({ code: "missingInput" });
         expect(replayHost.calls).toEqual([]);
+    });
+
+    it("rejects incorrectly typed inputs before executing step one", async () => {
+        const replayHost = host();
+
+        await expect(
+            replayMacro(
+                macro(),
+                "run-1",
+                { path: 42 },
+                replayHost.value,
+                new AbortController().signal,
+            ),
+        ).rejects.toMatchObject({ code: "invalidInputType" });
+        expect(replayHost.calls).toEqual([]);
+    });
+
+    it("fails a step whose result no longer satisfies its postconditions", async () => {
+        const replayHost = host({
+            callTool: async () => ({ changed: true }),
+        });
+
+        const run = await replayMacro(
+            macro(),
+            "run-1",
+            { path: "package.json" },
+            replayHost.value,
+            new AbortController().signal,
+        );
+
+        expect(run).toMatchObject({
+            status: "failed",
+            steps: [{ stepId: "step-1", status: "failed" }],
+            error: { code: "postconditionFailed" },
+        });
     });
 
     it("records cancellation without starting later steps", async () => {

--- a/ts/packages/copilot-macros/test/macroCatalog.spec.ts
+++ b/ts/packages/copilot-macros/test/macroCatalog.spec.ts
@@ -14,14 +14,16 @@ async function captureTrace(
         toolName?: string;
         mcpServerName?: string;
         status?: "completed" | "failed" | "denied";
+        prompt?: string;
     } = {},
 ): Promise<string> {
     const sessionId = options.sessionId ?? "session-1";
+    const prompt = options.prompt ?? "Read package";
     manager.armRecording({ sessionId });
     const claimed = manager.claimRecording({
         sessionId,
         cwd: ".",
-        promptHash: createHash("sha256").update("Read package").digest("hex"),
+        promptHash: createHash("sha256").update(prompt).digest("hex"),
     });
     const summary = await manager.finalizeRecording({
         tokenId: claimed!.id,
@@ -29,7 +31,7 @@ async function captureTrace(
             schemaVersion: 1,
             sessionId,
             cwd: ".",
-            prompt: "Read package",
+            prompt,
             response: "Done",
             startedAt: "2026-08-14T10:00:00.000Z",
             completedAt: "2026-08-14T10:00:01.000Z",
@@ -53,6 +55,46 @@ async function captureTrace(
 }
 
 describe("MacroManager draft catalog", () => {
+    it("replays a captured workflow with a different prompt-derived input", async () => {
+        const instanceDir = await mkdtemp(path.join(os.tmpdir(), "catalog-"));
+        const calls: unknown[] = [];
+        const manager = new MacroManager(instanceDir, {
+            inspectTool: async (mcpServerName, toolName) => ({
+                ...(mcpServerName ? { mcpServerName } : {}),
+                toolName,
+                schemaFingerprint: "v1",
+            }),
+            callTool: async (_server, _tool, argumentsValue) => {
+                calls.push(argumentsValue);
+                return { content: "{}" };
+            },
+        });
+        const traceId = await captureTrace(manager, {
+            prompt: "Read package.json",
+        });
+        const draft = await manager.createMacroFromTrace({
+            traceId,
+            name: "Read package",
+        });
+        const definition = await manager.inspectMacro(draft);
+        const approved = await manager.approveMacro(draft);
+
+        await expect(
+            manager.runMacro({
+                runId: "run-reused-input",
+                macroId: approved.macroId,
+                inputs: { step_1_path: "src/package.json" },
+            }),
+        ).resolves.toMatchObject({ status: "completed" });
+        expect(definition.inputs).toEqual([
+            expect.objectContaining({
+                name: "step_1_path",
+                valueType: "string",
+            }),
+        ]);
+        expect(calls).toEqual([{ path: "src/package.json" }]);
+    });
+
     it("persists and approves immutable macro versions across restart", async () => {
         const instanceDir = await mkdtemp(path.join(os.tmpdir(), "catalog-"));
         const manager = new MacroManager(instanceDir);
@@ -474,7 +516,7 @@ describe("MacroManager draft catalog", () => {
                 toolName,
                 schemaFingerprint: "v1",
             }),
-            callTool: async () => ({ text: "x".repeat(300 * 1024) }),
+            callTool: async () => ({ content: "x".repeat(300 * 1024) }),
         });
         const traceId = await captureTrace(manager);
         const draft = await manager.createMacroFromTrace({

--- a/ts/packages/copilot-macros/test/macroDefinition.spec.ts
+++ b/ts/packages/copilot-macros/test/macroDefinition.spec.ts
@@ -54,15 +54,37 @@ describe("macro induction and validation", () => {
             version: 1,
             state: "draft",
             executionClass: "replayable",
+            inputs: [
+                expect.objectContaining({
+                    name: "step_1_path",
+                    valueType: "string",
+                }),
+            ],
             steps: [
                 {
                     id: "step-1",
                     toolName: "read",
                     mcpServerName: "typeagent-workspace",
                     arguments: {
-                        kind: "literal",
+                        kind: "template",
                         value: { path: "package.json" },
+                        bindings: [
+                            {
+                                path: ["path"],
+                                expression: {
+                                    kind: "input",
+                                    name: "step_1_path",
+                                },
+                            },
+                        ],
                     },
+                    postconditions: [
+                        { kind: "resultType", valueType: "object" },
+                        {
+                            kind: "resultPathExists",
+                            path: ["content"],
+                        },
+                    ],
                 },
             ],
         });
@@ -113,15 +135,62 @@ describe("macro induction and validation", () => {
 
         expect(macro.inputs).toEqual([
             {
-                name: "step-1_secret",
-                description: "Secret value required by step-1",
+                name: "step_1_authorization",
+                description: "Secret value required by step-1 at authorization",
                 required: true,
                 secret: true,
             },
         ]);
         expect(macro.steps[0].arguments).toEqual({
-            kind: "input",
-            name: "step-1_secret",
+            kind: "template",
+            value: { authorization: "[REDACTED]" },
+            bindings: [
+                {
+                    path: ["authorization"],
+                    expression: {
+                        kind: "input",
+                        name: "step_1_authorization",
+                    },
+                },
+            ],
+        });
+    });
+
+    it("binds a later argument to an earlier captured result", () => {
+        const source = trace();
+        source.prompt = "Find package.json and inspect it";
+        source.toolCalls[0].result = { match: { path: "src/package.json" } };
+        source.toolCalls.push({
+            toolCallId: "call-2",
+            name: "read",
+            mcpServerName: "typeagent-workspace",
+            arguments: { path: "src/package.json", encoding: "utf8" },
+            result: { content: "{}" },
+            status: "completed",
+        });
+
+        const macro = induceMacroFromTrace(
+            "trace-1",
+            source,
+            "macro-1",
+            "Find and read package",
+            "",
+            "2026-08-14T10:01:00.000Z",
+        );
+
+        expect(macro.steps[1].arguments).toEqual({
+            kind: "template",
+            value: { path: "src/package.json", encoding: "utf8" },
+            bindings: [
+                {
+                    path: ["path"],
+                    expression: {
+                        kind: "stepResult",
+                        stepId: "step-1",
+                        path: ["match", "path"],
+                    },
+                },
+            ],
         });
     });
 

--- a/ts/packages/copilot-plugin/.mcp.json
+++ b/ts/packages/copilot-plugin/.mcp.json
@@ -9,6 +9,11 @@
       "command": "node",
       "args": ["${PLUGIN_ROOT}/dist/mcp/server.js", "--workspace"],
       "tools": ["read", "glob", "grep", "fetch"]
+    },
+    "typeagent-macros": {
+      "command": "node",
+      "args": ["${PLUGIN_ROOT}/dist/mcp/server.js", "--macros"],
+      "tools": ["*"]
     }
   }
 }

--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -382,7 +382,7 @@ The plugin stores config at `%USERPROFILE%\.typeagent-copilot\config.json` (Wind
 
 ### MCP Servers (`.mcp.json`)
 
-The plugin starts two logical MCP servers from the same bundled entry point and
+The plugin starts three logical MCP servers from the same bundled entry point and
 single-file release executable:
 
 | Server                | Tool                       | Description                                                                             |
@@ -394,6 +394,9 @@ single-file release executable:
 | `typeagent-workspace` | `glob`                     | Find bounded, deterministically ordered workspace files                                 |
 | `typeagent-workspace` | `grep`                     | Search bounded workspace text                                                           |
 | `typeagent-workspace` | `fetch`                    | Fetch bounded public HTTP(S) text without ambient credentials or private-network access |
+| `typeagent-macros`    | `list_macros`              | List and search reusable captured procedures                                            |
+| `typeagent-macros`    | `run_macro`                | Replay an approved macro or return an agent-runner handoff                              |
+| `typeagent-macros`    | lifecycle tools            | Capture-derived draft validation, approval, disablement, and candidate submission       |
 
 Workspace tools are available in direct, MCP, and dev modes. In bypass mode
 they remain discoverable because Copilot fixes the MCP catalog when the session

--- a/ts/packages/copilot-plugin/skills/typeagent-macros/SKILL.md
+++ b/ts/packages/copilot-plugin/skills/typeagent-macros/SKILL.md
@@ -12,9 +12,13 @@ Use the `typeagent-macros` MCP server for macro catalog and lifecycle work.
 1. Use `search_macros` or `list_macros` to find the macro.
 2. Use `inspect_macro` and `get_macro_requirements` before execution. Collect
    all required inputs without exposing secret values in chat.
+   Inputs may fill nested argument-template fields, and later steps may bind
+   values from earlier results.
 3. Call `run_macro` with `preference: "auto"`.
 4. For `completed`, report the sanitized result. For `failed` or `cancelled`,
-   report the structured failure without inventing a repair.
+   report the structured failure without inventing a repair. A
+   `postconditionFailed` result means the live tool output no longer has the
+   shape captured by the approved procedure.
 5. For `agentRequired`, invoke the `TypeAgent Macro Runner` agent with the
    complete returned `launch` object. Do not manually paraphrase or reconstruct
    the launch payload.

--- a/ts/packages/copilot-plugin/src/mcp/macroServer.ts
+++ b/ts/packages/copilot-plugin/src/mcp/macroServer.ts
@@ -274,7 +274,7 @@ const macroRefSchema = {
     version: z.number().int().positive().optional(),
 };
 
-const valueExpressionSchema = z.discriminatedUnion("kind", [
+const boundValueExpressionSchema = z.discriminatedUnion("kind", [
     z.object({ kind: z.literal("literal"), value: z.unknown() }),
     z.object({ kind: z.literal("input"), name: z.string().min(1) }),
     z.object({
@@ -284,12 +284,49 @@ const valueExpressionSchema = z.discriminatedUnion("kind", [
     }),
 ]);
 
+const valueExpressionSchema = z.discriminatedUnion("kind", [
+    ...boundValueExpressionSchema.options,
+    z.object({
+        kind: z.literal("template"),
+        value: z.unknown(),
+        bindings: z
+            .array(
+                z.object({
+                    path: z.array(z.string()).min(1),
+                    expression: boundValueExpressionSchema,
+                }),
+            )
+            .min(1),
+    }),
+]);
+
+const macroValueTypeSchema = z.enum([
+    "null",
+    "array",
+    "object",
+    "string",
+    "number",
+    "boolean",
+]);
+
 const macroInputSchema = z.object({
     name: z.string().min(1),
     description: z.string(),
     required: z.boolean(),
     secret: z.boolean(),
+    valueType: macroValueTypeSchema.optional(),
 });
+
+const macroPostconditionSchema = z.discriminatedUnion("kind", [
+    z.object({
+        kind: z.literal("resultType"),
+        valueType: macroValueTypeSchema,
+    }),
+    z.object({
+        kind: z.literal("resultPathExists"),
+        path: z.array(z.string()).min(1),
+    }),
+]);
 
 const macroStepSchema = z.object({
     id: z.string().min(1),
@@ -299,6 +336,7 @@ const macroStepSchema = z.object({
     executionClass: z.enum(["replayable", "agentRequired"]),
     sourceToolCallId: z.string().min(1),
     schemaFingerprint: z.string().optional(),
+    postconditions: z.array(macroPostconditionSchema).max(100).optional(),
 });
 
 export class TypeAgentMacroMcpServer {
@@ -431,7 +469,15 @@ export class TypeAgentMacroMcpServer {
                     sourceVersion: request.sourceVersion,
                     handoffRunId: request.handoffRunId,
                     reason: request.reason,
-                    inputs: request.inputs,
+                    inputs: request.inputs.map((input) => ({
+                        name: input.name,
+                        description: input.description,
+                        required: input.required,
+                        secret: input.secret,
+                        ...(input.valueType !== undefined
+                            ? { valueType: input.valueType }
+                            : {}),
+                    })),
                     executionEvidence: request.executionEvidence,
                     steps: request.steps.map((step) => ({
                         id: step.id,
@@ -444,6 +490,9 @@ export class TypeAgentMacroMcpServer {
                         sourceToolCallId: step.sourceToolCallId,
                         ...(step.schemaFingerprint !== undefined
                             ? { schemaFingerprint: step.schemaFingerprint }
+                            : {}),
+                        ...(step.postconditions !== undefined
+                            ? { postconditions: step.postconditions }
                             : {}),
                     })),
                     ...(request.name !== undefined

--- a/ts/packages/copilot-plugin/src/mcp/server.ts
+++ b/ts/packages/copilot-plugin/src/mcp/server.ts
@@ -28,6 +28,8 @@ import {
 } from "../shared/typeagent-client.js";
 import { extractMessageText } from "../shared/message-formatter.js";
 import { getMode } from "../shared/plugin-config.js";
+import { TypeAgentMacroMcpServer } from "./macroServer.js";
+import { selectMcpServer } from "./serverSelector.js";
 import { TypeAgentWorkspaceMcpServer } from "./workspaceServer.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -361,9 +363,13 @@ class TypeAgentMcpServer {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-const server = process.argv.includes("--workspace")
-    ? new TypeAgentWorkspaceMcpServer()
-    : new TypeAgentMcpServer();
+const serverKind = selectMcpServer(process.argv.slice(2));
+const server =
+    serverKind === "workspace"
+        ? new TypeAgentWorkspaceMcpServer()
+        : serverKind === "macros"
+          ? new TypeAgentMacroMcpServer()
+          : new TypeAgentMcpServer();
 server.start().catch((error) => {
     log(`Fatal error: ${error}`);
     process.exit(1);

--- a/ts/packages/copilot-plugin/test/pluginArtifact.spec.ts
+++ b/ts/packages/copilot-plugin/test/pluginArtifact.spec.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PluginMcpManifest {
+    mcpServers: Record<
+        string,
+        { command: string; args: string[]; tools: string[] }
+    >;
+}
+
+describe("staged plugin artifact", () => {
+    it("starts the bundled macro server declared by .mcp.json", async () => {
+        const testDir = path.dirname(fileURLToPath(import.meta.url));
+        const pluginRoot = path.resolve(testDir, "..", "..");
+        const manifest = JSON.parse(
+            await readFile(path.join(pluginRoot, ".mcp.json"), "utf8"),
+        ) as PluginMcpManifest;
+        const registration = manifest.mcpServers["typeagent-macros"];
+
+        expect(registration).toEqual({
+            command: "node",
+            args: ["${PLUGIN_ROOT}/dist/mcp/server.js", "--macros"],
+            tools: ["*"],
+        });
+
+        const transport = new StdioClientTransport({
+            command: process.execPath,
+            args: registration.args.map((argument) =>
+                argument.replace("${PLUGIN_ROOT}", pluginRoot),
+            ),
+            stderr: "pipe",
+        });
+        const client = new Client({
+            name: "typeagent-plugin-artifact-test",
+            version: "1.0.0",
+        });
+        try {
+            await client.connect(transport);
+            const catalog = await client.listTools();
+            expect(catalog.tools.map((tool) => tool.name)).toEqual(
+                expect.arrayContaining([
+                    "list_macros",
+                    "create_macro_from_trace",
+                    "run_macro",
+                    "submit_macro_candidate",
+                ]),
+            );
+        } finally {
+            await client.close();
+        }
+    });
+});


### PR DESCRIPTION
- Register the macro MCP server and route the bundled entry point correctly.
- Add artifact-level coverage proving the staged plugin exposes macro tools.
- Induce typed inputs and prior-step result bindings from captured traces.
- Add structural postconditions and replay-time validation.
- Update macro schemas, tests, documentation, and evaluation scenarios.

## Validation
- Full TypeAgent build
- 29 macro tests
- 49 plugin tests
- Policy and Prettier checks