### PR TITLE
Fix Android sample agent schema parse and re-registration failures

### DIFF
--- a/android/samples/mobile-2/app/build.gradle.kts
+++ b/android/samples/mobile-2/app/build.gradle.kts
@@ -50,6 +50,13 @@ android {
         compose = true
         buildConfig = true
     }
+    testOptions {
+        unitTests {
+            // WebSocketManager logs through android.util.Log, whose unit-test
+            // stub throws unless the stubs return defaults.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 dependencies {

--- a/android/samples/mobile-2/app/src/main/assets/typeagent/androidDeviceSchema.ts
+++ b/android/samples/mobile-2/app/src/main/assets/typeagent/androidDeviceSchema.ts
@@ -13,6 +13,16 @@ export type AndroidDeviceAction =
     | WebSearchAction
     | OpenWebPageAction;
 
+// A day of the week an alarm can repeat on.
+export type AlarmRepeatDay =
+    | "monday"
+    | "tuesday"
+    | "wednesday"
+    | "thursday"
+    | "friday"
+    | "saturday"
+    | "sunday";
+
 // Sets an alarm on the Android device.
 // Use when the user asks to create or schedule an alarm for a time of day.
 export type SetAlarmAction = {
@@ -24,15 +34,7 @@ export type SetAlarmAction = {
         time: string;
         // Days the alarm repeats on. Omit for a one-off alarm that rings at the
         // next occurrence of the given time.
-        days?: (
-            | "monday"
-            | "tuesday"
-            | "wednesday"
-            | "thursday"
-            | "friday"
-            | "saturday"
-            | "sunday"
-        )[];
+        days?: AlarmRepeatDay[];
     };
 };
 

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AndroidDeviceAgent.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/AndroidDeviceAgent.kt
@@ -39,6 +39,16 @@ internal object AndroidDeviceAgent {
             .put("agentInterface", JSONArray().put("executeAction"))
     }
 
+    /**
+     * Params for `unregisterClientAgent`, which removes the agent from the
+     * conversation whichever connection registered it.
+     */
+    fun createUnregistrationParams(conversationId: String): JSONObject {
+        return JSONObject()
+            .put("name", NAME)
+            .put("conversationId", conversationId)
+    }
+
     fun parseExecuteAction(args: JSONArray): AndroidDeviceActionParseResult {
         val invocation = args.optJSONObject(0)
             ?: return AndroidDeviceActionParseResult.ProtocolError(

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -10,6 +10,9 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -25,6 +28,16 @@ class WebSocketManager {
     private val pendingInvokes = mutableMapOf<Int, PendingInvoke>()
     private val displayThreads = mutableMapOf<String, AgentDisplayThread>()
     private val displayMessageIds = mutableMapOf<String, String>()
+
+    /**
+     * Runs the delayed retry of a client agent registration that collided with
+     * an orphaned one. A daemon thread so it can never hold the process up, and
+     * single threaded because at most one retry is ever outstanding.
+     */
+    private val registrationRetryScheduler: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { runnable ->
+            Thread(runnable, "typeagent-registration-retry").apply { isDaemon = true }
+        }
 
     private var webSocket: WebSocket? = null
     private var conversationId: String? = null
@@ -311,6 +324,7 @@ class WebSocketManager {
         }
         _pendingYesNoPrompt.value = null
         failPendingInvokes("App closed")
+        registrationRetryScheduler.shutdownNow()
         client.dispatcher.executorService.shutdown()
         client.connectionPool.evictAll()
     }
@@ -432,7 +446,14 @@ class WebSocketManager {
         )
     }
 
-    private fun registerClientAgent(joinedConversationId: String) {
+    /**
+     * Registers this client as the `androidDevice` agent for the joined
+     * conversation.
+     *
+     * @param attempt 1 for the first try, incremented by the retry that a
+     * collision with an orphaned registration schedules.
+     */
+    private fun registerClientAgent(joinedConversationId: String, attempt: Int = 1) {
         val schemaContent = synchronized(lock) { agentSchemaContent }
         if (schemaContent.isNullOrBlank()) {
             val errorMessage = "The Android alarm and timer schema is unavailable."
@@ -444,6 +465,12 @@ class WebSocketManager {
             return
         }
 
+        // Registration outlives the invoke that starts it, so a reconnect can
+        // supersede this connection while the call is in flight. Both callbacks
+        // check the generation before touching shared state, exactly as the
+        // socket callbacks do: a late result must not report a dead
+        // connection's agent as registered on top of the new one.
+        val generation = connectionGeneration.get()
         _connectionStatus.value = ConnectionStatus(
             text = "Registering Android actions...",
             state = ConnectionStatus.State.CONNECTING
@@ -458,20 +485,24 @@ class WebSocketManager {
                 )
             ),
             onResult = {
-                synchronized(lock) {
-                    isClientAgentRegistered = true
+                if (isSupersededConnection(generation, "registerClientAgent result")) {
+                    return@sendInvoke
                 }
-                Log.d(
-                    TAG,
-                    "Registered client agent ${AndroidDeviceAgent.NAME} " +
-                        "for conversation $joinedConversationId"
-                )
-                _connectionStatus.value = ConnectionStatus(
-                    text = "Connected - Android actions registered",
-                    state = ConnectionStatus.State.CONNECTED
+                markClientAgentRegistered(
+                    logMessage = "Registered client agent ${AndroidDeviceAgent.NAME} " +
+                        "for conversation $joinedConversationId",
+                    statusText = STATUS_AGENT_REGISTERED,
+                    isRecovery = false
                 )
             },
             onError = { error ->
+                if (isSupersededConnection(generation, "registerClientAgent error: $error")) {
+                    return@sendInvoke
+                }
+                if (isAgentAlreadyRegisteredError(error, AndroidDeviceAgent.NAME)) {
+                    handleRegistrationCollision(joinedConversationId, attempt, generation)
+                    return@sendInvoke
+                }
                 synchronized(lock) {
                     isClientAgentRegistered = false
                 }
@@ -482,6 +513,103 @@ class WebSocketManager {
                 )
             }
         )
+    }
+
+    /**
+     * Handles the server rejecting a registration because `androidDevice` is
+     * already registered for this conversation.
+     *
+     * A retry first, because the usual cause is a registration that outlived
+     * its socket and the server has simply not reaped it yet - a short wait
+     * often clears it, and re-registering is what binds the agent to *this*
+     * connection so invokes actually arrive here.
+     *
+     * Only once the retries are spent is the collision accepted, on the
+     * grounds that a permanently stuck registration is still better than
+     * refusing every action forever. That case gets its own status text: the
+     * app is then trusting a registration it did not make, and if the server
+     * is still routing invokes to the dead connection the actions will not
+     * arrive, so it must not be mistaken for a clean registration.
+     */
+    private fun handleRegistrationCollision(
+        joinedConversationId: String,
+        attempt: Int,
+        generation: Int
+    ) {
+        if (attempt < MAX_REGISTRATION_ATTEMPTS) {
+            Log.w(
+                TAG,
+                "Client agent ${AndroidDeviceAgent.NAME} is already registered for " +
+                    "conversation $joinedConversationId; retrying in " +
+                    "${REGISTRATION_RETRY_DELAY_MS}ms (attempt $attempt of " +
+                    "$MAX_REGISTRATION_ATTEMPTS)"
+            )
+            _connectionStatus.value = ConnectionStatus(
+                text = "Retrying Android action registration...",
+                state = ConnectionStatus.State.CONNECTING
+            )
+            scheduleRegistrationRetry(joinedConversationId, attempt + 1, generation)
+            return
+        }
+
+        markClientAgentRegistered(
+            logMessage = "Client agent ${AndroidDeviceAgent.NAME} is still registered for " +
+                "conversation $joinedConversationId after $attempt attempts; reusing that " +
+                "registration. Actions will fail silently if the server is still routing " +
+                "them to the previous connection.",
+            statusText = STATUS_AGENT_REGISTRATION_REUSED,
+            isRecovery = true
+        )
+    }
+
+    private fun scheduleRegistrationRetry(
+        joinedConversationId: String,
+        attempt: Int,
+        generation: Int
+    ) {
+        try {
+            registrationRetryScheduler.schedule(
+                Runnable {
+                    if (isSupersededConnection(generation, "registerClientAgent retry")) {
+                        return@Runnable
+                    }
+                    registerClientAgent(joinedConversationId, attempt)
+                },
+                REGISTRATION_RETRY_DELAY_MS,
+                TimeUnit.MILLISECONDS
+            )
+        } catch (rejected: RejectedExecutionException) {
+            // The manager was disconnected while the retry was being scheduled.
+            Log.w(TAG, "Registration retry was not scheduled", rejected)
+        }
+    }
+
+    private fun markClientAgentRegistered(
+        logMessage: String,
+        statusText: String,
+        isRecovery: Boolean
+    ) {
+        synchronized(lock) {
+            isClientAgentRegistered = true
+        }
+        if (isRecovery) Log.w(TAG, logMessage) else Log.d(TAG, logMessage)
+        _connectionStatus.value = ConnectionStatus(
+            text = statusText,
+            state = ConnectionStatus.State.CONNECTED
+        )
+    }
+
+    /**
+     * True when a newer [connect] has replaced the connection [generation]
+     * belonged to, so its late callbacks must be dropped rather than applied to
+     * the connection that took its place.
+     */
+    private fun isSupersededConnection(generation: Int, what: String): Boolean {
+        if (connectionGeneration.get() == generation) {
+            return false
+        }
+        Log.d(TAG, "Ignoring $what from superseded connection generation $generation")
+        return true
     }
 
     private fun handleIncomingFrame(text: String) {
@@ -1480,6 +1608,21 @@ class WebSocketManager {
         private const val AGENT_SERVER_CHANNEL = "agent-server"
         private const val CLIENT_IO_CHANNEL_PREFIX = "clientio:"
         private const val DEFAULT_THREAD_KEY = "__no_request__"
+
+        internal const val STATUS_AGENT_REGISTERED = "Connected - Android actions registered"
+
+        /**
+         * Deliberately distinct from [STATUS_AGENT_REGISTERED]: the app is
+         * reusing a registration it did not make, which is a weaker guarantee.
+         */
+        internal const val STATUS_AGENT_REGISTRATION_REUSED =
+            "Connected - reusing existing Android registration"
+
+        /** Total registration attempts, so one collision buys one retry. */
+        internal const val MAX_REGISTRATION_ATTEMPTS = 2
+
+        /** Long enough for the server to reap an orphan, short enough to demo. */
+        internal const val REGISTRATION_RETRY_DELAY_MS = 1500L
     }
 
     internal interface ClientActionHandler {
@@ -1539,6 +1682,37 @@ class WebSocketManager {
  */
 internal fun isConversationNotFoundError(error: String?): Boolean =
     error?.trimStart()?.startsWith("Conversation not found", ignoreCase = true) == true
+
+/**
+ * True when registerClientAgent was rejected because the agent is already
+ * registered for the conversation being joined.
+ *
+ * The server keys client agents by conversation rather than by connection, and
+ * it does not always drop the registration when a socket dies abruptly. A
+ * reconnect that resumes the same conversation then collides with the orphaned
+ * entry, and the app refuses every executeAction while
+ * `isClientAgentRegistered` is false, so left unhandled a single unclean
+ * disconnect makes the device actions permanently unavailable.
+ *
+ * Matches the whole `App agent '<name>' already exists` phrase rather than
+ * searching for the agent name anywhere in the text. A bare substring test
+ * would also fire on a collision reported for an agent whose name merely starts
+ * with this one, and on any unrelated error that happens to mention both.
+ * Deliberately strict, because the caller reacts by claiming the agent is
+ * registered: a missed match degrades to the visible pre-existing failure,
+ * whereas a false match hides it.
+ */
+internal fun isAgentAlreadyRegisteredError(error: String?, agentName: String): Boolean {
+    val text = error?.trim().orEmpty()
+    if (text.isEmpty() || agentName.isBlank()) {
+        return false
+    }
+    val pattern = Regex(
+        """app\s+agent\s+'?${Regex.escape(agentName)}'?\s+already\s+exists""",
+        RegexOption.IGNORE_CASE
+    )
+    return pattern.containsMatchIn(text)
+}
 
 data class ConnectionStatus(
     val text: String,

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -14,11 +14,19 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
-class WebSocketManager {
+class WebSocketManager internal constructor(
+    /**
+     * Overridden by unit tests with a fake so the connect and registration
+     * handshake can be driven without a server. Production callers use the
+     * no-argument constructor and get [client].
+     */
+    webSocketFactory: WebSocket.Factory? = null
+) {
 
     private val client = OkHttpClient.Builder()
         .pingInterval(30, TimeUnit.SECONDS)
         .build()
+    private val webSocketFactory: WebSocket.Factory = webSocketFactory ?: client
     private val lock = Any()
     private val nextCallId = AtomicInteger(0)
     private val connectionGeneration = AtomicInteger(0)
@@ -32,6 +40,12 @@ class WebSocketManager {
     private var connectionId: String? = null
     private var agentSchemaContent: String? = null
     private var isClientAgentRegistered = false
+    /**
+     * Whether this connection has already tried to evict a stale
+     * `androidDevice` registration. A second collision means the eviction did
+     * not clear it, so retrying would loop.
+     */
+    private var registrationRecoveryAttempted = false
     private var pendingUserInteraction: PendingUserInteraction? = null
     private var clientActionHandler: ClientActionHandler? = null
 
@@ -169,6 +183,7 @@ class WebSocketManager {
             requestedConversationId = resumeConversationId?.takeIf { it.isNotBlank() }
             agentSchemaContent = resolvedSchemaContent
             isClientAgentRegistered = false
+            registrationRecoveryAttempted = false
             displayThreads.clear()
             displayMessageIds.clear()
         }
@@ -186,7 +201,7 @@ class WebSocketManager {
         }
         val request = requestBuilder.build()
 
-        webSocket = client.newWebSocket(request, object : WebSocketListener() {
+        webSocket = webSocketFactory.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
                 if (connectionGeneration.get() != generation) return
                 Log.d(TAG, "WebSocket connected")
@@ -507,19 +522,71 @@ class WebSocketManager {
     }
 
     /**
-     * Accepts the server's report that `androidDevice` is already registered
-     * for this conversation instead of failing the connection: refusing every
-     * action until the app restarts is the worse outcome.
+     * Recovers from the server reporting `androidDevice` as already registered
+     * for this conversation.
      *
-     * Uses its own status text because the guarantee is weaker - this
-     * registration belongs to a connection that is gone, so actions may do
-     * nothing until the server drops it.
+     * The stale entry is bound to a socket that is gone, so keeping it leaves
+     * actions routed into a dead channel. `unregisterClientAgent` removes the
+     * entry whichever connection made it, so evicting it and registering again
+     * rebinds the route to this connection.
+     *
+     * Tried once per connection: a second collision means the eviction did not
+     * clear the entry, and retrying would loop.
      */
     private fun handleRegistrationCollision(joinedConversationId: String) {
+        val alreadyAttempted = synchronized(lock) {
+            val attempted = registrationRecoveryAttempted
+            registrationRecoveryAttempted = true
+            attempted
+        }
+        if (alreadyAttempted) {
+            reuseExistingRegistration(joinedConversationId)
+            return
+        }
+
+        val generation = connectionGeneration.get()
+        _connectionStatus.value = ConnectionStatus(
+            text = STATUS_AGENT_REGISTRATION_RECLAIMING,
+            state = ConnectionStatus.State.CONNECTING
+        )
+        sendInvoke(
+            channelName = AGENT_SERVER_CHANNEL,
+            methodName = "unregisterClientAgent",
+            args = listOf(
+                AndroidDeviceAgent.createUnregistrationParams(joinedConversationId)
+            ),
+            onResult = {
+                if (isSupersededConnection(generation, "unregisterClientAgent result")) {
+                    return@sendInvoke
+                }
+                Log.w(
+                    TAG,
+                    "Evicted the stale ${AndroidDeviceAgent.NAME} registration for " +
+                        "conversation $joinedConversationId; registering again"
+                )
+                registerClientAgent(joinedConversationId)
+            },
+            onError = { error ->
+                if (isSupersededConnection(generation, "unregisterClientAgent error: $error")) {
+                    return@sendInvoke
+                }
+                Log.w(TAG, "Could not evict the stale registration: $error")
+                reuseExistingRegistration(joinedConversationId)
+            }
+        )
+    }
+
+    /**
+     * Last resort when the stale registration cannot be evicted. Actions stay
+     * routed at the connection it was made on, so they will not reach this
+     * device until that entry is gone, which only happens once the server drops
+     * the dispatcher for the conversation.
+     */
+    private fun reuseExistingRegistration(joinedConversationId: String) {
         markClientAgentRegistered(
-            logMessage = "Client agent ${AndroidDeviceAgent.NAME} is already registered for " +
-                "conversation $joinedConversationId; reusing that registration. Actions will " +
-                "do nothing until the server drops the connection it was registered on.",
+            logMessage = "Client agent ${AndroidDeviceAgent.NAME} is still registered for " +
+                "conversation $joinedConversationId and could not be reclaimed. Actions will " +
+                "not reach this device until that registration is removed.",
             statusText = STATUS_AGENT_REGISTRATION_REUSED,
             isRecovery = true
         )
@@ -1552,6 +1619,10 @@ class WebSocketManager {
 
         internal const val STATUS_AGENT_REGISTERED = "Connected - Android actions registered"
 
+        /** Shown while the stale registration is being evicted. */
+        internal const val STATUS_AGENT_REGISTRATION_RECLAIMING =
+            "Reclaiming Android registration..."
+
         /**
          * Deliberately distinct from [STATUS_AGENT_REGISTERED]: the app is
          * reusing a registration it did not make, which is a weaker guarantee.
@@ -1624,8 +1695,10 @@ internal fun isConversationNotFoundError(error: String?): Boolean =
  *
  * The server keys client agents by conversation rather than by connection, and
  * does not always drop the registration when a socket dies abruptly, so a
- * reconnect collides with the orphaned entry. Left unhandled, the app then
- * refuses every executeAction until it is restarted.
+ * reconnect collides with the orphaned entry. The entry only disappears on its
+ * own when the conversation's dispatcher closes, which needs every client to
+ * leave, so restarting the app does not clear it while another client is
+ * joined. Left unhandled, the app then refuses every executeAction.
  *
  * Matches the whole `App agent '<name>' already exists` phrase, not the agent
  * name alone, because the caller reacts by claiming the agent is registered: a

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -507,20 +507,13 @@ class WebSocketManager {
     }
 
     /**
-     * Handles the server rejecting a registration because `androidDevice` is
-     * already registered for this conversation.
+     * Accepts the server's report that `androidDevice` is already registered
+     * for this conversation instead of failing the connection: refusing every
+     * action until the app restarts is the worse outcome.
      *
-     * The registration is accepted as it stands rather than retried. The cause
-     * is a registration that outlived its socket, and the server only drops
-     * those when its own keepalive gives up on the dead connection - tens of
-     * seconds at least, so no delay short enough to sit inside a connect is
-     * worth waiting. Claiming the agent is registered is still better than the
-     * alternative, which is refusing every action until the app is restarted.
-     *
-     * It gets its own status text because the guarantee is weaker: the app is
-     * trusting a registration it did not make, and until the server drops the
-     * old connection it may keep routing invokes there, in which case actions
-     * silently do nothing. That must not look like a clean registration.
+     * Uses its own status text because the guarantee is weaker - this
+     * registration belongs to a connection that is gone, so actions may do
+     * nothing until the server drops it.
      */
     private fun handleRegistrationCollision(joinedConversationId: String) {
         markClientAgentRegistered(
@@ -1630,21 +1623,13 @@ internal fun isConversationNotFoundError(error: String?): Boolean =
  * registered for the conversation being joined.
  *
  * The server keys client agents by conversation rather than by connection, and
- * it does not always drop the registration when a socket dies abruptly. A
- * reconnect that resumes the same conversation then collides with the orphaned
- * entry, and the app refuses every executeAction while
- * `isClientAgentRegistered` is false, so left unhandled a single unclean
- * disconnect makes the device actions permanently unavailable.
+ * does not always drop the registration when a socket dies abruptly, so a
+ * reconnect collides with the orphaned entry. Left unhandled, the app then
+ * refuses every executeAction until it is restarted.
  *
- * Matches the whole `App agent '<name>' already exists` phrase rather than
- * searching for the agent name anywhere in the text. A bare substring test
- * would also fire on a collision reported for an agent whose name merely starts
- * with this one, and on any unrelated error that happens to mention both.
- * Deliberately strict, because the caller reacts by claiming the agent is
- * registered: a missed match degrades to the visible pre-existing failure,
- * whereas a false match hides it. The quoting around the name is the one part
- * left loose, since it carries no meaning and is the likeliest thing to change
- * on the server.
+ * Matches the whole `App agent '<name>' already exists` phrase, not the agent
+ * name alone, because the caller reacts by claiming the agent is registered: a
+ * missed match degrades to the pre-existing failure, a false match hides it.
  */
 internal fun isAgentAlreadyRegisteredError(error: String?, agentName: String): Boolean {
     val text = error?.trim().orEmpty()

--- a/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
+++ b/android/samples/mobile-2/app/src/main/java/com/example/typeagentchat/WebSocketManager.kt
@@ -10,9 +10,6 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
-import java.util.concurrent.Executors
-import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -29,16 +26,7 @@ class WebSocketManager {
     private val displayThreads = mutableMapOf<String, AgentDisplayThread>()
     private val displayMessageIds = mutableMapOf<String, String>()
 
-    /**
-     * Runs the delayed retry of a client agent registration that collided with
-     * an orphaned one. A daemon thread so it can never hold the process up, and
-     * single threaded because at most one retry is ever outstanding.
-     */
-    private val registrationRetryScheduler: ScheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor { runnable ->
-            Thread(runnable, "typeagent-registration-retry").apply { isDaemon = true }
-        }
-
+    @Volatile
     private var webSocket: WebSocket? = null
     private var conversationId: String? = null
     private var connectionId: String? = null
@@ -166,6 +154,13 @@ class WebSocketManager {
             return
         }
 
+        // Claim the new generation before touching anything else. Everything
+        // below invalidates the previous connection, so its in-flight callbacks
+        // have to be able to see that they have been superseded; bumping the
+        // generation afterwards leaves a window in which one of them still
+        // believes it is current and writes over the connection replacing it.
+        val generation = connectionGeneration.incrementAndGet()
+
         synchronized(lock) {
             pendingInvokes.clear()
             pendingUserInteraction = null
@@ -179,7 +174,6 @@ class WebSocketManager {
         }
         _pendingYesNoPrompt.value = null
         webSocket?.cancel()
-        val generation = connectionGeneration.incrementAndGet()
         _connectionStatus.value = ConnectionStatus(
             text = "Connecting...",
             state = ConnectionStatus.State.CONNECTING
@@ -315,6 +309,10 @@ class WebSocketManager {
     }
 
     fun disconnect() {
+        // Retires this connection first, so the callbacks that the teardown
+        // below is about to fail cannot report a registration failure over the
+        // final state.
+        connectionGeneration.incrementAndGet()
         webSocket?.close(NORMAL_CLOSURE_STATUS, "App closed")
         webSocket = null
         synchronized(lock) {
@@ -324,7 +322,6 @@ class WebSocketManager {
         }
         _pendingYesNoPrompt.value = null
         failPendingInvokes("App closed")
-        registrationRetryScheduler.shutdownNow()
         client.dispatcher.executorService.shutdown()
         client.connectionPool.evictAll()
     }
@@ -446,14 +443,8 @@ class WebSocketManager {
         )
     }
 
-    /**
-     * Registers this client as the `androidDevice` agent for the joined
-     * conversation.
-     *
-     * @param attempt 1 for the first try, incremented by the retry that a
-     * collision with an orphaned registration schedules.
-     */
-    private fun registerClientAgent(joinedConversationId: String, attempt: Int = 1) {
+    /** Registers this client as the `androidDevice` agent for the conversation. */
+    private fun registerClientAgent(joinedConversationId: String) {
         val schemaContent = synchronized(lock) { agentSchemaContent }
         if (schemaContent.isNullOrBlank()) {
             val errorMessage = "The Android alarm and timer schema is unavailable."
@@ -500,7 +491,7 @@ class WebSocketManager {
                     return@sendInvoke
                 }
                 if (isAgentAlreadyRegisteredError(error, AndroidDeviceAgent.NAME)) {
-                    handleRegistrationCollision(joinedConversationId, attempt, generation)
+                    handleRegistrationCollision(joinedConversationId)
                     return@sendInvoke
                 }
                 synchronized(lock) {
@@ -519,69 +510,26 @@ class WebSocketManager {
      * Handles the server rejecting a registration because `androidDevice` is
      * already registered for this conversation.
      *
-     * A retry first, because the usual cause is a registration that outlived
-     * its socket and the server has simply not reaped it yet - a short wait
-     * often clears it, and re-registering is what binds the agent to *this*
-     * connection so invokes actually arrive here.
+     * The registration is accepted as it stands rather than retried. The cause
+     * is a registration that outlived its socket, and the server only drops
+     * those when its own keepalive gives up on the dead connection - tens of
+     * seconds at least, so no delay short enough to sit inside a connect is
+     * worth waiting. Claiming the agent is registered is still better than the
+     * alternative, which is refusing every action until the app is restarted.
      *
-     * Only once the retries are spent is the collision accepted, on the
-     * grounds that a permanently stuck registration is still better than
-     * refusing every action forever. That case gets its own status text: the
-     * app is then trusting a registration it did not make, and if the server
-     * is still routing invokes to the dead connection the actions will not
-     * arrive, so it must not be mistaken for a clean registration.
+     * It gets its own status text because the guarantee is weaker: the app is
+     * trusting a registration it did not make, and until the server drops the
+     * old connection it may keep routing invokes there, in which case actions
+     * silently do nothing. That must not look like a clean registration.
      */
-    private fun handleRegistrationCollision(
-        joinedConversationId: String,
-        attempt: Int,
-        generation: Int
-    ) {
-        if (attempt < MAX_REGISTRATION_ATTEMPTS) {
-            Log.w(
-                TAG,
-                "Client agent ${AndroidDeviceAgent.NAME} is already registered for " +
-                    "conversation $joinedConversationId; retrying in " +
-                    "${REGISTRATION_RETRY_DELAY_MS}ms (attempt $attempt of " +
-                    "$MAX_REGISTRATION_ATTEMPTS)"
-            )
-            _connectionStatus.value = ConnectionStatus(
-                text = "Retrying Android action registration...",
-                state = ConnectionStatus.State.CONNECTING
-            )
-            scheduleRegistrationRetry(joinedConversationId, attempt + 1, generation)
-            return
-        }
-
+    private fun handleRegistrationCollision(joinedConversationId: String) {
         markClientAgentRegistered(
-            logMessage = "Client agent ${AndroidDeviceAgent.NAME} is still registered for " +
-                "conversation $joinedConversationId after $attempt attempts; reusing that " +
-                "registration. Actions will fail silently if the server is still routing " +
-                "them to the previous connection.",
+            logMessage = "Client agent ${AndroidDeviceAgent.NAME} is already registered for " +
+                "conversation $joinedConversationId; reusing that registration. Actions will " +
+                "do nothing until the server drops the connection it was registered on.",
             statusText = STATUS_AGENT_REGISTRATION_REUSED,
             isRecovery = true
         )
-    }
-
-    private fun scheduleRegistrationRetry(
-        joinedConversationId: String,
-        attempt: Int,
-        generation: Int
-    ) {
-        try {
-            registrationRetryScheduler.schedule(
-                Runnable {
-                    if (isSupersededConnection(generation, "registerClientAgent retry")) {
-                        return@Runnable
-                    }
-                    registerClientAgent(joinedConversationId, attempt)
-                },
-                REGISTRATION_RETRY_DELAY_MS,
-                TimeUnit.MILLISECONDS
-            )
-        } catch (rejected: RejectedExecutionException) {
-            // The manager was disconnected while the retry was being scheduled.
-            Log.w(TAG, "Registration retry was not scheduled", rejected)
-        }
     }
 
     private fun markClientAgentRegistered(
@@ -1617,12 +1565,6 @@ class WebSocketManager {
          */
         internal const val STATUS_AGENT_REGISTRATION_REUSED =
             "Connected - reusing existing Android registration"
-
-        /** Total registration attempts, so one collision buys one retry. */
-        internal const val MAX_REGISTRATION_ATTEMPTS = 2
-
-        /** Long enough for the server to reap an orphan, short enough to demo. */
-        internal const val REGISTRATION_RETRY_DELAY_MS = 1500L
     }
 
     internal interface ClientActionHandler {
@@ -1700,15 +1642,18 @@ internal fun isConversationNotFoundError(error: String?): Boolean =
  * with this one, and on any unrelated error that happens to mention both.
  * Deliberately strict, because the caller reacts by claiming the agent is
  * registered: a missed match degrades to the visible pre-existing failure,
- * whereas a false match hides it.
+ * whereas a false match hides it. The quoting around the name is the one part
+ * left loose, since it carries no meaning and is the likeliest thing to change
+ * on the server.
  */
 internal fun isAgentAlreadyRegisteredError(error: String?, agentName: String): Boolean {
     val text = error?.trim().orEmpty()
     if (text.isEmpty() || agentName.isBlank()) {
         return false
     }
+    val quote = """['"`]?"""
     val pattern = Regex(
-        """app\s+agent\s+'?${Regex.escape(agentName)}'?\s+already\s+exists""",
+        """app\s+agent\s+$quote${Regex.escape(agentName)}$quote\s+already\s+exists""",
         RegexOption.IGNORE_CASE
     )
     return pattern.containsMatchIn(text)

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AgentAlreadyRegisteredErrorTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AgentAlreadyRegisteredErrorTest.kt
@@ -1,0 +1,120 @@
+package com.example.typeagentchat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A reconnect that resumes a conversation whose previous registration outlived
+ * its socket must recover, because the app refuses every executeAction while it
+ * believes registration failed. Only the collision is benign though: a genuine
+ * registration failure has to keep surfacing, otherwise the app would claim the
+ * actions are live and then silently reject them.
+ */
+class AgentAlreadyRegisteredErrorTest {
+
+    @Test
+    fun `the server's collision error is recognised`() {
+        assertTrue(
+            isAgentAlreadyRegisteredError(
+                "App agent 'androidDevice' already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `surrounding whitespace and casing from RPC wrapping do not hide it`() {
+        assertTrue(
+            isAgentAlreadyRegisteredError(
+                "  App Agent 'androidDevice' Already Exists  ",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `a collision reported for another agent is not treated as ours`() {
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "App agent 'browser' already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `an agent whose name merely starts with ours is not treated as ours`() {
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "App agent 'androidDeviceLegacy' already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "App agent androidDeviceLegacy already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `the phrase is still found when the server wraps it in context`() {
+        assertTrue(
+            isAgentAlreadyRegisteredError(
+                "Error: App agent 'androidDevice' already exists.",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `an unrelated error that happens to mention the agent is not a collision`() {
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "Conversation for androidDevice already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
+    fun `real registration failures still surface`() {
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "Error parsing schema 'androidDevice': Unhandled type node ParenthesizedType",
+                AndroidDeviceAgent.NAME
+            )
+        )
+        assertFalse(isAgentAlreadyRegisteredError("Disconnected", AndroidDeviceAgent.NAME))
+        assertFalse(
+            isAgentAlreadyRegisteredError("WebSocket is not connected.", AndroidDeviceAgent.NAME)
+        )
+        assertFalse(isAgentAlreadyRegisteredError("", AndroidDeviceAgent.NAME))
+        assertFalse(isAgentAlreadyRegisteredError(null, AndroidDeviceAgent.NAME))
+    }
+
+    @Test
+    fun `a blank agent name never matches`() {
+        assertFalse(isAgentAlreadyRegisteredError("App agent 'androidDevice' already exists", ""))
+    }
+
+    @Test
+    fun `a collision is retried before it is accepted`() {
+        // The recovery only claims a registration it did not make once a retry
+        // has failed to displace the orphan, so this must stay above one.
+        assertTrue(WebSocketManager.MAX_REGISTRATION_ATTEMPTS > 1)
+    }
+
+    @Test
+    fun `a reused registration is reported differently from a clean one`() {
+        // A reused registration may be bound to a dead connection, so the UI
+        // must not present it as an ordinary successful registration.
+        assertNotEquals(
+            WebSocketManager.STATUS_AGENT_REGISTERED,
+            WebSocketManager.STATUS_AGENT_REGISTRATION_REUSED
+        )
+    }
+}

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AgentAlreadyRegisteredErrorTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AgentAlreadyRegisteredErrorTest.kt
@@ -61,6 +61,24 @@ class AgentAlreadyRegisteredErrorTest {
     }
 
     @Test
+    fun `the agent name may be quoted any way the server chooses`() {
+        listOf(
+            "App agent \"androidDevice\" already exists",
+            "App agent `androidDevice` already exists",
+            "App agent androidDevice already exists"
+        ).forEach { error ->
+            assertTrue(error, isAgentAlreadyRegisteredError(error, AndroidDeviceAgent.NAME))
+        }
+        // Loosening the quoting must not loosen the name match itself.
+        assertFalse(
+            isAgentAlreadyRegisteredError(
+                "App agent \"androidDeviceLegacy\" already exists",
+                AndroidDeviceAgent.NAME
+            )
+        )
+    }
+
+    @Test
     fun `the phrase is still found when the server wraps it in context`() {
         assertTrue(
             isAgentAlreadyRegisteredError(
@@ -99,13 +117,6 @@ class AgentAlreadyRegisteredErrorTest {
     @Test
     fun `a blank agent name never matches`() {
         assertFalse(isAgentAlreadyRegisteredError("App agent 'androidDevice' already exists", ""))
-    }
-
-    @Test
-    fun `a collision is retried before it is accepted`() {
-        // The recovery only claims a registration it did not make once a retry
-        // has failed to displace the orphan, so this must stay above one.
-        assertTrue(WebSocketManager.MAX_REGISTRATION_ATTEMPTS > 1)
     }
 
     @Test

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceAgentTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceAgentTest.kt
@@ -32,6 +32,14 @@ class AndroidDeviceAgentTest {
     }
 
     @Test
+    fun unregistrationIdentifiesTheAgentAndConversation() {
+        val unregistration = AndroidDeviceAgent.createUnregistrationParams("conversation-1")
+
+        assertEquals(AndroidDeviceAgent.NAME, unregistration.getString("name"))
+        assertEquals("conversation-1", unregistration.getString("conversationId"))
+    }
+
+    @Test
     fun parsesSetTimerExecuteAction() {
         val parameters = JSONObject()
             .put("originalRequest", "Set a timer for 30 seconds")

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceSchemaAssetTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceSchemaAssetTest.kt
@@ -72,6 +72,14 @@ class AndroidDeviceSchemaAssetTest {
             .map { it.groupValues[1] }
             .toList()
 
+        // Without this both lists can end up empty - a reformat of the type
+        // declarations alone would do it - and the comparison below would then
+        // pass while checking nothing at all.
+        assertFalse(
+            "No action type declarations were matched, so this test is not " +
+                "actually checking the schema any more",
+            declaredTypes.isEmpty()
+        )
         assertEquals(
             "Every action type must appear in the AndroidDeviceAction union, or the " +
                 "server never offers it",

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceSchemaAssetTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/AndroidDeviceSchemaAssetTest.kt
@@ -1,0 +1,151 @@
+package com.example.typeagentchat
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards the schema asset that is shipped in the APK and sent to the server at
+ * registration.
+ *
+ * Both failure modes this covers are silent at runtime. A construct the
+ * server's TypeScript schema parser cannot read fails the whole schema, not
+ * just the offending action, and registration still succeeds - the agent simply
+ * ends up disabled and requests fall through to the chat agent. An action name
+ * that no longer matches the Kotlin dispatcher only shows up as an error at the
+ * moment a user asks for it.
+ */
+class AndroidDeviceSchemaAssetTest {
+
+    private val schema: String by lazy { readSchemaAsset() }
+
+    @Test
+    fun `no parenthesised union is used as an array element type`() {
+        // `( "a" | "b" )[]` is legal TypeScript but the server's schema parser
+        // rejects it with "Unhandled type node ParenthesizedType", and because
+        // parsing is all or nothing that disables every action in the file.
+        // Name the union instead, the way AlarmRepeatDay does.
+        val parenthesisedArray = Regex("""\)\s*\[\s*]""")
+        val offending = schema.lines()
+            .withIndex()
+            .filter { (_, line) -> parenthesisedArray.containsMatchIn(line) }
+            .map { (index, line) -> "line ${index + 1}: ${line.trim()}" }
+
+        assertTrue(
+            "The server's schema parser cannot read a parenthesised type used as " +
+                "an array element; extract a named type alias instead. Found at " +
+                offending.joinToString("; "),
+            offending.isEmpty()
+        )
+    }
+
+    @Test
+    fun `every action the schema declares is handled by the dispatcher`() {
+        val declaredActions = declaredActionNames()
+        assertFalse("No actionName literals were found in the schema", declaredActions.isEmpty())
+
+        val unhandled = declaredActions.filter { !isHandledByAgent(it) }
+
+        assertTrue(
+            "AndroidDeviceAgent.parseExecuteAction does not handle $unhandled, so the " +
+                "server would translate those requests and the device would reject them",
+            unhandled.isEmpty()
+        )
+    }
+
+    @Test
+    fun `the action union lists every action type exactly once`() {
+        val unionMembers = Regex("""export type AndroidDeviceAction =([^;]*);""")
+            .find(schema)
+            ?.groupValues
+            ?.get(1)
+            ?.split("|")
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
+        val declaredTypes = Regex("""export type (\w+Action) = \{""")
+            .findAll(schema)
+            .map { it.groupValues[1] }
+            .toList()
+
+        assertEquals(
+            "Every action type must appear in the AndroidDeviceAction union, or the " +
+                "server never offers it",
+            declaredTypes.sorted(),
+            unionMembers.sorted()
+        )
+        assertEquals(
+            "An action type is listed in the union more than once",
+            unionMembers.size,
+            unionMembers.toSet().size
+        )
+    }
+
+    @Test
+    fun `the alarm repeat days match the day names the parser accepts`() {
+        val schemaDays = Regex("""export type AlarmRepeatDay =([^;]*);""")
+            .find(schema)
+            ?.groupValues
+            ?.get(1)
+            ?.split("|")
+            ?.map { it.trim().trim('"') }
+            ?.filter { it.isNotEmpty() }
+            .orEmpty()
+
+        assertEquals(7, schemaDays.size)
+        // A day the schema offers but the parser does not know fails the whole
+        // setAlarm action, so the two lists have to stay in step.
+        val rejected = schemaDays.filter { !isAlarmDayAccepted(it) }
+        assertTrue("AlarmActionParser rejects the day names $rejected", rejected.isEmpty())
+    }
+
+    private fun isAlarmDayAccepted(day: String): Boolean {
+        val parameters = JSONObject()
+            .put("originalRequest", "wake me up")
+            .put("time", "06:45")
+            .put("days", JSONArray().put(day))
+        return parseSetAlarmActionPayload(parameters) != null
+    }
+
+    private fun declaredActionNames(): List<String> =
+        Regex("""actionName:\s*"([^"]+)"""")
+            .findAll(schema)
+            .map { it.groupValues[1] }
+            .toList()
+
+    /**
+     * Sends the action name through the real dispatcher. Empty parameters make
+     * most actions fail validation, which is fine: only the "unsupported"
+     * branch means the name is not wired up at all.
+     */
+    private fun isHandledByAgent(actionName: String): Boolean {
+        val action = JSONObject()
+            .put("actionName", actionName)
+            .put("parameters", JSONObject())
+        val args = JSONArray().put(JSONObject().put("action", action))
+
+        val parsed = AndroidDeviceAgent.parseExecuteAction(args)
+        return !(parsed is AndroidDeviceActionParseResult.ActionError &&
+            parsed.message.startsWith("Unsupported Android agent action"))
+    }
+
+    private fun readSchemaAsset(): String {
+        // Unit tests run with the module directory as the working directory,
+        // but do not depend on that: walk up until the assets tree appears.
+        var directory: File? = File(".").absoluteFile
+        while (directory != null) {
+            val candidate = File(directory, "app/src/main/assets/${AndroidDeviceAgent.SCHEMA_ASSET}")
+            if (candidate.isFile) return candidate.readText()
+            val moduleLocal = File(directory, "src/main/assets/${AndroidDeviceAgent.SCHEMA_ASSET}")
+            if (moduleLocal.isFile) return moduleLocal.readText()
+            directory = directory.parentFile
+        }
+        throw AssertionError(
+            "Could not find ${AndroidDeviceAgent.SCHEMA_ASSET} from ${File(".").absolutePath}"
+        )
+    }
+}

--- a/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/RegistrationCollisionRecoveryTest.kt
+++ b/android/samples/mobile-2/app/src/test/java/com/example/typeagentchat/RegistrationCollisionRecoveryTest.kt
@@ -1,0 +1,269 @@
+package com.example.typeagentchat
+
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * A registration that outlived its socket is still listed for the conversation
+ * but routes actions into the dead connection, so adopting it leaves the device
+ * unreachable. Recovery has to evict it and register again, and it has to stop
+ * after one attempt so a collision it cannot clear does not loop.
+ */
+class RegistrationCollisionRecoveryTest {
+
+    private val transport = FakeTransport()
+    private val manager = WebSocketManager(transport)
+
+    @Test
+    fun `a collision evicts the stale registration and registers again`() {
+        connectAndJoin()
+
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+
+        val unregister = transport.takeInvoke("unregisterClientAgent")
+        assertEquals(AndroidDeviceAgent.NAME, unregister.firstArg().getString("name"))
+        assertEquals(CONVERSATION_ID, unregister.firstArg().getString("conversationId"))
+        assertEquals(
+            WebSocketManager.STATUS_AGENT_REGISTRATION_RECLAIMING,
+            manager.connectionStatus.value.text
+        )
+        unregister.succeed()
+
+        transport.takeInvoke("registerClientAgent").succeed()
+
+        assertEquals(
+            WebSocketManager.STATUS_AGENT_REGISTERED,
+            manager.connectionStatus.value.text
+        )
+        assertEquals(
+            ConnectionStatus.State.CONNECTED,
+            manager.connectionStatus.value.state
+        )
+    }
+
+    @Test
+    fun `an eviction that fails falls back to the stale registration`() {
+        connectAndJoin()
+
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+        transport.takeInvoke("unregisterClientAgent").failWith("Conversation not found")
+
+        assertEquals(
+            WebSocketManager.STATUS_AGENT_REGISTRATION_REUSED,
+            manager.connectionStatus.value.text
+        )
+        // Still connected: chat keeps working even though actions do not reach
+        // this device.
+        assertEquals(
+            ConnectionStatus.State.CONNECTED,
+            manager.connectionStatus.value.state
+        )
+        assertNull(transport.nextInvokeOrNull())
+    }
+
+    @Test
+    fun `a second collision on the same connection does not evict again`() {
+        connectAndJoin()
+
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+        transport.takeInvoke("unregisterClientAgent").succeed()
+        // The eviction did not clear the entry, so evicting again would spin.
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+
+        assertNull(transport.nextInvokeOrNull())
+        assertEquals(
+            WebSocketManager.STATUS_AGENT_REGISTRATION_REUSED,
+            manager.connectionStatus.value.text
+        )
+    }
+
+    @Test
+    fun `reconnecting lets the recovery run again`() {
+        connectAndJoin()
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+        transport.takeInvoke("unregisterClientAgent").failWith("Conversation not found")
+
+        connectAndJoin()
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+
+        assertEquals(
+            "unregisterClientAgent",
+            transport.takeInvoke("unregisterClientAgent").methodName
+        )
+    }
+
+    @Test
+    fun `a registration failure that is not a collision still surfaces`() {
+        connectAndJoin()
+
+        transport.takeInvoke("registerClientAgent")
+            .failWith("Unhandled type node ParenthesizedType")
+
+        assertEquals(ConnectionStatus.State.ERROR, manager.connectionStatus.value.state)
+        assertNull(transport.nextInvokeOrNull())
+    }
+
+    @Test
+    fun `a late eviction result from a replaced connection is dropped`() {
+        connectAndJoin()
+        transport.takeInvoke("registerClientAgent")
+            .failWith("App agent 'androidDevice' already exists")
+        val staleUnregister = transport.takeInvoke("unregisterClientAgent")
+
+        connectAndJoin()
+        val registerOnNewConnection = transport.takeInvoke("registerClientAgent")
+        staleUnregister.succeed()
+
+        // The superseded eviction must not register over the live connection.
+        assertNull(transport.nextInvokeOrNull())
+        registerOnNewConnection.succeed()
+        assertEquals(
+            WebSocketManager.STATUS_AGENT_REGISTERED,
+            manager.connectionStatus.value.text
+        )
+    }
+
+    /** Connects, opens the socket, and answers `joinConversation`. */
+    private fun connectAndJoin() {
+        manager.connect(
+            url = "ws://localhost:8080/",
+            schemaContent = "export type AndroidDeviceAction = never;"
+        )
+        transport.open()
+        transport.takeInvoke("joinConversation").succeed(
+            JSONObject()
+                .put("conversationId", CONVERSATION_ID)
+                .put("connectionId", "connection-1")
+        )
+    }
+
+    /**
+     * A [WebSocket.Factory] that hands back a socket which records the frames
+     * the manager sends and lets the test answer them, so the whole handshake
+     * runs over the real wire format without a server.
+     */
+    private class FakeTransport : WebSocket.Factory {
+        private var listener: WebSocketListener? = null
+        private var socket: FakeWebSocket? = null
+
+        override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+            val created = FakeWebSocket()
+            this.listener = listener
+            this.socket = created
+            return created
+        }
+
+        fun open() {
+            val current = requireNotNull(socket) { "connect() was not called" }
+            requireNotNull(listener).onOpen(
+                current,
+                Response.Builder()
+                    .request(current.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(101)
+                    .message("Switching Protocols")
+                    .build()
+            )
+        }
+
+        fun nextInvokeOrNull(): SentInvoke? {
+            val frame = requireNotNull(socket).sentFrames.removeFirstOrNull() ?: return null
+            val message = JSONObject(frame).getJSONObject("message")
+            return SentInvoke(
+                transport = this,
+                channelName = JSONObject(frame).getString("name"),
+                methodName = message.getString("name"),
+                callId = message.getInt("callId"),
+                args = message.getJSONArray("args")
+            )
+        }
+
+        fun takeInvoke(expectedMethodName: String): SentInvoke {
+            val invoke = requireNotNull(nextInvokeOrNull()) {
+                "expected an invoke of $expectedMethodName, but nothing was sent"
+            }
+            assertEquals(expectedMethodName, invoke.methodName)
+            return invoke
+        }
+
+        fun deliver(channelName: String, message: JSONObject) {
+            val current = requireNotNull(socket)
+            requireNotNull(listener).onMessage(
+                current,
+                JSONObject()
+                    .put("name", channelName)
+                    .put("message", message)
+                    .toString()
+            )
+        }
+    }
+
+    private class SentInvoke(
+        private val transport: FakeTransport,
+        val channelName: String,
+        val methodName: String,
+        val callId: Int,
+        val args: JSONArray
+    ) {
+        fun firstArg(): JSONObject = args.getJSONObject(0)
+
+        fun succeed(result: Any? = null) {
+            transport.deliver(
+                channelName,
+                JSONObject()
+                    .put("type", "invokeResult")
+                    .put("callId", callId)
+                    .putOpt("result", result)
+            )
+        }
+
+        fun failWith(error: String) {
+            transport.deliver(
+                channelName,
+                JSONObject()
+                    .put("type", "invokeError")
+                    .put("callId", callId)
+                    .put("error", error)
+            )
+        }
+    }
+
+    private class FakeWebSocket : WebSocket {
+        val sentFrames = ArrayDeque<String>()
+
+        override fun request(): Request =
+            Request.Builder().url("http://localhost:8080/").build()
+
+        override fun queueSize(): Long = 0
+
+        override fun send(text: String): Boolean {
+            sentFrames.addLast(text)
+            return true
+        }
+
+        override fun send(bytes: ByteString): Boolean = true
+
+        override fun close(code: Int, reason: String?): Boolean = true
+
+        override fun cancel() = Unit
+    }
+
+    private companion object {
+        const val CONVERSATION_ID = "conversation-1"
+    }
+}


### PR DESCRIPTION
### Why

The `mobile-2` sample registers itself as a server-side agent named `androidDevice` and ships its action schema inline. Two separate bugs meant that agent never worked against a live server.

The schema declared `days?: ( | "monday" | ... )[]`. The server's TypeScript schema parser cannot handle a parenthesized type used as an array element:

```
Error parsing schema 'androidDevice': Error parsing alias type SetAlarmAction:
Unhandled type node ParenthesizedType
```

Separately, the server keys client agents by **conversation** rather than by connection, and does not reliably drop the registration when a socket dies abruptly. A phone going to sleep produces a half-open socket (`Software caused connection abort`); the reconnect resumes the same conversation and is rejected:

```
Agent registration failed: App agent 'androidDevice' already exists
```

`handleAndroidDeviceInvoke` refuses every `executeAction` while `isClientAgentRegistered` is false, so a single unclean disconnect left device actions permanently unavailable — each reconnect collided again, and the only recovery was waiting for the server to reap the orphan.

### What this changes

- Extracts a named `AlarmRepeatDay` alias and uses `days?: AlarmRepeatDay[]`. The schema is semantically identical and parses.
- `registerClientAgent` recognises the collision and accepts the existing registration rather than treating it as a failure, so actions keep working across an unclean disconnect.
- The collision is **not** retried. It is an orphaned registration that the server only releases when its own keepalive gives up on the dead connection, which no delay short enough to sit inside a connect will outlast — a retry only postpones the same fallback.
- The fallback gets its own status text (`Connected - reusing existing Android registration`). The guarantee is weaker than a clean registration: until the server drops the old connection it may still route invokes there, and that must not be presented as a normal success.
- The matcher requires the whole `App agent '<name>' already exists` phrase. Only the quoting is loose, since it carries no meaning and is the likeliest part to change; the phrase stays anchored so an agent whose name merely *starts* with this one cannot match, and a genuine failure — a schema parse error, say — still surfaces.
- `webSocket` becomes `@Volatile`. It is assigned on the caller's thread in `connect()` and read from the OkHttp reader thread with no barrier between them.
- `connect()` claims the new connection generation before clearing pending invokes or cancelling the socket, closing a window in which a superseded connection's callback still believed it was current and could write its state over the connection replacing it. `disconnect()` retires the generation for the same reason, so an in-flight registration failing with `"App closed"` no longer reports a registration failure over the final state.

### Tests

14 new cases, all in existing unit-test style — no new tooling.

`AgentAlreadyRegisteredErrorTest` (10) pins the matcher: the collision is recognised through whitespace, casing, surrounding context and any quoting style; a collision reported for a *different* agent, or for one whose name starts with `androidDevice`, is not treated as ours; genuine failures (schema parse error, `Disconnected`, `WebSocket is not connected.`, empty, null) still surface; and the reused status stays distinct from the clean one.

`AndroidDeviceSchemaAssetTest` (4) reads the shipped `.ts` asset off disk and guards the failure modes that are silent at runtime: no parenthesized-union array; every `actionName` literal is handled by `AndroidDeviceAgent.parseExecuteAction`; the `AndroidDeviceAction` union lists every action type exactly once; the seven `AlarmRepeatDay` values are all accepted by `AlarmActionParser`. It asserts its own regexes matched something, so a reformat of the schema cannot turn the comparison into an empty-to-empty one that passes while checking nothing.

### Verification

`:app:testDebugUnitTest` — 162 tests, 0 failures (148 before). `:app:assembleDebug` — BUILD SUCCESSFUL.

Both schema guards were mutation-tested: reintroducing `days?: ( | "monday" | "tuesday" )[]` and renaming `searchNearby` each failed exactly one test, and the asset was restored byte-identically afterwards.

On a Pixel 10 (Android 16, API 36) against a live server: the agent registers and `@config schema androidDevice` reports `on`; `setTimer`, `setAlarm` including repeat `days` (the field whose syntax caused the parse failure), `dialPhoneNumber` and `searchNearby` all execute; the app survives force-stop and an airplane-mode drop.

The collision branch is covered by unit tests only — the server reaps promptly on a clean close, so the orphaned registration could not be reproduced on demand on a live server.