### PR TITLE
Add translation benchmark checkpoint primitives

### DIFF
--- a/ts/packages/benchmarks/README.AUTOGEN.md
+++ b/ts/packages/benchmarks/README.AUTOGEN.md
@@ -3,7 +3,7 @@
 
 <!-- AUTOGEN:DOCS:START -->
 
-<!-- AUTOGEN:DOCS:HASH:sha256=2853f050a188d6ffab33ce680178039afd9cacb5164a90898695116158224600 -->
+<!-- AUTOGEN:DOCS:HASH:sha256=a749dec91d7793643ac01b5e6c53d41e6db783c609eb366cf4e3fc052159e47b -->
 <!-- AUTOGEN:DOCS:SOURCE: ./README.md (hand-written documentation; this file is the AI-generated companion) -->
 
 # @typeagent/benchmarks — AI-generated documentation
@@ -52,10 +52,10 @@ _None._
 - [./src/core/prices.ts](./src/core/prices.ts)
 - [./src/core/rateLimiter.ts](./src/core/rateLimiter.ts)
 - [./src/core/tokenEstimate.ts](./src/core/tokenEstimate.ts)
-- _…and 38 more under `./src/`._
+- _…and 39 more under `./src/`._
 
 ---
 
-_Auto-generated against commit `7c6cbc823caaaf6dfa97f9c42b043ba7065c9472` on `2026-08-13T20:36:56.989Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
+_Auto-generated against commit `9f1ae936799eab4835b5fe5341f5d91917aba3f0` on `2026-08-18T21:14:35.318Z` by `docs-generate.yml`. Links validated at that commit; the working tree may have drifted by up to 24h. Re-run `pnpm --filter @typeagent/benchmarks docs:verify-links` to spot-check._
 
 <!-- AUTOGEN:DOCS:END -->

--- a/ts/packages/benchmarks/src/translationBench/runner/scale.ts
+++ b/ts/packages/benchmarks/src/translationBench/runner/scale.ts
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createHash } from "node:crypto";
+
+export interface TranslationBenchWorkIdentity {
+    phase: string;
+    model: string;
+    scenario: string;
+    caseId: string;
+}
+
+export interface TranslationBenchCheckpointRow<T = unknown>
+    extends TranslationBenchWorkIdentity {
+    kind: "translation-bench-row";
+    value: T;
+}
+
+export interface TranslationBenchCheckpointHeader {
+    kind: "translation-bench-checkpoint";
+    version: 1;
+    runFingerprint: string;
+    settings: unknown;
+    shardIndex: number;
+    shardCount: number;
+}
+
+export interface TranslationBenchCheckpoint<T = unknown> {
+    header: TranslationBenchCheckpointHeader;
+    rows: TranslationBenchCheckpointRow<T>[];
+    resumeKeys: Set<string>;
+}
+
+export interface TranslationBenchMergeCounts {
+    shardCount: number;
+    rowCount: number;
+    byPhase: Record<string, number>;
+    byModel: Record<string, number>;
+    byScenario: Record<string, number>;
+}
+
+export interface TranslationBenchMergeResult<T = unknown> {
+    runFingerprint: string;
+    settings: unknown;
+    rows: TranslationBenchCheckpointRow<T>[];
+    counts: TranslationBenchMergeCounts;
+}
+
+function sha256(value: string): string {
+    return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalJson(
+    value: unknown,
+    path = "$",
+    stack = new Set<object>(),
+): string {
+    if (value === null) return "null";
+    if (typeof value === "string" || typeof value === "boolean") {
+        return JSON.stringify(value);
+    }
+    if (typeof value === "number") {
+        if (!Number.isFinite(value)) {
+            throw new Error(`Non-finite JSON number at ${path}`);
+        }
+        return JSON.stringify(value);
+    }
+    if (typeof value !== "object") {
+        throw new Error(`Non-JSON value at ${path}`);
+    }
+    if (stack.has(value)) {
+        throw new Error(`Circular JSON value at ${path}`);
+    }
+    stack.add(value);
+    try {
+        if (Array.isArray(value)) {
+            return `[${value
+                .map((item, index) =>
+                    item === undefined
+                        ? "null"
+                        : canonicalJson(item, `${path}[${index}]`, stack),
+                )
+                .join(",")}]`;
+        }
+        if (Object.prototype.toString.call(value) !== "[object Object]") {
+            throw new Error(`Non-plain JSON object at ${path}`);
+        }
+        const record = value as Record<string, unknown>;
+        return `{${Object.keys(record)
+            .filter((key) => record[key] !== undefined)
+            .sort(compareText)
+            .map(
+                (key) =>
+                    `${JSON.stringify(key)}:${canonicalJson(
+                        record[key],
+                        `${path}.${key}`,
+                        stack,
+                    )}`,
+            )
+            .join(",")}}`;
+    } finally {
+        stack.delete(value);
+    }
+}
+
+function compareText(left: string, right: string): number {
+    return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function requireNonEmpty(
+    value: unknown,
+    name: string,
+): asserts value is string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new Error(`${name} must be a non-empty string`);
+    }
+}
+
+function requireShardCount(shardCount: number): void {
+    if (!Number.isInteger(shardCount) || shardCount <= 0) {
+        throw new Error(
+            "Translation bench shard count must be a positive integer",
+        );
+    }
+}
+
+export function validateTranslationBenchCheckpointHeader(
+    header: TranslationBenchCheckpointHeader,
+): void {
+    if (
+        header?.kind !== "translation-bench-checkpoint" ||
+        header.version !== 1
+    ) {
+        throw new Error("Invalid translation bench checkpoint header");
+    }
+    requireNonEmpty(header.runFingerprint, "Translation bench run fingerprint");
+    canonicalJson(header.settings);
+    requireShardCount(header.shardCount);
+    if (
+        !Number.isInteger(header.shardIndex) ||
+        header.shardIndex < 0 ||
+        header.shardIndex >= header.shardCount
+    ) {
+        throw new Error(
+            `Translation bench shard index must be between 0 and ${header.shardCount - 1}`,
+        );
+    }
+}
+
+export function validateTranslationBenchCheckpointRow<T>(
+    row: TranslationBenchCheckpointRow<T>,
+): void {
+    if (row?.kind !== "translation-bench-row") {
+        throw new Error("Invalid translation bench checkpoint row");
+    }
+    requireNonEmpty(row.phase, "Translation bench row phase");
+    requireNonEmpty(row.model, "Translation bench row model");
+    requireNonEmpty(row.scenario, "Translation bench row scenario");
+    requireNonEmpty(row.caseId, "Translation bench row caseId");
+    canonicalJson(row.value);
+}
+
+export function validateTranslationBenchCheckpointRowShard<T>(
+    row: TranslationBenchCheckpointRow<T>,
+    header: TranslationBenchCheckpointHeader,
+): void {
+    const actual = getTranslationBenchShardIndex(
+        translationBenchResumeKey(row),
+        header.shardCount,
+    );
+    if (actual !== header.shardIndex) {
+        throw new Error(
+            `Translation bench row '${translationBenchResumeKey(row)}' belongs to shard ${actual}, not shard ${header.shardIndex}`,
+        );
+    }
+}
+
+export function translationBenchCheckpointSettingsEqual(
+    left: unknown,
+    right: unknown,
+): boolean {
+    return canonicalJson(left) === canonicalJson(right);
+}
+
+export function assertTranslationBenchCheckpointHeadersCompatible(
+    actual: TranslationBenchCheckpointHeader,
+    expected: TranslationBenchCheckpointHeader,
+): void {
+    if (actual.runFingerprint !== expected.runFingerprint) {
+        throw new Error(
+            "Translation bench checkpoint run fingerprint is incompatible",
+        );
+    }
+    if (
+        !translationBenchCheckpointSettingsEqual(
+            actual.settings,
+            expected.settings,
+        )
+    ) {
+        throw new Error(
+            "Translation bench checkpoint settings are incompatible",
+        );
+    }
+    if (
+        actual.shardIndex !== expected.shardIndex ||
+        actual.shardCount !== expected.shardCount
+    ) {
+        throw new Error(
+            "Translation bench checkpoint shard metadata is incompatible",
+        );
+    }
+}
+
+export function createTranslationBenchRunFingerprint(
+    runInputs: unknown,
+): string {
+    return sha256(canonicalJson(runInputs));
+}
+
+export function translationBenchResumeKey(
+    identity: TranslationBenchWorkIdentity,
+): string {
+    requireNonEmpty(identity.phase, "Translation bench phase");
+    requireNonEmpty(identity.model, "Translation bench model");
+    requireNonEmpty(identity.scenario, "Translation bench scenario");
+    requireNonEmpty(identity.caseId, "Translation bench caseId");
+    return JSON.stringify([
+        identity.phase,
+        identity.model,
+        identity.scenario,
+        identity.caseId,
+    ]);
+}
+
+export function getTranslationBenchShardIndex(
+    stableKey: string,
+    shardCount: number,
+): number {
+    requireNonEmpty(stableKey, "Translation bench shard key");
+    requireShardCount(shardCount);
+    const digest = createHash("sha256").update(stableKey).digest();
+    return Number(digest.readBigUInt64BE(0) % BigInt(shardCount));
+}
+
+export function validateTranslationBenchCheckpointWork(
+    rows: readonly TranslationBenchCheckpointRow[],
+    expectedWork: readonly TranslationBenchWorkIdentity[],
+    requireComplete: boolean,
+): void {
+    const expectedKeys = new Set(expectedWork.map(translationBenchResumeKey));
+    if (expectedKeys.size !== expectedWork.length) {
+        throw new Error(
+            "Translation bench expected work contains duplicate identities",
+        );
+    }
+    const actualKeys = new Set<string>();
+    for (const row of rows) {
+        const key = translationBenchResumeKey(row);
+        if (!expectedKeys.has(key)) {
+            throw new Error(
+                `Unexpected translation bench checkpoint work '${key}'`,
+            );
+        }
+        if (actualKeys.has(key)) {
+            throw new Error(`Duplicate translation bench resume key '${key}'`);
+        }
+        actualKeys.add(key);
+    }
+    if (!requireComplete) return;
+    const missing = [...expectedKeys].filter((key) => !actualKeys.has(key));
+    if (missing.length > 0) {
+        throw new Error(
+            `Translation bench checkpoints are incomplete: missing ${missing.length} work row(s), first '${missing[0]}'`,
+        );
+    }
+}
+
+/**
+ * Split checkpoint JSONL into logical lines. A crash during append can leave
+ * the final line incomplete; prior complete rows remain resumable.
+ */
+export function splitTranslationBenchCheckpointLines(text: string): string[] {
+    if (text.length === 0) {
+        return [];
+    }
+    const raw = text.endsWith("\n")
+        ? text.slice(0, -1).split("\n")
+        : text.split("\n");
+    if (raw.length === 0) {
+        return [];
+    }
+    if (!text.endsWith("\n")) {
+        const last = raw[raw.length - 1]!;
+        try {
+            JSON.parse(last);
+        } catch {
+            raw.pop();
+        }
+    }
+    return raw;
+}

--- a/ts/packages/benchmarks/test/translationBench.checkpointPrimitives.spec.ts
+++ b/ts/packages/benchmarks/test/translationBench.checkpointPrimitives.spec.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "@jest/globals";
+
+import {
+    createTranslationBenchRunFingerprint,
+    getTranslationBenchShardIndex,
+    splitTranslationBenchCheckpointLines,
+} from "../src/translationBench/runner/scale.js";
+
+describe("translation bench checkpoint primitives", () => {
+    it("uses canonical fingerprints and stable shards", () => {
+        expect(createTranslationBenchRunFingerprint({ b: 2, a: 1 })).toBe(
+            createTranslationBenchRunFingerprint({ a: 1, b: 2 }),
+        );
+        expect(getTranslationBenchShardIndex("case-1", 8)).toBe(
+            getTranslationBenchShardIndex("case-1", 8),
+        );
+    });
+
+    it("drops only an incomplete trailing JSONL row", () => {
+        expect(
+            splitTranslationBenchCheckpointLines('{"header":1}\n{"row":'),
+        ).toEqual(['{"header":1}']);
+    });
+});


### PR DESCRIPTION
## Summary

- create canonical run fingerprints and stable resume keys
- assign work to deterministic shards
- validate checkpoint identities and tolerate one incomplete trailing JSONL row

## Testing

- pnpm --filter @typeagent/benchmarks build
- focused checkpoint primitives test
- repository policy check