### PR TITLE
[OTEL] Add shared failure telemetry semantics

### DIFF
--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -250,9 +250,11 @@ have matched. Redaction runs only after this bound and the result must also fit.
 
 The dispatcher places an allowlisted projection in front of `OtelLoggerSink`.
 Only bounded correlation identifiers, agent/schema/action names, state and
-reason fields, durations and counts, booleans, and command/schema-name arrays
-reach OTel. Prompt and response text, history, action parameters, errors and
-stacks, feedback comments and context, and all unknown fields are excluded.
+reason fields, the normalized failure classification
+(`errorCategory`/`errorCode`/`httpStatus`/`retryable`), durations and counts,
+booleans, and command/schema-name arrays reach OTel. Prompt and response text,
+history, action parameters, raw error names, messages and stacks, feedback
+comments and context, and all unknown fields are excluded.
 Other producers that attach `OtelLoggerSink` remain responsible for an
 equivalent source-specific projection. The sink applies known-secret and
 secret-format filtering as defense in depth, covering the promoted correlation
@@ -732,6 +734,134 @@ other fields are present only for decisions the code actually observed. The
 reduced local message appends `+llm` when a cache/grammar strategy still reached
 the model.
 
+### Failure classification
+
+Structured failure events carry a normalized classification instead of the
+original message and stack, so a failure is actionable without exporting user
+content. `classifyTelemetryError` in `@typeagent/telemetry` is the single
+normalizer; it is applied at `command:exception`, at failed
+`translation:completed` and `action:completed` events, and at failed
+`llm:completed` events.
+
+- `errorCategory` - a closed union: `authentication`, `authorization`,
+  `rate_limit`, `network`, `timeout`, `validation`, `provider`, `cancelled`,
+  or `internal`.
+- `errorCode` - present only when the error carries a `code` (or an explicit
+  `errorCode`) that is a member of `TELEMETRY_ERROR_CODES`, the closed reviewed
+  allowlist. A shape check is not enough on its own: a `code` that happens to
+  be an identifier-shaped GUID, account name, or API key passes any pattern and
+  then either blows up label cardinality or carries an identifier off the
+  machine, so an unlisted code is dropped rather than exported. A package that
+  needs its own code adds it to that list (one reviewed line) and declares it
+  through `TelemetryClassifiedError`. `error.name` is never used as a code: it
+  is usually just `Error` and can be assigned arbitrary text at runtime.
+- `httpStatus` - present only when the error (or its `response`) carries an
+  integer failure status in the 400-599 range. A string `"429"` is ignored
+  rather than coerced, and a 1xx/2xx/3xx value is ignored because it is not
+  evidence of a failure (`status` doubles as a non-HTTP enum elsewhere, such
+  as a `child_process` exit code).
+- `retryable` - present only when the matched signal actually determines it.
+
+Classification never parses free-text messages: a message is the part of an
+error most likely to contain a prompt, a path, or a user's request, and
+matching on its wording is both a privacy hazard and fragile across provider
+versions. Each link of the `cause` chain (and the first entry of an
+`AggregateError`) is examined in turn, outermost first, bounded in depth and
+guarded against cycles, so a `fetch` failure that wraps `ECONNREFUSED`
+classifies as `network`.
+
+**Precedence.** The first link that carries a recognized signal wins, and every
+reported field is read from that one link, so category, code, status, and
+retryability describe the same error rather than being stitched together across
+links (a cause's `ECONNRESET` must not be reported next to its wrapper's HTTP
+401). Within the winning link the order is: an explicit classification the
+thrower attached, then `error.name` against a closed table of standard platform
+names, then `error.code` against the code table, then an HTTP failure status. A
+link carrying only an allowlisted code with no category rule still wins and
+reports that code with the `internal` category. A thrown string, a thrown
+object, or a plain `Error` becomes `internal` with no invented code, status, or
+retryability.
+
+Classification never throws. A thrown value is hostile-shaped input - getters
+throw, proxies trap every operation, and a proxy can be revoked between two
+reads - so every property access is guarded and the entry point has a
+last-resort fallback. Classifying a hostile error degrades to `internal`
+instead of replacing the original failure with a telemetry one, and the same
+guarding covers the raw `name`/`message`/`stack` the dispatcher keeps for its
+private diagnostics.
+
+The normalizer is published on its own as
+`@typeagent/telemetry/errorClassification` and imports nothing, so
+browser-shared code can classify a failure without pulling the Node-only
+telemetry composition root into a bundle. A spec reads the module's source and
+fails if an import ever appears in it.
+
+A package that owns a typed error opts in by declaring `errorCategory` (and
+optionally `errorCode` / `retryable`) on it - see `TelemetryClassifiedError`
+and `CopilotEndpointUnavailableError`. That keeps domain error names out of the
+shared normalizer.
+
+**Failures that are returned rather than thrown.** `typechat`'s `Result`
+failure is `{ success: false, message }`, so by the time a caller sees one, the
+HTTP status or socket error the transport knew has been flattened into prose
+telemetry must not parse. The REST client and the Copilot transport therefore
+attach the bounded facts where they still have them, through
+`attachTelemetryErrorClassification`: a non-enumerable, symbol-keyed property
+that leaves spreads, `Object.keys`, `JSON.stringify`, and existing equality
+assertions unchanged. `otelChatModel` reads it back with
+`readTelemetryErrorClassification`, which re-validates the payload against the
+same closed vocabularies so a stale or forged carrier cannot smuggle an
+unbounded field into an export. A real 401, 403, 429, timeout, network failure,
+or `CopilotEndpointUnavailableError` therefore keeps its category on
+`llm:completed`; when nothing is attached, the event falls back to `provider`,
+which is truthful because every returned failure originates in the provider
+call.
+
+That fallback is only reachable if the transport declines to guess. `internal`
+is a claim - it says the failure came from our own code - so a layer attaching a
+classification to a value that already has a truthful default uses
+`classifyTelemetryErrorIfRecognized`, which returns nothing when no link of the
+chain carried a recognized signal, rather than `classifyTelemetryError`, which
+answers `internal`. An unexplained `fetch failed` therefore leaves the `Result`
+unclassified and is reported as `provider`, not as our own bug.
+
+The transport also has to describe one event the same way from every code path.
+`callFetch` reports a dropped connection either by throwing or by resolving
+without a `Response`; the single-endpoint path turns the second into a throw and
+the endpoint-pool path handles it inline. Both build from one
+`NO_RESPONSE_CLASSIFICATION` constant (`network`, retryable), so the same outage
+does not read as `network` from a single-endpoint deployment and as nothing from
+a pooled one.
+
+A cancellation is a disposition, not a failure: cancelled completions carry no
+classification fields at all. Cancellation is decided once, by
+`isTelemetryCancellation`, and every signal reads that one result - `cancelled`,
+the event `status`, the log severity, the span status and exception name, and
+the presence of classification fields cannot disagree. It takes two inputs: the
+thrown value, walked through its `cause` chain so an `AbortError` wrapped by a
+phase-level error is still recognized, and what the call site knows from outside
+the error, typically that the request's abort signal fired. The second matters
+on its own, because a cancelled request usually surfaces as whatever the
+provider was in the middle of. The phase spans (`typeagent.request`,
+`typeagent.translation`, `typeagent.reasoning`, `typeagent.action`) and the LLM
+span classify through the same call with the same signals the completion events
+use, so a span and the event beside it always agree. A cancelled span still
+carries `ERROR` status - the operation did not complete - and is distinguished
+by its `AbortError` exception name and `cancelled` message rather than the
+phase's own failure wording. A failure with no thrown value carries no
+classification either: an agent that reports failure through a typed
+`ActionResult.error` never threw, so `action:completed` records the failure
+status without asserting a category.
+
+The raw `request`, `name`, `message`, and `stack` remain on
+`command:exception` for the local debug sink and the opt-in database sinks
+(`@config log db on`). They are not in the dispatcher's OTel allowlist, so they
+never reach OTLP or the local JSONL file; only the classification does. The
+reduced local message renders the classification alone, for example
+`Command failed: rate_limit (HTTP 429, retryable)`. Failed phase completions
+append the same rendering to their existing line, for example
+`Action failed: player.play in 4 ms [timeout (retryable)]`.
+
 ### 5. Inspect the Same Logs in Grafana
 
 Open [http://localhost:3000](http://localhost:3000), select **Explore**, choose
@@ -892,7 +1022,12 @@ await createDispatcher(hostName, {
 ```
 
 Original exception messages and stacks are omitted because they can contain user
-content. Record a stable classification and message at the catch site.
+content. Record a stable classification and message at the catch site. For a
+structured log event, use `classifyTelemetryError` rather than hand-rolling a
+classification; see [Failure classification](#failure-classification). A span
+wrapper records the exception through `recordSpanFailure`, which applies the
+shared cancellation decision so the span cannot call a cancellation a phase
+failure while the completion event calls it a cancellation.
 
 ## Currently Captured Dispatcher Telemetry
 
@@ -950,7 +1085,11 @@ execution order.
 
 Translation spans carry the same available correlation attributes as the root
 request span. Errors record a privacy-safe `TranslationError`, or `AbortError`
-for cancellation, and set a stable error status before rethrowing.
+for cancellation, and set a stable error status before rethrowing. Cancellation
+is the shared decision described under
+[Failure classification](#failure-classification), so an abort carried as the
+`cause` of a translation error, or a request whose abort signal fired, is
+recorded as a cancellation on the span and on `translation:completed` alike.
 
 ### Action span
 
@@ -977,7 +1116,9 @@ Failure modes are recorded distinctly and use bounded, allowlisted values:
   `ActionResult.error` text itself is never stamped.
 - An exception that escapes the wrapper is recorded as `AbortError` /
   `cancelled` for cancellation and `ActionError` / `action failed`
-  otherwise, matching the request and translation span conventions.
+  otherwise, matching the request and translation span conventions. The
+  cancellation decision reads the `cause` chain and the request's abort
+  signal, the same two inputs `action:completed` uses.
 
 Auto-setup replacement results (produced when `setupOnFirstUse` runs setup
 in place of the user's action) leave the span status unset regardless of
@@ -1001,8 +1142,26 @@ prompts, responses, and reasoning text are never recorded on the span.
 Timeout and external cancellation are propagated to the underlying SDK
 operation before the span ends. Cancellation records the privacy-safe
 `AbortError` / `cancelled` exception classification and sets error status.
-Other escaping exceptions use `ReasoningError` / `reasoning failed`. Original
-exception messages and stack traces are never exported.
+A reasoning run that is cancelled usually throws whatever the SDK was in the
+middle of rather than an `AbortError`, so the decision also reads the reasoning
+deadline signal and the request's own signal - the same inputs
+`reasoning:completed` uses, so the two never disagree. Other escaping exceptions
+use `ReasoningError` / `reasoning failed`. Original exception messages and stack
+traces are never exported.
+
+### LLM span
+
+Each instrumented model call creates one `typeagent.llm` span. A returned
+failure result sets `ERROR` with `model returned failure`; a thrown failure
+records `ModelError` / `model call failed`, or `AbortError` / `cancelled` for a
+cancellation. Prompts, responses, and provider messages are never recorded on
+the span. The matching `llm:completed` log event carries the normalized failure
+classification described under
+[Failure classification](#failure-classification).
+
+The span is ended exactly once on every path, including when emitting the
+completion event throws: a broken sink degrades telemetry rather than leaking
+an unfinished span, and it never replaces the failure the call was reporting.
 
 | Signal          | Use                                          |
 | --------------- | -------------------------------------------- |

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -736,131 +736,35 @@ the model.
 
 ### Failure classification
 
-Structured failure events carry a normalized classification instead of the
-original message and stack, so a failure is actionable without exporting user
-content. `classifyTelemetryError` in `@typeagent/telemetry` is the single
-normalizer; it is applied at `command:exception`, at failed
-`translation:completed` and `action:completed` events, and at failed
-`llm:completed` events.
+Structured failure events use a small, shared classification instead of
+exporting error messages or stacks. This makes failures useful in telemetry
+without exposing user or provider content.
 
-- `errorCategory` - a closed union: `authentication`, `authorization`,
-  `rate_limit`, `network`, `timeout`, `validation`, `provider`, `cancelled`,
-  or `internal`.
-- `errorCode` - present only when the error carries a `code` (or an explicit
-  `errorCode`) that is a member of `TELEMETRY_ERROR_CODES`, the closed reviewed
-  allowlist. A shape check is not enough on its own: a `code` that happens to
-  be an identifier-shaped GUID, account name, or API key passes any pattern and
-  then either blows up label cardinality or carries an identifier off the
-  machine, so an unlisted code is dropped rather than exported. A package that
-  needs its own code adds it to that list (one reviewed line) and declares it
-  through `TelemetryClassifiedError`. `error.name` is never used as a code: it
-  is usually just `Error` and can be assigned arbitrary text at runtime.
-- `httpStatus` - present only when the error (or its `response`) carries an
-  integer failure status in the 400-599 range. A string `"429"` is ignored
-  rather than coerced, and a 1xx/2xx/3xx value is ignored because it is not
-  evidence of a failure (`status` doubles as a non-HTTP enum elsewhere, such
-  as a `child_process` exit code).
-- `retryable` - present only when the matched signal actually determines it.
+The classification can include:
 
-Classification never parses free-text messages: a message is the part of an
-error most likely to contain a prompt, a path, or a user's request, and
-matching on its wording is both a privacy hazard and fragile across provider
-versions. Each link of the `cause` chain (and the first entry of an
-`AggregateError`) is examined in turn, outermost first, bounded in depth and
-guarded against cycles, so a `fetch` failure that wraps `ECONNREFUSED`
-classifies as `network`.
+- `errorCategory` - for example `authentication`, `rate_limit`, `network`,
+  `timeout`, `provider`, or `internal`.
+- `errorCode` - only for codes in the reviewed allowlist.
+- `httpStatus` - only for HTTP failure statuses.
+- `retryable` - when the failure is known to be safe to retry.
 
-**Precedence.** The first link that carries a recognized signal wins, and every
-reported field is read from that one link, so category, code, status, and
-retryability describe the same error rather than being stitched together across
-links (a cause's `ECONNRESET` must not be reported next to its wrapper's HTTP
-401). Within the winning link the order is: an explicit classification the
-thrower attached, then `error.name` against a closed table of standard platform
-names, then `error.code` against the code table, then an HTTP failure status. A
-link carrying only an allowlisted code with no category rule still wins and
-reports that code with the `internal` category. A thrown string, a thrown
-object, or a plain `Error` becomes `internal` with no invented code, status, or
-retryability.
+Use `classifyTelemetryError` from `@typeagent/telemetry` rather than creating
+classification logic at individual call sites. It handles wrapped errors and
+unknown thrown values, and does not inspect free-text messages.
 
-Classification never throws. A thrown value is hostile-shaped input - getters
-throw, proxies trap every operation, and a proxy can be revoked between two
-reads - so every property access is guarded and the entry point has a
-last-resort fallback. Classifying a hostile error degrades to `internal`
-instead of replacing the original failure with a telemetry one, and the same
-guarding covers the raw `name`/`message`/`stack` the dispatcher keeps for its
-private diagnostics.
+Provider clients should attach a classification before converting a transport
+error into a returned failure result. This preserves useful details such as an
+HTTP status or network failure after the original error is no longer available.
 
-The normalizer is published on its own as
-`@typeagent/telemetry/errorClassification` and imports nothing, so
-browser-shared code can classify a failure without pulling the Node-only
-telemetry composition root into a bundle. A spec reads the module's source and
-fails if an import ever appears in it.
+Cancellation is handled separately from failure classification. Spans and
+structured completion events use the same cancellation check, including wrapped
+abort errors and abort signals, so they report the same outcome. Cancelled events
+do not include failure classification fields.
 
-A package that owns a typed error opts in by declaring `errorCategory` (and
-optionally `errorCode` / `retryable`) on it - see `TelemetryClassifiedError`
-and `CopilotEndpointUnavailableError`. That keeps domain error names out of the
-shared normalizer.
-
-**Failures that are returned rather than thrown.** `typechat`'s `Result`
-failure is `{ success: false, message }`, so by the time a caller sees one, the
-HTTP status or socket error the transport knew has been flattened into prose
-telemetry must not parse. The REST client and the Copilot transport therefore
-attach the bounded facts where they still have them, through
-`attachTelemetryErrorClassification`: a non-enumerable, symbol-keyed property
-that leaves spreads, `Object.keys`, `JSON.stringify`, and existing equality
-assertions unchanged. `otelChatModel` reads it back with
-`readTelemetryErrorClassification`, which re-validates the payload against the
-same closed vocabularies so a stale or forged carrier cannot smuggle an
-unbounded field into an export. A real 401, 403, 429, timeout, network failure,
-or `CopilotEndpointUnavailableError` therefore keeps its category on
-`llm:completed`; when nothing is attached, the event falls back to `provider`,
-which is truthful because every returned failure originates in the provider
-call.
-
-That fallback is only reachable if the transport declines to guess. `internal`
-is a claim - it says the failure came from our own code - so a layer attaching a
-classification to a value that already has a truthful default uses
-`classifyTelemetryErrorIfRecognized`, which returns nothing when no link of the
-chain carried a recognized signal, rather than `classifyTelemetryError`, which
-answers `internal`. An unexplained `fetch failed` therefore leaves the `Result`
-unclassified and is reported as `provider`, not as our own bug.
-
-The transport also has to describe one event the same way from every code path.
-`callFetch` reports a dropped connection either by throwing or by resolving
-without a `Response`; the single-endpoint path turns the second into a throw and
-the endpoint-pool path handles it inline. Both build from one
-`NO_RESPONSE_CLASSIFICATION` constant (`network`, retryable), so the same outage
-does not read as `network` from a single-endpoint deployment and as nothing from
-a pooled one.
-
-A cancellation is a disposition, not a failure: cancelled completions carry no
-classification fields at all. Cancellation is decided once, by
-`isTelemetryCancellation`, and every signal reads that one result - `cancelled`,
-the event `status`, the log severity, the span status and exception name, and
-the presence of classification fields cannot disagree. It takes two inputs: the
-thrown value, walked through its `cause` chain so an `AbortError` wrapped by a
-phase-level error is still recognized, and what the call site knows from outside
-the error, typically that the request's abort signal fired. The second matters
-on its own, because a cancelled request usually surfaces as whatever the
-provider was in the middle of. The phase spans (`typeagent.request`,
-`typeagent.translation`, `typeagent.reasoning`, `typeagent.action`) and the LLM
-span classify through the same call with the same signals the completion events
-use, so a span and the event beside it always agree. A cancelled span still
-carries `ERROR` status - the operation did not complete - and is distinguished
-by its `AbortError` exception name and `cancelled` message rather than the
-phase's own failure wording. A failure with no thrown value carries no
-classification either: an agent that reports failure through a typed
-`ActionResult.error` never threw, so `action:completed` records the failure
-status without asserting a category.
-
-The raw `request`, `name`, `message`, and `stack` remain on
-`command:exception` for the local debug sink and the opt-in database sinks
-(`@config log db on`). They are not in the dispatcher's OTel allowlist, so they
-never reach OTLP or the local JSONL file; only the classification does. The
-reduced local message renders the classification alone, for example
-`Command failed: rate_limit (HTTP 429, retryable)`. Failed phase completions
-append the same rendering to their existing line, for example
-`Action failed: player.play in 4 ms [timeout (retryable)]`.
+The dispatcher OTel projection exports only the normalized classification. Raw
+request and error details remain limited to local, explicitly enabled diagnostic
+sinks. Existing lifecycle messages show a short summary such as
+`rate_limit (HTTP 429, retryable)`.
 
 ### 5. Inspect the Same Logs in Grafana
 
@@ -1022,12 +926,9 @@ await createDispatcher(hostName, {
 ```
 
 Original exception messages and stacks are omitted because they can contain user
-content. Record a stable classification and message at the catch site. For a
-structured log event, use `classifyTelemetryError` rather than hand-rolling a
-classification; see [Failure classification](#failure-classification). A span
-wrapper records the exception through `recordSpanFailure`, which applies the
-shared cancellation decision so the span cannot call a cancellation a phase
-failure while the completion event calls it a cancellation.
+content. Record a stable classification and message at the catch site. Use the
+shared helpers described in [Failure classification](#failure-classification)
+for structured events and span failures.
 
 ## Currently Captured Dispatcher Telemetry
 
@@ -1085,11 +986,7 @@ execution order.
 
 Translation spans carry the same available correlation attributes as the root
 request span. Errors record a privacy-safe `TranslationError`, or `AbortError`
-for cancellation, and set a stable error status before rethrowing. Cancellation
-is the shared decision described under
-[Failure classification](#failure-classification), so an abort carried as the
-`cause` of a translation error, or a request whose abort signal fired, is
-recorded as a cancellation on the span and on `translation:completed` alike.
+for cancellation, and set a stable error status before rethrowing.
 
 ### Action span
 
@@ -1116,9 +1013,7 @@ Failure modes are recorded distinctly and use bounded, allowlisted values:
   `ActionResult.error` text itself is never stamped.
 - An exception that escapes the wrapper is recorded as `AbortError` /
   `cancelled` for cancellation and `ActionError` / `action failed`
-  otherwise, matching the request and translation span conventions. The
-  cancellation decision reads the `cause` chain and the request's abort
-  signal, the same two inputs `action:completed` uses.
+  otherwise, matching the request and translation span conventions.
 
 Auto-setup replacement results (produced when `setupOnFirstUse` runs setup
 in place of the user's action) leave the span status unset regardless of
@@ -1142,26 +1037,17 @@ prompts, responses, and reasoning text are never recorded on the span.
 Timeout and external cancellation are propagated to the underlying SDK
 operation before the span ends. Cancellation records the privacy-safe
 `AbortError` / `cancelled` exception classification and sets error status.
-A reasoning run that is cancelled usually throws whatever the SDK was in the
-middle of rather than an `AbortError`, so the decision also reads the reasoning
-deadline signal and the request's own signal - the same inputs
-`reasoning:completed` uses, so the two never disagree. Other escaping exceptions
-use `ReasoningError` / `reasoning failed`. Original exception messages and stack
-traces are never exported.
+Other escaping exceptions use `ReasoningError` / `reasoning failed`. Original
+exception messages and stack traces are never exported.
 
 ### LLM span
 
 Each instrumented model call creates one `typeagent.llm` span. A returned
 failure result sets `ERROR` with `model returned failure`; a thrown failure
 records `ModelError` / `model call failed`, or `AbortError` / `cancelled` for a
-cancellation. Prompts, responses, and provider messages are never recorded on
-the span. The matching `llm:completed` log event carries the normalized failure
-classification described under
-[Failure classification](#failure-classification).
-
-The span is ended exactly once on every path, including when emitting the
-completion event throws: a broken sink degrades telemetry rather than leaking
-an unfinished span, and it never replaces the failure the call was reporting.
+cancellation. Prompts, responses, and provider messages are never recorded.
+The matching `llm:completed` event carries the normalized failure
+classification.
 
 | Signal          | Use                                          |
 | --------------- | -------------------------------------------- |

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -39,6 +39,7 @@ import { readServerEventStream } from "./serverEvents.js";
 import { TokenCounter } from "./tokenCounter.js";
 import { CompletionUsageStats } from "./apiTypes.js";
 import { registerProviderChatModel } from "./providerChatModelRegistry.js";
+import { otel } from "@typeagent/telemetry";
 
 const debug = registerDebug("typeagent:aiclient:copilot");
 // Per-phase latency breakdown (client start / session create / send / total)
@@ -77,11 +78,57 @@ export interface CopilotEndpointProvider {
  * requested model (e.g. the tenant doesn't offer it and only "auto" is left, or
  * the SDK gate is disabled).
  */
-export class CopilotEndpointUnavailableError extends Error {
+export class CopilotEndpointUnavailableError
+    extends Error
+    implements otel.TelemetryClassifiedError
+{
+    /**
+     * Classifies this error for structured telemetry (see
+     * `classifyTelemetryError` in `@typeagent/telemetry`). The endpoint could
+     * not be minted by the provider, and retrying the same request hits the
+     * same tenant/gate configuration.
+     */
+    public readonly errorCategory = "provider";
+    public readonly retryable = false;
     constructor(message: string) {
         super(message);
         this.name = "CopilotEndpointUnavailableError";
     }
+}
+
+/**
+ * Turn a thrown value into a failure `Result` that still carries what the
+ * throw actually said.
+ *
+ * The message is a private diagnostic and is never parsed downstream; the
+ * attached classification is the bounded part telemetry reports, so a
+ * `CopilotEndpointUnavailableError` or a socket error keeps its identity
+ * instead of being flattened into an unexplained provider failure. See
+ * `attachTelemetryErrorClassification`.
+ *
+ * A throw with nothing recognizable in it gets no classification at all rather
+ * than `internal`: it still came out of a provider call, so the model
+ * wrapper's `provider` fallback is the truthful description.
+ */
+function classifiedFailure(message: string, thrown: unknown): Result<never> {
+    const classification = otel.classifyTelemetryErrorIfRecognized(thrown);
+    const result = error(message);
+    return classification === undefined
+        ? result
+        : otel.attachTelemetryErrorClassification(result, classification);
+}
+
+/**
+ * The failure `Result` for a call that ended because the caller cancelled.
+ * `isAbort` also treats "the caller's signal is aborted" as a cancellation
+ * even when the thrown value itself is not shaped like an `AbortError`, so the
+ * classification is stated here rather than re-derived from that value.
+ */
+function cancelledFailure(): Result<never> {
+    return otel.attachTelemetryErrorClassification(error("Request aborted"), {
+        errorCategory: "cancelled",
+        retryable: false,
+    });
 }
 
 type CopilotSdkLogLevel =
@@ -738,10 +785,11 @@ export function createCopilotTransportModel(
             try {
                 ep = await endpointProvider.getEndpoint();
             } catch (err) {
-                return error(
+                return classifiedFailure(
                     `getEndpoint failed: ${
                         err instanceof Error ? err.message : String(err)
                     }`,
+                    err,
                 );
             }
             member.settings.endpoint = ep.url;
@@ -795,10 +843,12 @@ export function createCopilotTransportModel(
         try {
             result = await callJsonApiWithPool(pool, request, options);
         } catch (err) {
-            if (isAbort(err, signal)) {
-                return error("Request aborted");
-            }
-            return error(err instanceof Error ? err.message : String(err));
+            return isAbort(err, signal)
+                ? cancelledFailure()
+                : classifiedFailure(
+                      err instanceof Error ? err.message : String(err),
+                      err,
+                  );
         }
 
         // A returned (non-thrown) error means a non-transient status (e.g.
@@ -812,10 +862,12 @@ export function createCopilotTransportModel(
             try {
                 result = await callJsonApiWithPool(pool, request, options);
             } catch (err) {
-                if (isAbort(err, signal)) {
-                    return error("Request aborted");
-                }
-                return error(err instanceof Error ? err.message : String(err));
+                return isAbort(err, signal)
+                    ? cancelledFailure()
+                    : classifiedFailure(
+                          err instanceof Error ? err.message : String(err),
+                          err,
+                      );
             }
             if (!result.success) {
                 return result;

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -82,12 +82,6 @@ export class CopilotEndpointUnavailableError
     extends Error
     implements otel.TelemetryClassifiedError
 {
-    /**
-     * Classifies this error for structured telemetry (see
-     * `classifyTelemetryError` in `@typeagent/telemetry`). The endpoint could
-     * not be minted by the provider, and retrying the same request hits the
-     * same tenant/gate configuration.
-     */
     public readonly errorCategory = "provider";
     public readonly retryable = false;
     constructor(message: string) {
@@ -98,17 +92,10 @@ export class CopilotEndpointUnavailableError
 
 /**
  * Turn a thrown value into a failure `Result` that still carries what the
- * throw actually said.
- *
- * The message is a private diagnostic and is never parsed downstream; the
- * attached classification is the bounded part telemetry reports, so a
- * `CopilotEndpointUnavailableError` or a socket error keeps its identity
- * instead of being flattened into an unexplained provider failure. See
- * `attachTelemetryErrorClassification`.
- *
- * A throw with nothing recognizable in it gets no classification at all rather
- * than `internal`: it still came out of a provider call, so the model
- * wrapper's `provider` fallback is the truthful description.
+ * throw said. The message is a private diagnostic never parsed downstream; the
+ * attached classification is the bounded part telemetry reports. An
+ * unrecognized throw gets no classification, leaving the model wrapper's
+ * `provider` fallback as the truthful description.
  */
 function classifiedFailure(message: string, thrown: unknown): Result<never> {
     const classification = otel.classifyTelemetryErrorIfRecognized(thrown);
@@ -119,10 +106,9 @@ function classifiedFailure(message: string, thrown: unknown): Result<never> {
 }
 
 /**
- * The failure `Result` for a call that ended because the caller cancelled.
- * `isAbort` also treats "the caller's signal is aborted" as a cancellation
- * even when the thrown value itself is not shaped like an `AbortError`, so the
- * classification is stated here rather than re-derived from that value.
+ * The failure `Result` for a caller-cancelled call. Stated rather than derived
+ * from the thrown value, because `isAbort` also treats an aborted caller
+ * signal as cancellation when the throw is not shaped like an `AbortError`.
  */
 function cancelledFailure(): Result<never> {
     return otel.attachTelemetryErrorClassification(error("Request aborted"), {

--- a/ts/packages/aiclient/src/otelChatModel.ts
+++ b/ts/packages/aiclient/src/otelChatModel.ts
@@ -129,10 +129,6 @@ export function instrumentChatModel(
     return model;
 }
 
-/**
- * Run a telemetry side effect that must never disturb the model call it
- * describes. A broken logger or span implementation degrades telemetry only.
- */
 function safely(body: () => void): void {
     try {
         body();
@@ -252,17 +248,10 @@ function cancelLlmCall(
 }
 
 /**
- * Record a call that returned rather than threw.
- *
- * A failure `Result` carries only typechat's message string, which may quote
- * the provider response and is never parsed here. The transport attaches what
- * it actually knew before flattening (see
- * `attachTelemetryErrorClassification`), so a real 401/429/timeout keeps its
- * category; when it recognized nothing it attaches nothing (see
- * `classifyTelemetryErrorIfRecognized`) rather than an `internal` that would
- * overwrite this fallback. Every path that produces a returned failure still
- * originates in the provider call, so `provider` is the truthful fallback and
- * nothing else about the failure is claimed.
+ * Record a call that returned rather than threw. A failure `Result` carries
+ * only typechat's message string, which is never parsed here; the transport
+ * attaches the bounded classification it knew, and `provider` is the fallback
+ * when it recognized nothing.
  */
 function finishLlmCall(
     state: LlmCallState,
@@ -303,11 +292,9 @@ function finishLlmCall(
 }
 
 /**
- * Record a call that threw. The thrown value is classified once, and the
- * span status, the event status, its severity, and whether classification
- * fields are emitted at all are all derived from that single result - so a
- * cancellation wrapped in another error cannot be reported as a failure on one
- * signal and a cancellation on another.
+ * Record a call that threw. Span status, event status, and severity all derive
+ * from one classification, so a wrapped cancellation cannot be reported as a
+ * failure on one signal and a cancellation on another.
  */
 function failLlmCall(
     state: LlmCallState,
@@ -342,10 +329,8 @@ function failLlmCall(
 }
 
 /**
- * End the span exactly once. `state.ended` already guards re-entry, so this
- * only has to survive a span implementation that throws - the span must be
- * ended even when emitting the completion event failed, or a broken logger
- * would leak an unfinished span per call.
+ * End the span even when emitting the completion event failed, so a broken
+ * logger cannot leak an unfinished span per call.
  */
 function endSpan(state: LlmCallState): void {
     safely(() => state.span.end());
@@ -374,8 +359,8 @@ function emitCompleted(
                     success,
                     status,
                     elapsedMs: Date.now() - state.startedAt,
-                    // A cancellation is a disposition, not a failure worth
-                    // classifying, so only real failures carry the fields.
+                    // A cancellation is a disposition, not a failure to
+                    // classify.
                     ...(status === "failed" && classification !== undefined
                         ? classification
                         : {}),

--- a/ts/packages/aiclient/src/otelChatModel.ts
+++ b/ts/packages/aiclient/src/otelChatModel.ts
@@ -129,6 +129,18 @@ export function instrumentChatModel(
     return model;
 }
 
+/**
+ * Run a telemetry side effect that must never disturb the model call it
+ * describes. A broken logger or span implementation degrades telemetry only.
+ */
+function safely(body: () => void): void {
+    try {
+        body();
+    } catch {
+        // Telemetry must not fail the model call it is describing.
+    }
+}
+
 function startLlmCall(
     info: ChatModelTelemetryInfo,
     streaming: boolean,
@@ -226,7 +238,7 @@ async function* instrumentStream(
         throw error;
     } finally {
         if (!state.ended) {
-            failLlmCall(state, info, { name: "AbortError" });
+            cancelLlmCall(state, info);
             await source.return?.();
         }
     }
@@ -239,6 +251,19 @@ function cancelLlmCall(
     failLlmCall(state, info, { name: "AbortError" });
 }
 
+/**
+ * Record a call that returned rather than threw.
+ *
+ * A failure `Result` carries only typechat's message string, which may quote
+ * the provider response and is never parsed here. The transport attaches what
+ * it actually knew before flattening (see
+ * `attachTelemetryErrorClassification`), so a real 401/429/timeout keeps its
+ * category; when it recognized nothing it attaches nothing (see
+ * `classifyTelemetryErrorIfRecognized`) rather than an `internal` that would
+ * overwrite this fallback. Every path that produces a returned failure still
+ * originates in the provider call, so `provider` is the truthful fallback and
+ * nothing else about the failure is claimed.
+ */
 function finishLlmCall(
     state: LlmCallState,
     info: ChatModelTelemetryInfo,
@@ -248,17 +273,42 @@ function finishLlmCall(
         return;
     }
     state.ended = true;
-    const success = result.success;
-    if (!success) {
-        state.span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: "model returned failure",
-        });
+    try {
+        const success = result.success;
+        const classification = success
+            ? undefined
+            : (otel.readTelemetryErrorClassification(result) ?? {
+                  errorCategory: "provider" as const,
+              });
+        const cancelled = classification?.errorCategory === "cancelled";
+        if (!success) {
+            const message = cancelled ? "cancelled" : "model returned failure";
+            safely(() =>
+                state.span.setStatus({
+                    code: SpanStatusCode.ERROR,
+                    message,
+                }),
+            );
+        }
+        emitCompleted(
+            state,
+            info,
+            success,
+            success ? "succeeded" : cancelled ? "cancelled" : "failed",
+            classification,
+        );
+    } finally {
+        endSpan(state);
     }
-    emitCompleted(state, info, success, success ? "succeeded" : "failed");
-    state.span.end();
 }
 
+/**
+ * Record a call that threw. The thrown value is classified once, and the
+ * span status, the event status, its severity, and whether classification
+ * fields are emitted at all are all derived from that single result - so a
+ * cancellation wrapped in another error cannot be reported as a failure on one
+ * signal and a cancellation on another.
+ */
 function failLlmCall(
     state: LlmCallState,
     info: ChatModelTelemetryInfo,
@@ -268,20 +318,37 @@ function failLlmCall(
         return;
     }
     state.ended = true;
-    const cancelled =
-        error !== null &&
-        typeof error === "object" &&
-        (error as { name?: unknown }).name === "AbortError";
-    state.span.recordException({
-        name: cancelled ? "AbortError" : "ModelError",
-        message: cancelled ? "cancelled" : "model call failed",
-    });
-    state.span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: cancelled ? "cancelled" : "model call failed",
-    });
-    emitCompleted(state, info, false, cancelled ? "cancelled" : "failed");
-    state.span.end();
+    try {
+        const classification = otel.classifyTelemetryError(error);
+        const cancelled = classification.errorCategory === "cancelled";
+        const message = cancelled ? "cancelled" : "model call failed";
+        safely(() => {
+            state.span.recordException({
+                name: cancelled ? "AbortError" : "ModelError",
+                message,
+            });
+            state.span.setStatus({ code: SpanStatusCode.ERROR, message });
+        });
+        emitCompleted(
+            state,
+            info,
+            false,
+            cancelled ? "cancelled" : "failed",
+            classification,
+        );
+    } finally {
+        endSpan(state);
+    }
+}
+
+/**
+ * End the span exactly once. `state.ended` already guards re-entry, so this
+ * only has to survive a span implementation that throws - the span must be
+ * ended even when emitting the completion event failed, or a broken logger
+ * would leak an unfinished span per call.
+ */
+function endSpan(state: LlmCallState): void {
+    safely(() => state.span.end());
 }
 
 function emitCompleted(
@@ -289,36 +356,44 @@ function emitCompleted(
     info: ChatModelTelemetryInfo,
     success: boolean,
     status: "succeeded" | "failed" | "cancelled",
+    classification: otel.TelemetryErrorClassification | undefined,
 ): void {
     if (!otel.isStructuredLoggingEnabled()) {
         return;
     }
-    context.with(state.activeContext, () =>
-        state.logger.logEvent(
-            "llm:completed",
-            {
-                provider: info.provider,
-                ...(info.model === undefined ? {} : { model: info.model }),
-                operation: "chat",
-                ...state.classification,
-                ...state.correlation,
-                success,
-                status,
-                elapsedMs: Date.now() - state.startedAt,
-                ...(state.usage === undefined
-                    ? {}
-                    : {
-                          inputTokens: state.usage.prompt_tokens,
-                          outputTokens: state.usage.completion_tokens,
-                          totalTokens: state.usage.total_tokens,
-                          ...(state.usage.cached_tokens === undefined
-                              ? {}
-                              : {
-                                    cachedTokens: state.usage.cached_tokens,
-                                }),
-                      }),
-            },
-            success ? "info" : status === "cancelled" ? "warning" : "error",
+    safely(() =>
+        context.with(state.activeContext, () =>
+            state.logger.logEvent(
+                "llm:completed",
+                {
+                    provider: info.provider,
+                    ...(info.model === undefined ? {} : { model: info.model }),
+                    operation: "chat",
+                    ...state.classification,
+                    ...state.correlation,
+                    success,
+                    status,
+                    elapsedMs: Date.now() - state.startedAt,
+                    // A cancellation is a disposition, not a failure worth
+                    // classifying, so only real failures carry the fields.
+                    ...(status === "failed" && classification !== undefined
+                        ? classification
+                        : {}),
+                    ...(state.usage === undefined
+                        ? {}
+                        : {
+                              inputTokens: state.usage.prompt_tokens,
+                              outputTokens: state.usage.completion_tokens,
+                              totalTokens: state.usage.total_tokens,
+                              ...(state.usage.cached_tokens === undefined
+                                  ? {}
+                                  : {
+                                        cachedTokens: state.usage.cached_tokens,
+                                    }),
+                          }),
+                },
+                success ? "info" : status === "cancelled" ? "warning" : "error",
+            ),
         ),
     );
 }

--- a/ts/packages/aiclient/src/restClient.ts
+++ b/ts/packages/aiclient/src/restClient.ts
@@ -4,6 +4,7 @@
 import { success, error, Result } from "typechat";
 import registerDebug from "debug";
 import { filterSecretsFromJsonString } from "@typeagent/common-utils";
+import { otel } from "@typeagent/telemetry";
 import type { EndpointPool, EndpointPoolMember } from "./endpointPool.js";
 import {
     markSuccess,
@@ -312,15 +313,61 @@ async function getErrorMessage(
     return `${response.status}: ${response.statusText}${bodyMessage ? `: ${bodyMessage}` : ""}${retries !== undefined ? ` Quitting after ${retries} retries` : ""}${timeTaken !== undefined ? ` in ${timeTaken}ms` : ""}`;
 }
 
+/**
+ * What "the transport produced no `Response` at all" means to telemetry.
+ *
+ * `callFetch` can report a dropped connection two ways: by throwing, or by
+ * resolving to `undefined`. The single-endpoint path turns the second into a
+ * throw ({@link noResponseError}) and the pool path handles it inline, so the
+ * two would otherwise describe the same event differently. Both build from
+ * this one value: a transport-level failure that another attempt may well
+ * answer.
+ */
+const NO_RESPONSE_CLASSIFICATION: otel.TelemetryErrorClassification =
+    Object.freeze({
+        errorCategory: "network",
+        retryable: true,
+    });
+
+/**
+ * The error the single-endpoint path throws when `callFetch` resolves without
+ * a `Response`. It declares its own classification (the opt-in
+ * `TelemetryClassifiedError` contract), so the generic catch below classifies
+ * it as exactly what the pool path states directly.
+ */
+function noResponseError(): Error {
+    return Object.assign(new Error("fetch: No response"), {
+        ...NO_RESPONSE_CLASSIFICATION,
+    });
+}
+
 // Append the endpoint to a fetch error so failures name which
 // deployment/region was hit (e.g. an Azure "deployment does not exist" 404
 // points at the exact endpoint). The URL carries no secret - the api-key
 // rides in request headers, not the URL.
+//
+// The message itself is a private diagnostic: it quotes the provider's
+// response body, so telemetry must never parse or export it. What telemetry
+// does need - was this auth, throttling, a timeout, the network? - is known
+// exactly here and nowhere upstream, because a `Result` failure has no room
+// for it. `classification` carries those bounded facts alongside the message
+// (invisibly to every existing consumer: see
+// `attachTelemetryErrorClassification`) so the model wrapper can report a real
+// 401/429/timeout instead of a blanket `provider`.
+//
+// `undefined` means "nothing recognizable was known here", and is left off
+// deliberately: the failure still came out of a provider call, and the model
+// wrapper's `provider` fallback describes that better than an `internal` this
+// layer would have had to invent.
 function fetchErrorWithEndpoint(
     endpoint: string,
     detail: string,
+    classification: otel.TelemetryErrorClassification | undefined,
 ): Result<Response> {
-    return error(`fetch error: ${detail} (endpoint: ${endpoint})`);
+    const result = error(`fetch error: ${detail} (endpoint: ${endpoint})`);
+    return classification === undefined
+        ? result
+        : otel.attachTelemetryErrorClassification(result, classification);
 }
 
 /**
@@ -357,7 +404,7 @@ export async function fetchWithRetry(
         while (true) {
             const result = await callFetch(url, options, timeout, throttler);
             if (result === undefined) {
-                throw new Error("fetch: No response");
+                throw noResponseError();
             }
             debugHeader(result.status, result.statusText);
             debugHeader(result.headers);
@@ -386,6 +433,7 @@ export async function fetchWithRetry(
                 return fetchErrorWithEndpoint(
                     url,
                     await getErrorMessage(result, retryCount, elapsed),
+                    otel.classifyTelemetryHttpStatus(result.status),
                 );
             } else if (debugError.enabled) {
                 debugError(await getErrorMessage(result));
@@ -429,7 +477,11 @@ export async function fetchWithRetry(
         if (isAbortError(e)) {
             throw e;
         }
-        return fetchErrorWithEndpoint(url, e.cause?.message ?? e.message);
+        return fetchErrorWithEndpoint(
+            url,
+            e.cause?.message ?? e.message,
+            otel.classifyTelemetryErrorIfRecognized(e),
+        );
     }
 }
 
@@ -527,7 +579,14 @@ async function fetchWithTimeout(
             throw e;
         }
         if (isAbortError(ex)) {
-            throw new Error(`fetch timeout ${timeoutMs}ms`);
+            // Our own deadline fired, not the caller's cancellation. Name it
+            // `TimeoutError` (the standard DOM name) so it is not mistaken for
+            // a cancellation and so telemetry classifies it as a retryable
+            // timeout rather than an unexplained internal failure. The message
+            // stays the same for existing local diagnostics.
+            const timeout = new Error(`fetch timeout ${timeoutMs}ms`);
+            timeout.name = "TimeoutError";
+            throw timeout;
         }
         throw e;
     } finally {
@@ -751,6 +810,7 @@ async function fetchWithPool(
             lastError = fetchErrorWithEndpoint(
                 member.settings.endpoint,
                 e?.cause?.message ?? e?.message ?? String(e),
+                otel.classifyTelemetryErrorIfRecognized(e),
             );
             continue;
         }
@@ -771,6 +831,9 @@ async function fetchWithPool(
             lastError = fetchErrorWithEndpoint(
                 member.settings.endpoint,
                 "No response",
+                // Same event, same classification as the single-endpoint path
+                // (which reaches it by throwing `noResponseError`).
+                NO_RESPONSE_CLASSIFICATION,
             );
             continue;
         }
@@ -792,6 +855,7 @@ async function fetchWithPool(
                     attempts,
                     Date.now() - startTime,
                 ),
+                otel.classifyTelemetryHttpStatus(response.status),
             );
             continue;
         }
@@ -807,6 +871,7 @@ async function fetchWithPool(
                     attempts,
                     Date.now() - startTime,
                 ),
+                otel.classifyTelemetryHttpStatus(response.status),
             );
             continue;
         }
@@ -816,6 +881,7 @@ async function fetchWithPool(
         return fetchErrorWithEndpoint(
             member.settings.endpoint,
             await getErrorMessage(response, attempts, Date.now() - startTime),
+            otel.classifyTelemetryHttpStatus(response.status),
         );
     }
 }

--- a/ts/packages/aiclient/src/restClient.ts
+++ b/ts/packages/aiclient/src/restClient.ts
@@ -314,14 +314,9 @@ async function getErrorMessage(
 }
 
 /**
- * What "the transport produced no `Response` at all" means to telemetry.
- *
- * `callFetch` can report a dropped connection two ways: by throwing, or by
- * resolving to `undefined`. The single-endpoint path turns the second into a
- * throw ({@link noResponseError}) and the pool path handles it inline, so the
- * two would otherwise describe the same event differently. Both build from
- * this one value: a transport-level failure that another attempt may well
- * answer.
+ * Shared by both "no `Response` at all" paths - the single-endpoint path
+ * throws {@link noResponseError}, the pool path uses this value inline - so
+ * they cannot describe the same event differently.
  */
 const NO_RESPONSE_CLASSIFICATION: otel.TelemetryErrorClassification =
     Object.freeze({
@@ -331,9 +326,8 @@ const NO_RESPONSE_CLASSIFICATION: otel.TelemetryErrorClassification =
 
 /**
  * The error the single-endpoint path throws when `callFetch` resolves without
- * a `Response`. It declares its own classification (the opt-in
- * `TelemetryClassifiedError` contract), so the generic catch below classifies
- * it as exactly what the pool path states directly.
+ * a `Response`. It declares its own classification so the generic catch below
+ * classifies it as exactly what the pool path states directly.
  */
 function noResponseError(): Error {
     return Object.assign(new Error("fetch: No response"), {
@@ -346,19 +340,11 @@ function noResponseError(): Error {
 // points at the exact endpoint). The URL carries no secret - the api-key
 // rides in request headers, not the URL.
 //
-// The message itself is a private diagnostic: it quotes the provider's
-// response body, so telemetry must never parse or export it. What telemetry
-// does need - was this auth, throttling, a timeout, the network? - is known
-// exactly here and nowhere upstream, because a `Result` failure has no room
-// for it. `classification` carries those bounded facts alongside the message
-// (invisibly to every existing consumer: see
-// `attachTelemetryErrorClassification`) so the model wrapper can report a real
-// 401/429/timeout instead of a blanket `provider`.
-//
-// `undefined` means "nothing recognizable was known here", and is left off
-// deliberately: the failure still came out of a provider call, and the model
-// wrapper's `provider` fallback describes that better than an `internal` this
-// layer would have had to invent.
+// The message quotes the provider's response body, so telemetry must never
+// parse or export it. `classification` carries the bounded facts instead,
+// since a `Result` failure has no room for them, letting the model wrapper
+// report a real 401/429/timeout instead of a blanket `provider`. `undefined`
+// is left off deliberately so that `provider` fallback still applies.
 function fetchErrorWithEndpoint(
     endpoint: string,
     detail: string,
@@ -579,11 +565,9 @@ async function fetchWithTimeout(
             throw e;
         }
         if (isAbortError(ex)) {
-            // Our own deadline fired, not the caller's cancellation. Name it
-            // `TimeoutError` (the standard DOM name) so it is not mistaken for
-            // a cancellation and so telemetry classifies it as a retryable
-            // timeout rather than an unexplained internal failure. The message
-            // stays the same for existing local diagnostics.
+            // Our own deadline fired, not the caller's cancellation. The
+            // standard `TimeoutError` name keeps it from being reported as a
+            // cancellation.
             const timeout = new Error(`fetch timeout ${timeoutMs}ms`);
             timeout.name = "TimeoutError";
             throw timeout;
@@ -831,8 +815,6 @@ async function fetchWithPool(
             lastError = fetchErrorWithEndpoint(
                 member.settings.endpoint,
                 "No response",
-                // Same event, same classification as the single-endpoint path
-                // (which reaches it by throwing `noResponseError`).
                 NO_RESPONSE_CLASSIFICATION,
             );
             continue;

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -9,6 +9,7 @@ import {
     selectCopilotModel,
 } from "../src/copilotModels.js";
 import type { ModelInfo } from "@github/copilot-sdk";
+import { otel } from "@typeagent/telemetry";
 import { CopilotApiSettings } from "../src/copilotSettings.js";
 import { ModelType } from "../src/openai.js";
 import { PromptSection } from "typechat";
@@ -323,6 +324,14 @@ describe("createCopilotTransportModel", () => {
         expect(result.success).toBe(false);
         // A single reactive refresh was attempted before giving up.
         expect(forceCalls.filter((f) => f === true)).toHaveLength(1);
+        // The HTTP status survives the flattening into a `Result` message, so
+        // the model wrapper reports an authentication failure rather than an
+        // unexplained provider one.
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "authentication",
+            httpStatus: 401,
+            retryable: false,
+        });
     });
 
     test("returns an error when the endpoint is unavailable", async () => {
@@ -346,6 +355,41 @@ describe("createCopilotTransportModel", () => {
         expect(result.success).toBe(false);
         // No HTTP call is made when the endpoint can't be minted.
         expect(fetchCalls).toBe(0);
+        // The typed error classifies itself, and that classification survives
+        // being turned into a `Result` failure.
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "provider",
+            retryable: false,
+        });
+    });
+
+    test("classifies a cancelled call as cancelled, not as a provider failure", async () => {
+        const controller = new AbortController();
+        globalThis.fetch = async () => {
+            controller.abort();
+            throw new DOMException("The operation was aborted.", "AbortError");
+        };
+        const { provider } = makeProvider([makeEndpoint()]);
+        const model = createCopilotTransportModel(
+            makeSettings(),
+            {},
+            undefined,
+            undefined,
+            provider,
+        );
+
+        const result = await model.complete(
+            "hi",
+            undefined,
+            undefined,
+            undefined,
+            controller.signal,
+        );
+        expect(result.success).toBe(false);
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "cancelled",
+            retryable: false,
+        });
     });
 
     test("sends image content through as vision input", async () => {

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -324,9 +324,7 @@ describe("createCopilotTransportModel", () => {
         expect(result.success).toBe(false);
         // A single reactive refresh was attempted before giving up.
         expect(forceCalls.filter((f) => f === true)).toHaveLength(1);
-        // The HTTP status survives the flattening into a `Result` message, so
-        // the model wrapper reports an authentication failure rather than an
-        // unexplained provider one.
+        // The HTTP status survives the flattening into a `Result` message.
         expect(otel.readTelemetryErrorClassification(result)).toEqual({
             errorCategory: "authentication",
             httpStatus: 401,
@@ -355,8 +353,8 @@ describe("createCopilotTransportModel", () => {
         expect(result.success).toBe(false);
         // No HTTP call is made when the endpoint can't be minted.
         expect(fetchCalls).toBe(0);
-        // The typed error classifies itself, and that classification survives
-        // being turned into a `Result` failure.
+        // The typed error's own classification survives being turned into a
+        // `Result` failure.
         expect(otel.readTelemetryErrorClassification(result)).toEqual({
             errorCategory: "provider",
             retryable: false,

--- a/ts/packages/aiclient/test/otelChatModel.spec.ts
+++ b/ts/packages/aiclient/test/otelChatModel.spec.ts
@@ -393,8 +393,6 @@ describe("instrumentChatModel", () => {
             const completed = events.find(
                 ({ name }) => name === "llm:completed",
             );
-            // The span status, the event status, the severity, and the absence
-            // of classification fields all follow the same classification.
             expect(completed?.data).toMatchObject({
                 status: "cancelled",
                 success: false,
@@ -456,8 +454,8 @@ describe("instrumentChatModel", () => {
             const completed = events.find(
                 ({ name }) => name === "llm:completed",
             );
-            // An unusable carrier falls back to the honest default rather than
-            // exporting whatever it happened to contain.
+            // An unusable carrier falls back to the default rather than
+            // exporting whatever it contained.
             expect(completed?.data).toMatchObject({
                 status: "failed",
                 errorCategory: "provider",
@@ -467,12 +465,9 @@ describe("instrumentChatModel", () => {
         });
 
         it("reports provider for a real transport failure nothing recognized", async () => {
-            // End to end with the actual REST client rather than a hand-built
-            // `Result`: an unexplained `fetch failed` has no signal the
-            // transport could attach, so the wrapper's `provider` fallback has
-            // to survive. If the transport ever attached `internal` for the
-            // unrecognized case, this reads `internal` instead - and every
-            // unexplained provider outage would be counted as our own bug.
+            // End to end with the real REST client: an unexplained
+            // `fetch failed` has no signal to attach, so the wrapper's
+            // `provider` fallback must survive rather than reading `internal`.
             otel.setStructuredLoggingEnabled(true);
             const events: CapturedEvent[] = [];
             const originalFetch = globalThis.fetch;
@@ -527,8 +522,7 @@ describe("instrumentChatModel", () => {
                 ).complete("private prompt"),
             ).rejects.toThrow("provider blew up");
 
-            // A broken sink must not leak an unfinished span or replace the
-            // original failure with a telemetry one.
+            // A broken sink must not leak an unfinished span.
             expect(spans.findSpansByName("typeagent.llm")).toHaveLength(1);
         });
 

--- a/ts/packages/aiclient/test/otelChatModel.spec.ts
+++ b/ts/packages/aiclient/test/otelChatModel.spec.ts
@@ -11,10 +11,21 @@ import type { Logger } from "@typeagent/telemetry";
 import { error, success } from "typechat";
 import type { ChatModelWithStreaming } from "../src/models.js";
 import { instrumentChatModel } from "../src/otelChatModel.js";
+import { fetchWithRetry } from "../src/restClient.js";
 import {
     withChatModelTelemetryContext,
     withChatModelTelemetryPurpose,
 } from "../src/chatModelTelemetryContext.js";
+
+type CapturedEvent = { name: string; data: Record<string, unknown> };
+
+function createCapturingLogger(events: CapturedEvent[]): Logger {
+    return {
+        logEvent(name, data) {
+            events.push({ name, data });
+        },
+    };
+}
 
 function createModel(): ChatModelWithStreaming {
     return {
@@ -160,15 +171,8 @@ describe("instrumentChatModel", () => {
     });
 
     it("gates lifecycle logs and preserves inherited correlation", async () => {
-        const events: Array<{
-            name: string;
-            data: Record<string, unknown>;
-        }> = [];
-        const logger: Logger = {
-            logEvent(name, data) {
-                events.push({ name, data });
-            },
-        };
+        const events: CapturedEvent[] = [];
+        const logger = createCapturingLogger(events);
 
         await instrumentChatModel(
             createModel(),
@@ -223,19 +227,11 @@ describe("instrumentChatModel", () => {
 
     it("records explicit lifecycle classification on spans and events", async () => {
         otel.setStructuredLoggingEnabled(true);
-        const events: Array<{
-            name: string;
-            data: Record<string, unknown>;
-        }> = [];
-        const logger: Logger = {
-            logEvent(name, data) {
-                events.push({ name, data });
-            },
-        };
+        const events: CapturedEvent[] = [];
         const model = instrumentChatModel(
             createModel(),
             { provider: "test-provider" },
-            logger,
+            createCapturingLogger(events),
         );
 
         await withChatModelTelemetryContext(
@@ -291,6 +287,282 @@ describe("instrumentChatModel", () => {
             "typeagent.llm.phase": "translation",
             "typeagent.llm.purpose": "schema-selection",
             "typeagent.llm.scope": "foreground",
+        });
+    });
+
+    describe("failure classification", () => {
+        it("classifies a thrown provider error without its message", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () => {
+                throw Object.assign(new Error("secret provider detail"), {
+                    status: 429,
+                });
+            };
+
+            await expect(
+                instrumentChatModel(
+                    base,
+                    { provider: "test-provider" },
+                    createCapturingLogger(events),
+                ).complete("private prompt"),
+            ).rejects.toThrow("secret provider detail");
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            expect(completed?.data).toMatchObject({
+                status: "failed",
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            });
+            expect(JSON.stringify(completed)).not.toContain("secret");
+        });
+
+        it("classifies a returned failure result as a provider failure", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () => error("secret provider detail");
+
+            await instrumentChatModel(
+                base,
+                { provider: "test-provider" },
+                createCapturingLogger(events),
+            ).complete("private prompt");
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            expect(completed?.data).toMatchObject({
+                status: "failed",
+                errorCategory: "provider",
+            });
+            expect(JSON.stringify(completed)).not.toContain("secret");
+        });
+
+        it("leaves a cancellation unclassified", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () => {
+                throw new DOMException(
+                    "The operation was aborted.",
+                    "AbortError",
+                );
+            };
+
+            await expect(
+                instrumentChatModel(
+                    base,
+                    { provider: "test-provider" },
+                    createCapturingLogger(events),
+                ).complete("private prompt"),
+            ).rejects.toThrow();
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            expect(completed?.data).toMatchObject({ status: "cancelled" });
+            expect(completed?.data.errorCategory).toBeUndefined();
+        });
+
+        it("treats a wrapped cancellation as cancelled on every signal", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () => {
+                throw Object.assign(new Error("translation failed"), {
+                    cause: new DOMException(
+                        "The operation was aborted.",
+                        "AbortError",
+                    ),
+                });
+            };
+
+            await expect(
+                instrumentChatModel(
+                    base,
+                    { provider: "test-provider" },
+                    createCapturingLogger(events),
+                ).complete("private prompt"),
+            ).rejects.toThrow();
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            // The span status, the event status, the severity, and the absence
+            // of classification fields all follow the same classification.
+            expect(completed?.data).toMatchObject({
+                status: "cancelled",
+                success: false,
+            });
+            expect(completed?.data.errorCategory).toBeUndefined();
+            expect(
+                spans.findSpansByName("typeagent.llm")[0]?.status,
+            ).toMatchObject({ code: 2, message: "cancelled" });
+        });
+
+        it("reports the classification the transport attached to a failure result", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () =>
+                otel.attachTelemetryErrorClassification(
+                    error("429: Too Many Requests: secret tenant detail"),
+                    {
+                        errorCategory: "rate_limit",
+                        httpStatus: 429,
+                        retryable: true,
+                    },
+                );
+
+            await instrumentChatModel(
+                base,
+                { provider: "test-provider" },
+                createCapturingLogger(events),
+            ).complete("private prompt");
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            expect(completed?.data).toMatchObject({
+                status: "failed",
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            });
+            expect(JSON.stringify(completed)).not.toContain("secret");
+        });
+
+        it("ignores a forged classification carrier on a failure result", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            base.complete = async () =>
+                otel.attachTelemetryErrorClassification(error("failed"), {
+                    errorCategory: "not-a-category",
+                    errorCode: "tenant-8f14e45f",
+                    httpStatus: 200,
+                } as unknown as otel.TelemetryErrorClassification);
+            await instrumentChatModel(
+                base,
+                { provider: "test-provider" },
+                createCapturingLogger(events),
+            ).complete("private prompt");
+
+            const completed = events.find(
+                ({ name }) => name === "llm:completed",
+            );
+            // An unusable carrier falls back to the honest default rather than
+            // exporting whatever it happened to contain.
+            expect(completed?.data).toMatchObject({
+                status: "failed",
+                errorCategory: "provider",
+            });
+            expect(completed?.data.errorCode).toBeUndefined();
+            expect(completed?.data.httpStatus).toBeUndefined();
+        });
+
+        it("reports provider for a real transport failure nothing recognized", async () => {
+            // End to end with the actual REST client rather than a hand-built
+            // `Result`: an unexplained `fetch failed` has no signal the
+            // transport could attach, so the wrapper's `provider` fallback has
+            // to survive. If the transport ever attached `internal` for the
+            // unrecognized case, this reads `internal` instead - and every
+            // unexplained provider outage would be counted as our own bug.
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const originalFetch = globalThis.fetch;
+            globalThis.fetch = async () => {
+                throw new TypeError("fetch failed");
+            };
+            let transportFailure;
+            try {
+                transportFailure = await fetchWithRetry(
+                    "https://example.test/openai/deployments/foo/chat/completions",
+                );
+            } finally {
+                globalThis.fetch = originalFetch;
+            }
+            if (transportFailure.success) {
+                throw new Error("expected the transport call to fail");
+            }
+
+            const base = createModel();
+            base.complete = async () => transportFailure;
+
+            await instrumentChatModel(
+                base,
+                { provider: "test-provider" },
+                createCapturingLogger(events),
+            ).complete("private prompt");
+
+            expect(
+                events.find(({ name }) => name === "llm:completed")?.data,
+            ).toMatchObject({ status: "failed", errorCategory: "provider" });
+        });
+
+        it("ends the span and rethrows even when the completion log throws", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const brokenLogger: Logger = {
+                logEvent(name) {
+                    if (name === "llm:completed") {
+                        throw new Error("sink is broken");
+                    }
+                },
+            };
+            const base = createModel();
+            base.complete = async () => {
+                throw new Error("provider blew up");
+            };
+
+            await expect(
+                instrumentChatModel(
+                    base,
+                    { provider: "test-provider" },
+                    brokenLogger,
+                ).complete("private prompt"),
+            ).rejects.toThrow("provider blew up");
+
+            // A broken sink must not leak an unfinished span or replace the
+            // original failure with a telemetry one.
+            expect(spans.findSpansByName("typeagent.llm")).toHaveLength(1);
+        });
+
+        it("still ends the span when classification is fed a hostile error", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            const base = createModel();
+            const hostile = new Proxy(new Error("hostile"), {
+                get(_target, property) {
+                    throw new Error(`no reads allowed: ${String(property)}`);
+                },
+            });
+            base.complete = async () => {
+                throw hostile;
+            };
+
+            let thrown: unknown;
+            try {
+                await instrumentChatModel(
+                    base,
+                    { provider: "test-provider" },
+                    createCapturingLogger(events),
+                ).complete("private prompt");
+            } catch (caught) {
+                thrown = caught;
+            }
+
+            // The original throw reaches the caller untouched, and the span is
+            // still closed.
+            expect(thrown).toBe(hostile);
+            expect(spans.findSpansByName("typeagent.llm")).toHaveLength(1);
+            expect(
+                events.find(({ name }) => name === "llm:completed")?.data,
+            ).toMatchObject({ status: "failed", errorCategory: "internal" });
         });
     });
 });

--- a/ts/packages/aiclient/test/restClient.spec.ts
+++ b/ts/packages/aiclient/test/restClient.spec.ts
@@ -11,9 +11,8 @@ import {
 } from "../src/restClient.js";
 
 /**
- * A stand-in for the global `fetch`. Typed loosely on purpose: one case
- * resolves without a `Response` at all, which is exactly the dropped-connection
- * shape the tests below exercise.
+ * A stand-in for the global `fetch`. Typed loosely because one case resolves
+ * without a `Response` at all.
  */
 type FetchStub = (
     input?: unknown,
@@ -91,10 +90,8 @@ describe("restClient", () => {
     });
 });
 
-// A `Result` failure carries only a message, and that message quotes the
-// provider's response body, so telemetry must not parse it. The transport is
-// the last place that still knows what actually happened, so it attaches the
-// bounded facts there (see `attachTelemetryErrorClassification`).
+// A `Result` failure carries only a message that quotes the provider's
+// response body, so the transport attaches the bounded facts instead.
 describe("restClient failure classification", () => {
     const origFetch = globalThis.fetch;
     const url = "https://example.test/openai/deployments/foo/chat/completions";
@@ -166,12 +163,10 @@ describe("restClient failure classification", () => {
     });
 
     test("classifies our own deadline as a retryable timeout", async () => {
-        // `fetchWithTimeout` aborts on its own deadline and re-throws a
-        // `TimeoutError`, which must not read as a caller cancellation. The
-        // abort is raised as a named `Error` rather than a `DOMException`
+        // The abort is raised as a named `Error` rather than a `DOMException`
         // because Jest's VM realm gives the test a `DOMException` whose
-        // prototype chain does not reach the realm's `Error`, which would
-        // defeat the `instanceof Error` check under test.
+        // prototype chain does not reach the realm's `Error`, defeating the
+        // `instanceof Error` check under test.
         stubFetch(
             (_input, init) =>
                 new Promise<Response>((_resolve, reject) => {
@@ -198,14 +193,12 @@ describe("restClient failure classification", () => {
         const result = await fetchWithRetry(url);
         const classification = otel.readTelemetryErrorClassification(result);
         expect(JSON.stringify(classification)).not.toContain("secret");
-        // The message stays available for the private local diagnostics.
+        // The message stays available for private local diagnostics.
         expect(result.success === false && result.message).toContain("secret");
     });
 
-    // `internal` is a claim about our own code. A transport failure nobody
-    // recognized is not that, and attaching it here would also overwrite the
-    // model wrapper's `provider` fallback (see `finishLlmCall`), which is the
-    // truthful description of "the provider call failed and nothing said why".
+    // `internal` would claim the failure came from our own code and would
+    // overwrite the model wrapper's truthful `provider` fallback.
     test("attaches nothing when the failure carries no recognized signal", async () => {
         stubFetch(async () => {
             throw new TypeError("fetch failed");
@@ -216,10 +209,9 @@ describe("restClient failure classification", () => {
     });
 });
 
-// One dropped connection, two code paths: `callFetch` resolving to `undefined`
-// is handled by a throw on the single-endpoint path and inline on the pool
-// path. They must describe it the same way, or the same outage reads as
-// `network` from one deployment and as nothing (or `internal`) from another.
+// `callFetch` resolving to `undefined` is handled by a throw on the
+// single-endpoint path and inline on the pool path; both must describe the
+// same outage the same way.
 describe("restClient dropped-connection parity", () => {
     const origFetch = globalThis.fetch;
     const url = "https://example.test/openai/deployments/foo/chat/completions";
@@ -250,13 +242,11 @@ describe("restClient dropped-connection parity", () => {
     }
 
     test("single-endpoint and multi-endpoint report the same classification", async () => {
-        // Resolving without a Response is what a dropped connection looks like
-        // here, and it is not a thrown error either path could classify.
+        // Resolving without a Response is what a dropped connection looks like.
         stubFetch(async () => undefined);
 
         const single = await fetchWithRetry(url);
-        // Two members, so the pool takes its own rotation branch rather than
-        // delegating to the single-endpoint path.
+        // Two members, so the pool takes its own rotation branch.
         const pooled = await callApiWithPool(
             makePool([url, "https://second.example.test/chat"]),
             async () => success({ headers: {}, body: { hello: "world" } }),

--- a/ts/packages/aiclient/test/restClient.spec.ts
+++ b/ts/packages/aiclient/test/restClient.spec.ts
@@ -1,7 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { fetchWithRetry, getRetryAfterMs } from "../src/restClient.js";
+import { otel } from "@typeagent/telemetry";
+import { success } from "typechat";
+import type { EndpointPool, EndpointPoolMember } from "../src/endpointPool.js";
+import {
+    callApiWithPool,
+    fetchWithRetry,
+    getRetryAfterMs,
+} from "../src/restClient.js";
+
+/**
+ * A stand-in for the global `fetch`. Typed loosely on purpose: one case
+ * resolves without a `Response` at all, which is exactly the dropped-connection
+ * shape the tests below exercise.
+ */
+type FetchStub = (
+    input?: unknown,
+    init?: { signal?: AbortSignal },
+) => Promise<Response | undefined>;
+
+function stubFetch(stub: FetchStub): void {
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch;
+}
 
 describe("restClient", () => {
     test("retryPauseHeader", () => {
@@ -67,5 +88,185 @@ describe("restClient", () => {
         } finally {
             globalThis.fetch = origFetch;
         }
+    });
+});
+
+// A `Result` failure carries only a message, and that message quotes the
+// provider's response body, so telemetry must not parse it. The transport is
+// the last place that still knows what actually happened, so it attaches the
+// bounded facts there (see `attachTelemetryErrorClassification`).
+describe("restClient failure classification", () => {
+    const origFetch = globalThis.fetch;
+    const url = "https://example.test/openai/deployments/foo/chat/completions";
+
+    afterEach(() => {
+        globalThis.fetch = origFetch;
+    });
+
+    function respondWith(status: number): void {
+        stubFetch(
+            async () =>
+                new Response(
+                    JSON.stringify({ error: "secret tenant detail" }),
+                    {
+                        status,
+                        headers: { "content-type": "application/json" },
+                    },
+                ),
+        );
+    }
+
+    const statusCases: readonly [number, string, boolean][] = [
+        [400, "validation", false],
+        [401, "authentication", false],
+        [403, "authorization", false],
+        [404, "validation", false],
+    ];
+
+    test.each(statusCases)(
+        "carries the classification for a non-transient %i",
+        async (status, errorCategory, retryable) => {
+            respondWith(status);
+            const result = await fetchWithRetry(url);
+            expect(result.success).toBe(false);
+            expect(otel.readTelemetryErrorClassification(result)).toEqual({
+                errorCategory,
+                httpStatus: status,
+                retryable,
+            });
+        },
+    );
+
+    test("carries the classification once throttling exhausts its retries", async () => {
+        respondWith(429);
+        const result = await fetchWithRetry(url, undefined, 0, 1);
+        expect(result.success).toBe(false);
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "rate_limit",
+            httpStatus: 429,
+            retryable: true,
+        });
+    });
+
+    test("classifies a transport-level network failure", async () => {
+        stubFetch(async () => {
+            throw Object.assign(new TypeError("fetch failed"), {
+                cause: Object.assign(new Error("connect ECONNREFUSED"), {
+                    code: "ECONNREFUSED",
+                }),
+            });
+        });
+        const result = await fetchWithRetry(url);
+        expect(result.success).toBe(false);
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "network",
+            errorCode: "ECONNREFUSED",
+            retryable: true,
+        });
+    });
+
+    test("classifies our own deadline as a retryable timeout", async () => {
+        // `fetchWithTimeout` aborts on its own deadline and re-throws a
+        // `TimeoutError`, which must not read as a caller cancellation. The
+        // abort is raised as a named `Error` rather than a `DOMException`
+        // because Jest's VM realm gives the test a `DOMException` whose
+        // prototype chain does not reach the realm's `Error`, which would
+        // defeat the `instanceof Error` check under test.
+        stubFetch(
+            (_input, init) =>
+                new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener("abort", () => {
+                        reject(
+                            Object.assign(
+                                new Error("The operation was aborted."),
+                                { name: "AbortError" },
+                            ),
+                        );
+                    });
+                }),
+        );
+        const result = await fetchWithRetry(url, undefined, 0, 1, 10);
+        expect(result.success).toBe(false);
+        expect(otel.readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "timeout",
+            retryable: true,
+        });
+    });
+
+    test("never carries the provider message in the classification", async () => {
+        respondWith(401);
+        const result = await fetchWithRetry(url);
+        const classification = otel.readTelemetryErrorClassification(result);
+        expect(JSON.stringify(classification)).not.toContain("secret");
+        // The message stays available for the private local diagnostics.
+        expect(result.success === false && result.message).toContain("secret");
+    });
+
+    // `internal` is a claim about our own code. A transport failure nobody
+    // recognized is not that, and attaching it here would also overwrite the
+    // model wrapper's `provider` fallback (see `finishLlmCall`), which is the
+    // truthful description of "the provider call failed and nothing said why".
+    test("attaches nothing when the failure carries no recognized signal", async () => {
+        stubFetch(async () => {
+            throw new TypeError("fetch failed");
+        });
+        const result = await fetchWithRetry(url);
+        expect(result.success).toBe(false);
+        expect(otel.readTelemetryErrorClassification(result)).toBeUndefined();
+    });
+});
+
+// One dropped connection, two code paths: `callFetch` resolving to `undefined`
+// is handled by a throw on the single-endpoint path and inline on the pool
+// path. They must describe it the same way, or the same outage reads as
+// `network` from one deployment and as nothing (or `internal`) from another.
+describe("restClient dropped-connection parity", () => {
+    const origFetch = globalThis.fetch;
+    const url = "https://example.test/openai/deployments/foo/chat/completions";
+
+    afterEach(() => {
+        globalThis.fetch = origFetch;
+    });
+
+    function makePool(endpoints: readonly string[]): EndpointPool {
+        return {
+            modelKey: "test",
+            members: endpoints.map((endpoint, index) => ({
+                suffix: `M${index}`,
+                priority: index + 1,
+                mode: "PAYG",
+                settings: {
+                    provider: "azure",
+                    modelType: "chat",
+                    endpoint,
+                    apiKey: "test-key",
+                    maxRetryAttempts: 1,
+                } as unknown as EndpointPoolMember["settings"],
+                cooldownUntil: 0,
+                consecutive429s: 0,
+                consecutiveSuccesses: 0,
+            })),
+        };
+    }
+
+    test("single-endpoint and multi-endpoint report the same classification", async () => {
+        // Resolving without a Response is what a dropped connection looks like
+        // here, and it is not a thrown error either path could classify.
+        stubFetch(async () => undefined);
+
+        const single = await fetchWithRetry(url);
+        // Two members, so the pool takes its own rotation branch rather than
+        // delegating to the single-endpoint path.
+        const pooled = await callApiWithPool(
+            makePool([url, "https://second.example.test/chat"]),
+            async () => success({ headers: {}, body: { hello: "world" } }),
+            { overallBudgetMs: 200 },
+        );
+
+        expect(single.success).toBe(false);
+        expect(pooled.success).toBe(false);
+        const expected = { errorCategory: "network", retryable: true };
+        expect(otel.readTelemetryErrorClassification(single)).toEqual(expected);
+        expect(otel.readTelemetryErrorClassification(pooled)).toEqual(expected);
     });
 });

--- a/ts/packages/dispatcher/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/command.ts
@@ -20,6 +20,7 @@ import {
 } from "@opentelemetry/api";
 import { otel } from "@typeagent/telemetry";
 import { wrapRootRequestSpan } from "../otel/rootRequestSpan.js";
+import { recordSpanFailure } from "../otel/spanFailure.js";
 import { getSessionName } from "../context/session.js";
 
 import {
@@ -41,6 +42,7 @@ import {
 import { DispatcherName } from "../context/dispatcher/dispatcherUtils.js";
 import { getAppAgentName } from "../internal.js";
 import {
+    logCommandException,
     logRequestCompleted,
     logRequestReceived,
 } from "../otel/structuredEvents.js";
@@ -392,18 +394,19 @@ export async function processCommandNoLock(
             attachments,
         );
     } catch (e: any) {
-        if (e.name === "AbortError" || context.currentAbortSignal?.aborted) {
+        if (
+            otel.isTelemetryCancellation(
+                e,
+                context.currentAbortSignal?.aborted === true,
+            )
+        ) {
             throw new DOMException("The operation was aborted.", "AbortError");
         }
         const activeSpan = trace.getActiveSpan();
         if (activeSpan !== undefined) {
-            activeSpan.recordException({
-                name: "CommandError",
-                message: "command failed",
-            });
-            activeSpan.setStatus({
-                code: SpanStatusCode.ERROR,
-                message: "command failed",
+            recordSpanFailure(activeSpan, e, {
+                errorName: "CommandError",
+                failureMessage: "command failed",
             });
         }
         context.clientIO.appendDisplay(
@@ -426,17 +429,11 @@ export async function processCommandNoLock(
             path: "command",
             mayHaveSideEffects: false,
         };
-        context?.logger?.logEvent(
-            "command:exception",
-            {
-                requestId: requestIdToString(getRequestId(context)),
-                request: originalInput,
-                name: e.name,
-                message: e.message,
-                stack: e.stack,
-            },
-            "error",
-        );
+        logCommandException(context?.logger, {
+            requestId: requestIdToString(getRequestId(context)),
+            request: originalInput,
+            error: e,
+        });
     }
 }
 

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -878,9 +878,8 @@ export class RequestCommandHandler implements CommandHandler {
                     // cache-stage failure is never mislabelled `llm_translation`.
                     strategy: "translate",
                     success: false,
-                    // Only what is known from outside the error. A cancellation
-                    // carried by the thrown value - including one wrapped as a
-                    // `cause` - is recognized from `error` itself.
+                    // Only what is known from outside the error; a cancellation
+                    // carried by the thrown value is recognized from `error`.
                     cancelled:
                         systemContext.currentAbortSignal?.aborted === true,
                     elapsedMs: Date.now() - translationStartedAt,

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/handlers/requestCommandHandler.ts
@@ -878,11 +878,14 @@ export class RequestCommandHandler implements CommandHandler {
                     // cache-stage failure is never mislabelled `llm_translation`.
                     strategy: "translate",
                     success: false,
+                    // Only what is known from outside the error. A cancellation
+                    // carried by the thrown value - including one wrapped as a
+                    // `cause` - is recognized from `error` itself.
                     cancelled:
-                        e?.name === "AbortError" ||
                         systemContext.currentAbortSignal?.aborted === true,
                     elapsedMs: Date.now() - translationStartedAt,
                     routing: readTranslationRoutingFromError(e),
+                    error: e,
                     actions: [],
                 });
                 debugRequest(`Request translation failed: ${e.message}`);

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -449,71 +449,80 @@ export async function executeAction(
         actionSpanAttributes.traceId = systemContext.traceId;
     }
 
-    return wrapActionSpan(actionSpanAttributes, async (actionSpan) => {
-        const eventData = {
-            requestId: requestId.requestId,
-            schemaName,
-            actionName: action.actionName,
-            appAgentName,
-            actionIndex,
-        };
-        // Measure the action-execution phase at this call boundary (same
-        // `Date.now()` convention as reasoning/translation) so success,
-        // failure, and cancellation completions all carry a real duration.
-        const actionStartedAt = Date.now();
-        logActionStarted(systemContext.logger, eventData);
-        try {
-            const outcome = await executeForActionSpan(actionSpan, {
-                executableAction,
-                context,
-                actionIndex,
-                systemContext,
-                appAgentName,
-                appAgent,
-                actionContext,
-            });
-            // If the agent ran to completion but a cancel arrived while it was executing,
-            // discard the result and treat this as a cancellation.
-            systemContext.currentAbortSignal?.throwIfAborted();
-            actionContext.profiler?.stop();
-            actionContext.profiler = undefined;
-
-            if (
-                !outcome.failureRecorded &&
-                !outcome.setupReplacementResult &&
-                outcome.result.error !== undefined
-            ) {
-                recordActionResultError(actionSpan);
-            }
-            emitActionResult(
-                outcome.result,
-                actionContext,
-                systemContext,
-                requestId,
-                appAgentName,
-                actionIndex,
+    return wrapActionSpan(
+        actionSpanAttributes,
+        async (actionSpan) => {
+            const eventData = {
+                requestId: requestId.requestId,
                 schemaName,
-            );
+                actionName: action.actionName,
+                appAgentName,
+                actionIndex,
+            };
+            // Measure the action-execution phase at this call boundary (same
+            // `Date.now()` convention as reasoning/translation) so success,
+            // failure, and cancellation completions all carry a real duration.
+            const actionStartedAt = Date.now();
+            logActionStarted(systemContext.logger, eventData);
+            try {
+                const outcome = await executeForActionSpan(actionSpan, {
+                    executableAction,
+                    context,
+                    actionIndex,
+                    systemContext,
+                    appAgentName,
+                    appAgent,
+                    actionContext,
+                });
+                // If the agent ran to completion but a cancel arrived while it was executing,
+                // discard the result and treat this as a cancellation.
+                systemContext.currentAbortSignal?.throwIfAborted();
+                actionContext.profiler?.stop();
+                actionContext.profiler = undefined;
 
-            logActionCompleted(systemContext.logger, {
-                ...eventData,
-                success: outcome.result.error === undefined,
-                elapsedMs: Date.now() - actionStartedAt,
-            });
-            closeActionContext();
-            return outcome.result;
-        } catch (error) {
-            logActionCompleted(systemContext.logger, {
-                ...eventData,
-                success: false,
-                cancelled:
-                    (error as { name?: unknown })?.name === "AbortError" ||
-                    systemContext.currentAbortSignal?.aborted === true,
-                elapsedMs: Date.now() - actionStartedAt,
-            });
-            throw error;
-        }
-    });
+                if (
+                    !outcome.failureRecorded &&
+                    !outcome.setupReplacementResult &&
+                    outcome.result.error !== undefined
+                ) {
+                    recordActionResultError(actionSpan);
+                }
+                emitActionResult(
+                    outcome.result,
+                    actionContext,
+                    systemContext,
+                    requestId,
+                    appAgentName,
+                    actionIndex,
+                    schemaName,
+                );
+
+                logActionCompleted(systemContext.logger, {
+                    ...eventData,
+                    success: outcome.result.error === undefined,
+                    elapsedMs: Date.now() - actionStartedAt,
+                });
+                closeActionContext();
+                return outcome.result;
+            } catch (error) {
+                logActionCompleted(systemContext.logger, {
+                    ...eventData,
+                    success: false,
+                    // Only what is known from outside the error. A cancellation
+                    // carried by the thrown value - including one wrapped as a
+                    // `cause` - is recognized from `error` itself.
+                    cancelled:
+                        systemContext.currentAbortSignal?.aborted === true,
+                    elapsedMs: Date.now() - actionStartedAt,
+                    error,
+                });
+                throw error;
+            }
+        },
+        // The same signal the completion event above uses, so the action span
+        // and `action:completed` classify a cancellation identically.
+        [systemContext.currentAbortSignal],
+    );
 }
 
 // Post-execution processing for an ActionResult: error / displayContent /

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -508,9 +508,8 @@ export async function executeAction(
                 logActionCompleted(systemContext.logger, {
                     ...eventData,
                     success: false,
-                    // Only what is known from outside the error. A cancellation
-                    // carried by the thrown value - including one wrapped as a
-                    // `cause` - is recognized from `error` itself.
+                    // Only what is known from outside the error; a cancellation
+                    // carried by the thrown value is recognized from `error`.
                     cancelled:
                         systemContext.currentAbortSignal?.aborted === true,
                     elapsedMs: Date.now() - actionStartedAt,
@@ -519,8 +518,8 @@ export async function executeAction(
                 throw error;
             }
         },
-        // The same signal the completion event above uses, so the action span
-        // and `action:completed` classify a cancellation identically.
+        // The same signal the completion event above uses, so the span and
+        // `action:completed` classify a cancellation identically.
         [systemContext.currentAbortSignal],
     );
 }

--- a/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
@@ -10,6 +10,16 @@ import {
 } from "@opentelemetry/api";
 import { withChatModelTelemetryContext } from "@typeagent/aiclient";
 import { otel } from "@typeagent/telemetry";
+import {
+    recordSpanFailure,
+    type CancellationSignals,
+    type SpanFailureNames,
+} from "./spanFailure.js";
+
+const ACTION_FAILURE: SpanFailureNames = {
+    errorName: "ActionError",
+    failureMessage: "action failed",
+};
 
 export const ACTION_SPAN_EVENTS = Object.freeze({
     RESULT_ERROR: "action.result.error",
@@ -64,10 +74,14 @@ export function recordActionFlowException(span: Span): void {
  *
  * Exceptions that escape the body are recorded with stable, privacy-safe
  * classifications matching the request/translation span conventions.
+ * `cancellationSignals` are the signals the caller holds, passed so a
+ * cancellation that surfaces as an unrelated-looking failure is recorded as a
+ * cancellation on the span and on the `action:completed` event alike.
  */
 export async function wrapActionSpan<T>(
     attributes: otel.TypeAgentSpanAttributes,
     body: (span: Span) => Promise<T>,
+    cancellationSignals?: CancellationSignals,
 ): Promise<T> {
     const tracer: Tracer = trace.getTracer(
         otel.INSTRUMENTATION_SCOPE_NAME,
@@ -97,22 +111,12 @@ export async function wrapActionSpan<T>(
                             try {
                                 return await body(span);
                             } catch (error) {
-                                const isAbort =
-                                    error !== null &&
-                                    typeof error === "object" &&
-                                    (error as { name?: unknown }).name ===
-                                        "AbortError";
-                                const name = isAbort
-                                    ? "AbortError"
-                                    : "ActionError";
-                                const message = isAbort
-                                    ? "cancelled"
-                                    : "action failed";
-                                span.recordException({ name, message });
-                                span.setStatus({
-                                    code: SpanStatusCode.ERROR,
-                                    message,
-                                });
+                                recordSpanFailure(
+                                    span,
+                                    error,
+                                    ACTION_FAILURE,
+                                    cancellationSignals,
+                                );
                                 throw error;
                             } finally {
                                 span.end();

--- a/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
@@ -74,9 +74,9 @@ export function recordActionFlowException(span: Span): void {
  *
  * Exceptions that escape the body are recorded with stable, privacy-safe
  * classifications matching the request/translation span conventions.
- * `cancellationSignals` are the signals the caller holds, passed so a
- * cancellation that surfaces as an unrelated-looking failure is recorded as a
- * cancellation on the span and on the `action:completed` event alike.
+ * `cancellationSignals` are the signals the caller holds, so a cancellation
+ * that surfaces as an unrelated-looking failure is recorded as a cancellation
+ * on the span and on the `action:completed` event alike.
  */
 export async function wrapActionSpan<T>(
     attributes: otel.TypeAgentSpanAttributes,

--- a/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
@@ -4,7 +4,6 @@
 import {
     context,
     createContextKey,
-    SpanStatusCode,
     trace,
     type Context,
     type Span,
@@ -16,9 +15,20 @@ import { otel } from "@typeagent/telemetry";
 import type { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import { getSessionName } from "../context/session.js";
 import {
+    anyCancellationSignalAborted,
+    recordSpanFailure,
+    type CancellationSignals,
+    type SpanFailureNames,
+} from "./spanFailure.js";
+import {
     logReasoningCompleted,
     logReasoningStarted,
 } from "./structuredEvents.js";
+
+const REASONING_FAILURE: SpanFailureNames = {
+    errorName: "ReasoningError",
+    failureMessage: "reasoning failed",
+};
 
 export const REASONING_SPAN_EVENTS = Object.freeze({
     TOOL_CALL: "reasoning.tool_call",
@@ -66,13 +76,18 @@ export function emitReasoningToolCall(toolCallNumber: number): void {
     });
 }
 
+/**
+ * Run a reasoning body inside a `typeagent.reasoning` span.
+ *
+ * `cancellationSignals` are the signals the caller holds. Reasoning is the
+ * phase where the signal matters most: a cancelled or timed-out run usually
+ * throws whatever the provider was in the middle of, which says nothing about
+ * having been cancelled.
+ */
 export async function wrapReasoningSpan<T>(
     attributes: otel.TypeAgentSpanAttributes,
     body: (span: Span) => Promise<T>,
-    isCancellation: (error: unknown) => boolean = (error) =>
-        error !== null &&
-        typeof error === "object" &&
-        (error as { name?: unknown }).name === "AbortError",
+    cancellationSignals?: CancellationSignals,
 ): Promise<T> {
     const tracer: Tracer = trace.getTracer(
         otel.INSTRUMENTATION_SCOPE_NAME,
@@ -107,14 +122,12 @@ export async function wrapReasoningSpan<T>(
                     ),
                 );
             } catch (error) {
-                const isAbort = isCancellation(error);
-                const name = isAbort ? "AbortError" : "ReasoningError";
-                const message = isAbort ? "cancelled" : "reasoning failed";
-                span.recordException({ name, message });
-                span.setStatus({
-                    code: SpanStatusCode.ERROR,
-                    message,
-                });
+                recordSpanFailure(
+                    span,
+                    error,
+                    REASONING_FAILURE,
+                    cancellationSignals,
+                );
                 throw error;
             } finally {
                 state.ended = true;
@@ -159,6 +172,13 @@ export function runInReasoningSpan<T>(
             ? {}
             : { model: modelAttributes.genAiRequestModel }),
     };
+    // The reasoning-specific signal (a per-run deadline, say) and the request's
+    // own. Both the span and the `reasoning:completed` event below classify
+    // from this one list, so they cannot disagree.
+    const cancellationSignals: CancellationSignals = [
+        cancellationSignal,
+        context.abortSignal,
+    ];
     return wrapReasoningSpan(
         attributes,
         async (span) => {
@@ -182,12 +202,10 @@ export function runInReasoningSpan<T>(
                 }
                 return result;
             } catch (error) {
-                const cancelled =
-                    cancellationSignal?.aborted === true ||
-                    context.abortSignal?.aborted === true ||
-                    (error !== null &&
-                        typeof error === "object" &&
-                        (error as { name?: unknown }).name === "AbortError");
+                const cancelled = otel.isTelemetryCancellation(
+                    error,
+                    anyCancellationSignalAborted(cancellationSignals),
+                );
                 if (requestId !== undefined) {
                     logReasoningCompleted(systemContext.logger, {
                         requestId,
@@ -200,11 +218,6 @@ export function runInReasoningSpan<T>(
                 throw error;
             }
         },
-        (error) =>
-            cancellationSignal?.aborted === true ||
-            context.abortSignal?.aborted === true ||
-            (error !== null &&
-                typeof error === "object" &&
-                (error as { name?: unknown }).name === "AbortError"),
+        cancellationSignals,
     );
 }

--- a/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
@@ -79,10 +79,9 @@ export function emitReasoningToolCall(toolCallNumber: number): void {
 /**
  * Run a reasoning body inside a `typeagent.reasoning` span.
  *
- * `cancellationSignals` are the signals the caller holds. Reasoning is the
- * phase where the signal matters most: a cancelled or timed-out run usually
- * throws whatever the provider was in the middle of, which says nothing about
- * having been cancelled.
+ * `cancellationSignals` are the signals the caller holds: a cancelled or
+ * timed-out run usually throws whatever the provider was in the middle of,
+ * which says nothing about having been cancelled.
  */
 export async function wrapReasoningSpan<T>(
     attributes: otel.TypeAgentSpanAttributes,
@@ -172,9 +171,8 @@ export function runInReasoningSpan<T>(
             ? {}
             : { model: modelAttributes.genAiRequestModel }),
     };
-    // The reasoning-specific signal (a per-run deadline, say) and the request's
-    // own. Both the span and the `reasoning:completed` event below classify
-    // from this one list, so they cannot disagree.
+    // Both the span and the `reasoning:completed` event below classify from
+    // this one list, so they cannot disagree.
     const cancellationSignals: CancellationSignals = [
         cancellationSignal,
         context.abortSignal,

--- a/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
@@ -11,6 +11,12 @@ import {
     type Tracer,
 } from "@opentelemetry/api";
 import { otel } from "@typeagent/telemetry";
+import { recordSpanFailure, type SpanFailureNames } from "./spanFailure.js";
+
+const REQUEST_FAILURE: SpanFailureNames = {
+    errorName: "RequestError",
+    failureMessage: "request failed",
+};
 
 /**
  * Result-shaped signal the wrapper uses to detect the caller-visible failure
@@ -60,22 +66,14 @@ export async function wrapRootRequestSpan<
                         }
                         return result;
                     } catch (e) {
-                        // Detect AbortError before wrapping: DOMException is not
-                        // always `instanceof Error` in Node, so we can't rely on
-                        // err.name after the wrapping fallback below.
-                        const isAbort =
-                            e !== null &&
-                            typeof e === "object" &&
-                            (e as { name?: unknown }).name === "AbortError";
-                        const name = isAbort ? "AbortError" : "RequestError";
-                        const message = isAbort
-                            ? "cancelled"
-                            : "request failed";
-                        span.recordException({ name, message });
-                        span.setStatus({
-                            code: SpanStatusCode.ERROR,
-                            message,
-                        });
+                        // The thrown value is classified rather than
+                        // name-checked: a cancellation is frequently wrapped,
+                        // and `DOMException` is not always `instanceof Error`
+                        // in Node, so nothing here may assume an `Error`. A
+                        // cancellation the request itself observed arrives as
+                        // `result.cancelled` above, not as a throw, so no
+                        // signal is threaded in here.
+                        recordSpanFailure(span, e, REQUEST_FAILURE);
                         throw e;
                     } finally {
                         span.end();

--- a/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
@@ -66,13 +66,11 @@ export async function wrapRootRequestSpan<
                         }
                         return result;
                     } catch (e) {
-                        // The thrown value is classified rather than
-                        // name-checked: a cancellation is frequently wrapped,
-                        // and `DOMException` is not always `instanceof Error`
-                        // in Node, so nothing here may assume an `Error`. A
-                        // cancellation the request itself observed arrives as
-                        // `result.cancelled` above, not as a throw, so no
-                        // signal is threaded in here.
+                        // Classified rather than name-checked: a cancellation
+                        // is frequently wrapped, and `DOMException` is not
+                        // always `instanceof Error` in Node. A cancellation the
+                        // request itself observed arrives as `result.cancelled`
+                        // above, not as a throw.
                         recordSpanFailure(span, e, REQUEST_FAILURE);
                         throw e;
                     } finally {

--- a/ts/packages/dispatcher/dispatcher/src/otel/spanFailure.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/spanFailure.ts
@@ -8,22 +8,13 @@ import { otel } from "@typeagent/telemetry";
  * One cancellation decision for every phase span, so a span and the structured
  * `*:completed` event recorded next to it cannot disagree about the same
  * failure.
- *
- * The decision itself is `otel.isTelemetryCancellation`, which the structured
- * events and the LLM wrapper already use. It walks the `cause` chain, so a
- * cancellation wrapped in a phase-level error is still a cancellation - the
- * `error.name === "AbortError"` check each span wrapper used to do saw only the
- * outermost value and reported those as ordinary failures.
  */
 
 /**
  * Signals whose aborted state means "this failure was a cancellation",
- * evaluated when the failure is recorded rather than when the span opened.
- *
- * This is the "signal-only" case: the work was torn down, so what surfaces is
- * whatever the provider or the phase happened to throw at that moment (a
- * socket error, a timeout, a partial-parse failure), and nothing in that value
- * says it was cancelled. The call site knows because it holds the signal.
+ * evaluated when the failure is recorded. Needed because a torn-down phase
+ * surfaces whatever it happened to throw at that moment (a socket error, a
+ * partial-parse failure), which says nothing about having been cancelled.
  */
 export type CancellationSignals = readonly (AbortSignal | undefined)[];
 
@@ -34,9 +25,8 @@ export function anyCancellationSignalAborted(
 }
 
 /**
- * How one phase names a real failure on its span: the exception type and the
- * status message. Both are fixed strings chosen by the phase - never the
- * original message, which can carry user input.
+ * How one phase names a real failure on its span. Both are fixed strings
+ * chosen by the phase - never the original message, which can carry user input.
  */
 export interface SpanFailureNames {
     readonly errorName: string;
@@ -44,12 +34,9 @@ export interface SpanFailureNames {
 }
 
 /**
- * A cancellation is reported the same way by every phase, so it is stated once
- * here rather than repeated per span. The status code stays `ERROR` (the
- * operation did not complete, and the LLM and request spans have always
- * recorded it that way); what marks it as a cancellation rather than a phase
- * failure is the `AbortError` name and the `cancelled` message, which is
- * exactly what the correlated `*:completed` event reports as its `status`.
+ * The status code stays `ERROR` (the operation did not complete); the
+ * `AbortError` name and `cancelled` message are what mark it as a
+ * cancellation, matching the correlated `*:completed` event's `status`.
  */
 const CANCELLED_NAMES: SpanFailureNames = Object.freeze({
     errorName: "AbortError",
@@ -57,10 +44,9 @@ const CANCELLED_NAMES: SpanFailureNames = Object.freeze({
 });
 
 /**
- * Record an exception that escaped a phase body onto that phase's span.
- *
- * Nothing derived from the thrown value's own message or stack is recorded:
- * only the fixed names above, chosen by the classification.
+ * Record an exception that escaped a phase body onto that phase's span. Only
+ * the fixed names above are recorded, never the thrown value's message or
+ * stack.
  */
 export function recordSpanFailure(
     span: Span,

--- a/ts/packages/dispatcher/dispatcher/src/otel/spanFailure.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/spanFailure.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { otel } from "@typeagent/telemetry";
+
+/**
+ * One cancellation decision for every phase span, so a span and the structured
+ * `*:completed` event recorded next to it cannot disagree about the same
+ * failure.
+ *
+ * The decision itself is `otel.isTelemetryCancellation`, which the structured
+ * events and the LLM wrapper already use. It walks the `cause` chain, so a
+ * cancellation wrapped in a phase-level error is still a cancellation - the
+ * `error.name === "AbortError"` check each span wrapper used to do saw only the
+ * outermost value and reported those as ordinary failures.
+ */
+
+/**
+ * Signals whose aborted state means "this failure was a cancellation",
+ * evaluated when the failure is recorded rather than when the span opened.
+ *
+ * This is the "signal-only" case: the work was torn down, so what surfaces is
+ * whatever the provider or the phase happened to throw at that moment (a
+ * socket error, a timeout, a partial-parse failure), and nothing in that value
+ * says it was cancelled. The call site knows because it holds the signal.
+ */
+export type CancellationSignals = readonly (AbortSignal | undefined)[];
+
+export function anyCancellationSignalAborted(
+    signals: CancellationSignals | undefined,
+): boolean {
+    return signals?.some((signal) => signal?.aborted === true) === true;
+}
+
+/**
+ * How one phase names a real failure on its span: the exception type and the
+ * status message. Both are fixed strings chosen by the phase - never the
+ * original message, which can carry user input.
+ */
+export interface SpanFailureNames {
+    readonly errorName: string;
+    readonly failureMessage: string;
+}
+
+/**
+ * A cancellation is reported the same way by every phase, so it is stated once
+ * here rather than repeated per span. The status code stays `ERROR` (the
+ * operation did not complete, and the LLM and request spans have always
+ * recorded it that way); what marks it as a cancellation rather than a phase
+ * failure is the `AbortError` name and the `cancelled` message, which is
+ * exactly what the correlated `*:completed` event reports as its `status`.
+ */
+const CANCELLED_NAMES: SpanFailureNames = Object.freeze({
+    errorName: "AbortError",
+    failureMessage: "cancelled",
+});
+
+/**
+ * Record an exception that escaped a phase body onto that phase's span.
+ *
+ * Nothing derived from the thrown value's own message or stack is recorded:
+ * only the fixed names above, chosen by the classification.
+ */
+export function recordSpanFailure(
+    span: Span,
+    error: unknown,
+    failure: SpanFailureNames,
+    cancellationSignals?: CancellationSignals,
+): void {
+    const { errorName, failureMessage } = otel.isTelemetryCancellation(
+        error,
+        anyCancellationSignalAborted(cancellationSignals),
+    )
+        ? CANCELLED_NAMES
+        : failure;
+    span.recordException({ name: errorName, message: failureMessage });
+    span.setStatus({ code: SpanStatusCode.ERROR, message: failureMessage });
+}

--- a/ts/packages/dispatcher/dispatcher/src/otel/structuredEvents.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/structuredEvents.ts
@@ -19,31 +19,19 @@ export const DISPATCHER_STRUCTURED_EVENTS = {
 } as const;
 
 /**
- * Classify a completion once, so every field derived from it agrees.
- *
- * `cancelled` is not simply what the call site guessed: a cancellation is
- * frequently wrapped (an `AbortError` arriving as the `cause` of a translation
- * error, for instance), and a call site that only inspects `error.name` sees a
- * plain failure. `otel.isTelemetryCancellation` walks the chain, so the
- * disposition, the event `status`, the log severity, and whether classification
- * fields are emitted at all are all read off this one result instead of being
- * decided independently and disagreeing. The phase spans record their
- * cancellation from the same function, so a span and the event beside it never
- * describe the same failure differently.
- *
- * `cancelledHint` is what the caller knows from outside the error - typically
- * that the request's abort signal has fired - and stands on its own, because a
- * cancellation can surface as an unrelated-looking failure.
+ * Classify a completion once, so the disposition, event `status`, log
+ * severity, and classification fields cannot disagree. The phase spans record
+ * their cancellation from the same `otel.isTelemetryCancellation`, which walks
+ * the `cause` chain, so a wrapped cancellation is not reported as a plain
+ * failure.
  */
 type CompletionOutcome = {
     readonly status: "succeeded" | "failed" | "cancelled";
     readonly cancelled: boolean;
     /**
-     * Emitted only for a real failure. A cancellation is a disposition, not a
-     * failure to classify, and a failure with no thrown value has nothing to
-     * classify: an agent that reports failure through a typed
-     * `ActionResult.error` never threw, so asserting `internal` would be an
-     * invention.
+     * Emitted only for a real failure with a thrown value: an agent reporting
+     * failure through a typed `ActionResult.error` never threw, so asserting a
+     * category would be an invention.
      */
     readonly classification: otel.TelemetryErrorClassification | undefined;
 };
@@ -53,8 +41,8 @@ function classifyCompletion(
     error: unknown,
     cancelledHint: boolean | undefined,
 ): CompletionOutcome {
-    // A thrown value only describes a failure. Ignoring it on the success path
-    // keeps `status` from contradicting `success`.
+    // Ignoring a thrown value on the success path keeps `status` from
+    // contradicting `success`.
     const failure = success ? undefined : error;
     const classification =
         failure === undefined
@@ -68,7 +56,7 @@ function classifyCompletion(
     };
 }
 
-/** Log severity implied by an outcome, kept in one place for every event. */
+/** Log severity implied by an outcome. */
 function outcomeLevel(
     outcome: CompletionOutcome,
 ): "info" | "warning" | "error" {
@@ -95,15 +83,10 @@ export function logRequestReceived(
 }
 
 /**
- * Record a command that failed with an exception.
- *
- * The event carries two kinds of data with different destinations. The
- * normalized classification (`errorCategory` and friends) is bounded and
- * content-free, so it is allowlisted through to OTel. The raw `request`,
- * `name`, `message`, and `stack` can contain user input and are deliberately
- * *not* allowlisted: they exist for the local debug sink and the opt-in
- * database sinks (`@config log db on`), which are private diagnostics. See
- * `createDispatcherOtelLoggerSink` for the projection that enforces this.
+ * Record a command that failed with an exception. Only the bounded
+ * classification is allowlisted through to OTel; `request`, `name`, `message`,
+ * and `stack` can contain user input and stay in the local debug and opt-in
+ * database sinks (see `createDispatcherOtelLoggerSink`).
  */
 export function logCommandException(
     logger: Logger | undefined,
@@ -129,10 +112,9 @@ export function logCommandException(
 }
 
 /**
- * Read one string property off a thrown value for the private diagnostic
- * fields. A thrown value can be anything, including an object whose getters
- * throw or a proxy that traps every access, so a read that fails contributes
- * nothing instead of turning logging into a second failure.
+ * Read one string property off a thrown value. A thrown value can be anything,
+ * including an object whose getters throw, so a failed read contributes
+ * nothing rather than turning logging into a second failure.
  */
 function stringField(
     source: unknown,
@@ -233,17 +215,15 @@ export function logTranslationCompleted(
         requestId: string;
         strategy: string;
         success: boolean;
-        // What the call site knows from outside the error, typically that the
-        // request's abort signal fired. A cancellation carried inside the
-        // thrown value is detected from the value itself.
+        // What the call site knows from outside the error; a cancellation
+        // carried inside the thrown value is detected from the value itself.
         cancelled?: boolean;
         // Duration of the translation phase measured at the call boundary.
         elapsedMs?: number;
         // Bounded routing decisions captured during translation.
         routing?: TranslationRoutingSummary | undefined;
-        // The thrown value on the failure path, normalized into bounded
-        // classification fields. Omit when the failure did not come from a
-        // thrown value; success ignores it.
+        // The thrown value on the failure path; omitted when the failure did
+        // not come from a throw.
         error?: unknown;
         actions: readonly {
             action: { schemaName: string; actionName: string };
@@ -323,9 +303,8 @@ export function logReasoningCompleted(
         provider?: string;
         model?: string;
         success: boolean;
-        // Whether this completion is a cancellation. The reasoning span
-        // decides it with the same `otel.isTelemetryCancellation` call, so the
-        // span status and this event always agree.
+        // Decided by the reasoning span's same cancellation test, so the span
+        // status and this event always agree.
         cancelled: boolean;
         elapsedMs: number;
     },
@@ -363,16 +342,13 @@ export function logActionCompleted(
         appAgentName: string;
         actionIndex: number;
         success: boolean;
-        // What the call site knows from outside the error, typically that the
-        // request's abort signal fired. A cancellation carried inside the
-        // thrown value is detected from the value itself.
+        // What the call site knows from outside the error; a cancellation
+        // carried inside the thrown value is detected from the value itself.
         cancelled?: boolean;
         // Duration of the action-execution phase measured at the call boundary.
         elapsedMs?: number;
-        // The thrown value on the failure path, normalized into bounded
-        // classification fields. An agent that reports failure through a typed
-        // `ActionResult.error` never threw, so it omits this and the event
-        // carries no classification; success ignores it.
+        // The thrown value on the failure path. An agent that reports failure
+        // through a typed `ActionResult.error` never threw, so it omits this.
         error?: unknown;
     },
 ): void {

--- a/ts/packages/dispatcher/dispatcher/src/otel/structuredEvents.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/structuredEvents.ts
@@ -3,10 +3,12 @@
 
 import type { CommandResult } from "@typeagent/dispatcher-types";
 import type { Logger } from "@typeagent/telemetry";
+import { otel } from "@typeagent/telemetry";
 import type { TranslationRoutingSummary } from "./translationSpan.js";
 
 export const DISPATCHER_STRUCTURED_EVENTS = {
     requestReceived: "request:received",
+    commandException: "command:exception",
     translationStarted: "translation:started",
     translationCompleted: "translation:completed",
     reasoningStarted: "reasoning:started",
@@ -15,6 +17,70 @@ export const DISPATCHER_STRUCTURED_EVENTS = {
     actionCompleted: "action:completed",
     requestCompleted: "request:completed",
 } as const;
+
+/**
+ * Classify a completion once, so every field derived from it agrees.
+ *
+ * `cancelled` is not simply what the call site guessed: a cancellation is
+ * frequently wrapped (an `AbortError` arriving as the `cause` of a translation
+ * error, for instance), and a call site that only inspects `error.name` sees a
+ * plain failure. `otel.isTelemetryCancellation` walks the chain, so the
+ * disposition, the event `status`, the log severity, and whether classification
+ * fields are emitted at all are all read off this one result instead of being
+ * decided independently and disagreeing. The phase spans record their
+ * cancellation from the same function, so a span and the event beside it never
+ * describe the same failure differently.
+ *
+ * `cancelledHint` is what the caller knows from outside the error - typically
+ * that the request's abort signal has fired - and stands on its own, because a
+ * cancellation can surface as an unrelated-looking failure.
+ */
+type CompletionOutcome = {
+    readonly status: "succeeded" | "failed" | "cancelled";
+    readonly cancelled: boolean;
+    /**
+     * Emitted only for a real failure. A cancellation is a disposition, not a
+     * failure to classify, and a failure with no thrown value has nothing to
+     * classify: an agent that reports failure through a typed
+     * `ActionResult.error` never threw, so asserting `internal` would be an
+     * invention.
+     */
+    readonly classification: otel.TelemetryErrorClassification | undefined;
+};
+
+function classifyCompletion(
+    success: boolean,
+    error: unknown,
+    cancelledHint: boolean | undefined,
+): CompletionOutcome {
+    // A thrown value only describes a failure. Ignoring it on the success path
+    // keeps `status` from contradicting `success`.
+    const failure = success ? undefined : error;
+    const classification =
+        failure === undefined
+            ? undefined
+            : otel.classifyTelemetryError(failure);
+    const cancelled = otel.isTelemetryCancellation(failure, cancelledHint);
+    return {
+        status: cancelled ? "cancelled" : success ? "succeeded" : "failed",
+        cancelled,
+        classification: cancelled ? undefined : classification,
+    };
+}
+
+/** Log severity implied by an outcome, kept in one place for every event. */
+function outcomeLevel(
+    outcome: CompletionOutcome,
+): "info" | "warning" | "error" {
+    switch (outcome.status) {
+        case "succeeded":
+            return "info";
+        case "cancelled":
+            return "warning";
+        default:
+            return "error";
+    }
+}
 
 export function logRequestReceived(
     logger: Logger | undefined,
@@ -26,6 +92,61 @@ export function logRequestReceived(
     },
 ): void {
     logger?.logEvent(DISPATCHER_STRUCTURED_EVENTS.requestReceived, data);
+}
+
+/**
+ * Record a command that failed with an exception.
+ *
+ * The event carries two kinds of data with different destinations. The
+ * normalized classification (`errorCategory` and friends) is bounded and
+ * content-free, so it is allowlisted through to OTel. The raw `request`,
+ * `name`, `message`, and `stack` can contain user input and are deliberately
+ * *not* allowlisted: they exist for the local debug sink and the opt-in
+ * database sinks (`@config log db on`), which are private diagnostics. See
+ * `createDispatcherOtelLoggerSink` for the projection that enforces this.
+ */
+export function logCommandException(
+    logger: Logger | undefined,
+    data: {
+        requestId: string;
+        request: string;
+        error: unknown;
+    },
+): void {
+    const outcome = classifyCompletion(false, data.error, undefined);
+    logger?.logEvent(
+        DISPATCHER_STRUCTURED_EVENTS.commandException,
+        {
+            requestId: data.requestId,
+            ...outcome.classification,
+            request: data.request,
+            ...stringField(data.error, "name"),
+            ...stringField(data.error, "message"),
+            ...stringField(data.error, "stack"),
+        },
+        outcomeLevel(outcome),
+    );
+}
+
+/**
+ * Read one string property off a thrown value for the private diagnostic
+ * fields. A thrown value can be anything, including an object whose getters
+ * throw or a proxy that traps every access, so a read that fails contributes
+ * nothing instead of turning logging into a second failure.
+ */
+function stringField(
+    source: unknown,
+    name: "name" | "message" | "stack",
+): Record<string, string> | Record<string, never> {
+    if (source === null || typeof source !== "object") {
+        return {};
+    }
+    try {
+        const value = (source as Record<string, unknown>)[name];
+        return typeof value === "string" ? { [name]: value } : {};
+    } catch {
+        return {};
+    }
 }
 
 export function logTranslationStarted(
@@ -112,11 +233,18 @@ export function logTranslationCompleted(
         requestId: string;
         strategy: string;
         success: boolean;
+        // What the call site knows from outside the error, typically that the
+        // request's abort signal fired. A cancellation carried inside the
+        // thrown value is detected from the value itself.
         cancelled?: boolean;
         // Duration of the translation phase measured at the call boundary.
         elapsedMs?: number;
         // Bounded routing decisions captured during translation.
         routing?: TranslationRoutingSummary | undefined;
+        // The thrown value on the failure path, normalized into bounded
+        // classification fields. Omit when the failure did not come from a
+        // thrown value; success ignores it.
+        error?: unknown;
         actions: readonly {
             action: { schemaName: string; actionName: string };
         }[];
@@ -129,23 +257,25 @@ export function logTranslationCompleted(
     const routingReason = data.success
         ? deriveTranslationRoutingReason(data.strategy)
         : deriveRoutingReasonFromRoutes(data.routing?.routes);
+    const outcome = classifyCompletion(
+        data.success,
+        data.error,
+        data.cancelled,
+    );
     logger?.logEvent(
         DISPATCHER_STRUCTURED_EVENTS.translationCompleted,
         {
             requestId: data.requestId,
             strategy: data.strategy,
             success: data.success,
-            ...(data.cancelled === undefined
+            ...(data.cancelled === undefined && !outcome.cancelled
                 ? {}
-                : { cancelled: data.cancelled }),
-            status: data.cancelled
-                ? "cancelled"
-                : data.success
-                  ? "succeeded"
-                  : "failed",
+                : { cancelled: outcome.cancelled }),
+            status: outcome.status,
             ...(data.elapsedMs === undefined
                 ? {}
                 : { elapsedMs: data.elapsedMs }),
+            ...outcome.classification,
             ...(routingReason === undefined ? {} : { routingReason }),
             ...(data.routing?.matchOutcome === undefined
                 ? {}
@@ -171,7 +301,7 @@ export function logTranslationCompleted(
             ),
             count: data.actions.length,
         },
-        data.success ? "info" : data.cancelled ? "warning" : "error",
+        outcomeLevel(outcome),
     );
 }
 
@@ -193,21 +323,21 @@ export function logReasoningCompleted(
         provider?: string;
         model?: string;
         success: boolean;
+        // Whether this completion is a cancellation. The reasoning span
+        // decides it with the same `otel.isTelemetryCancellation` call, so the
+        // span status and this event always agree.
         cancelled: boolean;
         elapsedMs: number;
     },
 ): void {
+    const outcome = classifyCompletion(data.success, undefined, data.cancelled);
     logger?.logEvent(
         DISPATCHER_STRUCTURED_EVENTS.reasoningCompleted,
         {
             ...data,
-            status: data.cancelled
-                ? "cancelled"
-                : data.success
-                  ? "succeeded"
-                  : "failed",
+            status: outcome.status,
         },
-        data.success ? "info" : data.cancelled ? "warning" : "error",
+        outcomeLevel(outcome),
     );
 }
 
@@ -233,22 +363,32 @@ export function logActionCompleted(
         appAgentName: string;
         actionIndex: number;
         success: boolean;
+        // What the call site knows from outside the error, typically that the
+        // request's abort signal fired. A cancellation carried inside the
+        // thrown value is detected from the value itself.
         cancelled?: boolean;
         // Duration of the action-execution phase measured at the call boundary.
         elapsedMs?: number;
+        // The thrown value on the failure path, normalized into bounded
+        // classification fields. An agent that reports failure through a typed
+        // `ActionResult.error` never threw, so it omits this and the event
+        // carries no classification; success ignores it.
+        error?: unknown;
     },
 ): void {
+    const { error, cancelled, ...eventData } = data;
+    const outcome = classifyCompletion(data.success, error, cancelled);
     logger?.logEvent(
         DISPATCHER_STRUCTURED_EVENTS.actionCompleted,
         {
-            ...data,
-            status: data.cancelled
-                ? "cancelled"
-                : data.success
-                  ? "succeeded"
-                  : "failed",
+            ...eventData,
+            ...(cancelled === undefined && !outcome.cancelled
+                ? {}
+                : { cancelled: outcome.cancelled }),
+            status: outcome.status,
+            ...outcome.classification,
         },
-        data.success ? "info" : data.cancelled ? "warning" : "error",
+        outcomeLevel(outcome),
     );
 }
 

--- a/ts/packages/dispatcher/dispatcher/src/otel/structuredLogSink.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/structuredLogSink.ts
@@ -31,6 +31,15 @@ const SAFE_STRING_FIELDS = [
     "routingReason",
     "matchOutcome",
     "cacheBypassReason",
+    // Normalized failure classification (see
+    // `@typeagent/telemetry` `classifyTelemetryError`). Both values come from
+    // closed vocabularies - `errorCategory` from a fixed union and `errorCode`
+    // from a reviewed allowlist - so neither can add cardinality here. The raw
+    // error `name`, `message`, `stack`, and the original `request` are
+    // deliberately absent from every list here so they never leave the local
+    // debug and opt-in database sinks.
+    "errorCategory",
+    "errorCode",
 ] as const;
 
 const SAFE_NUMBER_FIELDS = [
@@ -50,6 +59,7 @@ const SAFE_NUMBER_FIELDS = [
     "totalTokens",
     "cachedTokens",
     "retryCount",
+    "httpStatus",
 ] as const;
 
 const SAFE_BOOLEAN_FIELDS = [
@@ -60,6 +70,7 @@ const SAFE_BOOLEAN_FIELDS = [
     "cancelled",
     "streaming",
     "fallback",
+    "retryable",
 ] as const;
 
 const SAFE_STRING_ARRAY_FIELDS = [

--- a/ts/packages/dispatcher/dispatcher/src/otel/structuredLogSink.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/structuredLogSink.ts
@@ -31,13 +31,10 @@ const SAFE_STRING_FIELDS = [
     "routingReason",
     "matchOutcome",
     "cacheBypassReason",
-    // Normalized failure classification (see
-    // `@typeagent/telemetry` `classifyTelemetryError`). Both values come from
-    // closed vocabularies - `errorCategory` from a fixed union and `errorCode`
-    // from a reviewed allowlist - so neither can add cardinality here. The raw
-    // error `name`, `message`, `stack`, and the original `request` are
-    // deliberately absent from every list here so they never leave the local
-    // debug and opt-in database sinks.
+    // Both come from closed vocabularies (a fixed union and a reviewed
+    // allowlist), so neither adds cardinality. The raw error `name`,
+    // `message`, `stack`, and the original `request` are absent from every
+    // list here so they never leave the local and opt-in database sinks.
     "errorCategory",
     "errorCode",
 ] as const;

--- a/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
@@ -4,7 +4,6 @@
 import {
     context,
     createContextKey,
-    SpanStatusCode,
     trace,
     type Context,
     type Span,
@@ -15,6 +14,16 @@ import { withChatModelTelemetryContext } from "@typeagent/aiclient";
 import { otel } from "@typeagent/telemetry";
 import type { CommandHandlerContext } from "../context/commandHandlerContext.js";
 import { getSessionName } from "../context/session.js";
+import {
+    recordSpanFailure,
+    type CancellationSignals,
+    type SpanFailureNames,
+} from "./spanFailure.js";
+
+const TRANSLATION_FAILURE: SpanFailureNames = {
+    errorName: "TranslationError",
+    failureMessage: "translation failed",
+};
 
 export const TRANSLATION_SPAN_EVENTS = Object.freeze({
     GRAMMAR_MATCHED: "translation.grammar.matched",
@@ -254,10 +263,15 @@ export function readTranslationRoutingFromError(
  * Re-entrant calls reuse the current translation span so the outer
  * interpret-request path can include grammar/cache work while direct
  * `translateRequest` callers still receive translation telemetry.
+ *
+ * `cancellationSignals` are the signals the caller holds, so a cancellation
+ * that surfaces as an unrelated-looking failure is recorded as a cancellation
+ * on the span and on the `translation:completed` event alike.
  */
 export async function wrapTranslationSpan<T>(
     attributes: otel.TypeAgentSpanAttributes,
     body: (span: Span) => Promise<T>,
+    cancellationSignals?: CancellationSignals,
 ): Promise<T> {
     const activeState = getTranslationState();
     if (activeState !== undefined && !activeState.ended) {
@@ -311,17 +325,12 @@ export async function wrapTranslationSpan<T>(
                     ),
                 );
             } catch (error) {
-                const isAbort =
-                    error !== null &&
-                    typeof error === "object" &&
-                    (error as { name?: unknown }).name === "AbortError";
-                const name = isAbort ? "AbortError" : "TranslationError";
-                const message = isAbort ? "cancelled" : "translation failed";
-                span.recordException({ name, message });
-                span.setStatus({
-                    code: SpanStatusCode.ERROR,
-                    message,
-                });
+                recordSpanFailure(
+                    span,
+                    error,
+                    TRANSLATION_FAILURE,
+                    cancellationSignals,
+                );
                 throw error;
             } finally {
                 state.ended = true;
@@ -352,5 +361,10 @@ export function runInTranslationSpan<T>(
         attributes.traceId = systemContext.traceId;
     }
 
-    return wrapTranslationSpan(attributes, body);
+    // The same signal `requestCommandHandler` reads when it emits
+    // `translation:completed`, so the span and that event agree about a
+    // cancellation that surfaced as an ordinary translation failure.
+    return wrapTranslationSpan(attributes, body, [
+        systemContext.currentAbortSignal,
+    ]);
 }

--- a/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
@@ -362,8 +362,7 @@ export function runInTranslationSpan<T>(
     }
 
     // The same signal `requestCommandHandler` reads when it emits
-    // `translation:completed`, so the span and that event agree about a
-    // cancellation that surfaced as an ordinary translation failure.
+    // `translation:completed`, so the span and that event agree.
     return wrapTranslationSpan(attributes, body, [
         systemContext.currentAbortSignal,
     ]);

--- a/ts/packages/dispatcher/dispatcher/test/otelCancellationConsistency.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/otelCancellationConsistency.spec.ts
@@ -19,13 +19,10 @@ import {
 } from "../src/otel/structuredEvents.js";
 import { wrapTranslationSpan } from "../src/otel/translationSpan.js";
 
-// A phase span and the `*:completed` event recorded next to it describe the
-// same failure, so they have to reach the same verdict about it. The case that
-// broke that is a cancellation the outermost thrown value does not admit to:
-// the phase catches its own error and attaches the abort as the `cause`, or the
-// request was torn down and what surfaced is whatever the provider was in the
-// middle of. The events already classified through the cause chain; the spans
-// compared `error.name` and called those failures.
+// A phase span and the `*:completed` event recorded next to it must reach the
+// same verdict about a cancellation the outermost thrown value does not admit
+// to: the abort arrives as a `cause`, or the work was torn down and what
+// surfaced is whatever the provider was in the middle of.
 
 const ATTRIBUTES = {
     sessionId: "session-abc",
@@ -52,11 +49,7 @@ function createCapture(): { logger: Logger; events: CapturedEvent[] } {
     };
 }
 
-/**
- * What a phase actually throws when the work under it was cancelled: the
- * phase's own error, carrying the abort as its `cause`. Nothing on the outer
- * value says "cancelled".
- */
+/** A phase's own error carrying the abort as its `cause`. */
 function wrappedAbortError(detail: string): Error {
     return Object.assign(new Error(detail), {
         cause: new DOMException("The operation was aborted.", "AbortError"),
@@ -127,8 +120,7 @@ describe("span and structured-event cancellation agree", () => {
                     appAgentName: "player",
                     actionIndex: 0,
                     success: false,
-                    // The call site sees no cancellation from outside: the
-                    // signal never fired, the abort is inside the error.
+                    // The signal never fired; the abort is inside the error.
                     cancelled: false,
                     error,
                 });
@@ -232,8 +224,8 @@ describe("span and structured-event cancellation agree", () => {
     });
 });
 
-// The other half of the cancellation contract: the thrown value says nothing,
-// and the caller knows only because it holds the signal that fired.
+// The thrown value says nothing; the caller knows only because it holds the
+// signal that fired.
 describe("signal-only cancellation", () => {
     let manager: InMemorySpanManager;
 

--- a/ts/packages/dispatcher/dispatcher/test/otelCancellationConsistency.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/otelCancellationConsistency.spec.ts
@@ -1,0 +1,319 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SpanStatusCode } from "@opentelemetry/api";
+import type { ActionContext } from "@typeagent/agent-sdk";
+import type { Logger } from "@typeagent/telemetry";
+import {
+    createInMemorySpanManager,
+    type CapturedSpan,
+    type InMemorySpanManager,
+} from "@typeagent/telemetry/testing/inMemorySpanManager";
+import type { CommandHandlerContext } from "../src/context/commandHandlerContext.js";
+import { wrapActionSpan } from "../src/otel/actionSpan.js";
+import { runInReasoningSpan } from "../src/otel/reasoningSpan.js";
+import { wrapRootRequestSpan } from "../src/otel/rootRequestSpan.js";
+import {
+    logActionCompleted,
+    logTranslationCompleted,
+} from "../src/otel/structuredEvents.js";
+import { wrapTranslationSpan } from "../src/otel/translationSpan.js";
+
+// A phase span and the `*:completed` event recorded next to it describe the
+// same failure, so they have to reach the same verdict about it. The case that
+// broke that is a cancellation the outermost thrown value does not admit to:
+// the phase catches its own error and attaches the abort as the `cause`, or the
+// request was torn down and what surfaced is whatever the provider was in the
+// middle of. The events already classified through the cause chain; the spans
+// compared `error.name` and called those failures.
+
+const ATTRIBUTES = {
+    sessionId: "session-abc",
+    activationId: "activation-123",
+};
+
+const REQUEST_ID = "request-1";
+
+type CapturedEvent = {
+    name: string;
+    data: Record<string, unknown>;
+    severity: string | undefined;
+};
+
+function createCapture(): { logger: Logger; events: CapturedEvent[] } {
+    const events: CapturedEvent[] = [];
+    return {
+        events,
+        logger: {
+            logEvent(name, data, severity) {
+                events.push({ name, data, severity });
+            },
+        },
+    };
+}
+
+/**
+ * What a phase actually throws when the work under it was cancelled: the
+ * phase's own error, carrying the abort as its `cause`. Nothing on the outer
+ * value says "cancelled".
+ */
+function wrappedAbortError(detail: string): Error {
+    return Object.assign(new Error(detail), {
+        cause: new DOMException("The operation was aborted.", "AbortError"),
+    });
+}
+
+function getOnlySpan(manager: InMemorySpanManager, name: string): CapturedSpan {
+    const spans = manager.findSpansByName(name);
+    if (spans.length !== 1) {
+        throw new Error(`Expected one ${name} span, got ${spans.length}`);
+    }
+    return spans[0]!;
+}
+
+function expectCancelledSpan(span: CapturedSpan): void {
+    expect(span.status).toEqual({
+        code: SpanStatusCode.ERROR,
+        message: "cancelled",
+    });
+    const exception = span.events.find((event) => event.name === "exception");
+    expect(exception?.attributes?.["exception.type"]).toBe("AbortError");
+    expect(exception?.attributes?.["exception.message"]).toBe("cancelled");
+    // Never the phase's failure wording, and never the original message.
+    expect(exception?.attributes?.["exception.stacktrace"]).toBeUndefined();
+}
+
+function expectCancelledEvent(event: CapturedEvent | undefined): void {
+    expect(event?.data).toMatchObject({ status: "cancelled", success: false });
+    expect(event?.severity).toBe("warning");
+    // A cancellation is a disposition, not a failure to classify.
+    expect(event?.data.errorCategory).toBeUndefined();
+}
+
+function createReasoningContext(logger: Logger, abortSignal?: AbortSignal) {
+    return {
+        abortSignal,
+        sessionContext: {
+            agentContext: {
+                session: {},
+                logger,
+                currentRequestId: { requestId: REQUEST_ID },
+            },
+        },
+    } as unknown as ActionContext<CommandHandlerContext>;
+}
+
+describe("span and structured-event cancellation agree", () => {
+    let manager: InMemorySpanManager;
+
+    beforeEach(() => {
+        manager = createInMemorySpanManager();
+    });
+
+    afterEach(async () => {
+        await manager.shutdown();
+    });
+
+    it("reports a wrapped cancellation as cancelled on the action span and event", async () => {
+        const { logger, events } = createCapture();
+        const error = wrappedAbortError("private action failure detail");
+
+        await expect(
+            wrapActionSpan(ATTRIBUTES, async () => {
+                logActionCompleted(logger, {
+                    requestId: REQUEST_ID,
+                    schemaName: "player",
+                    actionName: "play",
+                    appAgentName: "player",
+                    actionIndex: 0,
+                    success: false,
+                    // The call site sees no cancellation from outside: the
+                    // signal never fired, the abort is inside the error.
+                    cancelled: false,
+                    error,
+                });
+                throw error;
+            }),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.action"));
+        expectCancelledEvent(
+            events.find(({ name }) => name === "action:completed"),
+        );
+    });
+
+    it("reports a wrapped cancellation as cancelled on the translation span and event", async () => {
+        const { logger, events } = createCapture();
+        const error = wrappedAbortError("private translation failure detail");
+
+        await expect(
+            wrapTranslationSpan(ATTRIBUTES, async () => {
+                throw error;
+            }),
+        ).rejects.toBe(error);
+        logTranslationCompleted(logger, {
+            requestId: REQUEST_ID,
+            strategy: "translate",
+            success: false,
+            cancelled: false,
+            error,
+            actions: [],
+        });
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.translation"));
+        expectCancelledEvent(
+            events.find(({ name }) => name === "translation:completed"),
+        );
+    });
+
+    it("reports a wrapped cancellation as cancelled on the reasoning span and event", async () => {
+        const { logger, events } = createCapture();
+        const error = wrappedAbortError("private reasoning failure detail");
+
+        await expect(
+            runInReasoningSpan(createReasoningContext(logger), async () => {
+                throw error;
+            }),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.reasoning"));
+        const event = events.find(({ name }) => name === "reasoning:completed");
+        expect(event?.data).toMatchObject({
+            status: "cancelled",
+            cancelled: true,
+            success: false,
+        });
+        expect(event?.severity).toBe("warning");
+    });
+
+    it("reports a wrapped cancellation as cancelled on the request span", async () => {
+        const error = wrappedAbortError("private request failure detail");
+
+        await expect(
+            wrapRootRequestSpan(ATTRIBUTES, async () => {
+                throw error;
+            }),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.request"));
+    });
+
+    it("still records an ordinary failure as a phase failure on both signals", async () => {
+        const { logger, events } = createCapture();
+        const error = new Error("private provider detail");
+
+        await expect(
+            wrapActionSpan(ATTRIBUTES, async () => {
+                logActionCompleted(logger, {
+                    requestId: REQUEST_ID,
+                    schemaName: "player",
+                    actionName: "play",
+                    appAgentName: "player",
+                    actionIndex: 0,
+                    success: false,
+                    cancelled: false,
+                    error,
+                });
+                throw error;
+            }),
+        ).rejects.toBe(error);
+
+        const span = getOnlySpan(manager, "typeagent.action");
+        expect(span.status).toEqual({
+            code: SpanStatusCode.ERROR,
+            message: "action failed",
+        });
+        const event = events.find(({ name }) => name === "action:completed");
+        expect(event?.data).toMatchObject({
+            status: "failed",
+            errorCategory: "internal",
+        });
+        expect(event?.severity).toBe("error");
+    });
+});
+
+// The other half of the cancellation contract: the thrown value says nothing,
+// and the caller knows only because it holds the signal that fired.
+describe("signal-only cancellation", () => {
+    let manager: InMemorySpanManager;
+
+    beforeEach(() => {
+        manager = createInMemorySpanManager();
+    });
+
+    afterEach(async () => {
+        await manager.shutdown();
+    });
+
+    it("classifies an action failure from the caller's aborted signal", async () => {
+        const { logger, events } = createCapture();
+        const controller = new AbortController();
+        const error = new Error("private socket detail");
+
+        await expect(
+            wrapActionSpan(ATTRIBUTES, async () => {
+                controller.abort();
+                logActionCompleted(logger, {
+                    requestId: REQUEST_ID,
+                    schemaName: "player",
+                    actionName: "play",
+                    appAgentName: "player",
+                    actionIndex: 0,
+                    success: false,
+                    cancelled: controller.signal.aborted,
+                    error,
+                });
+                throw error;
+            }, [controller.signal]),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.action"));
+        expectCancelledEvent(
+            events.find(({ name }) => name === "action:completed"),
+        );
+    });
+
+    it("classifies a reasoning failure from the reasoning deadline signal", async () => {
+        const { logger, events } = createCapture();
+        const controller = new AbortController();
+        const error = new Error("private timeout detail");
+        controller.abort(error);
+
+        await expect(
+            runInReasoningSpan(
+                createReasoningContext(logger),
+                async () => {
+                    throw error;
+                },
+                undefined,
+                controller.signal,
+            ),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.reasoning"));
+        expect(
+            events.find(({ name }) => name === "reasoning:completed")?.data,
+        ).toMatchObject({ status: "cancelled", cancelled: true });
+    });
+
+    it("classifies a reasoning failure from the request's own signal", async () => {
+        const { logger, events } = createCapture();
+        const controller = new AbortController();
+        controller.abort();
+        const error = new Error("private provider detail");
+
+        await expect(
+            runInReasoningSpan(
+                createReasoningContext(logger, controller.signal),
+                async () => {
+                    throw error;
+                },
+            ),
+        ).rejects.toBe(error);
+
+        expectCancelledSpan(getOnlySpan(manager, "typeagent.reasoning"));
+        expect(
+            events.find(({ name }) => name === "reasoning:completed")?.data,
+        ).toMatchObject({ status: "cancelled", cancelled: true });
+    });
+});

--- a/ts/packages/dispatcher/dispatcher/test/structuredEvents.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredEvents.spec.ts
@@ -203,8 +203,8 @@ describe("dispatcher failure classification", () => {
         expect(events[0]?.severity).toBe("error");
         expect(events[0]?.data).toMatchObject({
             requestId: "request-4",
-            // Code and status come from the same error, so they describe one
-            // failure; the code table wins the category.
+            // Code and status come from the same error; the code table wins
+            // the category.
             errorCategory: "timeout",
             errorCode: "ETIMEDOUT",
             httpStatus: 429,
@@ -269,7 +269,6 @@ describe("dispatcher failure classification", () => {
             requestId: "request-4c",
             errorCategory: "internal",
         });
-        // Nothing readable, so nothing raw is asserted either.
         expect(events[0]?.data).not.toHaveProperty("name");
         expect(events[0]?.data).not.toHaveProperty("message");
         expect(events[0]?.data).not.toHaveProperty("stack");
@@ -286,8 +285,8 @@ describe("dispatcher failure classification", () => {
             error,
         });
 
-        // These fields exist for the local debug sink and the opt-in database
-        // sinks; `createDispatcherOtelLoggerSink` strips them before OTel.
+        // These fields stay in the local debug and opt-in database sinks;
+        // `createDispatcherOtelLoggerSink` strips them before OTel.
         expect(events[0]?.data).toMatchObject({
             request: "play some private music",
             name: "TypeError",
@@ -346,7 +345,6 @@ describe("dispatcher failure classification", () => {
             cancelled: true,
             error: new DOMException("The operation was aborted.", "AbortError"),
         });
-        // Success never carries classification fields.
         logActionCompleted(logger, {
             requestId: "request-7",
             schemaName: "email",
@@ -369,7 +367,6 @@ describe("dispatcher failure classification", () => {
         });
         expect(events[2]?.data).not.toHaveProperty("errorCategory");
         expect(events[3]?.data).not.toHaveProperty("errorCategory");
-        // The thrown value itself never rides along on these events.
         expect(events[0]?.data).not.toHaveProperty("error");
         expect(events[1]?.data).not.toHaveProperty("error");
         expect(JSON.stringify(events)).not.toContain("secret");
@@ -379,7 +376,7 @@ describe("dispatcher failure classification", () => {
         const { logger, events } = createCapture();
 
         // The common agent failure: a typed `ActionResult.error` with no
-        // exception. There is nothing to classify, so nothing is asserted.
+        // exception, so there is nothing to classify.
         logActionCompleted(logger, {
             requestId: "request-8",
             schemaName: "email",
@@ -401,11 +398,9 @@ describe("dispatcher failure classification", () => {
     });
 });
 
-// `cancelled`, `status`, the log severity, and whether classification fields
-// are emitted all have to describe the same thing. They are derived from one
-// classification of the thrown value rather than decided independently, so a
-// cancellation the call site could not see - one wrapped as a `cause` - is
-// still a cancellation on every one of them.
+// `cancelled`, `status`, severity, and the classification fields all derive
+// from one classification, so a cancellation the call site could not see -
+// one wrapped as a `cause` - is a cancellation on every one of them.
 describe("dispatcher cancellation coherence", () => {
     function wrappedAbort(): Error {
         return Object.assign(new Error("Error translating request"), {
@@ -458,8 +453,7 @@ describe("dispatcher cancellation coherence", () => {
         const { logger, events } = createCapture();
 
         // The abort signal fired while a handler was failing for an unrelated
-        // reason: the disposition is still cancellation, and no failure
-        // category is asserted for it.
+        // reason; the disposition is still cancellation.
         logActionCompleted(logger, {
             requestId: "request-10",
             schemaName: "email",

--- a/ts/packages/dispatcher/dispatcher/test/structuredEvents.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredEvents.spec.ts
@@ -6,6 +6,7 @@ import {
     DISPATCHER_STRUCTURED_EVENTS,
     logActionCompleted,
     logActionStarted,
+    logCommandException,
     logRequestCompleted,
     logRequestReceived,
     logTranslationCompleted,
@@ -180,6 +181,326 @@ describe("dispatcher structured lifecycle events", () => {
                 status: "cancelled",
                 success: false,
                 cancelled: true,
+            },
+        });
+    });
+});
+
+describe("dispatcher failure classification", () => {
+    it("records a command exception with a bounded classification", () => {
+        const { logger, events } = createCapture();
+
+        logCommandException(logger, {
+            requestId: "request-4",
+            request: "play some private music",
+            error: Object.assign(new Error("secret provider detail"), {
+                status: 429,
+                code: "ETIMEDOUT",
+            }),
+        });
+
+        expect(events[0]?.name).toBe("command:exception");
+        expect(events[0]?.severity).toBe("error");
+        expect(events[0]?.data).toMatchObject({
+            requestId: "request-4",
+            // Code and status come from the same error, so they describe one
+            // failure; the code table wins the category.
+            errorCategory: "timeout",
+            errorCode: "ETIMEDOUT",
+            httpStatus: 429,
+            retryable: true,
+        });
+    });
+
+    it("does not export failure fields for a wrapped cancellation", () => {
+        const { logger, events } = createCapture();
+        const error = Object.assign(new Error("private wrapper detail"), {
+            cause: new DOMException("private abort detail", "AbortError"),
+        });
+
+        logCommandException(logger, {
+            requestId: "request-4a",
+            request: "private request",
+            error,
+        });
+
+        expect(events[0]?.data).not.toHaveProperty("errorCategory");
+        expect(events[0]?.data).not.toHaveProperty("errorCode");
+        expect(events[0]?.data).not.toHaveProperty("httpStatus");
+        expect(events[0]?.data).not.toHaveProperty("retryable");
+        expect(events[0]?.severity).toBe("warning");
+    });
+
+    it("drops a code outside the reviewed allowlist", () => {
+        const { logger, events } = createCapture();
+
+        logCommandException(logger, {
+            requestId: "request-4b",
+            request: "play some private music",
+            error: Object.assign(new Error("secret provider detail"), {
+                status: 429,
+                code: "ERR_TENANT_8f14e45f",
+            }),
+        });
+
+        expect(events[0]?.data).toMatchObject({
+            errorCategory: "rate_limit",
+            httpStatus: 429,
+        });
+        expect(events[0]?.data).not.toHaveProperty("errorCode");
+    });
+
+    it("survives an error whose property reads throw", () => {
+        const { logger, events } = createCapture();
+        const hostile = new Proxy(new Error("hostile"), {
+            get(_target, property) {
+                throw new Error(`no reads allowed: ${String(property)}`);
+            },
+        });
+
+        expect(() =>
+            logCommandException(logger, {
+                requestId: "request-4c",
+                request: "private request",
+                error: hostile,
+            }),
+        ).not.toThrow();
+        expect(events[0]?.data).toMatchObject({
+            requestId: "request-4c",
+            errorCategory: "internal",
+        });
+        // Nothing readable, so nothing raw is asserted either.
+        expect(events[0]?.data).not.toHaveProperty("name");
+        expect(events[0]?.data).not.toHaveProperty("message");
+        expect(events[0]?.data).not.toHaveProperty("stack");
+    });
+
+    it("keeps the raw error detail for the private diagnostic sinks", () => {
+        const { logger, events } = createCapture();
+        const error = new Error("secret provider detail");
+        error.name = "TypeError";
+
+        logCommandException(logger, {
+            requestId: "request-5",
+            request: "play some private music",
+            error,
+        });
+
+        // These fields exist for the local debug sink and the opt-in database
+        // sinks; `createDispatcherOtelLoggerSink` strips them before OTel.
+        expect(events[0]?.data).toMatchObject({
+            request: "play some private music",
+            name: "TypeError",
+            message: "secret provider detail",
+            stack: expect.any(String),
+        });
+    });
+
+    it("survives a non-Error throw without inventing raw fields", () => {
+        const { logger, events } = createCapture();
+
+        logCommandException(logger, {
+            requestId: "request-6",
+            request: "private request",
+            error: "just a string",
+        });
+
+        expect(events[0]?.data).toMatchObject({
+            requestId: "request-6",
+            errorCategory: "internal",
+        });
+        expect(events[0]?.data).not.toHaveProperty("message");
+        expect(events[0]?.data).not.toHaveProperty("stack");
+        expect(events[0]?.data).not.toHaveProperty("name");
+    });
+
+    it("classifies failed phase completions and leaves the rest untouched", () => {
+        const { logger, events } = createCapture();
+        const timeout = new Error("secret endpoint detail");
+        timeout.name = "TimeoutError";
+
+        logActionCompleted(logger, {
+            requestId: "request-7",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 0,
+            success: false,
+            error: timeout,
+        });
+        logTranslationCompleted(logger, {
+            requestId: "request-7",
+            strategy: "translate",
+            success: false,
+            error: Object.assign(new Error("secret detail"), { status: 503 }),
+            actions: [],
+        });
+        // Cancellation is a disposition, not a failure to classify.
+        logActionCompleted(logger, {
+            requestId: "request-7",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 1,
+            success: false,
+            cancelled: true,
+            error: new DOMException("The operation was aborted.", "AbortError"),
+        });
+        // Success never carries classification fields.
+        logActionCompleted(logger, {
+            requestId: "request-7",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 2,
+            success: true,
+        });
+
+        expect(events[0]?.data).toMatchObject({
+            status: "failed",
+            errorCategory: "timeout",
+            retryable: true,
+        });
+        expect(events[1]?.data).toMatchObject({
+            status: "failed",
+            errorCategory: "provider",
+            httpStatus: 503,
+            retryable: true,
+        });
+        expect(events[2]?.data).not.toHaveProperty("errorCategory");
+        expect(events[3]?.data).not.toHaveProperty("errorCategory");
+        // The thrown value itself never rides along on these events.
+        expect(events[0]?.data).not.toHaveProperty("error");
+        expect(events[1]?.data).not.toHaveProperty("error");
+        expect(JSON.stringify(events)).not.toContain("secret");
+    });
+
+    it("invents no classification when the failure had no thrown value", () => {
+        const { logger, events } = createCapture();
+
+        // The common agent failure: a typed `ActionResult.error` with no
+        // exception. There is nothing to classify, so nothing is asserted.
+        logActionCompleted(logger, {
+            requestId: "request-8",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 0,
+            success: false,
+        });
+        logTranslationCompleted(logger, {
+            requestId: "request-8",
+            strategy: "translate",
+            success: false,
+            actions: [],
+        });
+
+        expect(events[0]?.data).toMatchObject({ status: "failed" });
+        expect(events[0]?.data).not.toHaveProperty("errorCategory");
+        expect(events[1]?.data).not.toHaveProperty("errorCategory");
+    });
+});
+
+// `cancelled`, `status`, the log severity, and whether classification fields
+// are emitted all have to describe the same thing. They are derived from one
+// classification of the thrown value rather than decided independently, so a
+// cancellation the call site could not see - one wrapped as a `cause` - is
+// still a cancellation on every one of them.
+describe("dispatcher cancellation coherence", () => {
+    function wrappedAbort(): Error {
+        return Object.assign(new Error("Error translating request"), {
+            cause: new DOMException("The operation was aborted.", "AbortError"),
+        });
+    }
+
+    it("recognizes a wrapped cancellation on action completion", () => {
+        const { logger, events } = createCapture();
+
+        logActionCompleted(logger, {
+            requestId: "request-9",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 0,
+            success: false,
+            // The call site only knows the abort signal has not fired yet.
+            cancelled: false,
+            error: wrappedAbort(),
+        });
+
+        expect(events[0]).toMatchObject({
+            severity: "warning",
+            data: { status: "cancelled", cancelled: true, success: false },
+        });
+        expect(events[0]?.data).not.toHaveProperty("errorCategory");
+    });
+
+    it("recognizes a wrapped cancellation on translation completion", () => {
+        const { logger, events } = createCapture();
+
+        logTranslationCompleted(logger, {
+            requestId: "request-9",
+            strategy: "translate",
+            success: false,
+            cancelled: false,
+            error: wrappedAbort(),
+            actions: [],
+        });
+
+        expect(events[0]).toMatchObject({
+            severity: "warning",
+            data: { status: "cancelled", cancelled: true, success: false },
+        });
+        expect(events[0]?.data).not.toHaveProperty("errorCategory");
+    });
+
+    it("still honors a cancellation the call site knows about on its own", () => {
+        const { logger, events } = createCapture();
+
+        // The abort signal fired while a handler was failing for an unrelated
+        // reason: the disposition is still cancellation, and no failure
+        // category is asserted for it.
+        logActionCompleted(logger, {
+            requestId: "request-10",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 0,
+            success: false,
+            cancelled: true,
+            error: Object.assign(new Error("secret detail"), { status: 500 }),
+        });
+
+        expect(events[0]).toMatchObject({
+            severity: "warning",
+            data: { status: "cancelled", cancelled: true },
+        });
+        expect(events[0]?.data).not.toHaveProperty("errorCategory");
+        expect(events[0]?.data).not.toHaveProperty("httpStatus");
+    });
+
+    it("does not mark an ordinary failure as cancelled", () => {
+        const { logger, events } = createCapture();
+
+        logActionCompleted(logger, {
+            requestId: "request-11",
+            schemaName: "email",
+            actionName: "send",
+            appAgentName: "email",
+            actionIndex: 0,
+            success: false,
+            cancelled: false,
+            error: Object.assign(new Error("secret detail"), { status: 503 }),
+        });
+
+        expect(events[0]).toMatchObject({
+            severity: "error",
+            data: {
+                status: "failed",
+                cancelled: false,
+                errorCategory: "provider",
+                httpStatus: 503,
+                retryable: true,
             },
         });
     });

--- a/ts/packages/dispatcher/dispatcher/test/structuredLogSink.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredLogSink.spec.ts
@@ -86,6 +86,44 @@ describe("dispatcher structured log projection", () => {
         expect(JSON.stringify(captured)).not.toContain("PRIVATE_");
     });
 
+    it("keeps the failure classification and drops the raw error", () => {
+        const captured: LogEvent[] = [];
+        const sink = createDispatcherOtelLoggerSink({
+            logEvent(event) {
+                captured.push(event);
+            },
+        });
+
+        // Exactly the shape `logCommandException` produces: bounded
+        // classification for OTel, raw error detail for the local debug and
+        // opt-in database sinks only.
+        sink.logEvent({
+            eventName: "command:exception",
+            timestamp: new Date().toISOString(),
+            severity: "error",
+            event: {
+                requestId: "request",
+                errorCategory: "rate_limit",
+                errorCode: "ERR_TOO_MANY",
+                httpStatus: 429,
+                retryable: true,
+                request: "PRIVATE_REQUEST_MARKER",
+                name: "PRIVATE_NAME_MARKER",
+                message: "PRIVATE_ERROR_MARKER",
+                stack: "PRIVATE_STACK_MARKER",
+            },
+        });
+
+        expect(captured[0]?.event).toEqual({
+            requestId: "request",
+            errorCategory: "rate_limit",
+            errorCode: "ERR_TOO_MANY",
+            httpStatus: 429,
+            retryable: true,
+        });
+        expect(JSON.stringify(captured)).not.toContain("PRIVATE_");
+    });
+
     it("drops oversized and incorrectly typed allowlisted values", () => {
         const captured: LogEvent[] = [];
         const sink = createDispatcherOtelLoggerSink({

--- a/ts/packages/dispatcher/dispatcher/test/structuredLogSink.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredLogSink.spec.ts
@@ -94,9 +94,7 @@ describe("dispatcher structured log projection", () => {
             },
         });
 
-        // Exactly the shape `logCommandException` produces: bounded
-        // classification for OTel, raw error detail for the local debug and
-        // opt-in database sinks only.
+        // Exactly the shape `logCommandException` produces.
         sink.logEvent({
             eventName: "command:exception",
             timestamp: new Date().toISOString(),

--- a/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
@@ -67,4 +67,26 @@ describe("dispatcher structured request lifecycle", () => {
         ).toBe(lifecycle[0]?.event.requestId);
         expect(JSON.stringify(lifecycle)).not.toContain("@help");
     });
+
+    it("classifies a failed command without exporting the request", async () => {
+        captured.length = 0;
+
+        await awaitCommand(dispatcher, "@definitelyNotACommand");
+
+        const exception = captured.find(
+            (event) => event.eventName === "dispatcher:command:exception",
+        );
+        expect(exception?.severity).toBe("error");
+        // Nothing about an unknown command is retryable, an HTTP failure, or
+        // an enumerated provider code, so only the category is asserted - the
+        // optional fields must stay absent rather than be invented.
+        expect(exception?.event).toMatchObject({ errorCategory: "internal" });
+        expect(exception?.event.httpStatus).toBeUndefined();
+        expect(exception?.event.retryable).toBeUndefined();
+        expect(exception?.event.requestId).toBe(
+            captured.find(
+                (event) => event.eventName === "dispatcher:request:received",
+            )?.event.requestId,
+        );
+    });
 });

--- a/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
@@ -77,9 +77,7 @@ describe("dispatcher structured request lifecycle", () => {
             (event) => event.eventName === "dispatcher:command:exception",
         );
         expect(exception?.severity).toBe("error");
-        // Nothing about an unknown command is retryable, an HTTP failure, or
-        // an enumerated provider code, so only the category is asserted - the
-        // optional fields must stay absent rather than be invented.
+        // The optional fields must stay absent rather than be invented.
         expect(exception?.event).toMatchObject({ errorCategory: "internal" });
         expect(exception?.event.httpStatus).toBeUndefined();
         expect(exception?.event.retryable).toBeUndefined();

--- a/ts/packages/telemetry/package.json
+++ b/ts/packages/telemetry/package.json
@@ -22,6 +22,10 @@
     "./traceContext": {
       "types": "./dist/otel/traceContract.d.ts",
       "default": "./dist/otel/traceContract.js"
+    },
+    "./errorClassification": {
+      "types": "./dist/otel/errorClassification.d.ts",
+      "default": "./dist/otel/errorClassification.js"
     }
   },
   "files": [

--- a/ts/packages/telemetry/src/logger/structuredLogMessage.ts
+++ b/ts/packages/telemetry/src/logger/structuredLogMessage.ts
@@ -27,6 +27,8 @@ export function getStructuredLogMessage(
             return `Request cancelled while ${stringValue(data, "phase", "queued")}`;
         case "dispatcher:request:received":
             return "Dispatcher began processing request";
+        case "dispatcher:command:exception":
+            return `Command failed: ${formatErrorClassification(data)}`;
         case "dispatcher:translation:started":
             return `Translation started with ${numberValue(data, "count", 0)} candidate schemas`;
         case "dispatcher:translation:completed":
@@ -38,7 +40,7 @@ export function getStructuredLogMessage(
         case "dispatcher:action:started":
             return `Action started: ${formatAction(data)}`;
         case "dispatcher:action:completed":
-            return `Action ${stringValue(data, "status", "completed")}: ${formatAction(data)}${formatElapsed(data)}`;
+            return `Action ${stringValue(data, "status", "completed")}: ${formatAction(data)}${formatElapsed(data)}${formatFailureNote(data)}`;
         case "dispatcher:request:completed":
             return `Request completed: ${stringValue(data, "status", "completed")}`;
         case "aiclient:llm:started":
@@ -56,7 +58,43 @@ function formatTranslationCompleted(data: Record<string, unknown>): string {
     const actions = stringArrayValue(data, "actionNames");
     return `Translation ${status} via ${strategy}${formatRoutingNote(
         data,
-    )}${formatElapsed(data)}${actions.length === 0 ? "" : `: ${actions.join(", ")}`}`;
+    )}${formatElapsed(data)}${formatFailureNote(data)}${actions.length === 0 ? "" : `: ${actions.join(", ")}`}`;
+}
+
+/**
+ * Render the normalized failure classification (`errorCategory` and the
+ * optional `errorCode` / `httpStatus` / `retryable`). Only these bounded
+ * fields are read - the original message and stack are never part of a
+ * rendered message.
+ */
+function formatErrorClassification(data: Record<string, unknown>): string {
+    const category = stringValue(data, "errorCategory", "internal");
+    const details: string[] = [];
+    const code = data.errorCode;
+    if (typeof code === "string" && code.length > 0) {
+        details.push(code);
+    }
+    const httpStatus = data.httpStatus;
+    if (typeof httpStatus === "number" && Number.isFinite(httpStatus)) {
+        details.push(`HTTP ${httpStatus}`);
+    }
+    if (data.retryable === true) {
+        details.push("retryable");
+    }
+    return details.length === 0
+        ? category
+        : `${category} (${details.join(", ")})`;
+}
+
+/**
+ * Append the failure classification to a lifecycle message, but only when the
+ * event actually carries one. Successful and cancelled completions have no
+ * classification, so they read exactly as before.
+ */
+function formatFailureNote(data: Record<string, unknown>): string {
+    return typeof data.errorCategory === "string" && data.errorCategory !== ""
+        ? ` [${formatErrorClassification(data)}]`
+        : "";
 }
 
 // Note only the routing nuance that `strategy` does not already convey: a
@@ -93,7 +131,7 @@ function formatLlmCompleted(data: Record<string, unknown>): string {
     const totalTokens = data.totalTokens;
     return `LLM ${status}: ${formatLlmOperation(data)}${formatScope(data)}${formatModel(data)} in ${elapsedMs} ms${
         typeof totalTokens === "number" ? ` (${totalTokens} tokens)` : ""
-    }`;
+    }${formatFailureNote(data)}`;
 }
 
 function formatLlmOperation(data: Record<string, unknown>): string {

--- a/ts/packages/telemetry/src/logger/structuredLogMessage.ts
+++ b/ts/packages/telemetry/src/logger/structuredLogMessage.ts
@@ -62,10 +62,8 @@ function formatTranslationCompleted(data: Record<string, unknown>): string {
 }
 
 /**
- * Render the normalized failure classification (`errorCategory` and the
- * optional `errorCode` / `httpStatus` / `retryable`). Only these bounded
- * fields are read - the original message and stack are never part of a
- * rendered message.
+ * Render the bounded classification fields only - the original message and
+ * stack are never part of a rendered message.
  */
 function formatErrorClassification(data: Record<string, unknown>): string {
     const category = stringValue(data, "errorCategory", "internal");
@@ -88,8 +86,7 @@ function formatErrorClassification(data: Record<string, unknown>): string {
 
 /**
  * Append the failure classification to a lifecycle message, but only when the
- * event actually carries one. Successful and cancelled completions have no
- * classification, so they read exactly as before.
+ * event carries one.
  */
 function formatFailureNote(data: Record<string, unknown>): string {
     return typeof data.errorCategory === "string" && data.errorCategory !== ""

--- a/ts/packages/telemetry/src/otel/errorClassification.ts
+++ b/ts/packages/telemetry/src/otel/errorClassification.ts
@@ -1,0 +1,629 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Shared normalizer that turns an arbitrary thrown value into bounded,
+ * low-cardinality structured fields that are safe to export.
+ *
+ * Structured failure events need to answer "what kind of failure was this,
+ * and is it worth retrying?" without carrying the original message, stack, or
+ * any user content. This module produces exactly that: a closed
+ * {@link TelemetryErrorCategory}, plus optional `errorCode`, `httpStatus`, and
+ * `retryable` fields that are emitted only when they are actually known.
+ *
+ * Classification never parses free-text messages. A message is the one part of
+ * an error most likely to contain a prompt, a file path, or a user's request,
+ * and matching on its wording is both a privacy hazard and fragile across
+ * provider/library versions. The only inputs are:
+ *
+ * 1. An explicit `errorCategory` (and optional `errorCode` / `retryable`) that
+ *    the thrower attached - the opt-in extension point for a package that owns
+ *    a typed error and knows how it should be classified.
+ * 2. `error.name`, matched against a closed table of standard platform names
+ *    (DOM, Node, undici).
+ * 3. `error.code`, matched against {@link TELEMETRY_ERROR_CODES}, a closed
+ *    reviewed allowlist. A code outside it is dropped rather than exported.
+ * 4. An HTTP *failure* status (400-599) read from a small set of well-known
+ *    numeric properties. A 1xx/2xx/3xx value is not evidence of a failure, and
+ *    `status` is also used as a non-HTTP enum elsewhere (a `child_process`
+ *    exit code, for instance), so those values are ignored rather than
+ *    reported.
+ *
+ * ## Precedence
+ *
+ * Each error in the `cause` chain is examined in turn, outermost first, so a
+ * `fetch` failure (`TypeError` wrapping a `cause` carrying `ECONNREFUSED`)
+ * classifies as `network` rather than falling through. The **first link that
+ * yields a recognized signal wins, and every reported field comes from that
+ * one link**: category, code, status, and retryability then describe the same
+ * error instead of being stitched together across links (a cause's
+ * `ECONNRESET` must not be reported next to its wrapper's HTTP 401).
+ *
+ * Within the winning link the order is: an explicit classification from the
+ * thrower, then `error.name`, then `error.code`, then an HTTP failure status.
+ * A link carrying only an allowlisted code with no category rule still wins:
+ * it reports that code with the `internal` category rather than dropping a
+ * reviewed, useful code.
+ *
+ * Anything that yields no signal - a thrown string, a thrown object, or a
+ * plain `Error` - becomes `internal` with no fabricated code, status, or
+ * retryability. A caller that has its own truthful default for that case uses
+ * {@link classifyTelemetryErrorIfRecognized} instead and gets `undefined`.
+ *
+ * ## Never throws
+ *
+ * A thrown value is hostile-shaped input: getters can throw, proxies trap
+ * every operation, and a proxy can be revoked between two reads. Every
+ * property access here is guarded and the entry point has a last-resort
+ * fallback, so classifying a hostile error degrades to `internal` instead of
+ * replacing the original failure with a telemetry one.
+ */
+
+export const TELEMETRY_ERROR_CATEGORIES = [
+    "authentication",
+    "authorization",
+    "rate_limit",
+    "network",
+    "timeout",
+    "validation",
+    "provider",
+    "cancelled",
+    "internal",
+] as const;
+
+/**
+ * Closed set of failure categories. Low-cardinality by construction, so it is
+ * safe as a metric dimension or a log/span attribute.
+ */
+export type TelemetryErrorCategory =
+    (typeof TELEMETRY_ERROR_CATEGORIES)[number];
+
+/**
+ * A code that is allowed to leave the process: a member of
+ * {@link TELEMETRY_ERROR_CODES}. Kept as a `string` alias rather than a
+ * literal union so a package can declare a constant without importing a
+ * generated type; the allowlist is the runtime authority either way.
+ */
+export type TelemetryErrorCode = string;
+
+/**
+ * The normalized, export-safe view of a failure. Only `errorCategory` is
+ * always present; the optional fields are omitted rather than guessed when the
+ * error carries no evidence for them.
+ */
+export interface TelemetryErrorClassification {
+    readonly errorCategory: TelemetryErrorCategory;
+    /** A reviewed code from {@link TELEMETRY_ERROR_CODES}. */
+    readonly errorCode?: TelemetryErrorCode;
+    /** HTTP status when the failure carries one, in the range 400-599. */
+    readonly httpStatus?: number;
+    /** Whether retrying the same operation could plausibly succeed. */
+    readonly retryable?: boolean;
+}
+
+/**
+ * The properties a package sets on its own error type to classify it without
+ * this module having to know the type's name. `errorCategory` must be a member
+ * of {@link TELEMETRY_ERROR_CATEGORIES} and `errorCode` a member of
+ * {@link TELEMETRY_ERROR_CODES}; anything else is ignored.
+ */
+export interface TelemetryClassifiedError {
+    readonly errorCategory: TelemetryErrorCategory;
+    readonly errorCode?: TelemetryErrorCode;
+    readonly retryable?: boolean;
+}
+
+type CategoryRule = {
+    readonly category: TelemetryErrorCategory;
+    // Omitted when retryability genuinely depends on the situation.
+    readonly retryable?: boolean;
+};
+
+/**
+ * Standard platform error names. Deliberately limited to names defined by the
+ * DOM, Node, or undici so this table does not become a registry of every
+ * TypeAgent error type - a package with its own typed error attaches
+ * `errorCategory` to it instead (see {@link TelemetryClassifiedError}).
+ */
+const CATEGORY_BY_ERROR_NAME: ReadonlyMap<string, CategoryRule> = new Map([
+    ["AbortError", { category: "cancelled", retryable: false }],
+    ["TimeoutError", { category: "timeout", retryable: true }],
+    ["HeadersTimeoutError", { category: "timeout", retryable: true }],
+    ["BodyTimeoutError", { category: "timeout", retryable: true }],
+    ["ConnectTimeoutError", { category: "timeout", retryable: true }],
+    ["FetchError", { category: "network", retryable: true }],
+    ["SocketError", { category: "network", retryable: true }],
+] as const);
+
+/** Standard Node/undici `error.code` values that also determine a category. */
+const CATEGORY_BY_ERROR_CODE: ReadonlyMap<string, CategoryRule> = new Map([
+    ["ABORT_ERR", { category: "cancelled", retryable: false }],
+    ["ETIMEDOUT", { category: "timeout", retryable: true }],
+    ["ESOCKETTIMEDOUT", { category: "timeout", retryable: true }],
+    ["UND_ERR_HEADERS_TIMEOUT", { category: "timeout", retryable: true }],
+    ["UND_ERR_BODY_TIMEOUT", { category: "timeout", retryable: true }],
+    ["UND_ERR_CONNECT_TIMEOUT", { category: "timeout", retryable: true }],
+    ["ERR_SOCKET_CONNECTION_TIMEOUT", { category: "timeout", retryable: true }],
+    ["ECONNREFUSED", { category: "network", retryable: true }],
+    ["ECONNRESET", { category: "network", retryable: true }],
+    ["ECONNABORTED", { category: "network", retryable: true }],
+    ["EHOSTUNREACH", { category: "network", retryable: true }],
+    ["ENETUNREACH", { category: "network", retryable: true }],
+    ["ENETDOWN", { category: "network", retryable: true }],
+    ["ENOTFOUND", { category: "network", retryable: true }],
+    ["EAI_AGAIN", { category: "network", retryable: true }],
+    ["EPIPE", { category: "network", retryable: true }],
+    ["EPROTO", { category: "network", retryable: true }],
+    ["UND_ERR_SOCKET", { category: "network", retryable: true }],
+    // TLS trust failures are network-layer but never fix themselves on retry.
+    ["CERT_HAS_EXPIRED", { category: "network", retryable: false }],
+    ["DEPTH_ZERO_SELF_SIGNED_CERT", { category: "network", retryable: false }],
+    ["SELF_SIGNED_CERT_IN_CHAIN", { category: "network", retryable: false }],
+    [
+        "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        { category: "network", retryable: false },
+    ],
+] as const);
+
+/**
+ * Reviewed codes that are safe to export but say nothing about the category on
+ * their own. Kept out of {@link CATEGORY_BY_ERROR_CODE} so the category tables
+ * stay honest: these are reported as `errorCode` alongside whatever category
+ * the rest of the link established, which is `internal` when nothing else did.
+ */
+const UNCATEGORIZED_ERROR_CODES = [
+    "EACCES",
+    "EADDRINUSE",
+    "EADDRNOTAVAIL",
+    "EBUSY",
+    "EEXIST",
+    "EISDIR",
+    "EMFILE",
+    "ENOENT",
+    "ENOMEM",
+    "ENOSPC",
+    "ENOTDIR",
+    "EPERM",
+    "ERR_INVALID_ARG_TYPE",
+    "ERR_INVALID_ARG_VALUE",
+    "ERR_INVALID_URL",
+    "ERR_OUT_OF_RANGE",
+    "ERR_STREAM_PREMATURE_CLOSE",
+    "UND_ERR_ABORTED",
+    "UND_ERR_DESTROYED",
+    "UND_ERR_RESPONSE_STATUS_CODE",
+] as const;
+
+/**
+ * The closed, reviewed set of codes this module will ever export.
+ *
+ * A code becomes a log/metric label, so a shape check is not enough on its
+ * own: a `code` that happens to be an identifier-shaped GUID, account name, or
+ * API key passes any pattern and then either blows up label cardinality or
+ * carries an identifier off the machine. Exporting only reviewed constants
+ * bounds both. A package that needs its own code adds it here (one reviewed
+ * line) and declares it through {@link TelemetryClassifiedError}.
+ */
+export const TELEMETRY_ERROR_CODES: readonly TelemetryErrorCode[] =
+    Object.freeze([
+        ...CATEGORY_BY_ERROR_CODE.keys(),
+        ...UNCATEGORIZED_ERROR_CODES,
+    ]);
+
+const TELEMETRY_ERROR_CODE_SET: ReadonlySet<string> = new Set(
+    TELEMETRY_ERROR_CODES,
+);
+
+/** HTTP statuses that callers can generally retry safely. */
+const RETRYABLE_HTTP_STATUSES: ReadonlySet<number> = new Set([
+    408, 429, 500, 502, 503, 504,
+]);
+
+/** Numeric properties an HTTP status is conventionally exposed under. */
+const HTTP_STATUS_PROPERTIES = ["status", "statusCode", "httpStatus"] as const;
+
+/**
+ * How far the `cause` chain is walked. Deep enough for the wrapping that
+ * `fetch`, undici, and the Azure SDKs actually do, shallow enough that a
+ * hostile or accidental chain cannot turn classification into real work.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+const INTERNAL_CLASSIFICATION: TelemetryErrorClassification = Object.freeze({
+    errorCategory: "internal",
+});
+
+/**
+ * Normalize any thrown value into bounded, export-safe structured fields.
+ * Never throws and never returns the original message, stack, or any other
+ * free-text content. A value carrying no recognized signal is reported as
+ * `internal`.
+ */
+export function classifyTelemetryError(
+    error: unknown,
+): TelemetryErrorClassification {
+    return classifyTelemetryErrorIfRecognized(error) ?? INTERNAL_CLASSIFICATION;
+}
+
+/**
+ * The same classification, except that a value carrying no recognized signal
+ * yields `undefined` instead of `internal`.
+ *
+ * `internal` is a claim, not an absence: it says the failure came from our own
+ * code. A caller that already knows something truer about the failure must not
+ * have that claim written over its own. The transport turning a provider call
+ * into a `Result` failure is the case that matters - `provider` is the honest
+ * description of "the model call failed and nothing told us why", and
+ * attaching `internal` to it would both mislabel the failure and pre-empt the
+ * fallback the reporting layer would otherwise apply.
+ *
+ * Use this wherever a classification is *attached* to a value that already has
+ * a meaningful default; use {@link classifyTelemetryError} where a category is
+ * required and `internal` is the honest answer. Never throws.
+ */
+export function classifyTelemetryErrorIfRecognized(
+    error: unknown,
+): TelemetryErrorClassification | undefined {
+    try {
+        return classifyErrorChain(collectErrorChain(error));
+    } catch {
+        // Defense in depth: every read below is already guarded, so reaching
+        // here means an assumption broke. A telemetry helper must still not
+        // replace the failure it was asked to describe.
+        return undefined;
+    }
+}
+
+/**
+ * Whether a failure should be reported as a cancellation.
+ *
+ * The single cancellation test for spans, structured events, and the model
+ * wrapper, so a span status and the log record next to it cannot disagree
+ * about the same failure. Two things make it a cancellation:
+ *
+ * - The thrown value classifies as `cancelled`. This walks the `cause` chain,
+ *   so an `AbortError` wrapped by a phase-level error still counts - a call
+ *   site that only compared `error.name` would report a plain failure.
+ * - `cancelledHint`, what the caller knows from outside the error: typically
+ *   that the request's abort signal has fired. It stands on its own, because a
+ *   cancellation frequently surfaces as an unrelated-looking failure (a
+ *   provider socket error, a timeout) once the signal has torn the work down.
+ */
+export function isTelemetryCancellation(
+    error: unknown,
+    cancelledHint?: boolean,
+): boolean {
+    return (
+        cancelledHint === true ||
+        classifyTelemetryErrorIfRecognized(error)?.errorCategory === "cancelled"
+    );
+}
+
+/**
+ * Classify an HTTP failure status directly, for a caller that holds the status
+ * but no error object - a REST client turning a non-OK response into a typed
+ * failure result, for instance. Returns `undefined` for a status that is not a
+ * failure so the caller omits the classification rather than inventing one.
+ */
+export function classifyTelemetryHttpStatus(
+    status: number,
+): TelemetryErrorClassification | undefined {
+    if (!isHttpFailureStatus(status)) {
+        return undefined;
+    }
+    const rule = ruleForHttpStatus(status);
+    return {
+        errorCategory: rule.category,
+        httpStatus: status,
+        ...(rule.retryable === undefined ? {} : { retryable: rule.retryable }),
+    };
+}
+
+/**
+ * Where a classification is stashed on a value that is not itself an error.
+ *
+ * A registered symbol rather than a string key: it cannot collide with a
+ * domain property, `JSON.stringify` and `Object.keys` skip it, and
+ * `Symbol.for` resolves to the same symbol when two copies of this package are
+ * loaded in one process.
+ */
+const CLASSIFICATION_CARRIER = Symbol.for(
+    "typeagent.telemetry.errorClassification",
+);
+
+/**
+ * Record a classification on a value that reports failure without throwing.
+ *
+ * `typechat`'s `Result` failure is `{ success: false, message }` - a string
+ * with no room for structure, so by the time a caller sees one, everything
+ * that was known at the transport layer (the HTTP status, the socket error)
+ * has been flattened into prose that telemetry must not parse. This lets the
+ * layer that still has the facts attach them, and
+ * {@link readTelemetryErrorClassification} lets the layer that reports
+ * telemetry pick them back up.
+ *
+ * The property is non-enumerable, so it does not change spreads, `Object.keys`,
+ * `JSON.stringify`, or deep-equality assertions on existing results. Returns
+ * the same object and never throws: a frozen or exotic target simply carries
+ * no classification.
+ */
+export function attachTelemetryErrorClassification<T extends object>(
+    target: T,
+    classification: TelemetryErrorClassification,
+): T {
+    try {
+        Object.defineProperty(target, CLASSIFICATION_CARRIER, {
+            value: classification,
+            enumerable: false,
+            configurable: true,
+            writable: true,
+        });
+    } catch {
+        // A frozen or sealed result is not worth failing the call over.
+    }
+    return target;
+}
+
+/**
+ * Read back a classification attached by
+ * {@link attachTelemetryErrorClassification}. The stored value is re-validated
+ * against the same closed vocabularies used for a thrown error, so a stale or
+ * forged carrier cannot smuggle an unbounded field into an export.
+ */
+export function readTelemetryErrorClassification(
+    value: unknown,
+): TelemetryErrorClassification | undefined {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+    let carried: unknown;
+    try {
+        carried = (value as Record<symbol, unknown>)[CLASSIFICATION_CARRIER];
+    } catch {
+        return undefined;
+    }
+    return sanitizeClassification(carried);
+}
+
+function sanitizeClassification(
+    value: unknown,
+): TelemetryErrorClassification | undefined {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+    const category = readStringProperty(value, "errorCategory");
+    if (category === undefined || !isTelemetryErrorCategory(category)) {
+        return undefined;
+    }
+    const errorCode = readAllowlistedCode(value, "errorCode");
+    const httpStatus = readProperty(value, "httpStatus");
+    const retryable = readProperty(value, "retryable");
+    return {
+        errorCategory: category,
+        ...(errorCode === undefined ? {} : { errorCode }),
+        ...(typeof httpStatus === "number" && isHttpFailureStatus(httpStatus)
+            ? { httpStatus }
+            : {}),
+        ...(typeof retryable === "boolean" ? { retryable } : {}),
+    };
+}
+
+/**
+ * Read one property without trusting the object. A getter can throw, and a
+ * proxy can trap (or have been revoked since the previous read), so every
+ * access degrades to `undefined` instead of propagating.
+ */
+function readProperty(node: object, key: string): unknown {
+    try {
+        return (node as Record<string, unknown>)[key];
+    } catch {
+        return undefined;
+    }
+}
+
+function readStringProperty(node: object, key: string): string | undefined {
+    const value = readProperty(node, key);
+    return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Flatten the `cause` chain (and the first entry of an `AggregateError`) into
+ * an ordered list, outermost first. Bounded by {@link MAX_CAUSE_DEPTH} and
+ * guarded by a visited set, so a self-referential or mutually-referential
+ * chain terminates instead of recursing forever.
+ */
+function collectErrorChain(error: unknown): readonly object[] {
+    const chain: object[] = [];
+    const visited = new Set<object>();
+    let current: unknown = error;
+    while (
+        chain.length < MAX_CAUSE_DEPTH &&
+        current !== null &&
+        typeof current === "object" &&
+        !visited.has(current)
+    ) {
+        visited.add(current);
+        chain.push(current);
+        // Stopping the walk must not discard the links already collected: an
+        // outer `AbortError` still classifies the failure even when the value
+        // hanging off it is unreadable.
+        try {
+            current = nextInChain(current);
+        } catch {
+            break;
+        }
+    }
+    return chain;
+}
+
+function nextInChain(node: object): unknown {
+    const cause = readProperty(node, "cause");
+    if (cause !== undefined) {
+        return cause;
+    }
+    // Only the first aggregated error is followed. Walking all of them would
+    // make the cost unbounded, and the categories of sibling failures are
+    // usually the same anyway.
+    const errors = readProperty(node, "errors");
+    try {
+        // `Array.isArray` is not a safe predicate: it throws on a revoked
+        // proxy rather than returning false. It and the index read are both
+        // inside the guard so an unreadable `errors` ends the walk instead.
+        return Array.isArray(errors) ? errors[0] : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Report the first link of the chain that carries a recognized signal, with
+ * every field read from that link. See the precedence contract at the top of
+ * the module. `undefined` when no link carried anything recognized.
+ */
+function classifyErrorChain(
+    chain: readonly object[],
+): TelemetryErrorClassification | undefined {
+    for (const node of chain) {
+        const classification = classifyNode(node);
+        if (classification !== undefined) {
+            return classification;
+        }
+    }
+    return undefined;
+}
+
+function classifyNode(node: object): TelemetryErrorClassification | undefined {
+    const explicit = readExplicitClassification(node);
+    const errorCode = explicit?.errorCode ?? readAllowlistedCode(node, "code");
+    const httpStatus = readHttpStatus(node);
+    const rule =
+        explicit?.rule ??
+        readNameRule(node) ??
+        (errorCode === undefined
+            ? undefined
+            : CATEGORY_BY_ERROR_CODE.get(errorCode)) ??
+        (httpStatus === undefined ? undefined : ruleForHttpStatus(httpStatus));
+    if (rule === undefined && errorCode === undefined) {
+        // Nothing on this link is evidence of anything. Keep walking rather
+        // than reporting an `internal` that a cause could have explained.
+        return undefined;
+    }
+    return {
+        errorCategory: rule?.category ?? "internal",
+        ...(errorCode === undefined ? {} : { errorCode }),
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+        ...(rule?.retryable === undefined ? {} : { retryable: rule.retryable }),
+    };
+}
+
+function readNameRule(node: object): CategoryRule | undefined {
+    const name = readStringProperty(node, "name");
+    return name === undefined ? undefined : CATEGORY_BY_ERROR_NAME.get(name);
+}
+
+/** Read a code from `key`, keeping it only if it is in the allowlist. */
+function readAllowlistedCode(
+    node: object,
+    key: "code" | "errorCode",
+): TelemetryErrorCode | undefined {
+    const code = readStringProperty(node, key);
+    return code !== undefined && TELEMETRY_ERROR_CODE_SET.has(code)
+        ? code
+        : undefined;
+}
+
+type ExplicitClassification = {
+    readonly rule?: CategoryRule;
+    readonly errorCode?: TelemetryErrorCode;
+};
+
+/**
+ * Read the classification a thrower declared on its own error type. Returns
+ * `undefined` when it declared neither a usable category nor an allowlisted
+ * code, so the link falls through to the platform signals.
+ */
+function readExplicitClassification(
+    node: object,
+): ExplicitClassification | undefined {
+    const errorCode = readAllowlistedCode(node, "errorCode");
+    const category = readStringProperty(node, "errorCategory");
+    if (category === undefined || !isTelemetryErrorCategory(category)) {
+        return errorCode === undefined ? undefined : { errorCode };
+    }
+    const retryable = readProperty(node, "retryable");
+    return {
+        rule: {
+            category,
+            ...(typeof retryable === "boolean" ? { retryable } : {}),
+        },
+        ...(errorCode === undefined ? {} : { errorCode }),
+    };
+}
+
+function isTelemetryErrorCategory(
+    value: string,
+): value is TelemetryErrorCategory {
+    return (TELEMETRY_ERROR_CATEGORIES as readonly string[]).includes(value);
+}
+
+function ruleForHttpStatus(status: number): CategoryRule {
+    const retryable = RETRYABLE_HTTP_STATUSES.has(status);
+    return { category: categoryForHttpStatus(status), retryable };
+}
+
+function categoryForHttpStatus(status: number): TelemetryErrorCategory {
+    switch (status) {
+        case 401:
+            return "authentication";
+        case 403:
+            return "authorization";
+        case 408:
+        case 504:
+            return "timeout";
+        case 429:
+            return "rate_limit";
+    }
+    // Only failure statuses reach here (see readOwnHttpStatus). The remaining
+    // 4xx codes all say the request itself was unacceptable; 5xx is the
+    // provider failing to serve an acceptable request.
+    return status < 500 ? "validation" : "provider";
+}
+
+/**
+ * Read an HTTP failure status off the node itself or off its `response`
+ * object (the shape most HTTP clients use). `cause` is deliberately not
+ * followed here: the chain walk already visits it as its own link, so
+ * following it would let a cause's status pre-empt that same cause's more
+ * specific `name`/`code`.
+ *
+ * Only a finite integer in the 400-599 range counts. A string `"429"` is
+ * ignored rather than coerced, and a 1xx/2xx/3xx value is ignored because it
+ * says nothing about a failure - `status` is also used as a non-HTTP enum
+ * elsewhere (a `child_process` exit code, for instance), and treating such a
+ * value as a signal would both fabricate an `httpStatus` and stop the cause
+ * walk before the real signal.
+ */
+function readHttpStatus(node: object): number | undefined {
+    const own = readOwnHttpStatus(node);
+    if (own !== undefined) {
+        return own;
+    }
+    const response = readProperty(node, "response");
+    return response !== null && typeof response === "object"
+        ? readOwnHttpStatus(response)
+        : undefined;
+}
+
+function readOwnHttpStatus(node: object): number | undefined {
+    for (const property of HTTP_STATUS_PROPERTIES) {
+        const value = readProperty(node, property);
+        if (typeof value === "number" && isHttpFailureStatus(value)) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+function isHttpFailureStatus(value: number): boolean {
+    return Number.isInteger(value) && value >= 400 && value <= 599;
+}

--- a/ts/packages/telemetry/src/otel/errorClassification.ts
+++ b/ts/packages/telemetry/src/otel/errorClassification.ts
@@ -2,61 +2,22 @@
 // Licensed under the MIT License.
 
 /**
- * Shared normalizer that turns an arbitrary thrown value into bounded,
- * low-cardinality structured fields that are safe to export.
+ * Turns an arbitrary thrown value into bounded, low-cardinality fields that
+ * are safe to export.
  *
- * Structured failure events need to answer "what kind of failure was this,
- * and is it worth retrying?" without carrying the original message, stack, or
- * any user content. This module produces exactly that: a closed
- * {@link TelemetryErrorCategory}, plus optional `errorCode`, `httpStatus`, and
- * `retryable` fields that are emitted only when they are actually known.
+ * Free-text messages are never parsed or exported: a message is the part of an
+ * error most likely to contain a prompt, path, or user request. Signals are
+ * only an explicit classification from the thrower, `error.name`,
+ * `error.code` (allowlisted), and an HTTP failure status (400-599).
  *
- * Classification never parses free-text messages. A message is the one part of
- * an error most likely to contain a prompt, a file path, or a user's request,
- * and matching on its wording is both a privacy hazard and fragile across
- * provider/library versions. The only inputs are:
+ * Precedence: the `cause` chain is walked outermost first and the first link
+ * carrying a recognized signal wins, with every reported field read from that
+ * same link, so a cause's `ECONNRESET` is never reported next to its wrapper's
+ * HTTP 401. Within a link: explicit, then name, then code, then status.
  *
- * 1. An explicit `errorCategory` (and optional `errorCode` / `retryable`) that
- *    the thrower attached - the opt-in extension point for a package that owns
- *    a typed error and knows how it should be classified.
- * 2. `error.name`, matched against a closed table of standard platform names
- *    (DOM, Node, undici).
- * 3. `error.code`, matched against {@link TELEMETRY_ERROR_CODES}, a closed
- *    reviewed allowlist. A code outside it is dropped rather than exported.
- * 4. An HTTP *failure* status (400-599) read from a small set of well-known
- *    numeric properties. A 1xx/2xx/3xx value is not evidence of a failure, and
- *    `status` is also used as a non-HTTP enum elsewhere (a `child_process`
- *    exit code, for instance), so those values are ignored rather than
- *    reported.
- *
- * ## Precedence
- *
- * Each error in the `cause` chain is examined in turn, outermost first, so a
- * `fetch` failure (`TypeError` wrapping a `cause` carrying `ECONNREFUSED`)
- * classifies as `network` rather than falling through. The **first link that
- * yields a recognized signal wins, and every reported field comes from that
- * one link**: category, code, status, and retryability then describe the same
- * error instead of being stitched together across links (a cause's
- * `ECONNRESET` must not be reported next to its wrapper's HTTP 401).
- *
- * Within the winning link the order is: an explicit classification from the
- * thrower, then `error.name`, then `error.code`, then an HTTP failure status.
- * A link carrying only an allowlisted code with no category rule still wins:
- * it reports that code with the `internal` category rather than dropping a
- * reviewed, useful code.
- *
- * Anything that yields no signal - a thrown string, a thrown object, or a
- * plain `Error` - becomes `internal` with no fabricated code, status, or
- * retryability. A caller that has its own truthful default for that case uses
- * {@link classifyTelemetryErrorIfRecognized} instead and gets `undefined`.
- *
- * ## Never throws
- *
- * A thrown value is hostile-shaped input: getters can throw, proxies trap
- * every operation, and a proxy can be revoked between two reads. Every
- * property access here is guarded and the entry point has a last-resort
- * fallback, so classifying a hostile error degrades to `internal` instead of
- * replacing the original failure with a telemetry one.
+ * Never throws - a thrown value is hostile-shaped input (throwing getters,
+ * revocable proxies), so classification must not replace the failure it was
+ * asked to describe.
  */
 
 export const TELEMETRY_ERROR_CATEGORIES = [
@@ -71,25 +32,21 @@ export const TELEMETRY_ERROR_CATEGORIES = [
     "internal",
 ] as const;
 
-/**
- * Closed set of failure categories. Low-cardinality by construction, so it is
- * safe as a metric dimension or a log/span attribute.
- */
+/** Closed, low-cardinality set: safe as a metric dimension or span attribute. */
 export type TelemetryErrorCategory =
     (typeof TELEMETRY_ERROR_CATEGORIES)[number];
 
 /**
- * A code that is allowed to leave the process: a member of
- * {@link TELEMETRY_ERROR_CODES}. Kept as a `string` alias rather than a
- * literal union so a package can declare a constant without importing a
- * generated type; the allowlist is the runtime authority either way.
+ * A code allowed to leave the process: a member of
+ * {@link TELEMETRY_ERROR_CODES}. A `string` alias rather than a literal union
+ * so a package can declare a constant without importing a generated type; the
+ * allowlist is the runtime authority either way.
  */
 export type TelemetryErrorCode = string;
 
 /**
- * The normalized, export-safe view of a failure. Only `errorCategory` is
- * always present; the optional fields are omitted rather than guessed when the
- * error carries no evidence for them.
+ * The export-safe view of a failure. Optional fields are omitted rather than
+ * guessed when the error carries no evidence for them.
  */
 export interface TelemetryErrorClassification {
     readonly errorCategory: TelemetryErrorCategory;
@@ -102,10 +59,9 @@ export interface TelemetryErrorClassification {
 }
 
 /**
- * The properties a package sets on its own error type to classify it without
- * this module having to know the type's name. `errorCategory` must be a member
- * of {@link TELEMETRY_ERROR_CATEGORIES} and `errorCode` a member of
- * {@link TELEMETRY_ERROR_CODES}; anything else is ignored.
+ * Properties a package sets on its own error type to classify it. Values
+ * outside {@link TELEMETRY_ERROR_CATEGORIES} / {@link TELEMETRY_ERROR_CODES}
+ * are ignored.
  */
 export interface TelemetryClassifiedError {
     readonly errorCategory: TelemetryErrorCategory;
@@ -120,10 +76,9 @@ type CategoryRule = {
 };
 
 /**
- * Standard platform error names. Deliberately limited to names defined by the
- * DOM, Node, or undici so this table does not become a registry of every
- * TypeAgent error type - a package with its own typed error attaches
- * `errorCategory` to it instead (see {@link TelemetryClassifiedError}).
+ * Standard platform error names (DOM, Node, undici) only. A package with its
+ * own typed error attaches `errorCategory` to it instead (see
+ * {@link TelemetryClassifiedError}).
  */
 const CATEGORY_BY_ERROR_NAME: ReadonlyMap<string, CategoryRule> = new Map([
     ["AbortError", { category: "cancelled", retryable: false }],
@@ -166,10 +121,8 @@ const CATEGORY_BY_ERROR_CODE: ReadonlyMap<string, CategoryRule> = new Map([
 ] as const);
 
 /**
- * Reviewed codes that are safe to export but say nothing about the category on
- * their own. Kept out of {@link CATEGORY_BY_ERROR_CODE} so the category tables
- * stay honest: these are reported as `errorCode` alongside whatever category
- * the rest of the link established, which is `internal` when nothing else did.
+ * Reviewed codes that are safe to export but imply no category on their own;
+ * reported alongside whatever category the rest of the link established.
  */
 const UNCATEGORIZED_ERROR_CODES = [
     "EACCES",
@@ -195,14 +148,11 @@ const UNCATEGORIZED_ERROR_CODES = [
 ] as const;
 
 /**
- * The closed, reviewed set of codes this module will ever export.
- *
- * A code becomes a log/metric label, so a shape check is not enough on its
- * own: a `code` that happens to be an identifier-shaped GUID, account name, or
- * API key passes any pattern and then either blows up label cardinality or
- * carries an identifier off the machine. Exporting only reviewed constants
- * bounds both. A package that needs its own code adds it here (one reviewed
- * line) and declares it through {@link TelemetryClassifiedError}.
+ * The closed set of codes this module will ever export. A code becomes a
+ * log/metric label, so a shape check is not enough: an identifier-shaped
+ * `code` (GUID, account name, key) would pass a pattern and then either blow
+ * up label cardinality or carry an identifier off the machine. Adding a code
+ * is a reviewed change here.
  */
 export const TELEMETRY_ERROR_CODES: readonly TelemetryErrorCode[] =
     Object.freeze([
@@ -223,9 +173,8 @@ const RETRYABLE_HTTP_STATUSES: ReadonlySet<number> = new Set([
 const HTTP_STATUS_PROPERTIES = ["status", "statusCode", "httpStatus"] as const;
 
 /**
- * How far the `cause` chain is walked. Deep enough for the wrapping that
- * `fetch`, undici, and the Azure SDKs actually do, shallow enough that a
- * hostile or accidental chain cannot turn classification into real work.
+ * How far the `cause` chain is walked - deep enough for the wrapping `fetch`,
+ * undici, and the Azure SDKs do, shallow enough to bound a hostile chain.
  */
 const MAX_CAUSE_DEPTH = 8;
 
@@ -234,10 +183,9 @@ const INTERNAL_CLASSIFICATION: TelemetryErrorClassification = Object.freeze({
 });
 
 /**
- * Normalize any thrown value into bounded, export-safe structured fields.
- * Never throws and never returns the original message, stack, or any other
- * free-text content. A value carrying no recognized signal is reported as
- * `internal`.
+ * Normalize any thrown value into bounded, export-safe fields. Never throws
+ * and never returns the message, stack, or any other free-text content. An
+ * unrecognized value is reported as `internal`.
  */
 export function classifyTelemetryError(
     error: unknown,
@@ -246,20 +194,13 @@ export function classifyTelemetryError(
 }
 
 /**
- * The same classification, except that a value carrying no recognized signal
- * yields `undefined` instead of `internal`.
+ * As {@link classifyTelemetryError}, but an unrecognized value yields
+ * `undefined` instead of `internal`.
  *
  * `internal` is a claim, not an absence: it says the failure came from our own
- * code. A caller that already knows something truer about the failure must not
- * have that claim written over its own. The transport turning a provider call
- * into a `Result` failure is the case that matters - `provider` is the honest
- * description of "the model call failed and nothing told us why", and
- * attaching `internal` to it would both mislabel the failure and pre-empt the
- * fallback the reporting layer would otherwise apply.
- *
- * Use this wherever a classification is *attached* to a value that already has
- * a meaningful default; use {@link classifyTelemetryError} where a category is
- * required and `internal` is the honest answer. Never throws.
+ * code. Use this where a classification is attached to a value whose caller
+ * already has a truer default (the transport reporting `provider` for a failed
+ * model call, say). Never throws.
  */
 export function classifyTelemetryErrorIfRecognized(
     error: unknown,
@@ -267,27 +208,19 @@ export function classifyTelemetryErrorIfRecognized(
     try {
         return classifyErrorChain(collectErrorChain(error));
     } catch {
-        // Defense in depth: every read below is already guarded, so reaching
-        // here means an assumption broke. A telemetry helper must still not
-        // replace the failure it was asked to describe.
+        // Every read below is already guarded; a telemetry helper must still
+        // never replace the failure it was asked to describe.
         return undefined;
     }
 }
 
 /**
- * Whether a failure should be reported as a cancellation.
- *
  * The single cancellation test for spans, structured events, and the model
- * wrapper, so a span status and the log record next to it cannot disagree
- * about the same failure. Two things make it a cancellation:
+ * wrapper, so a span status and the log record next to it cannot disagree.
  *
- * - The thrown value classifies as `cancelled`. This walks the `cause` chain,
- *   so an `AbortError` wrapped by a phase-level error still counts - a call
- *   site that only compared `error.name` would report a plain failure.
- * - `cancelledHint`, what the caller knows from outside the error: typically
- *   that the request's abort signal has fired. It stands on its own, because a
- *   cancellation frequently surfaces as an unrelated-looking failure (a
- *   provider socket error, a timeout) once the signal has torn the work down.
+ * `cancelledHint` (typically "the abort signal fired") stands on its own,
+ * because a cancellation often surfaces as an unrelated-looking failure once
+ * the signal has torn the work down.
  */
 export function isTelemetryCancellation(
     error: unknown,
@@ -300,10 +233,9 @@ export function isTelemetryCancellation(
 }
 
 /**
- * Classify an HTTP failure status directly, for a caller that holds the status
- * but no error object - a REST client turning a non-OK response into a typed
- * failure result, for instance. Returns `undefined` for a status that is not a
- * failure so the caller omits the classification rather than inventing one.
+ * Classify an HTTP failure status for a caller that holds a status but no
+ * error object. `undefined` for a non-failure status, so the caller omits the
+ * classification rather than inventing one.
  */
 export function classifyTelemetryHttpStatus(
     status: number,
@@ -320,12 +252,9 @@ export function classifyTelemetryHttpStatus(
 }
 
 /**
- * Where a classification is stashed on a value that is not itself an error.
- *
- * A registered symbol rather than a string key: it cannot collide with a
- * domain property, `JSON.stringify` and `Object.keys` skip it, and
- * `Symbol.for` resolves to the same symbol when two copies of this package are
- * loaded in one process.
+ * Where a classification is stashed on a non-error value. `Symbol.for` so it
+ * cannot collide with a domain property, is skipped by `JSON.stringify` and
+ * `Object.keys`, and resolves identically across two copies of this package.
  */
 const CLASSIFICATION_CARRIER = Symbol.for(
     "typeagent.telemetry.errorClassification",
@@ -334,18 +263,11 @@ const CLASSIFICATION_CARRIER = Symbol.for(
 /**
  * Record a classification on a value that reports failure without throwing.
  *
- * `typechat`'s `Result` failure is `{ success: false, message }` - a string
- * with no room for structure, so by the time a caller sees one, everything
- * that was known at the transport layer (the HTTP status, the socket error)
- * has been flattened into prose that telemetry must not parse. This lets the
- * layer that still has the facts attach them, and
- * {@link readTelemetryErrorClassification} lets the layer that reports
- * telemetry pick them back up.
- *
- * The property is non-enumerable, so it does not change spreads, `Object.keys`,
- * `JSON.stringify`, or deep-equality assertions on existing results. Returns
- * the same object and never throws: a frozen or exotic target simply carries
- * no classification.
+ * `typechat`'s `Result` failure is `{ success: false, message }`, so the facts
+ * known at the transport layer (HTTP status, socket error) are otherwise
+ * flattened into prose that telemetry must not parse. The property is
+ * non-enumerable, so spreads, `Object.keys`, and deep-equality assertions are
+ * unaffected. Returns the same object and never throws.
  */
 export function attachTelemetryErrorClassification<T extends object>(
     target: T,
@@ -366,9 +288,9 @@ export function attachTelemetryErrorClassification<T extends object>(
 
 /**
  * Read back a classification attached by
- * {@link attachTelemetryErrorClassification}. The stored value is re-validated
- * against the same closed vocabularies used for a thrown error, so a stale or
- * forged carrier cannot smuggle an unbounded field into an export.
+ * {@link attachTelemetryErrorClassification}. Re-validated against the same
+ * closed vocabularies, so a stale or forged carrier cannot smuggle an
+ * unbounded field into an export.
  */
 export function readTelemetryErrorClassification(
     value: unknown,
@@ -409,9 +331,8 @@ function sanitizeClassification(
 }
 
 /**
- * Read one property without trusting the object. A getter can throw, and a
- * proxy can trap (or have been revoked since the previous read), so every
- * access degrades to `undefined` instead of propagating.
+ * Read one property without trusting the object: a getter can throw and a
+ * proxy can be revoked between reads.
  */
 function readProperty(node: object, key: string): unknown {
     try {
@@ -428,9 +349,8 @@ function readStringProperty(node: object, key: string): string | undefined {
 
 /**
  * Flatten the `cause` chain (and the first entry of an `AggregateError`) into
- * an ordered list, outermost first. Bounded by {@link MAX_CAUSE_DEPTH} and
- * guarded by a visited set, so a self-referential or mutually-referential
- * chain terminates instead of recursing forever.
+ * an ordered list, outermost first. Bounded by {@link MAX_CAUSE_DEPTH} and a
+ * visited set so a cyclic chain terminates.
  */
 function collectErrorChain(error: unknown): readonly object[] {
     const chain: object[] = [];
@@ -444,9 +364,7 @@ function collectErrorChain(error: unknown): readonly object[] {
     ) {
         visited.add(current);
         chain.push(current);
-        // Stopping the walk must not discard the links already collected: an
-        // outer `AbortError` still classifies the failure even when the value
-        // hanging off it is unreadable.
+        // An unreadable `cause` must not discard the links already collected.
         try {
             current = nextInChain(current);
         } catch {
@@ -461,14 +379,11 @@ function nextInChain(node: object): unknown {
     if (cause !== undefined) {
         return cause;
     }
-    // Only the first aggregated error is followed. Walking all of them would
-    // make the cost unbounded, and the categories of sibling failures are
-    // usually the same anyway.
+    // Only the first aggregated error is followed, to keep the cost bounded.
     const errors = readProperty(node, "errors");
     try {
-        // `Array.isArray` is not a safe predicate: it throws on a revoked
-        // proxy rather than returning false. It and the index read are both
-        // inside the guard so an unreadable `errors` ends the walk instead.
+        // `Array.isArray` throws on a revoked proxy rather than returning
+        // false, so it and the index read are both inside the guard.
         return Array.isArray(errors) ? errors[0] : undefined;
     } catch {
         return undefined;
@@ -476,9 +391,8 @@ function nextInChain(node: object): unknown {
 }
 
 /**
- * Report the first link of the chain that carries a recognized signal, with
- * every field read from that link. See the precedence contract at the top of
- * the module. `undefined` when no link carried anything recognized.
+ * Report the first link carrying a recognized signal, with every field read
+ * from that link (see the precedence contract at the top of the module).
  */
 function classifyErrorChain(
     chain: readonly object[],
@@ -504,8 +418,8 @@ function classifyNode(node: object): TelemetryErrorClassification | undefined {
             : CATEGORY_BY_ERROR_CODE.get(errorCode)) ??
         (httpStatus === undefined ? undefined : ruleForHttpStatus(httpStatus));
     if (rule === undefined && errorCode === undefined) {
-        // Nothing on this link is evidence of anything. Keep walking rather
-        // than reporting an `internal` that a cause could have explained.
+        // Keep walking rather than reporting an `internal` that a cause could
+        // have explained.
         return undefined;
     }
     return {
@@ -538,7 +452,7 @@ type ExplicitClassification = {
 };
 
 /**
- * Read the classification a thrower declared on its own error type. Returns
+ * Read the classification a thrower declared on its own error type.
  * `undefined` when it declared neither a usable category nor an allowlisted
  * code, so the link falls through to the platform signals.
  */
@@ -583,25 +497,16 @@ function categoryForHttpStatus(status: number): TelemetryErrorCategory {
         case 429:
             return "rate_limit";
     }
-    // Only failure statuses reach here (see readOwnHttpStatus). The remaining
-    // 4xx codes all say the request itself was unacceptable; 5xx is the
-    // provider failing to serve an acceptable request.
+    // Only failure statuses reach here: the remaining 4xx say the request was
+    // unacceptable, 5xx is the provider failing an acceptable request.
     return status < 500 ? "validation" : "provider";
 }
 
 /**
- * Read an HTTP failure status off the node itself or off its `response`
- * object (the shape most HTTP clients use). `cause` is deliberately not
- * followed here: the chain walk already visits it as its own link, so
- * following it would let a cause's status pre-empt that same cause's more
+ * Read an HTTP failure status off the node or its `response`. `cause` is
+ * deliberately not followed: the chain walk visits it as its own link, so
+ * following it here would let a cause's status pre-empt that same cause's more
  * specific `name`/`code`.
- *
- * Only a finite integer in the 400-599 range counts. A string `"429"` is
- * ignored rather than coerced, and a 1xx/2xx/3xx value is ignored because it
- * says nothing about a failure - `status` is also used as a non-HTTP enum
- * elsewhere (a `child_process` exit code, for instance), and treating such a
- * value as a signal would both fabricate an `httpStatus` and stop the cause
- * walk before the real signal.
  */
 function readHttpStatus(node: object): number | undefined {
     const own = readOwnHttpStatus(node);

--- a/ts/packages/telemetry/src/otel/index.ts
+++ b/ts/packages/telemetry/src/otel/index.ts
@@ -124,3 +124,18 @@ export {
     isStructuredLoggingEnabled,
     setStructuredLoggingEnabled,
 } from "./structuredLogging.js";
+
+export {
+    attachTelemetryErrorClassification,
+    classifyTelemetryError,
+    classifyTelemetryErrorIfRecognized,
+    classifyTelemetryHttpStatus,
+    isTelemetryCancellation,
+    readTelemetryErrorClassification,
+    TELEMETRY_ERROR_CATEGORIES,
+    TELEMETRY_ERROR_CODES,
+    type TelemetryClassifiedError,
+    type TelemetryErrorCategory,
+    type TelemetryErrorClassification,
+    type TelemetryErrorCode,
+} from "./errorClassification.js";

--- a/ts/packages/telemetry/test/errorClassification.spec.ts
+++ b/ts/packages/telemetry/test/errorClassification.spec.ts
@@ -1,0 +1,858 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    attachTelemetryErrorClassification,
+    classifyTelemetryError,
+    classifyTelemetryErrorIfRecognized,
+    classifyTelemetryHttpStatus,
+    isTelemetryCancellation,
+    readTelemetryErrorClassification,
+    TELEMETRY_ERROR_CODES,
+    type TelemetryErrorClassification,
+} from "../src/otel/errorClassification.js";
+
+// `Error`'s `cause` option is ES2022; the repo compiles against ES2021 libs,
+// so the tests attach `cause` (and the other structured properties they
+// exercise) explicitly.
+function errorWith<T extends object>(
+    message: string,
+    properties: T,
+): Error & T {
+    return Object.assign(new Error(message), properties);
+}
+
+/** An object whose every property read throws, as a hostile error would. */
+function hostileObject(): object {
+    return new Proxy(
+        {},
+        {
+            get(_target, property) {
+                throw new Error(`no reads allowed: ${String(property)}`);
+            },
+            has() {
+                throw new Error("no `in` allowed");
+            },
+            ownKeys() {
+                throw new Error("no enumeration allowed");
+            },
+        },
+    );
+}
+
+describe("classifyTelemetryError", () => {
+    describe("typed and named errors", () => {
+        it("maps standard platform error names", () => {
+            expect(
+                classifyTelemetryError(
+                    new DOMException(
+                        "The operation was aborted.",
+                        "AbortError",
+                    ),
+                ),
+            ).toEqual({ errorCategory: "cancelled", retryable: false });
+
+            const timeout = new Error("private endpoint detail");
+            timeout.name = "TimeoutError";
+            expect(classifyTelemetryError(timeout)).toEqual({
+                errorCategory: "timeout",
+                retryable: true,
+            });
+
+            const undici = new Error("private endpoint detail");
+            undici.name = "ConnectTimeoutError";
+            expect(classifyTelemetryError(undici)).toEqual({
+                errorCategory: "timeout",
+                retryable: true,
+            });
+        });
+
+        it("leaves an unrecognized name unclassified", () => {
+            const error = new Error("private message");
+            error.name = "SomeAgentSpecificError";
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "internal",
+            });
+        });
+
+        it("honors an explicit classification attached by the thrower", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        errorCategory: "provider",
+                        retryable: false,
+                    }),
+                ),
+            ).toEqual({ errorCategory: "provider", retryable: false });
+        });
+
+        it("honors an explicit code from the reviewed allowlist", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        errorCategory: "validation",
+                        errorCode: "ERR_INVALID_URL",
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "validation",
+                errorCode: "ERR_INVALID_URL",
+            });
+        });
+
+        it("ignores an explicit category outside the closed union", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        errorCategory: "catastrophe",
+                        retryable: true,
+                    }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+        });
+
+        it("omits retryable when the thrower did not state it", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        errorCategory: "validation",
+                    }),
+                ),
+            ).toEqual({ errorCategory: "validation" });
+        });
+    });
+
+    describe("codes", () => {
+        const codeCases: readonly [string, string, boolean][] = [
+            ["ECONNREFUSED", "network", true],
+            ["EAI_AGAIN", "network", true],
+            ["ETIMEDOUT", "timeout", true],
+            ["UND_ERR_HEADERS_TIMEOUT", "timeout", true],
+            ["ABORT_ERR", "cancelled", false],
+            ["CERT_HAS_EXPIRED", "network", false],
+        ];
+
+        it("maps standard platform codes", () => {
+            for (const [code, errorCategory, retryable] of codeCases) {
+                expect(
+                    classifyTelemetryError(
+                        errorWith("private message", { code }),
+                    ),
+                ).toEqual({ errorCategory, errorCode: code, retryable });
+            }
+        });
+
+        it("reports an allowlisted code that implies no category", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", { code: "ENOENT" }),
+                ),
+            ).toEqual({ errorCategory: "internal", errorCode: "ENOENT" });
+        });
+    });
+
+    describe("HTTP status", () => {
+        const statusCases: readonly [number, string, boolean][] = [
+            [400, "validation", false],
+            [401, "authentication", false],
+            [403, "authorization", false],
+            [404, "validation", false],
+            [408, "timeout", true],
+            [422, "validation", false],
+            [429, "rate_limit", true],
+            [500, "provider", true],
+            [503, "provider", true],
+            [504, "timeout", true],
+        ];
+
+        it("maps status codes to categories and retryability", () => {
+            for (const [status, errorCategory, retryable] of statusCases) {
+                expect(
+                    classifyTelemetryError(
+                        errorWith("private message", { status }),
+                    ),
+                ).toEqual({ errorCategory, httpStatus: status, retryable });
+            }
+        });
+
+        it("classifies a bare status the same way", () => {
+            for (const [status, errorCategory, retryable] of statusCases) {
+                expect(classifyTelemetryHttpStatus(status)).toEqual({
+                    errorCategory,
+                    httpStatus: status,
+                    retryable,
+                });
+            }
+        });
+
+        it("reports nothing for a status that is not a failure", () => {
+            for (const status of [0, 100, 200, 304, 143, 600, 429.5]) {
+                expect(classifyTelemetryHttpStatus(status)).toBeUndefined();
+            }
+        });
+
+        it("reads the status off a response object", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        response: { status: 429 },
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            });
+        });
+
+        it("never coerces a non-numeric or non-failure status", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", { status: "429" }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", { statusCode: 42 }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+            // 1xx/2xx/3xx say nothing about a failure, and `status` is used as
+            // a non-HTTP enum elsewhere (a child_process exit code, say).
+            for (const status of [100, 200, 304, 143]) {
+                expect(
+                    classifyTelemetryError(
+                        errorWith("private message", { status }),
+                    ),
+                ).toEqual({ errorCategory: "internal" });
+            }
+        });
+
+        it("does not let a non-failure status hide the real signal", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        status: 200,
+                        cause: errorWith("inner", { code: "ECONNREFUSED" }),
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "network",
+                errorCode: "ECONNREFUSED",
+                retryable: true,
+            });
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        status: 143,
+                        cause: new DOMException(
+                            "The operation was aborted.",
+                            "AbortError",
+                        ),
+                    }),
+                ),
+            ).toEqual({ errorCategory: "cancelled", retryable: false });
+        });
+    });
+
+    // The reported fields must describe one error, not a mixture: a cause's
+    // code next to its wrapper's HTTP status would read as a coherent failure
+    // that never happened.
+    describe("precedence", () => {
+        it("prefers a code over a status carried on the same error", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        code: "ECONNRESET",
+                        status: 500,
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "network",
+                errorCode: "ECONNRESET",
+                httpStatus: 500,
+                retryable: true,
+            });
+        });
+
+        it("prefers a name over a code carried on the same error", () => {
+            const error = errorWith("private message", { code: "ECONNRESET" });
+            error.name = "TimeoutError";
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "timeout",
+                errorCode: "ECONNRESET",
+                retryable: true,
+            });
+        });
+
+        it("prefers the thrower's classification over every platform signal", () => {
+            const error = errorWith("private message", {
+                errorCategory: "authorization",
+                retryable: false,
+                code: "ECONNRESET",
+                status: 500,
+            });
+            error.name = "TimeoutError";
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "authorization",
+                errorCode: "ECONNRESET",
+                httpStatus: 500,
+                retryable: false,
+            });
+        });
+
+        it("never mixes fields from different links of the chain", () => {
+            // The wrapper's 401 wins, so the cause's ECONNRESET is not
+            // reported alongside it: the two describe different failures.
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", {
+                        status: 401,
+                        cause: errorWith("inner", { code: "ECONNRESET" }),
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "authentication",
+                httpStatus: 401,
+                retryable: false,
+            });
+        });
+
+        it("takes every field from the first link that carries a signal", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("outer with nothing to say", {
+                        cause: errorWith("inner", {
+                            code: "ECONNRESET",
+                            status: 503,
+                        }),
+                    }),
+                ),
+            ).toEqual({
+                errorCategory: "network",
+                errorCode: "ECONNRESET",
+                httpStatus: 503,
+                retryable: true,
+            });
+        });
+    });
+
+    // A code becomes a log/metric label. Only reviewed constants may leave the
+    // process, so an identifier-shaped value cannot ride out as one.
+    describe("error code bounds", () => {
+        it("drops every code outside the reviewed allowlist", () => {
+            const rejected = [
+                "rate limit exceeded for user bob@example.com",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "550E8400E29B41D4A716446655440000",
+                "user_3f8a2b1c",
+                "bob@example.com",
+                "sk-ABCDEF0123456789",
+                "AKIAIOSFODNN7EXAMPLE",
+                "ERR_BAD_REQUEST",
+                "E_CUSTOM_AGENT_FAILURE",
+                "429",
+                "",
+                "a".repeat(65),
+                "  ETIMEDOUT",
+                "etimedout",
+            ];
+            for (const code of rejected) {
+                expect(
+                    classifyTelemetryError(
+                        errorWith("private message", { code }),
+                    ).errorCode,
+                ).toBeUndefined();
+                expect(
+                    classifyTelemetryError(
+                        errorWith("private message", {
+                            errorCategory: "provider",
+                            errorCode: code,
+                        }),
+                    ).errorCode,
+                ).toBeUndefined();
+            }
+        });
+
+        it("ignores a numeric code such as the legacy DOMException code", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("private message", { code: 20 }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+        });
+
+        it("keeps the allowlist small and shaped like an enum", () => {
+            // The bound is the point: a code is a label dimension, so the
+            // whole vocabulary has to stay reviewable and low-cardinality.
+            expect(TELEMETRY_ERROR_CODES.length).toBeLessThanOrEqual(64);
+            expect(new Set(TELEMETRY_ERROR_CODES).size).toBe(
+                TELEMETRY_ERROR_CODES.length,
+            );
+            for (const code of TELEMETRY_ERROR_CODES) {
+                expect(code).toMatch(/^[A-Z][A-Z0-9_]{1,39}$/);
+            }
+        });
+    });
+
+    describe("cause traversal", () => {
+        it("classifies from the cause when the wrapper says nothing", () => {
+            const error = errorWith("fetch failed", {
+                cause: errorWith("private message", {
+                    code: "ECONNREFUSED",
+                }),
+            });
+            error.name = "TypeError";
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "network",
+                errorCode: "ECONNREFUSED",
+                retryable: true,
+            });
+        });
+
+        it("follows the first error of an AggregateError", () => {
+            expect(
+                classifyTelemetryError(
+                    new AggregateError(
+                        [
+                            errorWith("private message", { status: 429 }),
+                            new Error("second"),
+                        ],
+                        "all failed",
+                    ),
+                ),
+            ).toEqual({
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            });
+        });
+
+        it("terminates on a self-referential cause", () => {
+            const error = new Error("private message") as unknown as Record<
+                string,
+                unknown
+            >;
+            error.cause = error;
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "internal",
+            });
+        });
+
+        it("terminates on a mutually-referential cause cycle", () => {
+            const first = new Error("first") as unknown as Record<
+                string,
+                unknown
+            >;
+            const second = errorWith("second", {
+                code: "ECONNRESET",
+            }) as unknown as Record<string, unknown>;
+            first.cause = second;
+            second.cause = first;
+            expect(classifyTelemetryError(first)).toEqual({
+                errorCategory: "network",
+                errorCode: "ECONNRESET",
+                retryable: true,
+            });
+        });
+
+        it("stops walking a chain longer than the depth bound", () => {
+            // The only signal sits past the bound, so it is never reached: the
+            // classification stays honest rather than paying unbounded cost.
+            let error: Error = errorWith("deep", { code: "ECONNREFUSED" });
+            for (let index = 0; index < 20; index++) {
+                error = errorWith(`wrapper ${index}`, { cause: error });
+            }
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "internal",
+            });
+        });
+    });
+
+    // Classification runs on a value the process did not construct, so every
+    // read has to survive a getter that throws or a proxy that traps.
+    describe("hostile values", () => {
+        it("survives an error whose every property read throws", () => {
+            expect(classifyTelemetryError(hostileObject())).toEqual({
+                errorCategory: "internal",
+            });
+        });
+
+        it("survives a throwing getter on each classification input", () => {
+            const throwing = ["name", "code", "errorCategory", "errorCode"];
+            for (const property of throwing) {
+                const error = new Error("private message");
+                Object.defineProperty(error, property, {
+                    get() {
+                        throw new Error(`${property} is hostile`);
+                    },
+                    configurable: true,
+                });
+                expect(classifyTelemetryError(error)).toEqual({
+                    errorCategory: "internal",
+                });
+            }
+        });
+
+        it("survives throwing status, response, retryable, and cause getters", () => {
+            const error = errorWith("private message", {
+                code: "ECONNRESET",
+                errorCategory: "provider",
+            });
+            for (const property of [
+                "status",
+                "statusCode",
+                "httpStatus",
+                "response",
+                "retryable",
+                "cause",
+                "errors",
+            ]) {
+                Object.defineProperty(error, property, {
+                    get() {
+                        throw new Error(`${property} is hostile`);
+                    },
+                    configurable: true,
+                });
+            }
+            expect(classifyTelemetryError(error)).toEqual({
+                errorCategory: "provider",
+                errorCode: "ECONNRESET",
+            });
+        });
+
+        it("survives a hostile value in the cause chain", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("outer", { cause: hostileObject() }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+            expect(
+                classifyTelemetryError(
+                    errorWith("outer", {
+                        cause: errorWith("middle", {
+                            cause: hostileObject(),
+                        }),
+                    }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+        });
+
+        it("survives a revoked proxy", () => {
+            const revocable = Proxy.revocable(
+                errorWith("private message", { code: "ECONNRESET" }),
+                {},
+            );
+            revocable.revoke();
+            expect(classifyTelemetryError(revocable.proxy)).toEqual({
+                errorCategory: "internal",
+            });
+            expect(
+                classifyTelemetryError(
+                    errorWith("outer", { cause: revocable.proxy }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+        });
+
+        it("survives an AggregateError whose errors array traps reads", () => {
+            const errors = new Proxy([new Error("inner")], {
+                get(target, property) {
+                    if (property === "0") {
+                        throw new Error("index read is hostile");
+                    }
+                    return Reflect.get(target, property);
+                },
+            });
+            expect(
+                classifyTelemetryError(errorWith("aggregate", { errors })),
+            ).toEqual({ errorCategory: "internal" });
+        });
+
+        it("keeps a link it already classified when the walk cannot continue", () => {
+            // `Array.isArray` throws on a revoked proxy rather than returning
+            // false, so an unreadable `errors` must end the walk without
+            // discarding the outer link that already carried the signal.
+            const revocable = Proxy.revocable([new Error("inner")], {});
+            revocable.revoke();
+            const cancelled = errorWith("aborted by user", {
+                errors: revocable.proxy,
+            });
+            cancelled.name = "AbortError";
+            expect(classifyTelemetryError(cancelled)).toEqual({
+                errorCategory: "cancelled",
+                retryable: false,
+            });
+
+            const throttled = errorWith("throttled", {
+                status: 429,
+                errors: revocable.proxy,
+            });
+            expect(classifyTelemetryError(throttled)).toEqual({
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            });
+        });
+
+        it("survives an AggregateError carrying a hostile first entry", () => {
+            expect(
+                classifyTelemetryError(
+                    errorWith("aggregate", { errors: [hostileObject()] }),
+                ),
+            ).toEqual({ errorCategory: "internal" });
+        });
+    });
+
+    describe("unknown throws", () => {
+        const unknownThrows: readonly unknown[] = [
+            "boom: user said hello",
+            undefined,
+            null,
+            42,
+            { message: "user said hello" },
+            new Error("user said hello"),
+            Object.create(null),
+        ];
+
+        it("classifies unknown throws as internal without inventing fields", () => {
+            for (const value of unknownThrows) {
+                const classification: TelemetryErrorClassification =
+                    classifyTelemetryError(value);
+                expect(classification).toEqual({ errorCategory: "internal" });
+            }
+        });
+
+        it("never returns the original message or stack", () => {
+            const classification = classifyTelemetryError(
+                new Error("secret user request text"),
+            );
+            expect(Object.keys(classification)).toEqual(["errorCategory"]);
+            expect(JSON.stringify(classification)).not.toContain("secret");
+        });
+    });
+});
+
+// The difference between "we recognized nothing" and "this was internal".
+// A caller that attaches a classification to a value with its own truthful
+// default needs the first; a caller that must report a category needs the
+// second.
+describe("classifyTelemetryErrorIfRecognized", () => {
+    it("reports nothing for a value carrying no recognized signal", () => {
+        for (const value of [
+            "boom: user said hello",
+            undefined,
+            null,
+            42,
+            { message: "user said hello" },
+            new Error("user said hello"),
+            new TypeError("fetch failed"),
+            hostileObject(),
+        ]) {
+            expect(classifyTelemetryErrorIfRecognized(value)).toBeUndefined();
+            // The same value still classifies as `internal` where a category
+            // is required.
+            expect(classifyTelemetryError(value)).toEqual({
+                errorCategory: "internal",
+            });
+        }
+    });
+
+    it("agrees with classifyTelemetryError whenever anything was recognized", () => {
+        const recognized: readonly unknown[] = [
+            new DOMException("The operation was aborted.", "AbortError"),
+            errorWith("private endpoint detail", { code: "ECONNREFUSED" }),
+            errorWith("throttled", { status: 429 }),
+            errorWith("fetch failed", {
+                cause: errorWith("connect", { code: "ECONNRESET" }),
+            }),
+            errorWith("typed", { errorCategory: "provider", retryable: false }),
+        ];
+        for (const value of recognized) {
+            const classification = classifyTelemetryErrorIfRecognized(value);
+            expect(classification).toBeDefined();
+            expect(classification).toEqual(classifyTelemetryError(value));
+        }
+    });
+
+    it("reports an allowlisted code with no category rule as internal, not as unrecognized", () => {
+        // A reviewed code is a signal even when it says nothing about the
+        // category, so it is reported rather than dropped.
+        const enoent = errorWith("private path detail", { code: "ENOENT" });
+        expect(classifyTelemetryErrorIfRecognized(enoent)).toEqual({
+            errorCategory: "internal",
+            errorCode: "ENOENT",
+        });
+    });
+});
+
+// One cancellation test for spans, structured events, and the LLM wrapper, so
+// a span status and the log record beside it cannot disagree.
+describe("isTelemetryCancellation", () => {
+    it("recognizes a cancellation wrapped inside a phase-level error", () => {
+        const wrapped = errorWith("translation failed", {
+            cause: new DOMException("The operation was aborted.", "AbortError"),
+        });
+        // What a call site comparing `error.name` would have seen.
+        expect(wrapped.name).toBe("Error");
+        expect(isTelemetryCancellation(wrapped)).toBe(true);
+    });
+
+    it("honors a hint the thrown value cannot carry", () => {
+        // Signal-only: the work was torn down, and what surfaced is whatever
+        // the provider was in the middle of.
+        expect(isTelemetryCancellation(new Error("socket hang up"), true)).toBe(
+            true,
+        );
+        expect(isTelemetryCancellation(undefined, true)).toBe(true);
+    });
+
+    it("does not treat an ordinary failure as cancelled", () => {
+        expect(isTelemetryCancellation(new Error("boom"))).toBe(false);
+        expect(isTelemetryCancellation(new Error("boom"), false)).toBe(false);
+        expect(
+            isTelemetryCancellation(errorWith("throttled", { status: 429 })),
+        ).toBe(false);
+        expect(isTelemetryCancellation(undefined)).toBe(false);
+    });
+
+    it("never throws on a hostile value", () => {
+        expect(isTelemetryCancellation(hostileObject())).toBe(false);
+    });
+});
+
+describe("classification carrier", () => {
+    it("round-trips a classification through a failure result", () => {
+        const result = attachTelemetryErrorClassification(
+            { success: false as const, message: "429: secret tenant detail" },
+            { errorCategory: "rate_limit", httpStatus: 429, retryable: true },
+        );
+        expect(readTelemetryErrorClassification(result)).toEqual({
+            errorCategory: "rate_limit",
+            httpStatus: 429,
+            retryable: true,
+        });
+    });
+
+    it("stays invisible to existing consumers of the result", () => {
+        const result = attachTelemetryErrorClassification(
+            { success: false as const, message: "failed" },
+            { errorCategory: "network", retryable: true },
+        );
+        expect(result).toEqual({ success: false, message: "failed" });
+        expect(Object.keys(result)).toEqual(["success", "message"]);
+        expect(JSON.parse(JSON.stringify(result))).toEqual({
+            success: false,
+            message: "failed",
+        });
+    });
+
+    it("reports nothing for a value that carries no classification", () => {
+        for (const value of [
+            undefined,
+            null,
+            "failed",
+            { success: false, message: "failed" },
+        ]) {
+            expect(readTelemetryErrorClassification(value)).toBeUndefined();
+        }
+    });
+
+    it("re-validates the carrier against the same closed vocabularies", () => {
+        const forged = attachTelemetryErrorClassification({}, {
+            errorCategory: "catastrophe",
+        } as unknown as TelemetryErrorClassification);
+        expect(readTelemetryErrorClassification(forged)).toBeUndefined();
+
+        const partlyForged = attachTelemetryErrorClassification({}, {
+            errorCategory: "provider",
+            errorCode: "tenant-8f14e45f",
+            httpStatus: 200,
+            retryable: "yes",
+        } as unknown as TelemetryErrorClassification);
+        expect(readTelemetryErrorClassification(partlyForged)).toEqual({
+            errorCategory: "provider",
+        });
+    });
+
+    it("never throws on a frozen target or a hostile read", () => {
+        const frozen = Object.freeze({ success: false as const, message: "x" });
+        expect(() =>
+            attachTelemetryErrorClassification(frozen, {
+                errorCategory: "internal",
+            }),
+        ).not.toThrow();
+        expect(readTelemetryErrorClassification(frozen)).toBeUndefined();
+        expect(
+            readTelemetryErrorClassification(hostileObject()),
+        ).toBeUndefined();
+    });
+});
+
+// The classifier is published on its own as
+// `@typeagent/telemetry/errorClassification` so browser-shared code can use it
+// without pulling in the Node-only telemetry composition root. A Node builtin
+// appearing here would either force a Node-only dependency into a browser
+// bundle or break bundling on an unresolvable `node:*` import.
+describe("browser-safe errorClassification boundary", () => {
+    const otelSrcDir = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../src/otel",
+    );
+
+    const NODE_BUILTINS = new Set([
+        "assert",
+        "async_hooks",
+        "buffer",
+        "child_process",
+        "crypto",
+        "dns",
+        "events",
+        "fs",
+        "http",
+        "https",
+        "module",
+        "net",
+        "os",
+        "path",
+        "perf_hooks",
+        "process",
+        "stream",
+        "timers",
+        "tls",
+        "url",
+        "util",
+        "v8",
+        "vm",
+        "worker_threads",
+        "zlib",
+    ]);
+
+    function isNodeBuiltin(specifier: string): boolean {
+        return (
+            specifier.startsWith("node:") ||
+            NODE_BUILTINS.has(specifier.split("/")[0]!)
+        );
+    }
+
+    // `from "x"`, bare `import "x"`, and `import("x")`. Deliberately crude:
+    // over-matching (a specifier quoted in a comment, say) can only make this
+    // check stricter, never weaker.
+    const SPECIFIER = /(?:\bfrom\s*|\bimport\s*\(?\s*)["']([^"']+)["']/g;
+
+    it("imports no Node builtin and reaches no other module", async () => {
+        const source = await readFile(
+            path.join(otelSrcDir, "errorClassification.ts"),
+            "utf8",
+        );
+        const specifiers = [...source.matchAll(SPECIFIER)].map(
+            ([, specifier]) => specifier!,
+        );
+        expect(specifiers.filter(isNodeBuiltin)).toEqual([]);
+        // It imports nothing at all today. Asserting that keeps the check
+        // above complete: a relative import would need its own graph walk
+        // before this file could still be called browser-safe.
+        expect(specifiers).toEqual([]);
+    });
+});

--- a/ts/packages/telemetry/test/errorClassification.spec.ts
+++ b/ts/packages/telemetry/test/errorClassification.spec.ts
@@ -16,8 +16,7 @@ import {
 } from "../src/otel/errorClassification.js";
 
 // `Error`'s `cause` option is ES2022; the repo compiles against ES2021 libs,
-// so the tests attach `cause` (and the other structured properties they
-// exercise) explicitly.
+// so the tests attach `cause` explicitly.
 function errorWith<T extends object>(
     message: string,
     properties: T,
@@ -257,9 +256,7 @@ describe("classifyTelemetryError", () => {
         });
     });
 
-    // The reported fields must describe one error, not a mixture: a cause's
-    // code next to its wrapper's HTTP status would read as a coherent failure
-    // that never happened.
+    // The reported fields must describe one error, not a mixture.
     describe("precedence", () => {
         it("prefers a code over a status carried on the same error", () => {
             expect(
@@ -305,7 +302,7 @@ describe("classifyTelemetryError", () => {
 
         it("never mixes fields from different links of the chain", () => {
             // The wrapper's 401 wins, so the cause's ECONNRESET is not
-            // reported alongside it: the two describe different failures.
+            // reported alongside it.
             expect(
                 classifyTelemetryError(
                     errorWith("private message", {
@@ -339,8 +336,8 @@ describe("classifyTelemetryError", () => {
         });
     });
 
-    // A code becomes a log/metric label. Only reviewed constants may leave the
-    // process, so an identifier-shaped value cannot ride out as one.
+    // A code becomes a log/metric label, so only reviewed constants may leave
+    // the process.
     describe("error code bounds", () => {
         it("drops every code outside the reviewed allowlist", () => {
             const rejected = [
@@ -385,8 +382,8 @@ describe("classifyTelemetryError", () => {
         });
 
         it("keeps the allowlist small and shaped like an enum", () => {
-            // The bound is the point: a code is a label dimension, so the
-            // whole vocabulary has to stay reviewable and low-cardinality.
+            // A code is a label dimension, so the vocabulary has to stay
+            // reviewable and low-cardinality.
             expect(TELEMETRY_ERROR_CODES.length).toBeLessThanOrEqual(64);
             expect(new Set(TELEMETRY_ERROR_CODES).size).toBe(
                 TELEMETRY_ERROR_CODES.length,
@@ -459,8 +456,7 @@ describe("classifyTelemetryError", () => {
         });
 
         it("stops walking a chain longer than the depth bound", () => {
-            // The only signal sits past the bound, so it is never reached: the
-            // classification stays honest rather than paying unbounded cost.
+            // The only signal sits past the bound, so it is never reached.
             let error: Error = errorWith("deep", { code: "ECONNREFUSED" });
             for (let index = 0; index < 20; index++) {
                 error = errorWith(`wrapper ${index}`, { cause: error });
@@ -472,7 +468,7 @@ describe("classifyTelemetryError", () => {
     });
 
     // Classification runs on a value the process did not construct, so every
-    // read has to survive a getter that throws or a proxy that traps.
+    // read has to survive a throwing getter or a trapping proxy.
     describe("hostile values", () => {
         it("survives an error whose every property read throws", () => {
             expect(classifyTelemetryError(hostileObject())).toEqual({
@@ -572,8 +568,7 @@ describe("classifyTelemetryError", () => {
 
         it("keeps a link it already classified when the walk cannot continue", () => {
             // `Array.isArray` throws on a revoked proxy rather than returning
-            // false, so an unreadable `errors` must end the walk without
-            // discarding the outer link that already carried the signal.
+            // false, so an unreadable `errors` must not discard the outer link.
             const revocable = Proxy.revocable([new Error("inner")], {});
             revocable.revoke();
             const cancelled = errorWith("aborted by user", {
@@ -635,9 +630,6 @@ describe("classifyTelemetryError", () => {
 });
 
 // The difference between "we recognized nothing" and "this was internal".
-// A caller that attaches a classification to a value with its own truthful
-// default needs the first; a caller that must report a category needs the
-// second.
 describe("classifyTelemetryErrorIfRecognized", () => {
     it("reports nothing for a value carrying no recognized signal", () => {
         for (const value of [
@@ -651,8 +643,6 @@ describe("classifyTelemetryErrorIfRecognized", () => {
             hostileObject(),
         ]) {
             expect(classifyTelemetryErrorIfRecognized(value)).toBeUndefined();
-            // The same value still classifies as `internal` where a category
-            // is required.
             expect(classifyTelemetryError(value)).toEqual({
                 errorCategory: "internal",
             });
@@ -677,8 +667,6 @@ describe("classifyTelemetryErrorIfRecognized", () => {
     });
 
     it("reports an allowlisted code with no category rule as internal, not as unrecognized", () => {
-        // A reviewed code is a signal even when it says nothing about the
-        // category, so it is reported rather than dropped.
         const enoent = errorWith("private path detail", { code: "ENOENT" });
         expect(classifyTelemetryErrorIfRecognized(enoent)).toEqual({
             errorCategory: "internal",
@@ -700,8 +688,7 @@ describe("isTelemetryCancellation", () => {
     });
 
     it("honors a hint the thrown value cannot carry", () => {
-        // Signal-only: the work was torn down, and what surfaced is whatever
-        // the provider was in the middle of.
+        // Signal-only: the thrown value says nothing about the cancellation.
         expect(isTelemetryCancellation(new Error("socket hang up"), true)).toBe(
             true,
         );
@@ -790,11 +777,9 @@ describe("classification carrier", () => {
     });
 });
 
-// The classifier is published on its own as
-// `@typeagent/telemetry/errorClassification` so browser-shared code can use it
-// without pulling in the Node-only telemetry composition root. A Node builtin
-// appearing here would either force a Node-only dependency into a browser
-// bundle or break bundling on an unresolvable `node:*` import.
+// The classifier is published as `@typeagent/telemetry/errorClassification` so
+// browser-shared code can use it; a Node builtin here would force a Node-only
+// dependency into a browser bundle or break bundling outright.
 describe("browser-safe errorClassification boundary", () => {
     const otelSrcDir = path.resolve(
         path.dirname(fileURLToPath(import.meta.url)),
@@ -836,9 +821,8 @@ describe("browser-safe errorClassification boundary", () => {
         );
     }
 
-    // `from "x"`, bare `import "x"`, and `import("x")`. Deliberately crude:
-    // over-matching (a specifier quoted in a comment, say) can only make this
-    // check stricter, never weaker.
+    // `from "x"`, bare `import "x"`, and `import("x")`. Crude on purpose:
+    // over-matching can only make this check stricter, never weaker.
     const SPECIFIER = /(?:\bfrom\s*|\bimport\s*\(?\s*)["']([^"']+)["']/g;
 
     it("imports no Node builtin and reaches no other module", async () => {
@@ -850,9 +834,8 @@ describe("browser-safe errorClassification boundary", () => {
             ([, specifier]) => specifier!,
         );
         expect(specifiers.filter(isNodeBuiltin)).toEqual([]);
-        // It imports nothing at all today. Asserting that keeps the check
-        // above complete: a relative import would need its own graph walk
-        // before this file could still be called browser-safe.
+        // It imports nothing at all today; a relative import would need its
+        // own graph walk before the check above stayed complete.
         expect(specifiers).toEqual([]);
     });
 });

--- a/ts/packages/telemetry/test/structuredLogMessage.spec.ts
+++ b/ts/packages/telemetry/test/structuredLogMessage.spec.ts
@@ -136,7 +136,7 @@ describe("getStructuredLogMessage", () => {
                 httpStatus: 429,
                 retryable: true,
                 // Present in the raw event for the private diagnostic sinks;
-                // the rendered message must not reach for any of it.
+                // never rendered.
                 request: "play some private music",
                 name: "Error",
                 message: "secret provider detail",

--- a/ts/packages/telemetry/test/structuredLogMessage.spec.ts
+++ b/ts/packages/telemetry/test/structuredLogMessage.spec.ts
@@ -128,6 +128,82 @@ describe("getStructuredLogMessage", () => {
         );
     });
 
+    it("summarizes a failure from its classification, never its message", () => {
+        expect(
+            getStructuredLogMessage("dispatcher:command:exception", {
+                requestId: "request-1",
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+                // Present in the raw event for the private diagnostic sinks;
+                // the rendered message must not reach for any of it.
+                request: "play some private music",
+                name: "Error",
+                message: "secret provider detail",
+                stack: "at secret()",
+            }),
+        ).toBe("Command failed: rate_limit (HTTP 429, retryable)");
+        expect(
+            getStructuredLogMessage("dispatcher:command:exception", {
+                errorCategory: "internal",
+            }),
+        ).toBe("Command failed: internal");
+        expect(
+            getStructuredLogMessage("dispatcher:command:exception", {
+                errorCategory: "network",
+                errorCode: "ECONNREFUSED",
+            }),
+        ).toBe("Command failed: network (ECONNREFUSED)");
+    });
+
+    it("appends the classification to failed completions only", () => {
+        expect(
+            getStructuredLogMessage("dispatcher:action:completed", {
+                status: "failed",
+                schemaName: "player",
+                actionName: "play",
+                elapsedMs: 4,
+                errorCategory: "timeout",
+                retryable: true,
+            }),
+        ).toBe("Action failed: player.play in 4 ms [timeout (retryable)]");
+        expect(
+            getStructuredLogMessage("dispatcher:translation:completed", {
+                status: "failed",
+                strategy: "translate",
+                actionNames: [],
+                errorCategory: "provider",
+                httpStatus: 500,
+                retryable: true,
+            }),
+        ).toBe(
+            "Translation failed via translate [provider (HTTP 500, retryable)]",
+        );
+        expect(
+            getStructuredLogMessage("aiclient:llm:completed", {
+                provider: "azure",
+                status: "failed",
+                elapsedMs: 12,
+                phase: "translation",
+                purpose: "action-generation",
+                scope: "foreground",
+                errorCategory: "rate_limit",
+                httpStatus: 429,
+                retryable: true,
+            }),
+        ).toBe(
+            "LLM failed: translation.action-generation (azure) in 12 ms [rate_limit (HTTP 429, retryable)]",
+        );
+        // Cancellations carry no classification, so the line is unchanged.
+        expect(
+            getStructuredLogMessage("dispatcher:action:completed", {
+                status: "cancelled",
+                schemaName: "player",
+                actionName: "play",
+            }),
+        ).toBe("Action cancelled: player.play");
+    });
+
     it("does not invent messages for diagnostic events", () => {
         expect(
             getStructuredLogMessage("debug", {


### PR DESCRIPTION
## Goal 
This change establishes shared, privacy-safe failure classification across telemetry, provider clients, dispatcher spans, and structured events. It ensures cancellations and failures are reported consistently without exporting raw error messages, stacks, or request data.

## Stack position

**1/3 — bottom layer**, targeting `main`.

Exact base/head at creation:
- Base: `main` @ `9763ccf5a4a4159aa3f0e52993bdc087385c5711`
- Head: `georgengmsft-failure-semantics-layer` @ `3aa146995b3167351422d6b536c90f4c50bd6e9c`
- Frozen source carve: `ec66539fa40a7812a8c0a0273db56d8442000e2b..b2805c438ef81bdadbd57f4893052095bb9bfa51`

## Scope

- Add a browser-safe shared telemetry error classifier with bounded cause traversal, reviewed error-code/status allowlists, safe classification attachment, and hostile-value handling.
- Propagate bounded classifications through real REST, Copilot, and provider failures, including dropped-connection parity.
- Add structured dispatcher completion failure fields and an explicit OTel projection allowlist.
- Use one cancellation decision across action, translation, reasoning, request, command, and LLM telemetry, including wrapped aborts and caller signal hints.
- Add bounded human-readable failure notes to existing lifecycle messages.
- Document the failure-classification and cancellation contracts and add focused unit coverage.

## Invariants

- Spans and correlated structured completion events derive cancellation from the same shared classifier.
- Cancellations do not export failure classification fields.
- OTel receives only bounded `errorCategory`, reviewed `errorCode`, numeric `httpStatus`, and `retryable`; raw messages, stacks, requests, hostnames, paths, query strings, and payloads remain excluded.
- Cause traversal is depth-bounded and cycle-safe, and survives throwing getters, revoked proxies, symbols, and other hostile thrown values.
- The browser-safe classifier has no Node-only imports.
