### PR TITLE
Add native VS Code Chat install to MSI and installer

### DIFF
--- a/pipelines/azure-build-publish-all.yml
+++ b/pipelines/azure-build-publish-all.yml
@@ -42,6 +42,10 @@ parameters:
     type: boolean
     default: true
     displayName: "Publish copilot-plugin Universal package"
+  - name: publishVsCodeChat
+    type: boolean
+    default: true
+    displayName: "Publish TypeAgent VS Code Chat Universal package"
   - name: publishMcp
     type: boolean
     default: true
@@ -171,6 +175,23 @@ stages:
           - publish: $(stagingDir)/copilot-plugin
             displayName: "Upload artifact: copilot-plugin"
             artifact: copilot-plugin
+
+          - script: |
+              pnpm --filter vscode-chat run package
+            displayName: "Package TypeAgent VS Code Chat"
+            workingDirectory: $(buildDirectory)
+
+          - bash: |
+              set -euo pipefail
+              mkdir -p "$(stagingDir)/vscode-chat"
+              cp "packages/vscode-chat/dist-pub/vscode-chat.vsix" \
+                "$(stagingDir)/vscode-chat/typeagent-vscode-chat.vsix"
+            displayName: "Stage TypeAgent VS Code Chat artifact"
+            workingDirectory: $(buildDirectory)
+
+          - publish: $(stagingDir)/vscode-chat
+            displayName: "Upload artifact: vscode-chat"
+            artifact: vscode-chat
 
       # ── Job 1b: Platform-specific artifacts (matrix) ──────────────
       # Produces: bundled agent-server, optional agent bundles, MCP exe per RID.
@@ -701,6 +722,34 @@ stages:
             displayName: "Upload pipeline artifact (for inspection)"
             artifact: copilot-plugin-published
 
+      # ── Publish VS Code Chat Universal package ───────────────────
+      - job: publish_vscode_chat
+        displayName: "Publish TypeAgent VS Code Chat"
+        condition: eq('${{ parameters.publishVsCodeChat }}', 'true')
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+
+          - download: current
+            artifact: vscode-chat
+            displayName: "Download vscode-chat artifact"
+
+          - bash: |
+              set -euo pipefail
+              az extension add --name azure-devops --only-show-errors || true
+              echo "Publishing typeagent-vscode-chat v$(packageVersion)"
+              az artifacts universal publish \
+                --organization "$(adoOrgUrl)" --project "$(adoProject)" --scope project \
+                --feed "$(adoFeed)" \
+                --name "typeagent-vscode-chat" \
+                --version "$(packageVersion)" \
+                --path "$(Pipeline.Workspace)/vscode-chat" \
+                --description "TypeAgent native VS Code Chat extension"
+            displayName: "Publish typeagent-vscode-chat"
+            env:
+              AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+
       # ── Publish MCP exe Universal packages ────────────────────────
       - job: publish_mcp
         displayName: "Publish typeagent-mcp"
@@ -835,7 +884,7 @@ stages:
 
       # ── Build, sign, and publish MSI ──────────────────────────────
       # The MSI job must run on Windows (WiX + signtool). It downloads
-      # the agent-server and copilot-plugin artifacts built in Stage 1
+      # the agent-server, copilot-plugin, and vscode-chat artifacts built in Stage 1
       # instead of rebuilding from source.
       - job: build_sign_publish_msi
         displayName: "Build, sign & publish MSI"
@@ -865,6 +914,10 @@ stages:
           - download: current
             artifact: copilot-plugin
             displayName: "Download copilot-plugin"
+
+          - download: current
+            artifact: vscode-chat
+            displayName: "Download vscode-chat"
 
           # Set up internal npm registry (required by org policy).
           - bash: |
@@ -938,19 +991,23 @@ stages:
               Set-Location "$(buildDirectory)/tools/scripts"
               $agentDir  = "$(Pipeline.Workspace)/agent-server-win32-x64"
               $pluginDir = "$(Pipeline.Workspace)/copilot-plugin"
+              $vscodeChatVsix = "$(Pipeline.Workspace)/vscode-chat/typeagent-vscode-chat.vsix"
               Write-Host "Building MSI with:"
               Write-Host "  - RID:        $(msiRid)"
               Write-Host "  - Version:    $(packageVersion)"
               Write-Host "  - Agent dir:  $agentDir"
               Write-Host "  - Plugin dir: $pluginDir"
+              Write-Host "  - VSIX:       $vscodeChatVsix"
 
               node .\build-msi.mjs `
                 --rid "$(msiRid)" `
                 --skip-download `
                 --agent-dir "$agentDir" `
                 --plugin-dir "$pluginDir" `
+                --vscode-chat-vsix "$vscodeChatVsix" `
                 --version "$(packageVersion)" `
                 --plugin-version "$(packageVersion)" `
+                --vscode-chat-version "$(packageVersion)" `
                 --shell-storage "$(azureStorageAccountName)" `
                 --shell-container "$(azureStorageContainerName)" `
                 --shell-channel "$(resolvedChannel)" `

--- a/ts/packages/vscode-chat/README.md
+++ b/ts/packages/vscode-chat/README.md
@@ -7,9 +7,11 @@ sidebar; sending a prompt in a TypeAgent session routes through the running
 agent server.
 
 This extension uses VS Code's **proposed** `chatSessionsProvider` API. It
-must be sideloaded into a VS Code build that runs proposed APIs (typically
-Insiders, launched with `--enable-proposed-api typeagent.vscode-chat`). It
-is **not** Marketplace-eligible while the API remains proposed.
+must be sideloaded and VS Code must be launched with
+`--enable-proposed-api=typeagent.vscode-chat`. VS Code 1.133 stable supports
+the explicit flag; Insiders remains the officially documented environment for
+proposed API development. The extension is **not** Marketplace-eligible while
+the API remains proposed.
 
 If you want the stable, Marketplace-eligible TypeAgent chat surface, see
 the sibling `vscode-shell` extension — that one uses a custom webview and
@@ -17,7 +19,7 @@ does not depend on proposed APIs.
 
 ## Prerequisites
 
-- VS Code **1.95** or newer (Insiders recommended).
+- VS Code **1.133** or newer (Insiders recommended).
 - A running TypeAgent **agent server** reachable on `ws://localhost:8999`
   (the default). Start it from the TypeAgent monorepo:
 
@@ -37,10 +39,10 @@ npm run deploy:local
 `code` CLI. After install, launch VS Code with the proposed API enabled:
 
 ```sh
-code-insiders --enable-proposed-api typeagent.vscode-chat
+code --enable-proposed-api=typeagent.vscode-chat
 ```
 
-(or set the `enable-proposed-api` flag in your Insiders launch config.)
+(Use `code-insiders` instead when installing into VS Code Insiders.)
 
 ## Usage
 

--- a/ts/packages/vscode-chat/package.json
+++ b/ts/packages/vscode-chat/package.json
@@ -128,7 +128,7 @@
     "typescript": "~5.4.5"
   },
   "engines": {
-    "vscode": "^1.95.0"
+    "vscode": "^1.133.0"
   },
   "icon": "media/icons/icon-80.png",
   "enabledApiProposals": [

--- a/ts/packages/vscode-chat/src/sessionManager.ts
+++ b/ts/packages/vscode-chat/src/sessionManager.ts
@@ -31,7 +31,7 @@ type ChatRequestTurnConstructor = new (
     toolReferences: vscode.ChatLanguageModelToolReference[],
 ) => vscode.ChatRequestTurn;
 
-type ChatResponseTurnConstructor = new (
+type ChatResponseTurn2Constructor = new (
     response: ReadonlyArray<
         | vscode.ChatResponseMarkdownPart
         | vscode.ChatResponseFileTreePart
@@ -40,13 +40,12 @@ type ChatResponseTurnConstructor = new (
     >,
     result: vscode.ChatResult,
     participant: string,
-    command?: string,
-) => vscode.ChatResponseTurn;
+) => vscode.ChatResponseTurn2;
 
 const ChatRequestTurn =
     vscode.ChatRequestTurn as unknown as ChatRequestTurnConstructor;
-const ChatResponseTurn =
-    vscode.ChatResponseTurn as unknown as ChatResponseTurnConstructor;
+const ChatResponseTurn2 =
+    vscode.ChatResponseTurn2 as unknown as ChatResponseTurn2Constructor;
 
 function chatMarkdown(value: string): vscode.MarkdownString {
     const markdown = new vscode.MarkdownString(value);
@@ -326,7 +325,7 @@ export const PARTICIPANT_ID = "typeagent";
 async function buildHistory(
     dispatcher: Dispatcher,
     participantId: string,
-): Promise<(vscode.ChatRequestTurn | vscode.ChatResponseTurn)[]> {
+): Promise<(vscode.ChatRequestTurn | vscode.ChatResponseTurn2)[]> {
     let entries: DisplayLogEntry[];
     try {
         entries = await dispatcher.getDisplayHistory();
@@ -364,7 +363,7 @@ async function buildHistory(
         }
     }
 
-    const history: (vscode.ChatRequestTurn | vscode.ChatResponseTurn)[] = [];
+    const history: (vscode.ChatRequestTurn | vscode.ChatResponseTurn2)[] = [];
     for (const rid of order) {
         const group = groups.get(rid)!;
         if (!group.userText) continue;
@@ -381,7 +380,7 @@ async function buildHistory(
 
         if (group.lines.length > 0) {
             history.push(
-                new ChatResponseTurn(
+                new ChatResponseTurn2(
                     [
                         new vscode.ChatResponseMarkdownPart(
                             chatMarkdown(group.lines.join("\n\n")),

--- a/ts/packages/vscode-chat/src/vscode.proposed.chatSessionsProvider.d.ts
+++ b/ts/packages/vscode-chat/src/vscode.proposed.chatSessionsProvider.d.ts
@@ -95,12 +95,36 @@ declare module "vscode" {
 
     export interface ChatSession {
         readonly title?: string;
-        readonly history: ReadonlyArray<ChatRequestTurn | ChatResponseTurn>;
+        readonly history: ReadonlyArray<ChatRequestTurn | ChatResponseTurn2>;
         readonly activeResponseCallback?: (
             stream: ChatResponseStream,
             token: CancellationToken,
         ) => Thenable<void>;
         readonly requestHandler: ChatRequestHandler | undefined;
+    }
+
+    export class ChatResponseTurn2 {
+        readonly id?: string;
+        readonly response: ReadonlyArray<
+            | ChatResponseMarkdownPart
+            | ChatResponseFileTreePart
+            | ChatResponseAnchorPart
+            | ChatResponseCommandButtonPart
+        >;
+        readonly result: ChatResult;
+        readonly participant: string;
+        readonly command?: string;
+
+        constructor(
+            response: ReadonlyArray<
+                | ChatResponseMarkdownPart
+                | ChatResponseFileTreePart
+                | ChatResponseAnchorPart
+                | ChatResponseCommandButtonPart
+            >,
+            result: ChatResult,
+            participant: string,
+        );
     }
 
     export interface ChatSessionContentProvider {

--- a/ts/tools/installers/common/install-vscode-chat.ps1
+++ b/ts/tools/installers/common/install-vscode-chat.ps1
@@ -1,0 +1,396 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Installs or removes the TypeAgent VS Code Chat extension and desktop shortcut.
+
+.DESCRIPTION
+  Shared by install-typeagent.ps1 and the WiX MSI. Discovers a compatible
+  per-user or system VS Code installation, installs the supplied VSIX, and
+  creates a desktop shortcut that enables the proposed chat sessions API.
+
+  Exit codes:
+    0  Success.
+    2  VS Code was not found.
+    3  VS Code is older than MinimumVersion.
+    10 Installation or removal failed.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet("Discover", "Install", "Uninstall")]
+    [string]$Action = "Install",
+    [string]$VsixPath = "",
+    [version]$MinimumVersion = "1.133.0",
+    [string]$ExtensionId = "typeagent.vscode-chat",
+    [string]$Owner = "standalone",
+    [string]$ShortcutName = "VS Code with TypeAgent.lnk",
+    [string]$LogPath = "$env:LOCALAPPDATA\TypeAgent\logs\vscode-chat-install.log"
+)
+
+$ErrorActionPreference = "Stop"
+$ownershipKey = "HKCU:\Software\Microsoft\TypeAgent\VSCodeChat"
+
+function Write-Log {
+    param([string]$Message)
+
+    $line = "[$([DateTime]::UtcNow.ToString('o'))] $Message"
+    Write-Host $line
+    if (-not $LogPath) {
+        return
+    }
+
+    try {
+        $directory = Split-Path -Parent $LogPath
+        if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+            New-Item -ItemType Directory -Force -Path $directory | Out-Null
+        }
+        Add-Content -LiteralPath $LogPath -Value $line -Encoding utf8
+    } catch {
+        # Logging must not block installation.
+    }
+}
+
+function Invoke-CodeCli {
+    param(
+        [Parameter(Mandatory = $true)][string]$CliPath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        # VS Code may emit Node warnings on stderr even when the command succeeds.
+        $ErrorActionPreference = "Continue"
+        $output = & $CliPath @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = @($output)
+    }
+}
+
+function Get-CodeExeFromCli {
+    param([string]$CliPath)
+
+    if (-not $CliPath) {
+        return $null
+    }
+
+    $item = Get-Item -LiteralPath $CliPath -ErrorAction SilentlyContinue
+    if (-not $item) {
+        return $null
+    }
+
+    if ($item.Name -ieq "Code.exe") {
+        return $item.FullName
+    }
+
+    if ($item.Directory.Name -ieq "bin") {
+        $candidate = Join-Path $item.Directory.Parent.FullName "Code.exe"
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Add-CodeCandidate {
+    param(
+        [System.Collections.Generic.List[object]]$Candidates,
+        [System.Collections.Generic.HashSet[string]]$Seen,
+        [string]$CliPath,
+        [string]$ExePath
+    )
+
+    if (-not $CliPath -or -not (Test-Path -LiteralPath $CliPath)) {
+        return
+    }
+    if (-not $ExePath) {
+        $ExePath = Get-CodeExeFromCli -CliPath $CliPath
+    }
+    if (-not $ExePath -or -not (Test-Path -LiteralPath $ExePath)) {
+        return
+    }
+
+    $resolvedCli = (Resolve-Path -LiteralPath $CliPath).Path
+    $resolvedExe = (Resolve-Path -LiteralPath $ExePath).Path
+    if ($resolvedCli -like "*\github.copilot-chat\copilotCli\*") {
+        return
+    }
+    if (-not $Seen.Add($resolvedExe.ToLowerInvariant())) {
+        return
+    }
+
+    $Candidates.Add([pscustomobject]@{
+        CliPath = $resolvedCli
+        ExePath = $resolvedExe
+    })
+}
+
+function Get-CodeCandidates {
+    $candidates = [System.Collections.Generic.List[object]]::new()
+    $seen = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+
+    $command = Get-Command code -ErrorAction SilentlyContinue
+    if ($command -and $command.Source) {
+        Add-CodeCandidate -Candidates $candidates -Seen $seen `
+            -CliPath $command.Source -ExePath (Get-CodeExeFromCli $command.Source)
+    }
+
+    $roots = @(
+        (Join-Path $env:LOCALAPPDATA "Programs\Microsoft VS Code")
+    )
+    if ($env:ProgramFiles) {
+        $roots += Join-Path $env:ProgramFiles "Microsoft VS Code"
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $roots += Join-Path ${env:ProgramFiles(x86)} "Microsoft VS Code"
+    }
+
+    foreach ($root in $roots) {
+        Add-CodeCandidate -Candidates $candidates -Seen $seen `
+            -CliPath (Join-Path $root "bin\code.cmd") `
+            -ExePath (Join-Path $root "Code.exe")
+    }
+
+    $appPathKeys = @(
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\App Paths\Code.exe",
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\App Paths\Code.exe",
+        "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths\Code.exe"
+    )
+    foreach ($key in $appPathKeys) {
+        $entry = Get-ItemProperty -LiteralPath $key -ErrorAction SilentlyContinue
+        if (-not $entry) {
+            continue
+        }
+        $exePath = [string]$entry."(default)"
+        if ($exePath -and (Test-Path -LiteralPath $exePath)) {
+            $root = Split-Path -Parent $exePath
+            Add-CodeCandidate -Candidates $candidates -Seen $seen `
+                -CliPath (Join-Path $root "bin\code.cmd") -ExePath $exePath
+        }
+    }
+
+    return $candidates
+}
+
+function Get-CodeVersion {
+    param([string]$CliPath)
+
+    $result = Invoke-CodeCli -CliPath $CliPath -Arguments @("--version")
+    if ($result.ExitCode -ne 0) {
+        throw "VS Code version check failed for '$CliPath': $($result.Output | Out-String)"
+    }
+    $versionText = @($result.Output)[0].ToString().Trim()
+    $parsed = $null
+    if (-not [version]::TryParse($versionText, [ref]$parsed)) {
+        throw "Unable to parse VS Code version '$versionText' from '$CliPath'."
+    }
+    return $parsed
+}
+
+function Find-CompatibleCode {
+    $foundVersion = $null
+    foreach ($candidate in Get-CodeCandidates) {
+        try {
+            $version = Get-CodeVersion -CliPath $candidate.CliPath
+            if (-not $foundVersion -or $version -gt $foundVersion) {
+                $foundVersion = $version
+            }
+            if ($version -ge $MinimumVersion) {
+                return [pscustomobject]@{
+                    CliPath = $candidate.CliPath
+                    ExePath = $candidate.ExePath
+                    Version = $version
+                }
+            }
+        } catch {
+            Write-Log "Ignoring VS Code candidate '$($candidate.CliPath)': $($_.Exception.Message)"
+        }
+    }
+
+    if ($foundVersion) {
+        Write-Log "VS Code $foundVersion is installed, but TypeAgent Chat requires $MinimumVersion or newer."
+        exit 3
+    }
+
+    Write-Log "Compatible VS Code was not found. Skipping TypeAgent Chat integration."
+    exit 2
+}
+
+function Get-DesktopShortcutPath {
+    $desktop = [Environment]::GetFolderPath("Desktop")
+    if (-not $desktop) {
+        $shell = New-Object -ComObject WScript.Shell
+        $desktop = $shell.SpecialFolders.Item("Desktop")
+    }
+    if (-not $desktop) {
+        throw "Unable to resolve the current user's desktop directory."
+    }
+    return Join-Path $desktop $ShortcutName
+}
+
+function Get-InstalledExtensionVersion {
+    param([string]$CliPath)
+
+    $result = Invoke-CodeCli -CliPath $CliPath -Arguments @(
+        "--list-extensions",
+        "--show-versions"
+    )
+    if ($result.ExitCode -ne 0) {
+        throw "Unable to list VS Code extensions: $($result.Output | Out-String)"
+    }
+    $prefix = "$ExtensionId@"
+    $match = @($result.Output | Where-Object {
+        $_.ToString().StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)
+    } | Select-Object -First 1)
+    if ($match.Count -eq 0) {
+        return $null
+    }
+    return $match[0].ToString().Substring($prefix.Length)
+}
+
+function Save-Ownership {
+    param(
+        [object]$Code,
+        [string]$ExtensionVersion,
+        [string]$ShortcutPath
+    )
+
+    New-Item -Path $ownershipKey -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name InstalledByTypeAgent -Value 1 `
+        -PropertyType DWord -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name ExtensionId -Value $ExtensionId `
+        -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name Owner -Value $Owner `
+        -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name ExtensionVersion -Value $ExtensionVersion `
+        -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name CliPath -Value $Code.CliPath `
+        -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name VsCodePath -Value $Code.ExePath `
+        -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $ownershipKey -Name ShortcutPath -Value $ShortcutPath `
+        -PropertyType String -Force | Out-Null
+}
+
+function Install-VsCodeChat {
+    if (-not $VsixPath) {
+        throw "-VsixPath is required for installation."
+    }
+    if (-not (Test-Path -LiteralPath $VsixPath -PathType Leaf)) {
+        throw "VSIX not found: $VsixPath"
+    }
+
+    $code = Find-CompatibleCode
+    Write-Log "Installing TypeAgent Chat into VS Code $($code.Version) using '$($code.CliPath)'."
+    $result = Invoke-CodeCli -CliPath $code.CliPath -Arguments @(
+        "--install-extension",
+        $VsixPath,
+        "--force"
+    )
+    $result.Output | ForEach-Object { Write-Log "code> $_" }
+    if ($result.ExitCode -ne 0) {
+        throw "VS Code extension installation failed with exit code $($result.ExitCode)."
+    }
+
+    $installedVersion = Get-InstalledExtensionVersion -CliPath $code.CliPath
+    if (-not $installedVersion) {
+        throw "VS Code did not report '$ExtensionId' after installation."
+    }
+
+    $shortcutPath = Get-DesktopShortcutPath
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($shortcutPath)
+    $shortcut.TargetPath = $code.ExePath
+    $shortcut.Arguments = "--new-window --enable-proposed-api=$ExtensionId"
+    $shortcut.WorkingDirectory = $env:USERPROFILE
+    $shortcut.IconLocation = "$($code.ExePath),0"
+    $shortcut.Description = "Launch VS Code with TypeAgent Chat enabled"
+    $shortcut.Save()
+
+    Save-Ownership -Code $code -ExtensionVersion $installedVersion `
+        -ShortcutPath $shortcutPath
+    Write-Log "Installed $ExtensionId@$installedVersion."
+    Write-Log "Created desktop shortcut: $shortcutPath"
+}
+
+function Uninstall-VsCodeChat {
+    $ownership = Get-ItemProperty -LiteralPath $ownershipKey -ErrorAction SilentlyContinue
+    if (-not $ownership -or [string]$ownership.Owner -ne $Owner) {
+        Write-Log "No TypeAgent VS Code Chat installation owned by '$Owner' was found."
+        return
+    }
+
+    $shortcutPath = if ($ownership.ShortcutPath) {
+        [string]$ownership.ShortcutPath
+    } else {
+        $null
+    }
+    if ($shortcutPath -and (Test-Path -LiteralPath $shortcutPath)) {
+        Remove-Item -LiteralPath $shortcutPath -Force
+        Write-Log "Removed desktop shortcut: $shortcutPath"
+    }
+
+    if ($ownership.InstalledByTypeAgent -eq 1) {
+        $cliPath = [string]$ownership.CliPath
+        if (-not $cliPath -or -not (Test-Path -LiteralPath $cliPath)) {
+            $candidate = @(Get-CodeCandidates | Select-Object -First 1)
+            $cliPath = if ($candidate.Count -gt 0) {
+                [string]$candidate[0].CliPath
+            } else {
+                ""
+            }
+        }
+
+        $installedVersion = if ($cliPath) {
+            Get-InstalledExtensionVersion -CliPath $cliPath
+        } else {
+            $null
+        }
+        $ownedVersion = [string]$ownership.ExtensionVersion
+        if ($installedVersion -and $installedVersion -eq $ownedVersion) {
+            $result = Invoke-CodeCli -CliPath $cliPath -Arguments @(
+                "--uninstall-extension",
+                $ExtensionId
+            )
+            $result.Output | ForEach-Object { Write-Log "code> $_" }
+            if ($result.ExitCode -ne 0) {
+                throw "VS Code extension removal failed with exit code $($result.ExitCode)."
+            }
+            Write-Log "Removed $ExtensionId@$installedVersion."
+        } elseif ($installedVersion) {
+            Write-Log "Leaving $ExtensionId@$installedVersion installed because TypeAgent owns version $ownedVersion."
+        }
+    }
+
+    if (Test-Path -LiteralPath $ownershipKey) {
+        Remove-Item -LiteralPath $ownershipKey -Recurse -Force
+    }
+}
+
+try {
+    switch ($Action) {
+        "Discover" {
+            $code = Find-CompatibleCode
+            Write-Log "Found VS Code $($code.Version) at '$($code.ExePath)'."
+        }
+        "Install" {
+            Install-VsCodeChat
+        }
+        "Uninstall" {
+            Uninstall-VsCodeChat
+        }
+    }
+    exit 0
+} catch {
+    Write-Log "ERROR: $($_.Exception.Message)"
+    exit 10
+}

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -7,7 +7,9 @@ Automated build and signing for the TypeAgent headless agent-server MSI installe
 This implementation builds a lightweight Windows Installer (MSI) that:
 
 - Downloads the `agent-server.<rid>` artifact from the ADO feed
-- Bundles it with a launcher (`typeagent-serve.mjs`)
+- Bundles it with the Copilot plugin and TypeAgent VS Code Chat VSIX
+- Installs TypeAgent Chat and creates a desktop shortcut when VS Code 1.133+
+  is present
 - Signs with the TypeAgent development certificate (from Key Vault)
 - Produces a signed `.msi` ready for distribution
 
@@ -24,6 +26,9 @@ ts/tools/installers/wix/
   ├── extract-payload.ps1         # Deferred CA: unpack payload/*.zip at install time
   ├── install-prereqs.ps1         # Deferred CA: npm i -g claude+copilot, warn on Node<22
   └── register-plugin.ps1         # Deferred CA: register/unregister the Copilot CLI plugin
+
+ts/tools/installers/common/
+  └── install-vscode-chat.ps1     # Shared VSIX install + desktop shortcut lifecycle
 
 pipelines/
   └── azure-build-publish-all.yml   # ADO pipeline (build_sign_publish_msi job)
@@ -114,12 +119,16 @@ Copy-Item -Recurse "$plugin/skills"     "$out/skills"
 #### 4. Run the WiX build with local staged artifacts
 
 ```powershell
+pnpm --filter vscode-chat run package
+
 node tools/scripts/build-msi.mjs `
   --skip-download `
   --agent-dir  "$env:TEMP\typeagent-msi-stage\agent-server" `
   --plugin-dir "$env:TEMP\typeagent-msi-stage\copilot-plugin" `
+  --vscode-chat-vsix "packages\vscode-chat\dist-pub\vscode-chat.vsix" `
   --version 0.0.1-local `
   --plugin-version 0.0.1-local `
+  --vscode-chat-version 0.0.1-local `
   --output "$env:TEMP\typeagent-msi-stage\out"
 ```
 
@@ -164,9 +173,10 @@ node build-msi.mjs --rid win32-x64 --version 0.0.1-<buildId> --output ./msi-out
 **What it does:**
 
 1. Downloads `agent-server.win32-x64` from the `typeagent` feed
-2. Extracts to `./msi-out/artifact`
-3. Compiles WiX definition (`.wxs` → `.wixobj`)
-4. Links to create `TypeAgent-<version>-win32-x64.msi`
+2. Downloads `typeagent-copilot-plugin` and `typeagent-vscode-chat`
+3. Extracts/stages the artifacts under `./msi-out/artifact`
+4. Compiles WiX definition (`.wxs` → `.wixobj`)
+5. Links to create `TypeAgent-<version>-win32-x64.msi`
 
 **Output:**
 
@@ -197,6 +207,32 @@ msiexec /i "$env:TEMP\typeagent-msi-stage\out\TypeAgent-0.0.1-local-win32-x64.ms
 # Verify
 Get-Item "$env:LOCALAPPDATA\TypeAgent\agent-server" -ErrorAction SilentlyContinue
 ```
+
+## Native VS Code Chat integration
+
+`VSCODECHAT=1` is enabled by default. During install, the MSI runs the shared
+`install-vscode-chat.ps1` helper as the current user. The helper:
+
+1. Finds user- or system-installed VS Code.
+2. Requires VS Code 1.133.0 or newer.
+3. Installs the bundled `typeagent.vscode-chat` VSIX.
+4. Creates `TypeAgent Chat.lnk` on the current user's desktop with:
+
+   ```text
+   --new-window --enable-proposed-api=typeagent.vscode-chat
+   ```
+
+If compatible VS Code is absent, the step logs a warning and the rest of the
+TypeAgent installation continues. Disable the component for a silent install
+with:
+
+```powershell
+msiexec /i TypeAgent-<version>-win32-x64.msi VSCODECHAT=0
+```
+
+The MSI removes the shortcut on uninstall. It removes the extension only when
+the installed version still matches the version originally installed by
+TypeAgent, so it does not delete an independently upgraded extension.
 
 ## Endpoint provider selection (self-host)
 

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -22,6 +22,7 @@
     ProductVersion      e.g. 0.0.1-12345
     AgentServerZip      path to the built agent-server.zip
     CopilotPluginZip    path to the built copilot-plugin.zip
+    VsCodeChatVsix      path to the packaged TypeAgent Chat VSIX
     MarketplaceDir      path to directory containing the generated marketplace.json
     InstallerSourceDir  path to this file's directory (for register-plugin.ps1)
     ShellBaseUrl        default SHELLBASEURL (anonymous blob base for the shell); may be ""
@@ -73,6 +74,7 @@
          ═══════════════════════════════════════════════ -->
     <Property Id="STARTSERVER" Value="1" Secure="yes" />
     <Property Id="AUTOSTART" Value="1" Secure="yes" />
+    <Property Id="VSCODECHAT" Value="1" Secure="yes" />
 
     <!-- ═══════════════════════════════════════════════
          Optional TypeAgent Shell install (Electron app)
@@ -145,6 +147,7 @@
         <Directory Id="TYPEAGENTROOT" Name="TypeAgent">
           <Directory Id="INSTALLFOLDER" Name="agent-server" />
           <Directory Id="PLUGINFOLDER" Name="copilot-plugin" />
+          <Directory Id="VSCODECHATFOLDER" Name="vscode-chat" />
           <Directory Id="PAYLOADFOLDER" Name="payload" />
           <Directory Id="GITHUBFOLDER" Name=".github">
             <Directory Id="PLUGINREGFOLDER" Name="plugin" />
@@ -160,10 +163,12 @@
       <!-- Payload archives (extracted at install time by ExtractPayload) -->
       <ComponentRef Id="AgentServerZipComponent" />
       <ComponentRef Id="CopilotPluginZipComponent" />
+      <ComponentRef Id="VsCodeChatVsixComponent" />
       <!-- Static files and registry -->
       <ComponentRef Id="MarketplaceJsonComponent" />
       <ComponentRef Id="RegisterPluginPs1Component" />
       <ComponentRef Id="RegisterPluginMjsComponent" />
+      <ComponentRef Id="InstallVsCodeChatPs1Component" />
       <ComponentRef Id="ExtractPayloadPs1Component" />
       <ComponentRef Id="InstallPrereqsPs1Component" />
       <ComponentRef Id="ResolveNodePs1Component" />
@@ -191,6 +196,14 @@
       </Component>
     </DirectoryRef>
 
+    <DirectoryRef Id="VSCODECHATFOLDER">
+      <Component Id="VsCodeChatVsixComponent" Guid="*">
+        <File Id="VsCodeChatVsix" Name="typeagent-vscode-chat.vsix"
+              Source="$(var.VsCodeChatVsix)" KeyPath="yes" />
+        <RemoveFolder Id="RemoveVsCodeChatFolder" Directory="VSCODECHATFOLDER" On="uninstall" />
+      </Component>
+    </DirectoryRef>
+
     <!-- marketplace.json — enables `copilot plugin marketplace add <TYPEAGENTROOT>` -->
     <DirectoryRef Id="PLUGINREGFOLDER">
       <Component Id="MarketplaceJsonComponent" Guid="*">
@@ -211,6 +224,10 @@
       <Component Id="RegisterPluginMjsComponent" Guid="*">
         <File Id="RegisterPluginMjs" Name="register-plugin.mjs"
               Source="$(var.InstallerSourceDir)\..\common\register-plugin.mjs" />
+      </Component>
+      <Component Id="InstallVsCodeChatPs1Component" Guid="*">
+        <File Id="InstallVsCodeChatPs1" Name="install-vscode-chat.ps1"
+              Source="$(var.InstallerSourceDir)\..\common\install-vscode-chat.ps1" />
       </Component>
       <Component Id="InstallShellPs1Component" Guid="*">
         <File Id="InstallShellPs1" Name="install-shell.ps1"
@@ -241,6 +258,7 @@
           <RegistryValue Name="InstallDir"        Value="[TYPEAGENTROOT]" Type="string" KeyPath="yes" />
           <RegistryValue Name="AgentServerDir"    Value="[INSTALLFOLDER]"   Type="string" />
           <RegistryValue Name="CopilotPluginDir"  Value="[PLUGINFOLDER]"    Type="string" />
+          <RegistryValue Name="VsCodeChatDir"     Value="[VSCODECHATFOLDER]" Type="string" />
           <RegistryValue Name="Version"           Value="$(var.ProductVersion)" Type="string" />
         </RegistryKey>
       </Component>
@@ -317,6 +335,36 @@
            Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]register-plugin.ps1&quot; -Uninstall -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-register-plugin.log&quot;" />
 
     <CustomAction Id="UnregisterCopilotPlugin"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <!-- ═══════════════════════════════════════════════
+         Custom actions — native VS Code Chat integration
+         The shared helper discovers VS Code >= 1.133, installs the VSIX, and
+         creates a desktop shortcut with the proposed API enabled. Missing or
+         incompatible VS Code is a non-fatal skip.
+         ═══════════════════════════════════════════════ -->
+    <SetProperty Id="InstallVsCodeChat"
+           Before="InstallVsCodeChat"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-vscode-chat.ps1&quot; -Action Install -Owner msi -VsixPath &quot;[VSCODECHATFOLDER]typeagent-vscode-chat.vsix&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\vscode-chat-install.log&quot;" />
+
+    <CustomAction Id="InstallVsCodeChat"
+                  BinaryKey="WixCA"
+                  DllEntry="WixQuietExec64"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+
+    <SetProperty Id="UninstallVsCodeChat"
+           Before="UninstallVsCodeChat"
+           Sequence="execute"
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]install-vscode-chat.ps1&quot; -Action Uninstall -Owner msi -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\vscode-chat-install.log&quot;" />
+
+    <CustomAction Id="UninstallVsCodeChat"
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
                   Execute="deferred"
@@ -529,6 +577,12 @@
                   Execute="deferred"
                   Return="check"
                   Impersonate="yes" />
+    <CustomAction Id="MainProgress8"
+                  BinaryKey="ProgressVbs"
+                  VBScriptCall="AdvanceProgress"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="yes" />
     <CustomAction Id="ResetShellProgress"
                   BinaryKey="ProgressVbs"
                   VBScriptCall="ResetShellProgress"
@@ -563,16 +617,18 @@
       <Custom Action="MainProgress3"            After="ExtractCopilotPluginPayload">NOT REMOVE~="ALL"</Custom>
       <Custom Action="RegisterCopilotPlugin"    After="MainProgress3">NOT REMOVE~="ALL"</Custom>
       <Custom Action="MainProgress4"            After="RegisterCopilotPlugin">NOT REMOVE~="ALL"</Custom>
-      <Custom Action="ProvisionSelfHostConfig" After="MainProgress4">(NOT REMOVE~="ALL") AND (PROVIDER&lt;&gt;"AISYSTEMS")</Custom>
+      <Custom Action="InstallVsCodeChat"        After="MainProgress4">(NOT REMOVE~="ALL") AND (VSCODECHAT="1")</Custom>
+      <Custom Action="MainProgress5"            After="InstallVsCodeChat">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="ProvisionSelfHostConfig" After="MainProgress5">(NOT REMOVE~="ALL") AND (PROVIDER&lt;&gt;"AISYSTEMS")</Custom>
       <Custom Action="ProvisionAiSystemsConfig" After="ProvisionSelfHostConfig">(NOT REMOVE~="ALL") AND (PROVIDER="AISYSTEMS")</Custom>
       <!-- Prereqs (claude/copilot from the feed) run AFTER provisioning so the
            AISYSTEMS az login has established a session the feed token reuses. -->
-      <Custom Action="MainProgress5"           After="ProvisionAiSystemsConfig">NOT REMOVE~="ALL"</Custom>
-      <Custom Action="InstallPrereqs"          After="MainProgress5">NOT REMOVE~="ALL"</Custom>
-      <Custom Action="MainProgress6"           After="InstallPrereqs">NOT REMOVE~="ALL"</Custom>
-      <Custom Action="StartAgentServer"        After="MainProgress6">(NOT REMOVE~="ALL") AND (STARTSERVER="1")</Custom>
-      <Custom Action="MainProgress7"           After="StartAgentServer">NOT REMOVE~="ALL"</Custom>
-      <Custom Action="EnableAutostart"         After="MainProgress7">(NOT REMOVE~="ALL") AND (AUTOSTART="1")</Custom>
+      <Custom Action="MainProgress6"           After="ProvisionAiSystemsConfig">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="InstallPrereqs"          After="MainProgress6">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="MainProgress7"           After="InstallPrereqs">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="StartAgentServer"        After="MainProgress7">(NOT REMOVE~="ALL") AND (STARTSERVER="1")</Custom>
+      <Custom Action="MainProgress8"           After="StartAgentServer">NOT REMOVE~="ALL"</Custom>
+      <Custom Action="EnableAutostart"         After="MainProgress8">(NOT REMOVE~="ALL") AND (AUTOSTART="1")</Custom>
       <Custom Action="ShellLocationMissing"    After="EnableAutostart">(NOT REMOVE~="ALL") AND (SHELL="1") AND (NOT SHELLBASEURL) AND (NOT SHELLSTORAGE) AND ((NOT SHELLFEED) OR (NOT SHELLPACKAGE) OR (NOT SHELLORG) OR (NOT SHELLPROJECT))</Custom>
       <Custom Action="ResetShellProgress"      After="ShellLocationMissing">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
       <Custom Action="ShellProgress1"          After="ResetShellProgress">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
@@ -581,7 +637,8 @@
       <Custom Action="InstallTypeAgentShell"   After="ShellProgress2">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
       <Custom Action="ShellProgress3"          After="InstallTypeAgentShell">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
       <Custom Action="VerifyTypeAgentShell"    After="ShellProgress3">(NOT REMOVE~="ALL") AND (SHELL="1")</Custom>
-      <Custom Action="DisableAutostart"        Before="UnregisterCopilotPlugin">REMOVE~="ALL"</Custom>
+      <Custom Action="DisableAutostart"        Before="UninstallVsCodeChat">REMOVE~="ALL"</Custom>
+      <Custom Action="UninstallVsCodeChat"     Before="UnregisterCopilotPlugin">REMOVE~="ALL"</Custom>
       <Custom Action="UnregisterCopilotPlugin" Before="RemoveFiles">REMOVE~="ALL"</Custom>
       <Custom Action="CleanupPayload"          After="UnregisterCopilotPlugin">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
@@ -608,18 +665,20 @@
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="InstallDir" />
 
-      <ProgressText Action="ExtractAgentServerPayload">Step 1 of 7: Extracting TypeAgent agent server...</ProgressText>
-      <ProgressText Action="ExtractCopilotPluginPayload">Step 2 of 7: Extracting Copilot plugin...</ProgressText>
-      <ProgressText Action="RegisterCopilotPlugin">Step 3 of 7: Registering Copilot plugin...</ProgressText>
-      <ProgressText Action="ProvisionSelfHostConfig">Step 4 of 7: Configuring TypeAgent...</ProgressText>
-      <ProgressText Action="ProvisionAiSystemsConfig">Step 4 of 7: Downloading TypeAgent configuration...</ProgressText>
-      <ProgressText Action="InstallPrereqs">Step 5 of 7: Checking TypeAgent prerequisites...</ProgressText>
-      <ProgressText Action="StartAgentServer">Step 6 of 7: Starting TypeAgent agent server...</ProgressText>
-      <ProgressText Action="EnableAutostart">Step 7 of 7: Enabling TypeAgent automatic startup...</ProgressText>
+      <ProgressText Action="ExtractAgentServerPayload">Step 1 of 8: Extracting TypeAgent agent server...</ProgressText>
+      <ProgressText Action="ExtractCopilotPluginPayload">Step 2 of 8: Extracting Copilot plugin...</ProgressText>
+      <ProgressText Action="RegisterCopilotPlugin">Step 3 of 8: Registering Copilot plugin...</ProgressText>
+      <ProgressText Action="InstallVsCodeChat">Step 4 of 8: Installing TypeAgent Chat for VS Code...</ProgressText>
+      <ProgressText Action="ProvisionSelfHostConfig">Step 5 of 8: Configuring TypeAgent...</ProgressText>
+      <ProgressText Action="ProvisionAiSystemsConfig">Step 5 of 8: Downloading TypeAgent configuration...</ProgressText>
+      <ProgressText Action="InstallPrereqs">Step 6 of 8: Checking TypeAgent prerequisites...</ProgressText>
+      <ProgressText Action="StartAgentServer">Step 7 of 8: Starting TypeAgent agent server...</ProgressText>
+      <ProgressText Action="EnableAutostart">Step 8 of 8: Enabling TypeAgent automatic startup...</ProgressText>
       <ProgressText Action="DownloadTypeAgentShell">Downloading TypeAgent Shell...</ProgressText>
       <ProgressText Action="InstallTypeAgentShell">Installing TypeAgent Shell...</ProgressText>
       <ProgressText Action="VerifyTypeAgentShell">Verifying TypeAgent Shell...</ProgressText>
       <ProgressText Action="DisableAutostart">Disabling TypeAgent automatic startup...</ProgressText>
+      <ProgressText Action="UninstallVsCodeChat">Removing TypeAgent Chat from VS Code...</ProgressText>
       <ProgressText Action="UnregisterCopilotPlugin">Unregistering Copilot plugin...</ProgressText>
       <ProgressText Action="CleanupPayload">Removing TypeAgent components...</ProgressText>
 
@@ -633,7 +692,7 @@
       <DialogRef Id="UserExit" />
 
       <!-- ═══ Provider / embedding selection dialog ═══ -->
-      <Dialog Id="ProviderDlg" Width="370" Height="270" Title="[ProductName] Setup">
+      <Dialog Id="ProviderDlg" Width="370" Height="290" Title="[ProductName] Setup">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
                  TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
@@ -695,16 +754,20 @@
           <Condition Action="enable">PROVIDER&lt;&gt;"AISYSTEMS"</Condition>
         </Control>
 
-        <Control Id="ShellCheckBox" Type="CheckBox" X="20" Y="221" Width="340" Height="12"
+        <Control Id="VsCodeChatCheckBox" Type="CheckBox" X="20" Y="221" Width="340" Height="12"
+                 Property="VSCODECHAT" CheckBoxValue="1"
+                 Text="Install TypeAgent Chat for VS Code 1.133 or newer" />
+
+        <Control Id="ShellCheckBox" Type="CheckBox" X="20" Y="237" Width="340" Height="12"
                  Property="SHELL" CheckBoxValue="1"
                  Text="Also install the TypeAgent Shell desktop app" />
 
-        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17"
+        <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" />
+        <Control Id="Back" Type="PushButton" X="180" Y="263" Width="56" Height="17"
                  Text="!(loc.WixUIBack)" />
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17"
+        <Control Id="Next" Type="PushButton" X="236" Y="263" Width="56" Height="17"
                  Default="yes" Text="!(loc.WixUINext)" />
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17"
+        <Control Id="Cancel" Type="PushButton" X="304" Y="263" Width="56" Height="17"
                  Cancel="yes" Text="!(loc.WixUICancel)">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -8,7 +8,7 @@
  * build-msi.mjs
  *
  * Orchestrates the TypeAgent MSI build:
- * 1. Resolve artifact inputs (pipeline default: pre-staged local directories via --skip-download)
+ * 1. Resolve artifact inputs (pipeline default: pre-staged local artifacts via --skip-download)
  * 2. Generate marketplace.json for Copilot CLI plugin registration
  * 3. Zip each artifact dir into a single payload archive (extracted at install time)
  * 4. Compile WiX (candle) + link to MSI (light)
@@ -16,7 +16,7 @@
  * Usage:
  *   node build-msi.mjs --rid win32-x64 --version 0.0.1-12345 --output ./out
  *   node build-msi.mjs --rid win32-x64 --version 0.0.1-12345 --plugin-version 0.0.1-12345
- *   node build-msi.mjs --skip-download --agent-dir ./agent-server --plugin-dir ./copilot-plugin --version 0.0.1-test --plugin-version 0.0.1-test --output ./out
+ *   node build-msi.mjs --skip-download --agent-dir ./agent-server --plugin-dir ./copilot-plugin --vscode-chat-vsix ./typeagent-vscode-chat.vsix --version 0.0.1-test --plugin-version 0.0.1-test --output ./out
  */
 
 import fs from "node:fs";
@@ -35,6 +35,8 @@ let outputDir = "./msi-out";
 let skipDownload = false;
 let stagedAgentDir = "";
 let stagedPluginDir = "";
+let stagedVsCodeChatVsix = "";
+let vscodeChatVersion = "latest";
 // Optional TypeAgent Shell download coordinates, baked into the MSI as the
 // SHELLBASEURL / SHELLSTORAGE / SHELLCONTAINER / SHELLCHANNEL property defaults
 // so the "install the shell" option has a location on a fresh machine.
@@ -59,6 +61,8 @@ for (let i = 0; i < args.length; i++) {
     else if (args[i] === "--skip-download") skipDownload = true;
     else if (args[i] === "--agent-dir") stagedAgentDir = args[++i];
     else if (args[i] === "--plugin-dir") stagedPluginDir = args[++i];
+    else if (args[i] === "--vscode-chat-vsix") stagedVsCodeChatVsix = args[++i];
+    else if (args[i] === "--vscode-chat-version") vscodeChatVersion = args[++i];
     else if (args[i] === "--shell-base-url") shellBaseUrl = args[++i];
     else if (args[i] === "--shell-storage") shellStorage = args[++i];
     else if (args[i] === "--shell-container") shellContainer = args[++i];
@@ -69,14 +73,18 @@ for (let i = 0; i < args.length; i++) {
     else if (args[i] === "--shell-org") shellOrg = args[++i];
     else if (args[i] === "--shell-project") shellProject = args[++i];
 }
+if (vscodeChatVersion === "latest") vscodeChatVersion = version;
 
 console.log(`📦 Building TypeAgent MSI`);
 console.log(`   RID:            ${rid}`);
 console.log(`   Agent version:  ${version}`);
 console.log(`   Plugin version: ${pluginVersion}`);
+console.log(`   VS Code Chat:   ${vscodeChatVersion}`);
 console.log(`   Output:         ${outputDir}`);
 if (stagedAgentDir) console.log(`   Agent dir:      ${stagedAgentDir}`);
 if (stagedPluginDir) console.log(`   Plugin dir:     ${stagedPluginDir}`);
+if (stagedVsCodeChatVsix)
+    console.log(`   VS Code VSIX:   ${stagedVsCodeChatVsix}`);
 
 // The shell download is authenticated: install-shell.ps1 uses `az storage blob
 // download --auth-mode login` first, then the Azure Artifacts feed as a
@@ -110,10 +118,15 @@ const wxsFile = path.join(wxsDir, "TypeAgent-AgentServer.wxs");
 const outputPath = path.resolve(outputDir);
 const agentArtifactDir = path.join(outputPath, "artifact", "agent-server");
 const pluginArtifactDir = path.join(outputPath, "artifact", "copilot-plugin");
+const vscodeChatArtifactDir = path.join(outputPath, "artifact", "vscode-chat");
 const marketplaceDir = path.join(outputPath, "marketplace");
 const payloadDir = path.join(outputPath, "payload");
 const agentZipFile = path.join(payloadDir, "agent-server.zip");
 const pluginZipFile = path.join(payloadDir, "copilot-plugin.zip");
+const vscodeChatVsixFile = path.join(
+    vscodeChatArtifactDir,
+    "typeagent-vscode-chat.vsix",
+);
 
 if (!fs.existsSync(outputPath)) fs.mkdirSync(outputPath, { recursive: true });
 
@@ -285,6 +298,34 @@ function prepareFromStagedDir(sourceDir, targetDir, label) {
     console.log(`✅ Using staged ${label}: ${resolvedSource}`);
 }
 
+function prepareVsix(sourceFile, targetFile) {
+    const resolvedSource = path.resolve(sourceFile);
+    if (
+        !fs.existsSync(resolvedSource) ||
+        !fs.statSync(resolvedSource).isFile() ||
+        path.extname(resolvedSource).toLowerCase() !== ".vsix"
+    ) {
+        console.error(`❌ VS Code Chat VSIX not found: ${resolvedSource}`);
+        process.exit(1);
+    }
+    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+    fs.copyFileSync(resolvedSource, targetFile);
+    console.log(`✅ Using staged VS Code Chat VSIX: ${resolvedSource}`);
+}
+
+function findSingleVsix(directory) {
+    const files = fs
+        .readdirSync(directory)
+        .filter((name) => path.extname(name).toLowerCase() === ".vsix");
+    if (files.length !== 1) {
+        console.error(
+            `❌ Expected exactly one VSIX in ${directory}; found ${files.length}.`,
+        );
+        process.exit(1);
+    }
+    return path.join(directory, files[0]);
+}
+
 function downloadArtifact(packageName, ver, targetDir) {
     if (fs.existsSync(targetDir)) fs.rmSync(targetDir, { recursive: true });
     fs.mkdirSync(targetDir, { recursive: true });
@@ -357,6 +398,17 @@ if (!skipDownload) {
         pluginVersion,
         pluginArtifactDir,
     );
+
+    console.log(`\n📥 Downloading typeagent-vscode-chat...`);
+    downloadArtifact(
+        "typeagent-vscode-chat",
+        vscodeChatVersion,
+        vscodeChatArtifactDir,
+    );
+    const downloadedVsix = findSingleVsix(vscodeChatArtifactDir);
+    if (path.resolve(downloadedVsix) !== path.resolve(vscodeChatVsixFile)) {
+        fs.renameSync(downloadedVsix, vscodeChatVsixFile);
+    }
 } else {
     if (stagedAgentDir) {
         prepareFromStagedDir(stagedAgentDir, agentArtifactDir, "agent-server");
@@ -367,6 +419,9 @@ if (!skipDownload) {
             pluginArtifactDir,
             "copilot-plugin",
         );
+    }
+    if (stagedVsCodeChatVsix) {
+        prepareVsix(stagedVsCodeChatVsix, vscodeChatVsixFile);
     }
 
     for (const [label, dir] of [
@@ -381,6 +436,15 @@ if (!skipDownload) {
         }
         console.log(`⏭️  Skipping download, using: ${dir}`);
     }
+    if (!fs.existsSync(vscodeChatVsixFile)) {
+        console.error(
+            `❌ --skip-download set but VS Code Chat VSIX was not provided: ${vscodeChatVsixFile}`,
+        );
+        process.exit(1);
+    }
+    console.log(
+        `⏭️  Skipping download, using VS Code Chat VSIX: ${vscodeChatVsixFile}`,
+    );
 }
 
 // ── Step 2: Generate marketplace.json ─────────────────────────────────────────
@@ -489,6 +553,7 @@ runCommand(candleExe, [
     `-dProductVersion=${wixProductVersion}`,
     `-dAgentServerZip=${agentZipFile}`,
     `-dCopilotPluginZip=${pluginZipFile}`,
+    `-dVsCodeChatVsix=${vscodeChatVsixFile}`,
     `-dMarketplaceDir=${marketplaceDir}`,
     `-dInstallerSourceDir=${wxsDir}`,
     `-dShellBaseUrl=${shellBaseUrl}`,

--- a/ts/tools/scripts/install-typeagent.ps1
+++ b/ts/tools/scripts/install-typeagent.ps1
@@ -17,13 +17,15 @@
        variant bundles those runtimes, so this step is skipped.
     3. Downloads the agent-server Universal package for this RID from the feed.
     4. Installs and registers the Copilot CLI plugin (from feed by default, or -PluginSource).
-    5. Runs config provisioning and starts the daemon via the artifact's
+    5. When VS Code 1.133 or newer is present, installs TypeAgent Chat and
+       creates a desktop shortcut that enables the proposed chat sessions API.
+    6. Runs config provisioning and starts the daemon via the artifact's
        typeagent-serve.mjs. Config provisioning depends on -Provider:
          aisystems (default) - getKeys + browser login (AI Systems Key Vault).
          ollama / copilot     - synthesize config.local.yaml locally (no Key Vault).
-    6. Registers a per-user Scheduled Task (logon trigger) so the agent-server
+    7. Registers a per-user Scheduled Task (logon trigger) so the agent-server
        starts again after logout/reboot. Skip with -NoAutoStart.
-    7. (Optional, -DevTunnel) sets up a Microsoft Dev Tunnel and hosts it so a
+    8. (Optional, -DevTunnel) sets up a Microsoft Dev Tunnel and hosts it so a
        client on another device can reach the service.
 
   Azure CLI (with az login) is used to download from the feed. This is the
@@ -38,7 +40,9 @@
   pwsh ./install-typeagent.ps1 -DevTunnel   # also expose the service via a Dev Tunnel
   pwsh ./install-typeagent.ps1 -BootstrapPrereqs
   pwsh ./install-typeagent.ps1 -Upgrade     # force fresh download, replacing existing assets
-    pwsh ./install-typeagent.ps1 -PluginSource C:\temp\typeagent-plugin   # install plugin from local folder
+  pwsh ./install-typeagent.ps1 -PluginSource C:\temp\typeagent-plugin   # install plugin from local folder
+  pwsh ./install-typeagent.ps1 -VsCodeChatSource C:\temp\typeagent-vscode-chat.vsix
+  pwsh ./install-typeagent.ps1 -NoVsCodeChat   # skip native VS Code integration
   pwsh ./install-typeagent.ps1 -Shell -ShellStorage myacct -ShellContainer mycontainer   # also install the desktop shell
 #>
 
@@ -60,6 +64,15 @@ param(
     [string]$PluginInstallDir = "$env:USERPROFILE\.copilot\available-plugins\typeagent",
     [string]$PluginMarketplaceName = "typeagent-local",
     [string]$PluginMarketplaceDir = "$env:USERPROFILE\.copilot\marketplaces\typeagent-local",
+    # Install the native TypeAgent Chat extension when compatible VS Code is
+    # present. Pass -NoVsCodeChat to skip this component.
+    [switch]$NoVsCodeChat,
+    # Local VSIX file or directory containing one VSIX. When omitted, the
+    # extension is downloaded from the TypeAgent Universal Package feed.
+    [string]$VsCodeChatSource = "",
+    [string]$VsCodeChatVersion = "latest",
+    [string]$VsCodeChatPackageName = "typeagent-vscode-chat",
+    [string]$VsCodeChatInstallDir = "$env:LOCALAPPDATA\TypeAgent\vscode-chat",
     [switch]$NoStart,
     # Opt-out: by default the installer registers a per-user Scheduled Task so the
     # agent-server starts again at logon. Pass -NoAutoStart to skip registration.
@@ -581,7 +594,95 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Host "  Copilot plugin '$pluginName' registered successfully"
 
-# --- 5. Provision config + start the daemon ----------------------------------
+# --- 5. Install the native VS Code Chat extension ----------------------------
+$vscodeChatInstalled = $false
+if (-not $NoVsCodeChat) {
+    $vscodeChatHelper = Join-Path (Split-Path -Parent $PSScriptRoot) "installers\common\install-vscode-chat.ps1"
+    if (-not (Test-Path -LiteralPath $vscodeChatHelper)) {
+        Fail "Shared VS Code Chat installer not found: $vscodeChatHelper"
+    }
+
+    $psExe = (Get-Process -Id $PID).Path
+    if (-not $psExe) {
+        $psExe = "powershell.exe"
+    }
+
+    Write-Step "Checking for compatible VS Code"
+    & $psExe -NoProfile -ExecutionPolicy Bypass -File $vscodeChatHelper -Action Discover
+    $discoveryExitCode = $LASTEXITCODE
+    if ($discoveryExitCode -eq 2) {
+        Write-Host "  VS Code was not found. Skipping TypeAgent Chat and desktop shortcut." -ForegroundColor Yellow
+    } elseif ($discoveryExitCode -eq 3) {
+        Write-Host "  VS Code is older than 1.133.0. Skipping TypeAgent Chat and desktop shortcut." -ForegroundColor Yellow
+    } elseif ($discoveryExitCode -ne 0) {
+        Fail "VS Code discovery failed. See $env:LOCALAPPDATA\TypeAgent\logs\vscode-chat-install.log."
+    } else {
+        Write-Step "Installing TypeAgent Chat for VS Code"
+        $vscodeChatVsix = ""
+        if ($VsCodeChatSource) {
+            if (Test-Path -LiteralPath $VsCodeChatSource -PathType Leaf) {
+                $vscodeChatVsix = (Resolve-Path -LiteralPath $VsCodeChatSource).Path
+            } elseif (Test-Path -LiteralPath $VsCodeChatSource -PathType Container) {
+                $vsixFiles = @(Get-ChildItem -LiteralPath $VsCodeChatSource -Filter "*.vsix" -File)
+                if ($vsixFiles.Count -ne 1) {
+                    Fail "Expected exactly one VSIX in '$VsCodeChatSource'; found $($vsixFiles.Count)."
+                }
+                $vscodeChatVsix = $vsixFiles[0].FullName
+            } else {
+                Fail "VS Code Chat source not found: $VsCodeChatSource"
+            }
+        } else {
+            if (Test-Path -LiteralPath $VsCodeChatInstallDir) {
+                Remove-Item -LiteralPath $VsCodeChatInstallDir -Recurse -Force
+            }
+            New-Item -ItemType Directory -Force -Path $VsCodeChatInstallDir | Out-Null
+
+            $resolvedVsCodeChatVersion = $VsCodeChatVersion
+            if ($VsCodeChatVersion -eq "latest") {
+                Write-Host "  Resolving latest version for $VsCodeChatPackageName..."
+                $resolvedVsCodeChatVersion = Resolve-LatestUniversalPackageVersion `
+                    -Organization $Org `
+                    -ProjectName $Project `
+                    -FeedName $Feed `
+                    -PackageName $VsCodeChatPackageName
+                Write-Host "  Resolved VS Code Chat version: $resolvedVsCodeChatVersion"
+            }
+
+            Write-Host "  Downloading $VsCodeChatPackageName ($resolvedVsCodeChatVersion) -> $VsCodeChatInstallDir"
+            $vscodeChatDownloadArgs = @(
+                "artifacts", "universal", "download",
+                "--organization", $Org,
+                "--project", $Project,
+                "--scope", "project",
+                "--feed", $Feed,
+                "--name", $VsCodeChatPackageName,
+                "--version", $resolvedVsCodeChatVersion,
+                "--path", $VsCodeChatInstallDir,
+                "--only-show-errors"
+            )
+            [void](Invoke-UniversalPackageDownload `
+                -Arguments $vscodeChatDownloadArgs `
+                -PackageName $VsCodeChatPackageName)
+
+            $vsixFiles = @(Get-ChildItem -LiteralPath $VsCodeChatInstallDir -Filter "*.vsix" -File)
+            if ($vsixFiles.Count -ne 1) {
+                Fail "Expected exactly one VSIX in '$VsCodeChatInstallDir'; found $($vsixFiles.Count)."
+            }
+            $vscodeChatVsix = $vsixFiles[0].FullName
+        }
+
+        & $psExe -NoProfile -ExecutionPolicy Bypass -File $vscodeChatHelper `
+            -Action Install `
+            -Owner standalone `
+            -VsixPath $vscodeChatVsix
+        if ($LASTEXITCODE -ne 0) {
+            Fail "TypeAgent Chat installation failed. See $env:LOCALAPPDATA\TypeAgent\logs\vscode-chat-install.log."
+        }
+        $vscodeChatInstalled = $true
+    }
+}
+
+# --- 6. Provision config + start the daemon ----------------------------------
 if ($Provider -eq "aisystems") {
     Write-Step "Provisioning config (getKeys, browser login)"
     $provisionOutput = & node $serve provision 2>&1
@@ -689,7 +790,7 @@ if (-not $hasEmbeddingEnv -and -not $hasEmbeddingInFile) {
     Write-Warning $msg
 }
 
-# --- 6. Optional: set up + host a Dev Tunnel for cross-device access ----------
+# --- 7. Optional: set up + host a Dev Tunnel for cross-device access ----------
 if ($DevTunnel) {
     Write-Step "Setting up Dev Tunnel (cross-device access)"
     if (-not (Test-Command devtunnel)) {
@@ -770,8 +871,11 @@ Write-Host "  Autostart: node `"$serve`" autostart status"
 if ($DevTunnel) {
     Write-Host "  Tunnel:   node `"$serve`" tunnel status   (list-tunnels.mjs shows the client URL + token)"
 }
+if ($vscodeChatInstalled) {
+    Write-Host "  VS Code:  TypeAgent Chat installed; launch from the 'TypeAgent Chat' desktop shortcut"
+}
 
-# --- 7. Optional: install the TypeAgent Shell desktop app --------------------
+# --- 8. Optional: install the TypeAgent Shell desktop app --------------------
 if ($Shell) {
     Write-Step "Installing TypeAgent Shell (desktop app)"
     $installShellScript = Join-Path $PSScriptRoot "install-shell.ps1"


### PR DESCRIPTION
Ports vscode-chat to the ChatResponseTurn2 API (VS Code 1.133+) and bumps the minimum engine version accordingly.

Adds end-to-end packaging and distribution for the TypeAgent VS Code Chat extension:
- New shared install-vscode-chat.ps1 helper that discovers a compatible VS Code install, installs the VSIX, and creates a desktop shortcut with the proposed API flag; supports install/uninstall/discover with ownership tracking so it doesn't clobber independently managed extensions.
- Wires the helper into both the WiX MSI (new component, custom actions, UI checkbox, and updated progress steps) and install-typeagent.ps1 (new -VsCodeChatSource/-NoVsCodeChat options, download-or-local VSIX resolution).
- Extends build-msi.mjs to stage/download the vscode-chat VSIX and pass it to WiX.
- Updates the ADO pipeline to build, stage, publish, and consume a new vscode-chat Universal package artifact.
- Updates READMEs to document the new prerequisites and installer behavior.