### PR TITLE
Don't fail startup on an unresolvable installed agent record

### DIFF
--- a/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
+++ b/ts/packages/defaultAgentProvider/src/defaultAgentProviders.ts
@@ -491,6 +491,16 @@ export function createDefaultInstalledAgentSource(
         return provider;
     }
 
+    // Records in `agents.json` whose source could not re-resolve them at startup
+    // (name -> reason), e.g. a catalog entry deleted after the install. Seeding
+    // one must not fail the whole source construction - that makes the host
+    // unstartable over a single stale record - so the name is not vended.
+    //
+    // The record is NOT dropped: unresolvability can be transient (an unreadable
+    // catalog resolves nothing), so it resolves again once its source is fixed;
+    // `@package uninstall` removes it when it is gone for good.
+    const unresolvedRecords = new Map<string, string>();
+
     // Seed active entries from agents.json. One single-agent,
     // single-root provider per record; shared (the same instance) across every
     // connected session.
@@ -499,10 +509,21 @@ export function createDefaultInstalledAgentSource(
         options?.configName,
     );
     for (const [name, record] of Object.entries(installedRecords)) {
-        entries.set(name, {
-            status: "active",
-            provider: buildAgentProvider(name, record),
-        });
+        let provider: AppAgentProvider;
+        try {
+            provider = buildAgentProvider(name, record);
+        } catch (e) {
+            const reason = e instanceof Error ? e.message : String(e);
+            unresolvedRecords.set(name, reason);
+            // Warn on the console, not just the debug trace: this is the only
+            // notice that an installed agent silently went missing.
+            console.warn(
+                `Installed agent '${name}' is not available: ${reason} ` +
+                    `Run '@package uninstall ${name}' to remove it.`,
+            );
+            continue;
+        }
+        entries.set(name, { status: "active", provider });
     }
 
     // Startup orphan sweep: keep only each installed agent's
@@ -999,12 +1020,25 @@ export function createDefaultInstalledAgentSource(
                 }
                 const uninstalledRoot = deletedRecord.installRoot;
 
+                // A record its source could not re-resolve at startup was never
+                // seeded, so nothing is loaded in any session and the barrier
+                // below has no provider to drain. Drop the record directly.
+                if (unresolvedRecords.has(name)) {
+                    mutateAgentsJson((agents) => {
+                        delete agents[name];
+                    });
+                    unresolvedRecords.delete(name);
+                    pruneRootIfUnreferenced(uninstalledRoot, name);
+                    onOutcome?.("uninstalled");
+                    return;
+                }
+
                 // Invariant: a recorded name is `active` in this source (a name
                 // mid-teardown — `removing` — was already rejected by
-                // `assertNameFree` above, and every record is seeded active at
-                // construction). Reaching here with no active entry means
-                // `agents.json` and this source's live set disagree, which can
-                // only come from an OUT-OF-BAND mutation of the store: the
+                // `assertNameFree` above, and every resolvable record is seeded
+                // active at construction). Reaching here with no active entry
+                // means `agents.json` and this source's live set disagree, which
+                // can only come from an OUT-OF-BAND mutation of the store: the
                 // instance-dir lock keeps one process per `agents.json`, and both
                 // multi-dispatcher hosts (agent server + web API) run a single
                 // shared source per process, so no concurrent sibling source can
@@ -1118,6 +1152,16 @@ export function createDefaultInstalledAgentSource(
                     throw new Error(`Agent '${name}' not found`);
                 }
                 const oldEntry = entries.get(name);
+                // An unresolvable record has no live version to swap out. Report
+                // that instead of the out-of-band store mutation below, which is
+                // a different problem.
+                const unresolvedReason = unresolvedRecords.get(name);
+                if (unresolvedReason !== undefined) {
+                    throw new Error(
+                        `Agent '${name}' could not be loaded from its install source: ${unresolvedReason} ` +
+                            `Fix the source and restart, or run '@package uninstall ${name}' and install it again.`,
+                    );
+                }
                 if (oldEntry?.status !== "active") {
                     throw new Error(
                         `Agent '${name}' is recorded but not active in this source; the install store may have been modified out of band.`,

--- a/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
+++ b/ts/packages/defaultAgentProvider/test/installSourcesInstalledProvider.spec.ts
@@ -2815,3 +2815,105 @@ describe("structural manifest check on install/update (5.3)", () => {
         expect(installedNames(built)).not.toContain("p");
     });
 });
+
+describe("installed record its source can no longer resolve", () => {
+    // Install a catalog-sourced agent, then delete its catalog key: the record
+    // stays in agents.json but a fresh source construction can no longer
+    // re-resolve it - the "agent removed from the catalog since install" case.
+    async function installThenDropCatalogKey(): Promise<string> {
+        const instanceDir = catalogPathInstanceDir("cat", "cat-mod", true);
+        const built = createDefaultInstalledAgentSource(instanceDir).testApi;
+        await built.install("x", "cat-mod", "cat", noopHost);
+        fs.writeFileSync(
+            path.join(instanceDir, "catalog.json"),
+            JSON.stringify({ agents: {} }),
+        );
+        return instanceDir;
+    }
+
+    // Build the source with console.warn captured, so the startup warning does
+    // not pollute the test output.
+    function buildCapturingWarnings(instanceDir: string): {
+        built: ReturnType<typeof createDefaultInstalledAgentSource>;
+        warnings: string[];
+    } {
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (message: string) => {
+            warnings.push(message);
+        };
+        try {
+            return {
+                built: createDefaultInstalledAgentSource(instanceDir),
+                warnings,
+            };
+        } finally {
+            console.warn = originalWarn;
+        }
+    }
+
+    it("is skipped with a warning instead of failing source construction", async () => {
+        const instanceDir = await installThenDropCatalogKey();
+        const { built, warnings } = buildCapturingWarnings(instanceDir);
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(/Installed agent 'x' is not available/);
+        expect(warnings[0]).toMatch(/@package uninstall x/);
+
+        // The agent is not vended to a connecting session...
+        const connection = built.connect(noopHost);
+        const names = (await connection.providers).flatMap((p) =>
+            p.getAppAgentNames(),
+        );
+        expect(names).not.toContain("x");
+        connection.dispose();
+
+        // ...but the record is kept (unresolvability can be transient).
+        expect(readAgentsJson(instanceDir)?.agents.x).toBeDefined();
+        expect(installedNames(built.testApi)).toContain("x");
+    });
+
+    it("resolves again once its source is repaired", async () => {
+        const instanceDir = await installThenDropCatalogKey();
+        buildCapturingWarnings(instanceDir);
+        fs.writeFileSync(
+            path.join(instanceDir, "catalog.json"),
+            JSON.stringify({ agents: { cat: { path: "catalog-package" } } }),
+        );
+
+        const built = createDefaultInstalledAgentSource(instanceDir);
+        const connection = built.connect(noopHost);
+        const names = (await connection.providers).flatMap((p) =>
+            p.getAppAgentNames(),
+        );
+        expect(names).toContain("x");
+        connection.dispose();
+    });
+
+    it("can be uninstalled (nothing to tear down, record dropped)", async () => {
+        const instanceDir = await installThenDropCatalogKey();
+        const { built } = buildCapturingWarnings(instanceDir);
+
+        const outcomes: string[] = [];
+        await built.testApi.uninstall("x", noopHost, (status) =>
+            outcomes.push(status),
+        );
+
+        expect(outcomes).toEqual(["uninstalled"]);
+        expect(readAgentsJson(instanceDir)?.agents.x).toBeUndefined();
+        expect(installedNames(built.testApi)).not.toContain("x");
+    });
+
+    it("reports why an update cannot run", async () => {
+        const instanceDir = await installThenDropCatalogKey();
+        const { built } = buildCapturingWarnings(instanceDir);
+
+        await expect(
+            built.testApi.update("x", undefined, noopHost),
+        ).rejects.toThrow(
+            /could not be loaded from its install source[\s\S]*@package uninstall x/,
+        );
+        // The record is left alone for the retry after the source is fixed.
+        expect(readAgentsJson(instanceDir)?.agents.x).toBeDefined();
+    });
+});


### PR DESCRIPTION
### Why

Startup seeding called `registry.load()` unguarded, so one stale record in
`agents.json` aborted the construction of every installed agent and the host
refused to start:
```
[agent-server] Fatal startup error: Error: agent 'androidMobile' is no longer resolvable from catalog source 'workspace'.
    at buildAgentProvider (.../defaultAgentProviders.js:249:37)
    at main (.../agentServer/server/dist/server.js:278:26)
```
There was no in-product recovery: the throw happens in `main()` before any
dispatcher session exists, so `@package uninstall` cannot run and the only fix
was hand-editing `agents.json`. All hosts fail identically — they build this
source through `getDefaultAppAgentSources`.


### What this changes

- Seeding wraps `buildAgentProvider` in try/catch: the failure is recorded in
  `unresolvedRecords` (name -> reason), the name is skipped, and a warning names
  the agent and the command to remove it. Everything else loads and the host
  starts.
- `uninstall` drops such a record directly (nothing was vended, so the
  coordinated teardown barrier has no provider to drain).
- `update` reports why it could not load, instead of the "modified out of band"
  invariant error, which describes a different problem.

The record is **not** deleted from `agents.json`: unresolvability can be
transient, so dropping it on sight would turn a temporary problem into permanent
loss of the user's installs. Fix the source, restart, and it loads again. A
record that resolves is seeded exactly as before.

Only the `catalog` source implements `load`, so it is the only source that could
hit this; `feed` and `path` records were never affected.

### Tests

Four cases in `installSourcesInstalledProvider.spec.ts` (install a catalog
agent, then delete its catalog key): construction warns and keeps the record
without vending it; the agent loads again once the entry is restored;
`uninstall` drops it; `update` fails with the actionable message.

### Verification

`pnpm run build defaultAgentProvider`; `pnpm --filter default-agent-provider
test:local` (54 suites, 3832 passed); `prettier:changed:fix` clean. On a real
profile with the stale record, the agent server now starts instead of dying and
`@package uninstall androidMobile` cleans it up.
