### PR TITLE
Add configurable Copilot model fallback list

### DIFF
--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -159,11 +159,10 @@ openAI:
 # --- Copilot (Copilot SDK chat + local embeddings) -------------------------
 # modelProvider: copilot
 # copilot:
-#   defaultModel: claude-haiku-4.5   # requires an authenticated `copilot` CLI;
-#                          # fast, non-reasoning default optimized for low
-#                          # latency. Falls back to `auto` if the tenant doesn't
-#                          # offer it. Use a reasoning model (e.g. gpt-5-mini)
-#                          # for higher-quality but slower translation.
+#   defaultModel: claude-haiku-4.5   # requires an authenticated `copilot` CLI
+#   fallbackModels:                 # first available concrete model is used
+#     - gpt-5-mini
+#     - gpt-5.4-mini
 #   # Optional: connect to an already-running Copilot CLI server over TCP
 #   # instead of spawning a CLI child per host. Eliminates the one-time
 #   # (multi-second) CLI startup latency. Format: "host:port" / "port".
@@ -340,7 +339,7 @@ wikipedia:
 
 reasoning:
   timeoutMs: 1200000 # reasoning-loop timeout (0 = disabled)
-  copilotModel: claude-sonnet-4.5 # override default Copilot reasoning model
+  copilotModel: claude-sonnet-5 # override default Copilot reasoning model
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  Embedding provider                                              ║

--- a/ts/packages/aiclient/src/copilotModelDefaults.ts
+++ b/ts/packages/aiclient/src/copilotModelDefaults.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
+
+export const DEFAULT_COPILOT_FALLBACK_MODELS: readonly string[] = [
+    "gpt-5-mini",
+    "gpt-5.4-mini",
+];

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -5,6 +5,7 @@ import {
     CopilotClient,
     RuntimeConnection,
     approveAll,
+    type ModelInfo,
     type SessionConfig,
 } from "@github/copilot-sdk";
 import { execSync } from "node:child_process";
@@ -26,7 +27,6 @@ import {
 import {
     CopilotApiSettings,
     copilotApiSettingsFromConfig,
-    COPILOT_FALLBACK_MODEL,
 } from "./copilotSettings.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { EndpointPool, makeSingleMemberPool } from "./endpointPool.js";
@@ -311,63 +311,125 @@ export async function warmupCopilotFromConfig(): Promise<void> {
     }
 }
 
-// Cached per-model capability info, populated from client.listModels() once per
-// process. Used to (a) fall back to an available model when the configured one
-// isn't offered by the tenant, and (b) decide reasoningEffort (invalid for
-// non-reasoning models; forced to minimal for reasoning models on translation).
-const reasoningSupportCache = new Map<string, boolean>();
-let modelListPromise: Promise<void> | undefined;
+let modelListPromise: Promise<readonly ModelInfo[] | undefined> | undefined;
 
-async function ensureModelList(client: CopilotClient): Promise<void> {
+async function ensureModelList(
+    client: CopilotClient,
+): Promise<readonly ModelInfo[] | undefined> {
     if (modelListPromise === undefined) {
-        modelListPromise = (async () => {
-            try {
-                const models = await client.listModels();
-                for (const m of models) {
-                    reasoningSupportCache.set(
-                        m.id,
-                        m.capabilities?.supports?.reasoningEffort === true,
-                    );
-                }
-            } catch (err) {
-                debug(
-                    `listModels failed; model capabilities unknown: ${
-                        err instanceof Error ? err.message : String(err)
-                    }`,
-                );
-            }
-        })();
+        const pending = client.listModels().catch((err) => {
+            debug(
+                `listModels failed; model capabilities unknown: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return undefined;
+        });
+        modelListPromise = pending;
+        const models = await pending;
+        if (models === undefined && modelListPromise === pending) {
+            modelListPromise = undefined;
+        }
+        return models;
     }
-    await modelListPromise;
+    return modelListPromise;
 }
 
-// Resolve the model to actually use for a session, falling back to
-// COPILOT_FALLBACK_MODEL when the requested model isn't offered by the tenant,
-// and reporting whether that model supports reasoning effort. When the model
-// list is unavailable (e.g. listModels failed), the requested model is used
-// as-is and reasoning support is left unknown.
+function isConcreteAvailableModel(model: ModelInfo): boolean {
+    return model.id !== "auto" && model.policy?.state !== "disabled";
+}
+
+function versionedFamily(
+    modelId: string,
+): { family: string; version: number[] } | undefined {
+    const match = /^(.*?)-(\d+(?:\.\d+)*)$/.exec(modelId);
+    if (match === null) return undefined;
+    return {
+        family: match[1],
+        version: match[2].split(".").map(Number),
+    };
+}
+
+function compareVersionsDescending(a: number[], b: number[]): number {
+    const count = Math.max(a.length, b.length);
+    for (let i = 0; i < count; i++) {
+        const difference = (b[i] ?? 0) - (a[i] ?? 0);
+        if (difference !== 0) return difference;
+    }
+    return 0;
+}
+
+export function selectCopilotModel(
+    requested: string,
+    fallbackModels: readonly string[],
+    models: readonly ModelInfo[],
+): ModelInfo | undefined {
+    const available = models.filter(isConcreteAvailableModel);
+    const byId = new Map(available.map((model) => [model.id, model]));
+
+    const requestedModel = byId.get(requested);
+    if (requestedModel !== undefined) return requestedModel;
+
+    for (const fallback of fallbackModels) {
+        const fallbackModel = byId.get(fallback);
+        if (fallbackModel !== undefined) return fallbackModel;
+    }
+
+    const requestedFamily = versionedFamily(requested);
+    if (requestedFamily !== undefined) {
+        const familyModels = available
+            .map((model) => ({
+                model,
+                version: versionedFamily(model.id),
+            }))
+            .filter(
+                (
+                    candidate,
+                ): candidate is {
+                    model: ModelInfo;
+                    version: { family: string; version: number[] };
+                } => candidate.version?.family === requestedFamily.family,
+            )
+            .sort((a, b) =>
+                compareVersionsDescending(a.version.version, b.version.version),
+            );
+        if (familyModels.length > 0) return familyModels[0].model;
+    }
+
+    return available.sort((a, b) => a.id.localeCompare(b.id))[0];
+}
+
+type ResolvedCopilotModel = {
+    model: string;
+    reasoningSupported: boolean | undefined;
+};
+
+// Resolve a concrete model for the direct HTTP transport. If model discovery
+// fails, preserve the requested model so endpoint acquisition can still work.
 async function resolveModel(
     client: CopilotClient,
-    requested: string,
-): Promise<{ model: string; reasoningSupported: boolean | undefined }> {
-    await ensureModelList(client);
-    if (reasoningSupportCache.size === 0) {
-        return { model: requested, reasoningSupported: undefined };
+    settings: CopilotApiSettings,
+): Promise<ResolvedCopilotModel | undefined> {
+    const models = await ensureModelList(client);
+    if (models === undefined) {
+        return { model: settings.modelName, reasoningSupported: undefined };
     }
-    if (reasoningSupportCache.has(requested)) {
-        return {
-            model: requested,
-            reasoningSupported: reasoningSupportCache.get(requested),
-        };
-    }
-    debug(
-        `model "${requested}" not available in this tenant; ` +
-            `falling back to "${COPILOT_FALLBACK_MODEL}"`,
+    const selected = selectCopilotModel(
+        settings.modelName,
+        settings.fallbackModels,
+        models,
     );
+    if (selected === undefined) return undefined;
+    if (selected.id !== settings.modelName) {
+        debug(
+            `model "${settings.modelName}" not available in this tenant; ` +
+                `falling back to "${selected.id}"`,
+        );
+    }
     return {
-        model: COPILOT_FALLBACK_MODEL,
+        model: selected.id,
         reasoningSupported:
-            reasoningSupportCache.get(COPILOT_FALLBACK_MODEL) ?? false,
+            selected.capabilities?.supports?.reasoningEffort === true,
     };
 }
 
@@ -388,7 +450,7 @@ function buildSessionConfig(
             | undefined) ?? settings.reasoningEffort;
     // Simple translation calls don't benefit from model-side "thinking" and it
     // adds significant latency, so we disable it wherever possible:
-    //  - Non-reasoning models (e.g. claude-haiku-4.5): never send reasoningEffort.
+    //  - Non-reasoning models: never send reasoningEffort.
     //    The SDK/CLI rejects it for models where capabilities.supports.reasoningEffort
     //    is false, and these models don't think anyway.
     //  - Reasoning-capable models with no explicit override: force the lowest
@@ -473,10 +535,7 @@ function mapEndpoint(ep: SdkProviderEndpoint, model: string): CopilotEndpoint {
 }
 
 // Acquire a fresh endpoint snapshot through a short-lived SDK session. Passing a
-// concrete `modelId` binds the endpoint to that model; when the requested model
-// isn't offered by the tenant (resolveModel falls back to "auto"), we throw
-// `CopilotEndpointUnavailableError` rather than dealing with an auto-bound
-// session token.
+// concrete `modelId` binds the endpoint and its token to that model.
 async function acquireEndpoint(
     settings: CopilotApiSettings,
 ): Promise<CopilotEndpoint> {
@@ -490,11 +549,31 @@ async function acquireEndpoint(
         cliPath: settings.cliPath,
         cliUrl: settings.cliUrl,
     });
-    const resolved = await resolveModel(client, settings.modelName);
-    if (resolved.model === COPILOT_FALLBACK_MODEL) {
+    try {
+        return await acquireEndpointForCurrentModelList(client, settings);
+    } catch (err) {
+        if (!isModelUnavailableError(err)) throw err;
+        modelListPromise = undefined;
+        return acquireEndpointForCurrentModelList(client, settings);
+    }
+}
+
+function isModelUnavailableError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return /model.*(?:not available|unavailable|not found|disabled)/i.test(
+        message,
+    );
+}
+
+async function acquireEndpointForCurrentModelList(
+    client: CopilotClient,
+    settings: CopilotApiSettings,
+): Promise<CopilotEndpoint> {
+    const resolved = await resolveModel(client, settings);
+    if (resolved === undefined) {
         throw new CopilotEndpointUnavailableError(
-            `Model "${settings.modelName}" is not available in this tenant; ` +
-                `the HTTP transport requires a concrete model.`,
+            `Model "${settings.modelName}" is not available in this tenant, ` +
+                `and no concrete fallback model was found.`,
         );
     }
     const tCreate = Date.now();

--- a/ts/packages/aiclient/src/copilotSettings.ts
+++ b/ts/packages/aiclient/src/copilotSettings.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 import { ModelType } from "./apiTypes.js";
+import {
+    DEFAULT_COPILOT_FALLBACK_MODELS,
+    DEFAULT_COPILOT_MODEL,
+} from "./copilotModelDefaults.js";
 import type { CommonApiSettings } from "./openai.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 
@@ -15,19 +19,8 @@ export type CopilotApiSettings = CommonApiSettings & {
     cliUrl?: string;
     reasoningEffort?: CopilotReasoningEffort;
     disableInfiniteSessions: boolean;
+    fallbackModels: readonly string[];
 };
-
-// claude-haiku-4.5 is a fast, non-reasoning model. It is the effective default
-// for Copilot provider mode because simple translation calls don't benefit from
-// model-side "thinking" and pay a large latency penalty for it. If a tenant
-// doesn't expose this model, the adapter falls back to "auto" at request time.
-// Users can still opt into any model via `copilot.defaultModel` in the config.
-const DEFAULT_MODEL = "claude-haiku-4.5";
-
-// Fallback used when the configured/default model is not available in the
-// current Copilot tenant (client.listModels() doesn't list it). "auto" is
-// always present and lets the CLI pick an available model.
-export const COPILOT_FALLBACK_MODEL = "auto";
 
 // Environment gate the SDK requires before `provider.getEndpoint` will return a
 // direct-CAPI endpoint. It must be set before the Copilot CLI child process is
@@ -41,7 +34,8 @@ export function copilotApiSettingsFromConfig(
 ): CopilotApiSettings {
     const config = getRuntimeConfig();
     const copilot = config.copilot;
-    const resolvedModel = modelName ?? copilot?.defaultModel ?? DEFAULT_MODEL;
+    const resolvedModel =
+        modelName ?? copilot?.defaultModel ?? DEFAULT_COPILOT_MODEL;
     if (!process.env[ENDPOINT_GATE_ENV]) {
         process.env[ENDPOINT_GATE_ENV] = "true";
     }
@@ -56,6 +50,8 @@ export function copilotApiSettingsFromConfig(
             ? { reasoningEffort: copilot.reasoningEffort }
             : {}),
         disableInfiniteSessions: copilot?.disableInfiniteSessions ?? true,
+        fallbackModels:
+            copilot?.fallbackModels ?? DEFAULT_COPILOT_FALLBACK_MODELS,
         maxConcurrency: copilot?.maxConcurrency,
         timeout: copilot?.maxTimeoutMs ?? 120_000,
         maxRetryAttempts: copilot?.maxRetryAttempts ?? 1,

--- a/ts/packages/aiclient/src/openai.ts
+++ b/ts/packages/aiclient/src/openai.ts
@@ -65,7 +65,11 @@ import {
 } from "./copilotSettings.js";
 import { getProviderChatModel } from "./providerChatModelRegistry.js";
 import type { WireApi } from "@typeagent/config";
-import { getActiveModelProvider, resolveTarget } from "./providerMode.js";
+import {
+    getActiveModelProvider,
+    resolveTarget,
+    usesProviderDefault,
+} from "./providerMode.js";
 import { instrumentChatModel } from "./otelChatModel.js";
 
 export { azureApiSettingsFromEnv, openAIApiSettingsFromEnv };
@@ -140,9 +144,12 @@ export function apiSettingsFromEnv(
     // and video stay on whatever the legacy resolver picks (Azure/OpenAI).
     const mode = getActiveModelProvider();
     if (mode !== undefined && modelType === ModelType.Chat) {
-        const target = resolveTarget(mode, endpointName ?? "DEFAULT");
+        const canonical = endpointName ?? "DEFAULT";
+        const target = resolveTarget(mode, canonical);
         if (mode === "copilot") {
-            return copilotApiSettingsFromConfig(target);
+            return copilotApiSettingsFromConfig(
+                usesProviderDefault(canonical) ? undefined : target,
+            );
         }
         if (mode === "ollama") {
             return ollamaApiSettingsFromEnv(modelType, env, target);
@@ -206,6 +213,9 @@ function parseEndPointName(endpoint?: string): {
     if (endpoint === undefined || endpoint === "") {
         const mode = getActiveModelProvider();
         if (mode !== undefined) {
+            if (mode === "copilot") {
+                return { provider: mode };
+            }
             return { provider: mode, name: resolveTarget(mode, "DEFAULT") };
         }
         return {
@@ -237,6 +247,9 @@ function parseEndPointName(endpoint?: string): {
     // the active mode's mapping. Explicit prefixes above always win.
     const mode = getActiveModelProvider();
     if (mode !== undefined) {
+        if (mode === "copilot" && usesProviderDefault(endpoint)) {
+            return { provider: mode };
+        }
         const target = resolveTarget(mode, endpoint);
         return { provider: mode, name: target };
     }

--- a/ts/packages/aiclient/src/providerMode.ts
+++ b/ts/packages/aiclient/src/providerMode.ts
@@ -17,6 +17,8 @@
  * `copilot.defaultModel`).
  */
 
+import { DEFAULT_COPILOT_MODEL } from "./copilotModelDefaults.js";
+
 export type ProviderMode = "azure" | "openai" | "ollama" | "copilot";
 
 export const PROVIDER_MODES: readonly ProviderMode[] = [
@@ -57,6 +59,11 @@ function isCanonicalName(s: string): s is CanonicalName {
     return (CANONICAL_NAMES as readonly string[]).includes(s);
 }
 
+export function usesProviderDefault(canonical: string): boolean {
+    const key = canonical.toUpperCase();
+    return key === "DEFAULT" || !isCanonicalName(key);
+}
+
 /**
  * Built-in name maps per non-Azure mode. Azure mode is identity — the
  * canonical names already are Azure deployment names, so no rewriting.
@@ -64,13 +71,13 @@ function isCanonicalName(s: string): s is CanonicalName {
  * names; the `openai:LOCAL` form is the explicit escape).
  */
 const COPILOT_MAP: Record<CanonicalName, string> = {
-    DEFAULT: "claude-sonnet-4.5",
-    GPT_35_TURBO: "claude-haiku-4.5",
-    GPT_4_O: "gpt-4o",
-    GPT_5: "claude-sonnet-4.5",
-    GPT_5_MINI: "gpt-4o-mini",
-    GPT_5_NANO: "gpt-4o-mini",
-    GPT_V: "gpt-4o",
+    DEFAULT: DEFAULT_COPILOT_MODEL,
+    GPT_35_TURBO: "gpt-5-mini",
+    GPT_4_O: "gpt-5.4",
+    GPT_5: DEFAULT_COPILOT_MODEL,
+    GPT_5_MINI: "gpt-5-mini",
+    GPT_5_NANO: "gpt-5-mini",
+    GPT_V: "gpt-5.4",
 };
 
 const OLLAMA_MAP: Record<CanonicalName, string> = {

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -6,7 +6,9 @@ import {
     CopilotEndpoint,
     CopilotEndpointProvider,
     CopilotEndpointUnavailableError,
+    selectCopilotModel,
 } from "../src/copilotModels.js";
+import type { ModelInfo } from "@github/copilot-sdk";
 import { CopilotApiSettings } from "../src/copilotSettings.js";
 import { ModelType } from "../src/openai.js";
 import { PromptSection } from "typechat";
@@ -18,6 +20,7 @@ function makeSettings(): CopilotApiSettings {
         endpoint: "copilot-cli",
         modelName: "claude-haiku-4.5",
         disableInfiniteSessions: true,
+        fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
         maxRetryAttempts: 0,
         retryPauseMs: 1,
         timeout: 5_000,
@@ -33,6 +36,29 @@ function makeEndpoint(overrides?: Partial<CopilotEndpoint>): CopilotEndpoint {
             "Copilot-Integration-Id": "copilot-developer-cli",
         },
         ...overrides,
+    };
+}
+
+function makeModel(
+    id: string,
+    options?: {
+        reasoning?: boolean;
+        policy?: "enabled" | "disabled" | "unconfigured";
+    },
+): ModelInfo {
+    return {
+        id,
+        name: id,
+        capabilities: {
+            supports: {
+                vision: false,
+                reasoningEffort: options?.reasoning ?? false,
+            },
+            limits: { max_context_window_tokens: 128_000 },
+        },
+        ...(options?.policy !== undefined
+            ? { policy: { state: options.policy, terms: "" } }
+            : {}),
     };
 }
 
@@ -111,6 +137,88 @@ const CAPI_OK = {
     choices: [{ message: { content: '{"action":"getTime"}' } }],
     usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
 };
+
+describe("selectCopilotModel", () => {
+    test("uses the requested model when it is available", () => {
+        const selected = selectCopilotModel(
+            "claude-haiku-4.5",
+            ["gpt-5-mini"],
+            [makeModel("gpt-5-mini"), makeModel("claude-haiku-4.5")],
+        );
+        expect(selected?.id).toBe("claude-haiku-4.5");
+    });
+
+    test("uses the first configured concrete fallback", () => {
+        const selected = selectCopilotModel(
+            "claude-haiku-4.5",
+            ["auto", "gpt-5-mini", "gpt-5.4-mini"],
+            [
+                makeModel("auto"),
+                makeModel("gpt-5-mini"),
+                makeModel("gpt-5.4-mini"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5-mini");
+    });
+
+    test("skips disabled fallback models", () => {
+        const selected = selectCopilotModel(
+            "claude-haiku-4.5",
+            ["gpt-5-mini", "gpt-5.4-mini"],
+            [
+                makeModel("gpt-5-mini", { policy: "disabled" }),
+                makeModel("gpt-5.4-mini"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5.4-mini");
+    });
+
+    test("allows fallback models without an explicit policy decision", () => {
+        const selected = selectCopilotModel(
+            "claude-haiku-4.5",
+            ["gpt-5-mini", "gpt-5.4-mini"],
+            [
+                makeModel("gpt-5-mini", { policy: "unconfigured" }),
+                makeModel("gpt-5.4-mini"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5-mini");
+    });
+
+    test("uses the newest available model in the requested family", () => {
+        const selected = selectCopilotModel(
+            "claude-sonnet-5",
+            [],
+            [
+                makeModel("claude-sonnet-4.6"),
+                makeModel("claude-sonnet-6"),
+                makeModel("claude-sonnet-5.2"),
+            ],
+        );
+        expect(selected?.id).toBe("claude-sonnet-6");
+    });
+
+    test("uses a deterministic concrete model as the final fallback", () => {
+        const selected = selectCopilotModel(
+            "missing-model",
+            [],
+            [makeModel("z-model"), makeModel("auto"), makeModel("a-model")],
+        );
+        expect(selected?.id).toBe("a-model");
+    });
+
+    test("returns undefined when no concrete model is enabled", () => {
+        const selected = selectCopilotModel(
+            "claude-haiku-4.5",
+            ["gpt-5-mini"],
+            [
+                makeModel("auto"),
+                makeModel("gpt-5-mini", { policy: "disabled" }),
+            ],
+        );
+        expect(selected).toBeUndefined();
+    });
+});
 
 describe("createCopilotTransportModel", () => {
     const origFetch = globalThis.fetch;

--- a/ts/packages/aiclient/test/providerMode.spec.ts
+++ b/ts/packages/aiclient/test/providerMode.spec.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { resolveTarget, usesProviderDefault } from "../src/providerMode.js";
+
+describe("Copilot provider mode", () => {
+    test("uses the provider-configured model for default and unknown names", () => {
+        expect(usesProviderDefault("DEFAULT")).toBe(true);
+        expect(usesProviderDefault("unknown-model-alias")).toBe(true);
+    });
+
+    test("maps canonical translation models to Haiku 4.5", () => {
+        expect(resolveTarget("copilot", "DEFAULT")).toBe("claude-haiku-4.5");
+        expect(resolveTarget("copilot", "GPT_5")).toBe("claude-haiku-4.5");
+    });
+
+    test("keeps explicit canonical model mappings", () => {
+        expect(usesProviderDefault("GPT_4_O")).toBe(false);
+        expect(resolveTarget("copilot", "GPT_4_O")).toBe("gpt-5.4");
+    });
+});

--- a/ts/packages/config/src/runtime/build.ts
+++ b/ts/packages/config/src/runtime/build.ts
@@ -865,6 +865,7 @@ function buildModelProvider(
 
 function buildCopilot(flat: Map<string, string>) {
     const defaultModel = popString(flat, "COPILOT_DEFAULT_MODEL");
+    const fallbackModelsRaw = popString(flat, "COPILOT_FALLBACK_MODELS");
     const cliPath = popString(flat, "COPILOT_CLI_PATH");
     const cliUrl = popString(flat, "COPILOT_CLI_URL");
     const reasoningEffortRaw = popString(flat, "COPILOT_REASONING_EFFORT");
@@ -879,6 +880,7 @@ function buildCopilot(flat: Map<string, string>) {
 
     if (
         defaultModel === undefined &&
+        fallbackModelsRaw === undefined &&
         cliPath === undefined &&
         cliUrl === undefined &&
         reasoningEffortRaw === undefined &&
@@ -907,9 +909,27 @@ function buildCopilot(flat: Map<string, string>) {
         enableLogging === undefined
             ? undefined
             : enableLogging === "1" || enableLogging.toLowerCase() === "true";
+    let fallbackModels: string[] | undefined;
+    if (fallbackModelsRaw !== undefined) {
+        try {
+            const parsed: unknown = JSON.parse(fallbackModelsRaw);
+            if (
+                Array.isArray(parsed) &&
+                parsed.every((value) => typeof value === "string")
+            ) {
+                fallbackModels = parsed;
+            }
+        } catch {
+            fallbackModels = fallbackModelsRaw
+                .split(",")
+                .map((value) => value.trim())
+                .filter((value) => value.length > 0);
+        }
+    }
 
     return {
         ...(defaultModel !== undefined ? { defaultModel } : {}),
+        ...(fallbackModels !== undefined ? { fallbackModels } : {}),
         ...(cliPath !== undefined ? { cliPath } : {}),
         ...(cliUrl !== undefined ? { cliUrl } : {}),
         ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),

--- a/ts/packages/config/src/runtime/tree.ts
+++ b/ts/packages/config/src/runtime/tree.ts
@@ -480,6 +480,8 @@ export function configToTree(config: Config): ConfigTree {
         const c: ConfigTree = {};
         if (config.copilot.defaultModel !== undefined)
             c.defaultModel = config.copilot.defaultModel;
+        if (config.copilot.fallbackModels !== undefined)
+            c.fallbackModels = [...config.copilot.fallbackModels];
         if (config.copilot.cliPath !== undefined)
             c.cliPath = config.copilot.cliPath;
         if (config.copilot.cliUrl !== undefined)
@@ -561,6 +563,16 @@ function asObject(node: unknown, where: string): Record<string, unknown> {
 function asString(node: unknown, where: string): string {
     if (typeof node !== "string") {
         throw new Error(`Expected a string at '${where}', got ${typeof node}.`);
+    }
+    return node;
+}
+
+function asStringArray(node: unknown, where: string): string[] {
+    if (
+        !Array.isArray(node) ||
+        node.some((value) => typeof value !== "string")
+    ) {
+        throw new Error(`Expected a string array at '${where}'.`);
     }
     return node;
 }
@@ -1034,6 +1046,10 @@ function emitCopilot(node: unknown, out: FlatEnv): void {
         out.COPILOT_DEFAULT_MODEL = asString(
             c.defaultModel,
             "copilot.defaultModel",
+        );
+    if (c.fallbackModels !== undefined)
+        out.COPILOT_FALLBACK_MODELS = JSON.stringify(
+            asStringArray(c.fallbackModels, "copilot.fallbackModels"),
         );
     if (c.cliPath !== undefined)
         out.COPILOT_CLI_PATH = asString(c.cliPath, "copilot.cliPath");

--- a/ts/packages/config/src/runtime/types.ts
+++ b/ts/packages/config/src/runtime/types.ts
@@ -328,6 +328,8 @@ export interface ReasoningConfig {
 export interface CopilotConfig {
     /** Model id used when `copilot:` is selected with no name. */
     readonly defaultModel?: string | undefined;
+    /** Concrete model ids to try when the requested model is unavailable. */
+    readonly fallbackModels?: readonly string[] | undefined;
     /** Override the auto-detected `copilot` CLI binary path. */
     readonly cliPath?: string | undefined;
     /**

--- a/ts/packages/config/test/flatten.spec.ts
+++ b/ts/packages/config/test/flatten.spec.ts
@@ -51,6 +51,19 @@ describe("flatten", () => {
         });
     });
 
+    test("flattens Copilot fallback models as a JSON array", () => {
+        const out = flatten({
+            copilot: {
+                defaultModel: "claude-haiku-4.5",
+                fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
+            },
+        });
+        expect(out).toEqual({
+            COPILOT_DEFAULT_MODEL: "claude-haiku-4.5",
+            COPILOT_FALLBACK_MODELS: '["gpt-5-mini","gpt-5.4-mini"]',
+        });
+    });
+
     test("env: top-level passthrough leaves keys verbatim", () => {
         const out = flatten({
             env: {

--- a/ts/packages/config/test/runtime.build.spec.ts
+++ b/ts/packages/config/test/runtime.build.spec.ts
@@ -54,6 +54,29 @@ describe("authModeFromString", () => {
     });
 });
 
+describe("buildConfig: Copilot", () => {
+    test("parses fallback models from the flattened JSON array", () => {
+        const config = buildConfig({
+            COPILOT_DEFAULT_MODEL: "claude-haiku-4.5",
+            COPILOT_FALLBACK_MODELS: '["gpt-5-mini","gpt-5.4-mini"]',
+        });
+        expect(config.copilot).toEqual({
+            defaultModel: "claude-haiku-4.5",
+            fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
+        });
+    });
+
+    test("accepts comma-separated fallback models from the environment", () => {
+        const config = buildConfig({
+            COPILOT_FALLBACK_MODELS: "gpt-5-mini, gpt-5.4-mini",
+        });
+        expect(config.copilot?.fallbackModels).toEqual([
+            "gpt-5-mini",
+            "gpt-5.4-mini",
+        ]);
+    });
+});
+
 describe("buildConfig: Azure OpenAI defaults", () => {
     test("default tuning knobs come from constants when env is empty", () => {
         const config = buildConfig({});

--- a/ts/tools/scripts/generate-selfhost-config.mjs
+++ b/ts/tools/scripts/generate-selfhost-config.mjs
@@ -54,6 +54,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
 const DEFAULT_OLLAMA_CHAT_MODEL = "llama3.2";
 const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
+const DEFAULT_COPILOT_FALLBACK_MODELS = ["gpt-5-mini", "gpt-5.4-mini"];
 const DEFAULT_LOCAL_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
 
@@ -166,6 +167,7 @@ function buildConfigTree(options) {
     if (provider === "copilot") {
         tree.copilot = {
             defaultModel: copilotModel || DEFAULT_COPILOT_MODEL,
+            fallbackModels: DEFAULT_COPILOT_FALLBACK_MODELS,
         };
     }
 

--- a/ts/tools/scripts/setModelProvider.mjs
+++ b/ts/tools/scripts/setModelProvider.mjs
@@ -58,6 +58,7 @@ const yaml = require("js-yaml");
 const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
 const DEFAULT_OLLAMA_CHAT_MODEL = "llama3.2";
 const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
+const DEFAULT_COPILOT_FALLBACK_MODELS = ["gpt-5-mini", "gpt-5.4-mini"];
 const DEFAULT_LOCAL_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
 
@@ -174,6 +175,7 @@ function patchConfig(cfg, options) {
     if (provider === "copilot") {
         const copilot = ensureObject(cfg, "copilot");
         copilot.defaultModel = options.copilotModel || DEFAULT_COPILOT_MODEL;
+        copilot.fallbackModels ??= DEFAULT_COPILOT_FALLBACK_MODELS;
     } else if (provider === "ollama") {
         const openAI = ensureObject(cfg, "openAI");
         openAI.apiKey ??= "ollama";


### PR DESCRIPTION
Replace the single hard-coded "auto" fallback with a configurable list of concrete fallback models (`copilot.fallbackModels`), plus family-based version matching and a deterministic last-resort pick when none of the requested/fallback models are available.

- Add `selectCopilotModel` to choose a concrete, enabled model from listModels(), preferring the requested model, then configured fallbacks, then the newest model in the same version family, then the lowest-id concrete model.
- Retry endpoint acquisition once with a refreshed model list if the CLI reports the model as unavailable.
- Add `copilotModelDefaults.ts` with shared default model/fallback constants; update `copilotSettings`, `providerMode`, config runtime (build/tree/types), selfhost config generator, and setModelProvider script to support `fallbackModels`.
- Update canonical model map to use gpt-5-mini/gpt-5.4 and bump sample config's reasoning model to claude-sonnet-5.
- Add tests for `selectCopilotModel` and provider-mode default resolution.