### PR TITLE
Add translation benchmark ambiguity analysis

### DIFF
--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=2853f050a188d6ffab33ce680178039afd9cacb5164a90898695116158224600 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=73404d2fce8c78dd5340363da5507bca898ca1e45ff8985eb842def955340b4a -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/prices.ts](./src/core/prices.ts)
 - [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
-- _…and 38 more under `./src/`._
+- _…and 39 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `7c6cbc823caaaf6dfa97f9c42b043ba7065c9472` on `2026-08-13T20:36:56.989Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `d4ad298492b2c9faf35ded928a7f78a7a4a30777` on `2026-08-18T21:14:57.012Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=73404d2fce8c78dd5340363da5507bca898ca1e45ff8985eb842def955340b4a -->
+<!-- AUTOGEN:DOCS:HASH:sha256=6f1aa37a1694e3324dfeee6b1c012130a9cadaa71a226d5d34b228678892a338 -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/prices.ts](./src/core/prices.ts)
 - [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
-- _…and 39 more under `./src/`._
+- _…and 40 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `d4ad298492b2c9faf35ded928a7f78a7a4a30777` on `2026-08-18T21:14:57.012Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `976315358682e68038137faed50bb938bd75b1f6` on `2026-08-19T01:04:55.685Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=6f1aa37a1694e3324dfeee6b1c012130a9cadaa71a226d5d34b228678892a338 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=3c2dd53d610036f99969bad09a179a0aa6a570c752057479b70f553a8d671d48 -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/prices.ts](./src/core/prices.ts)
 - [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
-- _…and 40 more under `./src/`._
+- _…and 41 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `976315358682e68038137faed50bb938bd75b1f6` on `2026-08-19T01:04:55.685Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `b98fbe01eee67122b76ae43f350b0a35cd6ed2cf` on `2026-08-19T02:28:23.647Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/ambiguityProbe.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/ambiguityProbe.ts
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { TranslationBenchBenchmarkAction } from "./benchmark.js";
+import type {
+    TranslationBenchGeneratedCandidate,
+    TranslationBenchReviewIssue,
+} from "./generationCandidate.js";
+
+export interface TranslationBenchAmbiguityProbeAction {
+    schemaName: string;
+    actionName: string;
+    parameters?: Record<string, unknown>;
+}
+
+export interface TranslationBenchAmbiguityProbeObservation {
+    model: string;
+    actions: TranslationBenchAmbiguityProbeAction[];
+    error?: string;
+}
+
+export interface TranslationBenchAmbiguityProbeRequest {
+    model: string;
+    utterance: string;
+    history?: unknown;
+    activeSchemas: readonly string[];
+}
+
+export const TRANSLATION_BENCH_DEFAULT_AMBIGUITY_PROBE_MODELS = [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+] as const;
+
+export interface TranslationBenchAmbiguityProbeTranslator {
+    models: readonly string[];
+    translate(
+        request: TranslationBenchAmbiguityProbeRequest,
+    ): Promise<TranslationBenchAmbiguityProbeObservation>;
+}
+
+export type TranslationBenchAmbiguityAgreement =
+    | "unanimous_gold"
+    | "unanimous_other"
+    | "split"
+    | "all_errors";
+
+export interface TranslationBenchAmbiguityProbeCaseResult {
+    path: string;
+    utterance: string;
+    expectedActions: TranslationBenchBenchmarkAction[];
+    observations: TranslationBenchAmbiguityProbeObservation[];
+    agreement: TranslationBenchAmbiguityAgreement;
+    routes: string[];
+}
+
+export interface TranslationBenchAmbiguityJudgeDecision {
+    candidateHash: string;
+    decision: "approve" | "reject";
+    ambiguous: boolean;
+    issues: TranslationBenchReviewIssue[];
+    summary: string;
+}
+
+export interface TranslationBenchAmbiguityCheckResult {
+    stage: "ambiguity_probe";
+    passed: boolean;
+    cases: TranslationBenchAmbiguityProbeCaseResult[];
+    judge?: {
+        decision: TranslationBenchAmbiguityJudgeDecision;
+        prompt: string;
+        completionText: string;
+    };
+    issues: TranslationBenchReviewIssue[];
+}
+
+function routeKey(
+    actions: readonly TranslationBenchAmbiguityProbeAction[],
+): string {
+    if (actions.length === 0) return "(empty)";
+    return actions
+        .map((a) => `${a.schemaName}.${a.actionName}`)
+        .sort()
+        .join("|");
+}
+
+function goldRouteKey(
+    expected: readonly TranslationBenchBenchmarkAction[],
+): string {
+    return routeKey(
+        expected.map((a) => ({
+            schemaName: a.schemaName,
+            actionName: a.actionName,
+        })),
+    );
+}
+
+export function classifyTranslationBenchAmbiguityAgreement(
+    expected: readonly TranslationBenchBenchmarkAction[],
+    observations: readonly TranslationBenchAmbiguityProbeObservation[],
+): {
+    agreement: TranslationBenchAmbiguityAgreement;
+    routes: string[];
+} {
+    const gold = goldRouteKey(expected);
+    const okRoutes: string[] = [];
+    for (const obs of observations) {
+        if (obs.error !== undefined && obs.error.trim().length > 0) {
+            continue;
+        }
+        okRoutes.push(routeKey(obs.actions));
+    }
+    const unique = [...new Set(okRoutes)].sort();
+    if (okRoutes.length === 0) {
+        return { agreement: "all_errors", routes: unique };
+    }
+    if (unique.length > 1) {
+        return { agreement: "split", routes: unique };
+    }
+    const only = unique[0]!;
+    if (only === gold) {
+        return { agreement: "unanimous_gold", routes: unique };
+    }
+    return { agreement: "unanimous_other", routes: unique };
+}
+
+export function listTranslationBenchAmbiguityProbeTargets(
+    candidate: TranslationBenchGeneratedCandidate,
+): Array<{
+    path: string;
+    utterance: string;
+    history?: unknown;
+    expectedActions: TranslationBenchBenchmarkAction[];
+}> {
+    const out: Array<{
+        path: string;
+        utterance: string;
+        history?: unknown;
+        expectedActions: TranslationBenchBenchmarkAction[];
+    }> = [
+        {
+            path: "$.seed.utterance",
+            utterance: candidate.seed.utterance,
+            ...(candidate.seed.history !== undefined
+                ? { history: candidate.seed.history }
+                : {}),
+            expectedActions: candidate.seed.expectedActions,
+        },
+    ];
+    candidate.genCases.forEach((genCase, index) => {
+        if (genCase.role !== "positive") return;
+        out.push({
+            path: `$.genCases[${index}].utterance`,
+            utterance: genCase.utterance,
+            ...(genCase.history !== undefined
+                ? { history: genCase.history }
+                : {}),
+            expectedActions: genCase.expectedActions,
+        });
+    });
+    return out;
+}
+
+export async function probeTranslationBenchAmbiguityCases(options: {
+    candidate: TranslationBenchGeneratedCandidate;
+    activeSchemas: readonly string[];
+    translator: TranslationBenchAmbiguityProbeTranslator;
+}): Promise<TranslationBenchAmbiguityProbeCaseResult[]> {
+    const models = options.translator.models;
+    if (models.length < 2) {
+        throw new Error(
+            "ambiguity probe requires at least 2 models (got " +
+                models.length +
+                ")",
+        );
+    }
+    const targets = listTranslationBenchAmbiguityProbeTargets(
+        options.candidate,
+    );
+    const cases: TranslationBenchAmbiguityProbeCaseResult[] = [];
+    for (const target of targets) {
+        const observations = await Promise.all(
+            models.map((model) =>
+                options.translator.translate({
+                    model,
+                    utterance: target.utterance,
+                    ...(target.history !== undefined
+                        ? { history: target.history }
+                        : {}),
+                    activeSchemas: options.activeSchemas,
+                }),
+            ),
+        );
+        const ordered = models.map((model) => {
+            const hit = observations.find((o) => o.model === model);
+            return (
+                hit ?? {
+                    model,
+                    actions: [],
+                    error: `Probe translator returned no observation for model '${model}'`,
+                }
+            );
+        });
+        const { agreement, routes } =
+            classifyTranslationBenchAmbiguityAgreement(
+                target.expectedActions,
+                ordered,
+            );
+        cases.push({
+            path: target.path,
+            utterance: target.utterance,
+            expectedActions: target.expectedActions,
+            observations: ordered,
+            agreement,
+            routes,
+        });
+    }
+    return cases;
+}
+
+export function translationBenchAmbiguityCasesClear(
+    cases: readonly TranslationBenchAmbiguityProbeCaseResult[],
+): boolean {
+    return (
+        cases.length > 0 && cases.every((c) => c.agreement === "unanimous_gold")
+    );
+}

--- a/ts/packages/benchmarks/src/translationBench/synthesizer/ambiguityProbe.ts
+++ b/ts/packages/benchmarks/src/translationBench/synthesizer/ambiguityProbe.ts
@@ -180,16 +180,27 @@ export async function probeTranslationBenchAmbiguityCases(options: {
     const cases: TranslationBenchAmbiguityProbeCaseResult[] = [];
     for (const target of targets) {
         const observations = await Promise.all(
-            models.map((model) =>
-                options.translator.translate({
-                    model,
-                    utterance: target.utterance,
-                    ...(target.history !== undefined
-                        ? { history: target.history }
-                        : {}),
-                    activeSchemas: options.activeSchemas,
-                }),
-            ),
+            models.map(async (model) => {
+                try {
+                    return await options.translator.translate({
+                        model,
+                        utterance: target.utterance,
+                        ...(target.history !== undefined
+                            ? { history: target.history }
+                            : {}),
+                        activeSchemas: options.activeSchemas,
+                    });
+                } catch (error) {
+                    return {
+                        model,
+                        actions: [],
+                        error:
+                            error instanceof Error
+                                ? error.message
+                                : String(error),
+                    };
+                }
+            }),
         );
         const ordered = models.map((model) => {
             const hit = observations.find((o) => o.model === model);

--- a/ts/packages/benchmarks/test/translationBench.ambiguityAnalysis.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.ambiguityAnalysis.spec.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "@jest/globals";
 
-import { classifyTranslationBenchAmbiguityAgreement } from "../src/translationBench/synthesizer/ambiguityProbe.js";
+import {
+    classifyTranslationBenchAmbiguityAgreement,
+    probeTranslationBenchAmbiguityCases,
+} from "../src/translationBench/synthesizer/ambiguityProbe.js";
 
 describe("translation bench ambiguity analysis", () => {
     it("reports disagreement between routes", () => {
@@ -27,5 +30,39 @@ describe("translation bench ambiguity analysis", () => {
 
         expect(result.agreement).toBe("split");
         expect(result.routes).toHaveLength(2);
+    });
+
+    it("records a rejected model translation", async () => {
+        const cases = await probeTranslationBenchAmbiguityCases({
+            candidate: {
+                seed: {
+                    utterance: "add a meeting",
+                    expectedActions: [
+                        { schemaName: "calendar", actionName: "addEvent" },
+                    ],
+                    order: "strict",
+                },
+                genCases: [],
+            },
+            activeSchemas: ["calendar"],
+            translator: {
+                models: ["one", "two"],
+                translate: async ({ model }) => {
+                    if (model === "two") throw new Error("unavailable");
+                    return {
+                        model,
+                        actions: [
+                            { schemaName: "calendar", actionName: "addEvent" },
+                        ],
+                    };
+                },
+            },
+        });
+
+        expect(cases[0]!.observations[1]).toEqual({
+            model: "two",
+            actions: [],
+            error: "unavailable",
+        });
     });
 });

--- a/ts/packages/benchmarks/test/translationBench.ambiguityAnalysis.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.ambiguityAnalysis.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "@jest/globals";
+
+import { classifyTranslationBenchAmbiguityAgreement } from "../src/translationBench/synthesizer/ambiguityProbe.js";
+
+describe("translation bench ambiguity analysis", () => {
+    it("reports disagreement between routes", () => {
+        const result = classifyTranslationBenchAmbiguityAgreement(
+            [{ schemaName: "calendar", actionName: "addEvent" }],
+            [
+                {
+                    model: "one",
+                    actions: [
+                        { schemaName: "calendar", actionName: "addEvent" },
+                    ],
+                },
+                {
+                    model: "two",
+                    actions: [
+                        { schemaName: "calendar", actionName: "findEvents" },
+                    ],
+                },
+            ],
+        );
+
+        expect(result.agreement).toBe("split");
+        expect(result.routes).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
- classify agreement across independent translation probes
- enumerate the seed and positive generated cases that require probing
- preserve model order and report missing observations as probe errors