### PR TITLE
[OTEL] Add LLM attribution telemetry

### DIFF
--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -149,6 +149,12 @@ Browser-shared RPC code reads active TypeAgent metadata through the
 `@typeagent/telemetry/traceContext` subpath. It does not import the Node-only
 telemetry composition root.
 
+The browser-safe contract contains no Node builtins. Its Node export condition
+loads `traceContextNode.ts`, which installs an `AsyncLocalStorage` attribute
+store into the contract. This keeps request correlation available to logs-only
+Node processes without making browser paths import `node:async_hooks`; browser
+callers continue to use the active OTel context.
+
 The trusted dispatcher RPC channel extends the same trace from a client host
 into agent-server request processing:
 
@@ -194,14 +200,14 @@ processable telemetry record.**
   auto-instrumentation.
 - Classify each LLM operation explicitly at the high-level call site. The
   central model wrapper records `typeagent.llm.phase`,
-  `typeagent.llm.purpose`, and `typeagent.llm.scope`; it never infers purpose
-  from prompt text, model output, timing, or token counts.
-- High-level classification contexts are complete. Nested operations may
-  override only the purpose while retaining their phase and scope.
-- A model call outside a classified operation records `unclassified` for all
-  three attributes and adds a `typeagent.llm.classification.missing` span
-  event. This makes missing instrumentation visible without failing the model
-  request.
+  `typeagent.llm.purpose`, `typeagent.llm.scope`, and
+  `typeagent.llm.classification_source`; it never infers purpose from prompt
+  text, model output, timing, or token counts.
+- Nested classification scopes may refine one field while retaining the
+  others. Calling the wrapper always records `classificationSource: explicit`.
+- A model call outside a classified operation records `phase: unknown`,
+  `purpose: unknown`, `scope: foreground`, and
+  `classificationSource: default`.
 
 ### Logs
 
@@ -672,7 +678,8 @@ such as `Request accepted and queued` or `Translation succeeded via grammar`.
 Use opt-in debug records for detailed diagnostics behind that lifecycle step.
 LLM messages include their explicit phase and purpose so parallel schema
 selection, action generation, and background cache generation are
-distinguishable without inspecting private model content.
+distinguishable without inspecting private model content. Default
+classification is marked `(unclassified)`.
 Correlation fields are elevated once rather than repeated in the body, and the
 redundant legacy `dispatcher:command` record is omitted from local JSONL.
 Repeated SDK metadata such as the observed timestamp, resource,
@@ -684,6 +691,35 @@ Structured dispatcher records include events such as `command` and
 `requestQueue:start`. Bridged debug records include their debug namespace.
 Prompt text, response text, action parameters, errors, stacks, and unknown
 dispatcher fields are excluded by the dispatcher projection.
+
+### LLM phase and purpose attribution
+
+`llm:started`, `llm:completed`, and the `typeagent.llm` span carry `phase`,
+`purpose`, `scope`, and `classificationSource`. `explicit` means a call site
+used `withChatModelTelemetryContext`; `default` means no call site classified
+the operation. An explicit `unknown` phase is therefore distinguishable from a
+missing classification.
+
+The classification context uses `AsyncLocalStorage` owned by `aiclient`, so it
+survives awaits, microtasks, and nested/retry calls even when traces are
+disabled. Work detached into a worker, child process, or later promise chain
+must classify itself at its entry point. Active correlation attributes use the
+runtime-supplied ambient store described above, so logs-only Node processes
+retain `sessionId`, `requestId`, and `traceId` without taking ownership of the
+global OTel context-manager slot.
+
+Statically identifiable offline work uses `phase: background`, `scope:
+background`, and a specific purpose. This includes keyword authoring, bulk
+sample-request generation, optimization case classification, hypothesis
+generation (including nested retries), and guideline distillation. Foreground
+capability descriptions and sample-request generation use specific purposes
+while retaining or explicitly stating their phase.
+
+An unattributed foreground call emits a rate-limited
+`llm:classification:default` diagnostic. It contains only the foreground scope,
+the number of calls covered by the window, and the fixed window length. It
+contains no prompt, model, provider, stack, or call-site identity and cannot
+fail the model call.
 
 ### Phase-completion durations and translation routing
 
@@ -1045,9 +1081,19 @@ exception messages and stack traces are never exported.
 Each instrumented model call creates one `typeagent.llm` span. A returned
 failure result sets `ERROR` with `model returned failure`; a thrown failure
 records `ModelError` / `model call failed`, or `AbortError` / `cancelled` for a
-cancellation. Prompts, responses, and provider messages are never recorded.
-The matching `llm:completed` event carries the normalized failure
-classification.
+cancellation. Prompts, responses, and provider messages are never recorded on
+the span. The matching `llm:completed` log event carries the normalized failure
+classification described under
+[Failure classification](#failure-classification).
+
+The readable `llm:started` and `llm:completed` messages include phase, purpose,
+background scope, provider/model, outcome, elapsed time, total token count when
+available, and bounded failure classification. They never include prompts,
+responses, provider messages, or stacks.
+
+The span is ended exactly once on every path, including when emitting the
+completion event throws: a broken sink degrades telemetry rather than leaking
+an unfinished span, and it never replaces the failure the call was reporting.
 
 | Signal          | Use                                          |
 | --------------- | -------------------------------------------- |

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -149,11 +149,9 @@ Browser-shared RPC code reads active TypeAgent metadata through the
 `@typeagent/telemetry/traceContext` subpath. It does not import the Node-only
 telemetry composition root.
 
-The browser-safe contract contains no Node builtins. Its Node export condition
-loads `traceContextNode.ts`, which installs an `AsyncLocalStorage` attribute
-store into the contract. This keeps request correlation available to logs-only
-Node processes without making browser paths import `node:async_hooks`; browser
-callers continue to use the active OTel context.
+The trace-context contract is browser-safe. Its Node export adds ambient
+context so logs-only processes retain request correlation when tracing is
+disabled.
 
 The trusted dispatcher RPC channel extends the same trace from a client host
 into agent-server request processing:
@@ -201,13 +199,10 @@ processable telemetry record.**
 - Classify each LLM operation explicitly at the high-level call site. The
   central model wrapper records `typeagent.llm.phase`,
   `typeagent.llm.purpose`, `typeagent.llm.scope`, and
-  `typeagent.llm.classification_source`; it never infers purpose from prompt
-  text, model output, timing, or token counts.
-- Nested classification scopes may refine one field while retaining the
-  others. Calling the wrapper always records `classificationSource: explicit`.
-- A model call outside a classified operation records `phase: unknown`,
-  `purpose: unknown`, `scope: foreground`, and
-  `classificationSource: default`.
+  `typeagent.llm.classification_source`. Nested scopes inherit unspecified
+  values.
+- Unclassified calls use `unknown` phase and purpose, `foreground` scope, and
+  `default` classification source.
 
 ### Logs
 
@@ -678,8 +673,7 @@ such as `Request accepted and queued` or `Translation succeeded via grammar`.
 Use opt-in debug records for detailed diagnostics behind that lifecycle step.
 LLM messages include their explicit phase and purpose so parallel schema
 selection, action generation, and background cache generation are
-distinguishable without inspecting private model content. Default
-classification is marked `(unclassified)`.
+distinguishable without inspecting private model content.
 Correlation fields are elevated once rather than repeated in the body, and the
 redundant legacy `dispatcher:command` record is omitted from local JSONL.
 Repeated SDK metadata such as the observed timestamp, resource,
@@ -697,29 +691,14 @@ dispatcher fields are excluded by the dispatcher projection.
 `llm:started`, `llm:completed`, and the `typeagent.llm` span carry `phase`,
 `purpose`, `scope`, and `classificationSource`. `explicit` means a call site
 used `withChatModelTelemetryContext`; `default` means no call site classified
-the operation. An explicit `unknown` phase is therefore distinguishable from a
-missing classification.
+the operation. Nested and retry calls inherit this context across async work.
 
-The classification context uses `AsyncLocalStorage` owned by `aiclient`, so it
-survives awaits, microtasks, and nested/retry calls even when traces are
-disabled. Work detached into a worker, child process, or later promise chain
-must classify itself at its entry point. Active correlation attributes use the
-runtime-supplied ambient store described above, so logs-only Node processes
-retain `sessionId`, `requestId`, and `traceId` without taking ownership of the
-global OTel context-manager slot.
+Known offline operations use background scope and a specific purpose. Detached
+workers and processes classify themselves at entry.
 
-Statically identifiable offline work uses `phase: background`, `scope:
-background`, and a specific purpose. This includes keyword authoring, bulk
-sample-request generation, optimization case classification, hypothesis
-generation (including nested retries), and guideline distillation. Foreground
-capability descriptions and sample-request generation use specific purposes
-while retaining or explicitly stating their phase.
-
-An unattributed foreground call emits a rate-limited
-`llm:classification:default` diagnostic. It contains only the foreground scope,
-the number of calls covered by the window, and the fixed window length. It
-contains no prompt, model, provider, stack, or call-site identity and cannot
-fail the model call.
+Unclassified foreground calls emit one aggregate warning per minute. The
+warning contains only scope, count, and window length; it never includes model
+content or call-site identity.
 
 ### Phase-completion durations and translation routing
 
@@ -1082,18 +1061,9 @@ Each instrumented model call creates one `typeagent.llm` span. A returned
 failure result sets `ERROR` with `model returned failure`; a thrown failure
 records `ModelError` / `model call failed`, or `AbortError` / `cancelled` for a
 cancellation. Prompts, responses, and provider messages are never recorded on
-the span. The matching `llm:completed` log event carries the normalized failure
-classification described under
-[Failure classification](#failure-classification).
-
-The readable `llm:started` and `llm:completed` messages include phase, purpose,
-background scope, provider/model, outcome, elapsed time, total token count when
-available, and bounded failure classification. They never include prompts,
-responses, provider messages, or stacks.
-
-The span is ended exactly once on every path, including when emitting the
-completion event throws: a broken sink degrades telemetry rather than leaking
-an unfinished span, and it never replaces the failure the call was reporting.
+the span. Lifecycle logs summarize attribution, outcome, elapsed time, token
+count, and bounded failure classification without recording model content or
+stacks. Telemetry failures do not affect the model call.
 
 | Signal          | Use                                          |
 | --------------- | -------------------------------------------- |

--- a/ts/packages/aiclient/src/chatModelTelemetryContext.ts
+++ b/ts/packages/aiclient/src/chatModelTelemetryContext.ts
@@ -7,7 +7,9 @@ export type ChatModelTelemetryPhase =
     | "translation"
     | "reasoning"
     | "action"
-    | "explanation";
+    | "explanation"
+    | "background"
+    | "unknown";
 
 export type ChatModelTelemetryPurpose =
     | "schema-selection"
@@ -16,39 +18,63 @@ export type ChatModelTelemetryPurpose =
     | "entity-resolution"
     | "reasoning"
     | "action"
-    | "cache-generation";
+    | "cache-generation"
+    | "capability-description"
+    | "keyword-authoring"
+    | "sample-request-generation"
+    | "optimization-case-classification"
+    | "optimization-hypothesis-generation"
+    | "optimization-guideline-distillation"
+    | "unknown";
 
 export type ChatModelTelemetryScope = "foreground" | "background";
+
+export type ChatModelTelemetryClassificationSource = "explicit" | "default";
 
 export interface ChatModelTelemetryContext {
     readonly phase: ChatModelTelemetryPhase;
     readonly purpose: ChatModelTelemetryPurpose;
     readonly scope: ChatModelTelemetryScope;
+    readonly classificationSource: ChatModelTelemetryClassificationSource;
 }
 
-const chatModelTelemetryContext =
-    new AsyncLocalStorage<ChatModelTelemetryContext>();
+export type ChatModelTelemetryClassification = Partial<
+    Omit<ChatModelTelemetryContext, "classificationSource">
+>;
 
-export function getChatModelTelemetryContext():
-    | ChatModelTelemetryContext
-    | undefined {
-    return chatModelTelemetryContext.getStore();
+const classificationStore = new AsyncLocalStorage<ChatModelTelemetryContext>();
+
+const DEFAULT_CHAT_MODEL_TELEMETRY_CONTEXT: ChatModelTelemetryContext =
+    Object.freeze({
+        phase: "unknown",
+        purpose: "unknown",
+        scope: "foreground",
+        classificationSource: "default",
+    });
+
+export function getChatModelTelemetryContext(): ChatModelTelemetryContext {
+    return (
+        classificationStore.getStore() ?? DEFAULT_CHAT_MODEL_TELEMETRY_CONTEXT
+    );
 }
 
 export function withChatModelTelemetryContext<T>(
-    telemetryContext: ChatModelTelemetryContext,
+    classification: ChatModelTelemetryClassification,
     body: () => T,
 ): T {
-    return chatModelTelemetryContext.run(telemetryContext, body);
+    return classificationStore.run(
+        {
+            ...getChatModelTelemetryContext(),
+            ...classification,
+            classificationSource: "explicit",
+        },
+        body,
+    );
 }
 
 export function withChatModelTelemetryPurpose<T>(
     purpose: ChatModelTelemetryPurpose,
     body: () => T,
 ): T {
-    const current = getChatModelTelemetryContext();
-    if (current === undefined) {
-        return body();
-    }
-    return withChatModelTelemetryContext({ ...current, purpose }, body);
+    return withChatModelTelemetryContext({ purpose }, body);
 }

--- a/ts/packages/aiclient/src/index.ts
+++ b/ts/packages/aiclient/src/index.ts
@@ -5,12 +5,15 @@ export * from "./common.js";
 export * from "./models.js";
 export {
     instrumentChatModel,
+    resetLlmClassificationDiagnostics,
     type ChatModelTelemetryInfo,
 } from "./otelChatModel.js";
 export {
     getChatModelTelemetryContext,
     withChatModelTelemetryContext,
     withChatModelTelemetryPurpose,
+    type ChatModelTelemetryClassification,
+    type ChatModelTelemetryClassificationSource,
     type ChatModelTelemetryContext,
     type ChatModelTelemetryPhase,
     type ChatModelTelemetryPurpose,

--- a/ts/packages/aiclient/src/otelChatModel.ts
+++ b/ts/packages/aiclient/src/otelChatModel.ts
@@ -31,6 +31,48 @@ const logger = new ChildLogger(
     "aiclient",
 );
 
+const DEFAULT_CLASSIFICATION_WINDOW_MS = 60_000;
+
+let defaultClassificationCount = 0;
+let defaultClassificationReportedAt: number | undefined;
+
+export function resetLlmClassificationDiagnostics(): void {
+    defaultClassificationCount = 0;
+    defaultClassificationReportedAt = undefined;
+}
+
+function noteClassificationSource(
+    classification: ChatModelTelemetryContext,
+    structuredLogger: Logger,
+): void {
+    if (
+        classification.scope !== "foreground" ||
+        classification.classificationSource !== "default"
+    ) {
+        return;
+    }
+    defaultClassificationCount += 1;
+    const now = Date.now();
+    if (
+        defaultClassificationReportedAt !== undefined &&
+        now - defaultClassificationReportedAt < DEFAULT_CLASSIFICATION_WINDOW_MS
+    ) {
+        return;
+    }
+    defaultClassificationReportedAt = now;
+    const count = defaultClassificationCount;
+    defaultClassificationCount = 0;
+    structuredLogger.logEvent(
+        "llm:classification:default",
+        {
+            scope: "foreground",
+            count,
+            windowMs: DEFAULT_CLASSIFICATION_WINDOW_MS,
+        },
+        "warning",
+    );
+}
+
 export type ChatModelTelemetryInfo = {
     provider: string;
     model?: string;
@@ -39,21 +81,14 @@ export type ChatModelTelemetryInfo = {
 type LlmCallState = {
     readonly span: Span;
     readonly activeContext: Context;
+    readonly attributes: otel.TypeAgentSpanAttributes;
     readonly startedAt: number;
     readonly correlation: LlmCorrelation;
-    readonly classification: LlmClassification;
+    readonly classification: ChatModelTelemetryContext;
     readonly logger: Logger;
     usage?: CompletionUsageStats;
     ended: boolean;
 };
-
-type LlmClassification =
-    | ChatModelTelemetryContext
-    | {
-          readonly phase: "unclassified";
-          readonly purpose: "unclassified";
-          readonly scope: "unclassified";
-      };
 
 type LlmCorrelation = {
     -readonly [Key in
@@ -83,7 +118,7 @@ export function instrumentChatModel(
         const signal = args[4];
         args[1] = captureUsage(args[1], state);
         try {
-            const result = await context.with(state.activeContext, () =>
+            const result = await runInCallContext(state, () =>
                 complete(...args),
             );
             if (signal?.aborted === true) {
@@ -104,7 +139,7 @@ export function instrumentChatModel(
         const signal = args[4];
         args[1] = captureUsage(args[1], state);
         try {
-            const result = await context.with(state.activeContext, () =>
+            const result = await runInCallContext(state, () =>
                 completeStream(...args),
             );
             if (signal?.aborted === true) {
@@ -129,6 +164,14 @@ export function instrumentChatModel(
     return model;
 }
 
+function runInCallContext<T>(state: LlmCallState, body: () => T): T {
+    return otel.runInTypeAgentTelemetryContext(
+        state.activeContext,
+        state.attributes,
+        body,
+    );
+}
+
 function safely(body: () => void): void {
     try {
         body();
@@ -148,12 +191,7 @@ function startLlmCall(
     );
     const span = tracer.startSpan(otel.TYPEAGENT_SPAN_NAMES.LLM);
     const inherited = otel.getActiveTypeAgentSpanAttributes();
-    const classification: LlmClassification =
-        getChatModelTelemetryContext() ?? {
-            phase: "unclassified",
-            purpose: "unclassified",
-            scope: "unclassified",
-        };
+    const classification = getChatModelTelemetryContext();
     const attributes = {
         ...inherited,
         genAiSystem: info.provider,
@@ -161,18 +199,16 @@ function startLlmCall(
         llmPhase: classification.phase,
         llmPurpose: classification.purpose,
         llmScope: classification.scope,
+        llmClassificationSource: classification.classificationSource,
     };
-    otel.setTypeAgentSpanAttributes(span, attributes);
-    if (classification.phase === "unclassified") {
-        span.addEvent("typeagent.llm.classification.missing");
-    }
-    const activeContext = otel.setActiveTypeAgentSpanAttributes(
-        trace.setSpan(context.active(), span),
-        attributes,
-    );
+    safely(() => otel.setTypeAgentSpanAttributes(span, attributes));
     const state = {
         span,
-        activeContext,
+        activeContext: otel.setActiveTypeAgentSpanAttributes(
+            trace.setSpan(context.active(), span),
+            attributes,
+        ),
+        attributes,
         startedAt: Date.now(),
         correlation: getLlmCorrelation(inherited),
         classification,
@@ -180,14 +216,17 @@ function startLlmCall(
         ended: false,
     };
     if (otel.isStructuredLoggingEnabled()) {
-        context.with(activeContext, () =>
-            structuredLogger.logEvent("llm:started", {
-                provider: info.provider,
-                ...(info.model === undefined ? {} : { model: info.model }),
-                operation: "chat",
-                streaming,
-                ...classification,
-                ...state.correlation,
+        safely(() =>
+            runInCallContext(state, () => {
+                structuredLogger.logEvent("llm:started", {
+                    provider: info.provider,
+                    ...(info.model === undefined ? {} : { model: info.model }),
+                    operation: "chat",
+                    streaming,
+                    ...classification,
+                    ...state.correlation,
+                });
+                noteClassificationSource(classification, structuredLogger);
             }),
         );
     }
@@ -212,9 +251,7 @@ async function* instrumentStream(
 ): AsyncIterableIterator<string> {
     try {
         while (true) {
-            const next = await context.with(state.activeContext, () =>
-                source.next(),
-            );
+            const next = await runInCallContext(state, () => source.next());
             if (next.done) {
                 if (signal?.aborted === true) {
                     cancelLlmCall(state, info);
@@ -347,7 +384,7 @@ function emitCompleted(
         return;
     }
     safely(() =>
-        context.with(state.activeContext, () =>
+        runInCallContext(state, () =>
             state.logger.logEvent(
                 "llm:completed",
                 {

--- a/ts/packages/aiclient/test/chatModelTelemetryContext.spec.ts
+++ b/ts/packages/aiclient/test/chatModelTelemetryContext.spec.ts
@@ -23,8 +23,16 @@ describe("chat model telemetry context", () => {
             },
         );
 
-        expect(observed).toEqual(classification);
-        expect(getChatModelTelemetryContext()).toBeUndefined();
+        expect(observed).toEqual({
+            ...classification,
+            classificationSource: "explicit",
+        });
+        expect(getChatModelTelemetryContext()).toEqual({
+            phase: "unknown",
+            purpose: "unknown",
+            scope: "foreground",
+            classificationSource: "default",
+        });
     });
 
     it("overrides purpose without changing phase or scope", () => {
@@ -44,14 +52,20 @@ describe("chat model telemetry context", () => {
             phase: "translation",
             purpose: "schema-selection",
             scope: "foreground",
+            classificationSource: "explicit",
         });
     });
 
-    it("does not invent phase or scope for a purpose-only operation", () => {
+    it("marks a purpose-only operation as explicit while retaining defaults", () => {
         const observed = withChatModelTelemetryPurpose("schema-selection", () =>
             getChatModelTelemetryContext(),
         );
 
-        expect(observed).toBeUndefined();
+        expect(observed).toEqual({
+            phase: "unknown",
+            purpose: "schema-selection",
+            scope: "foreground",
+            classificationSource: "explicit",
+        });
     });
 });

--- a/ts/packages/aiclient/test/otelChatModel.spec.ts
+++ b/ts/packages/aiclient/test/otelChatModel.spec.ts
@@ -10,7 +10,10 @@ import { otel } from "@typeagent/telemetry";
 import type { Logger } from "@typeagent/telemetry";
 import { error, success } from "typechat";
 import type { ChatModelWithStreaming } from "../src/models.js";
-import { instrumentChatModel } from "../src/otelChatModel.js";
+import {
+    instrumentChatModel,
+    resetLlmClassificationDiagnostics,
+} from "../src/otelChatModel.js";
 import { fetchWithRetry } from "../src/restClient.js";
 import {
     withChatModelTelemetryContext,
@@ -59,14 +62,16 @@ describe("instrumentChatModel", () => {
     beforeEach(() => {
         spans = createInMemorySpanManager();
         otel.setStructuredLoggingEnabled(false);
+        resetLlmClassificationDiagnostics();
     });
 
     afterEach(async () => {
         otel.setStructuredLoggingEnabled(false);
+        resetLlmClassificationDiagnostics();
         await spans.shutdown();
     });
 
-    it("marks calls outside a classified operation as unclassified", async () => {
+    it("marks calls outside a classified operation as default", async () => {
         const model = instrumentChatModel(createModel(), {
             provider: "test-provider",
             model: "test-model",
@@ -80,15 +85,12 @@ describe("instrumentChatModel", () => {
         expect(span?.attributes).toMatchObject({
             "gen_ai.system": "test-provider",
             "gen_ai.request.model": "test-model",
-            "typeagent.llm.phase": "unclassified",
-            "typeagent.llm.purpose": "unclassified",
-            "typeagent.llm.scope": "unclassified",
+            "typeagent.llm.phase": "unknown",
+            "typeagent.llm.purpose": "unknown",
+            "typeagent.llm.scope": "foreground",
+            "typeagent.llm.classification_source": "default",
         });
-        expect(span?.events).toEqual([
-            expect.objectContaining({
-                name: "typeagent.llm.classification.missing",
-            }),
-        ]);
+        expect(span?.events).toEqual([]);
         expect(span?.status.code).toBe(0);
     });
 
@@ -203,7 +205,12 @@ describe("instrumentChatModel", () => {
             ).complete("private prompt"),
         );
 
-        expect(events).toEqual([
+        expect(
+            events.filter(
+                ({ name }) =>
+                    name === "llm:started" || name === "llm:completed",
+            ),
+        ).toEqual([
             {
                 name: "llm:started",
                 data: expect.objectContaining({
@@ -249,17 +256,20 @@ describe("instrumentChatModel", () => {
             "typeagent.llm.phase": "explanation",
             "typeagent.llm.purpose": "cache-generation",
             "typeagent.llm.scope": "background",
+            "typeagent.llm.classification_source": "explicit",
         });
         expect(events.map(({ data }) => data)).toEqual([
             expect.objectContaining({
                 phase: "explanation",
                 purpose: "cache-generation",
                 scope: "background",
+                classificationSource: "explicit",
             }),
             expect.objectContaining({
                 phase: "explanation",
                 purpose: "cache-generation",
                 scope: "background",
+                classificationSource: "explicit",
             }),
         ]);
     });
@@ -287,6 +297,102 @@ describe("instrumentChatModel", () => {
             "typeagent.llm.phase": "translation",
             "typeagent.llm.purpose": "schema-selection",
             "typeagent.llm.scope": "foreground",
+            "typeagent.llm.classification_source": "explicit",
+        });
+    });
+
+    describe("foreground default diagnostic", () => {
+        it("reports once per window and counts suppressed calls", async () => {
+            const realNow = Date.now;
+            let now = realNow();
+            Date.now = () => now;
+            try {
+                otel.setStructuredLoggingEnabled(true);
+                const events: CapturedEvent[] = [];
+                const model = instrumentChatModel(
+                    createModel(),
+                    { provider: "test-provider" },
+                    createCapturingLogger(events),
+                );
+
+                for (let index = 0; index < 5; index++) {
+                    await model.complete("private prompt");
+                }
+
+                const diagnostics = () =>
+                    events.filter(
+                        ({ name }) => name === "llm:classification:default",
+                    );
+                expect(diagnostics()).toHaveLength(1);
+                expect(diagnostics()[0]?.data).toEqual({
+                    scope: "foreground",
+                    count: 1,
+                    windowMs: expect.any(Number),
+                });
+
+                const windowMs = diagnostics()[0]?.data.windowMs as number;
+                now += windowMs + 1;
+                await model.complete("private prompt");
+                expect(diagnostics()).toHaveLength(2);
+                expect(diagnostics()[1]?.data).toMatchObject({ count: 5 });
+            } finally {
+                Date.now = realNow;
+            }
+        });
+
+        it("omits prompt, provider, model, and call-site identity", async () => {
+            otel.setStructuredLoggingEnabled(true);
+            const events: CapturedEvent[] = [];
+            await instrumentChatModel(
+                createModel(),
+                { provider: "secret-provider", model: "secret-model" },
+                createCapturingLogger(events),
+            ).complete("private prompt");
+
+            const diagnostic = events.find(
+                ({ name }) => name === "llm:classification:default",
+            );
+            expect(Object.keys(diagnostic?.data ?? {}).sort()).toEqual([
+                "count",
+                "scope",
+                "windowMs",
+            ]);
+            expect(JSON.stringify(diagnostic)).not.toContain("secret");
+            expect(JSON.stringify(diagnostic)).not.toContain("private prompt");
+        });
+    });
+
+    it("keeps attribution and correlation when tracing is disabled", async () => {
+        await spans.shutdown();
+        otel.setStructuredLoggingEnabled(true);
+        const events: CapturedEvent[] = [];
+        const model = instrumentChatModel(
+            createModel(),
+            { provider: "test-provider" },
+            createCapturingLogger(events),
+        );
+
+        await otel.runInTypeAgentTelemetryContext(
+            context.active(),
+            { sessionId: "session", requestId: "request" },
+            () =>
+                withChatModelTelemetryContext(
+                    {
+                        phase: "background",
+                        purpose: "cache-generation",
+                        scope: "background",
+                    },
+                    () => model.complete("private prompt"),
+                ),
+        );
+
+        expect(events[0]?.data).toMatchObject({
+            sessionId: "session",
+            requestId: "request",
+            phase: "background",
+            purpose: "cache-generation",
+            scope: "background",
+            classificationSource: "explicit",
         });
     });
 

--- a/ts/packages/dispatcher/dispatcher/src/context/contextSelector/keywordDistiller.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/contextSelector/keywordDistiller.ts
@@ -12,7 +12,10 @@
 // model's JSON against the schema, with an auto-repair retry — goes through
 // TypeChat via the shared `distillJson` helper.
 
-import type { ChatModel } from "@typeagent/aiclient";
+import {
+    withChatModelTelemetryContext,
+    type ChatModel,
+} from "@typeagent/aiclient";
 import { KeywordExtractionInput } from "./keywordExtractor.js";
 import { tokenize } from "./tokenize.js";
 import { distillJson } from "../../utils/distillJson.js";
@@ -94,11 +97,19 @@ export async function distillKeywords(
     const topN = options.topN ?? DEFAULT_TOP_N;
     let result: KeywordVector | undefined;
     try {
-        result = await distillJson<KeywordVector>(
-            options.createModel("distill"),
-            buildRequest(input, topN),
-            KEYWORD_SCHEMA,
-            "KeywordVector",
+        result = await withChatModelTelemetryContext(
+            {
+                phase: "background",
+                purpose: "keyword-authoring",
+                scope: "background",
+            },
+            () =>
+                distillJson<KeywordVector>(
+                    options.createModel("distill"),
+                    buildRequest(input, topN),
+                    KEYWORD_SCHEMA,
+                    "KeywordVector",
+                ),
         );
     } catch {
         // Only reached if the model factory itself throws; distillJson never does.

--- a/ts/packages/dispatcher/dispatcher/src/context/dispatcher/dispatcherAgent.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/dispatcher/dispatcherAgent.ts
@@ -43,6 +43,7 @@ import { MatchCommandHandler } from "./handlers/matchCommandHandler.js";
 import { DispatcherEmoji } from "./dispatcherUtils.js";
 import { getHistoryContext } from "../../translation/interpretRequest.js";
 import { processCommandNoLock } from "../../command/command.js";
+import { withChatModelTelemetryPurpose } from "@typeagent/aiclient";
 import { PreferenceMember } from "../collisionPreferences.js";
 import { ReasoningAction } from "./schema/reasoningActionSchema.js";
 import {
@@ -456,7 +457,10 @@ async function clarifyWithLookup(
     const translator = getLookupClarifyTranslator(systemContext);
 
     const question = `What is ${action.parameters.reference}?`;
-    const result = await translator.translate(question);
+    const result = await withChatModelTelemetryPurpose(
+        "entity-resolution",
+        () => translator.translate(question),
+    );
 
     if (!result.success) {
         return undefined;

--- a/ts/packages/dispatcher/dispatcher/src/context/system/describe/describeCore.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/describe/describeCore.ts
@@ -15,6 +15,7 @@ import {
     createJsonTranslatorFromSchemaDef,
     type TypeChatJsonTranslatorWithSignal,
 } from "@typeagent/typechat-utils";
+import { withChatModelTelemetryContext } from "@typeagent/aiclient";
 import type { CommandHandlerContext } from "../../commandHandlerContext.js";
 import { getAgentSchemas } from "./agentSchemaInfo.js";
 
@@ -591,7 +592,10 @@ export async function polishAgentView(
         `capability listing. Base it only on these facts; do not invent features.\n\n` +
         `Agent description: ${agent.description}\n` +
         `Actions:\n${actionList}`;
-    const result = await translator.translate(request);
+    const result = await withChatModelTelemetryContext(
+        { purpose: "capability-description", scope: "foreground" },
+        () => translator.translate(request),
+    );
     if (!result.success) return deterministic;
 
     return renderPolishedAgentView(agent, deterministic, result.data);
@@ -646,7 +650,10 @@ export async function polishActionView(
         `Base it only on the facts below; do not invent parameters or behavior.\n\n` +
         `Action summary: ${match.action.description}\n` +
         `Parameters:\n${paramList || "(none)"}`;
-    const result = await translator.translate(request);
+    const result = await withChatModelTelemetryContext(
+        { purpose: "capability-description", scope: "foreground" },
+        () => translator.translate(request),
+    );
     if (!result.success) return deterministic;
 
     return renderPolishedActionView(match, result.data);

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/collisionCorpusHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/collisionCorpusHandlers.ts
@@ -39,7 +39,7 @@ import {
     displayWarn,
 } from "@typeagent/agent-sdk/helpers/display";
 
-import { openai } from "@typeagent/aiclient";
+import { openai, withChatModelTelemetryContext } from "@typeagent/aiclient";
 
 import {
     CommandHandlerContext,
@@ -765,7 +765,14 @@ async function generateCorpus(
         async (task) => {
             const prompt = buildCorpusPrompt(task.action, opts.styles);
             try {
-                const result = await task.model.complete(prompt);
+                const result = await withChatModelTelemetryContext(
+                    {
+                        phase: "background",
+                        purpose: "sample-request-generation",
+                        scope: "background",
+                    },
+                    () => task.model.complete(prompt),
+                );
                 if (!result.success) {
                     perCallErrors.push({
                         schemaName: task.action.schemaName,

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/randomCommandHandler.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/randomCommandHandler.ts
@@ -12,6 +12,7 @@ import {
     ChatModelWithStreaming,
     CompletionSettings,
     openai,
+    withChatModelTelemetryContext,
 } from "@typeagent/aiclient";
 import { createTypeChat, promptLib } from "@typeagent/agent-runtime";
 import { PromptSection, Result, TypeChatJsonTranslator } from "typechat";
@@ -149,9 +150,17 @@ class RandomOnlineCommandHandler implements CommandHandlerNoParams {
         userInput: string,
         chat: TypeChatJsonTranslator<UserRequestList>,
     ): Promise<Result<UserRequestList>> {
-        const chatResponse = await chat.translate(
-            userInput,
-            promptLib.dateTimePrompt(), // Always include the current date and time. Makes the bot much smarter
+        const chatResponse = await withChatModelTelemetryContext(
+            {
+                phase: "unknown",
+                purpose: "sample-request-generation",
+                scope: "foreground",
+            },
+            () =>
+                chat.translate(
+                    userInput,
+                    promptLib.dateTimePrompt(), // Always include the current date and time. Makes the bot much smarter
+                ),
         );
 
         return chatResponse;

--- a/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/caseAnalyzer.ts
+++ b/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/caseAnalyzer.ts
@@ -21,7 +21,10 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import type { ChatModel } from "@typeagent/aiclient";
+import {
+    withChatModelTelemetryContext,
+    type ChatModel,
+} from "@typeagent/aiclient";
 import type { ActionConfigProvider } from "../../translation/actionConfigProvider.js";
 import { getSchemaContent } from "../../translation/actionConfig.js";
 import type { Neighborhood, NeighborhoodMember } from "../types.js";
@@ -374,7 +377,14 @@ Return JSON only:
 }`;
 
     const model = opts.createModel("classify");
-    const result = await model.complete(prompt);
+    const result = await withChatModelTelemetryContext(
+        {
+            phase: "background",
+            purpose: "optimization-case-classification",
+            scope: "background",
+        },
+        () => model.complete(prompt),
+    );
     if (!result.success) {
         throw new Error(`caseAnalyzer LLM failure: ${result.message}`);
     }

--- a/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/guidelineDistiller.ts
+++ b/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/guidelineDistiller.ts
@@ -24,7 +24,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import type { ChatModel } from "@typeagent/aiclient";
+import {
+    withChatModelTelemetryContext,
+    type ChatModel,
+} from "@typeagent/aiclient";
 import type { GuidelineHook, Mechanism } from "./types.js";
 import { parsePatternsJsonl, type PatternRow } from "./patternMiner.js";
 import { extractJSON } from "./util.js";
@@ -269,7 +272,14 @@ async function distillGroup(
     });
 
     const model = createModel("propose");
-    const result = await model.complete(prompt);
+    const result = await withChatModelTelemetryContext(
+        {
+            phase: "background",
+            purpose: "optimization-guideline-distillation",
+            scope: "background",
+        },
+        () => model.complete(prompt),
+    );
     if (!result.success) {
         return null;
     }

--- a/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/hypothesisGenerator.ts
+++ b/ts/packages/dispatcher/dispatcher/src/neighborhoods/optimize/hypothesisGenerator.ts
@@ -12,6 +12,7 @@
 // for diffing two attempts archives produced by the same corpus).
 
 import type { AttemptRecord, CaseDescription, Hypothesis } from "./types.js";
+import { withChatModelTelemetryContext } from "@typeagent/aiclient";
 import {
     listLevers,
     type LeverPlugin,
@@ -49,10 +50,18 @@ export async function generateHypotheses(
     const out: Hypothesis[] = [];
 
     for (const lever of levers) {
-        const proposed = await lever.proposeHypotheses(
-            opts.caseDesc,
-            opts.priorAttempts,
-            opts.ctx,
+        const proposed = await withChatModelTelemetryContext(
+            {
+                phase: "background",
+                purpose: "optimization-hypothesis-generation",
+                scope: "background",
+            },
+            () =>
+                lever.proposeHypotheses(
+                    opts.caseDesc,
+                    opts.priorAttempts,
+                    opts.ctx,
+                ),
         );
         for (const h of proposed) {
             // Levers MAY return IDs (typically of the form

--- a/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/actionSpan.ts
@@ -95,11 +95,12 @@ export async function wrapActionSpan<T>(
                 ...attributes,
             };
             otel.setTypeAgentSpanAttributes(span, effectiveAttributes);
-            return context.with(
+            return otel.runInTypeAgentTelemetryContext(
                 otel.setActiveTypeAgentSpanAttributes(
                     context.active(),
                     effectiveAttributes,
                 ),
+                effectiveAttributes,
                 async () => {
                     return withChatModelTelemetryContext(
                         {

--- a/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/reasoningSpan.ts
@@ -110,15 +110,18 @@ export async function wrapReasoningSpan<T>(
                 effectiveAttributes,
             );
             try {
-                return await context.with(spanContext, () =>
-                    withChatModelTelemetryContext(
-                        {
-                            phase: "reasoning",
-                            purpose: "reasoning",
-                            scope: "foreground",
-                        },
-                        () => body(span),
-                    ),
+                return await otel.runInTypeAgentTelemetryContext(
+                    spanContext,
+                    effectiveAttributes,
+                    () =>
+                        withChatModelTelemetryContext(
+                            {
+                                phase: "reasoning",
+                                purpose: "reasoning",
+                                scope: "foreground",
+                            },
+                            () => body(span),
+                        ),
                 );
             } catch (error) {
                 recordSpanFailure(

--- a/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/rootRequestSpan.ts
@@ -50,11 +50,12 @@ export async function wrapRootRequestSpan<
         options?.parentContext ?? ROOT_CONTEXT,
         async (span) => {
             otel.setTypeAgentSpanAttributes(span, attributes);
-            return context.with(
+            return otel.runInTypeAgentTelemetryContext(
                 otel.setActiveTypeAgentSpanAttributes(
                     context.active(),
                     attributes,
                 ),
+                attributes,
                 async () => {
                     try {
                         const result = await body(span);

--- a/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
+++ b/ts/packages/dispatcher/dispatcher/src/otel/translationSpan.ts
@@ -314,15 +314,18 @@ export async function wrapTranslationSpan<T>(
                 effectiveAttributes,
             );
             try {
-                return await context.with(spanContext, () =>
-                    withChatModelTelemetryContext(
-                        {
-                            phase: "translation",
-                            purpose: "action-generation",
-                            scope: "foreground",
-                        },
-                        () => body(span),
-                    ),
+                return await otel.runInTypeAgentTelemetryContext(
+                    spanContext,
+                    effectiveAttributes,
+                    () =>
+                        withChatModelTelemetryContext(
+                            {
+                                phase: "translation",
+                                purpose: "action-generation",
+                                scope: "foreground",
+                            },
+                            () => body(span),
+                        ),
                 );
             } catch (error) {
                 recordSpanFailure(

--- a/ts/packages/dispatcher/dispatcher/test/llmClassification.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/llmClassification.spec.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { jest } from "@jest/globals";
+import type { AgentSchemaInfo } from "@typeagent/dispatcher-types";
+import {
+    getChatModelTelemetryContext,
+    withChatModelTelemetryContext,
+    type ChatModelTelemetryContext,
+} from "@typeagent/aiclient";
+import type { KeywordExtractionInput } from "../src/context/contextSelector/keywordExtractor.js";
+import type { CreateChatModel } from "../src/context/contextSelector/keywordDistiller.js";
+
+const observed: ChatModelTelemetryContext[] = [];
+
+const typechatUtils = await import("@typeagent/typechat-utils");
+jest.unstable_mockModule("@typeagent/typechat-utils", () => ({
+    ...typechatUtils,
+    createJsonTranslatorFromSchemaDef: () => ({
+        translate: async () => {
+            observed.push(getChatModelTelemetryContext());
+            return { success: true, data: { summary: "", explanation: "" } };
+        },
+    }),
+}));
+
+const { polishAgentView } = await import(
+    "../src/context/system/describe/describeCore.js"
+);
+const { distillKeywords } = await import(
+    "../src/context/contextSelector/keywordDistiller.js"
+);
+
+function makeAgent(): AgentSchemaInfo {
+    return {
+        name: "spotify",
+        emoji: "music",
+        description: "controls your local Spotify instance",
+        subSchemas: [
+            {
+                schemaName: "spotify",
+                description: "Spotify playback control",
+                schemaText: undefined,
+                actions: [{ name: "play", description: "Play a track" }],
+            },
+        ],
+    };
+}
+
+const keywordInput: KeywordExtractionInput = {
+    actionName: "addItems",
+    actionComments: ["Add items to a list"],
+    paramNames: ["items"],
+    paramComments: ["the items to add"],
+    schemaDescription: "manages lists",
+};
+
+const keywordModel: CreateChatModel = () =>
+    ({
+        completionSettings: {},
+        complete: async () => {
+            observed.push(getChatModelTelemetryContext());
+            return {
+                success: true,
+                data: JSON.stringify({ keywords: ["list", "item"] }),
+            };
+        },
+    }) as ReturnType<CreateChatModel>;
+
+describe("dispatcher LLM classification call sites", () => {
+    beforeEach(() => {
+        observed.length = 0;
+    });
+
+    it("classifies capability description and inherits the caller's phase", async () => {
+        await polishAgentView(makeAgent(), "deterministic");
+
+        expect(observed).toEqual([
+            {
+                phase: "unknown",
+                purpose: "capability-description",
+                scope: "foreground",
+                classificationSource: "explicit",
+            },
+        ]);
+
+        observed.length = 0;
+        await withChatModelTelemetryContext(
+            { phase: "action", purpose: "action", scope: "foreground" },
+            () => polishAgentView(makeAgent(), "deterministic"),
+        );
+        expect(observed).toEqual([
+            {
+                phase: "action",
+                purpose: "capability-description",
+                scope: "foreground",
+                classificationSource: "explicit",
+            },
+        ]);
+    });
+
+    it("classifies keyword authoring as explicit background work", async () => {
+        await distillKeywords(keywordInput, { createModel: keywordModel });
+
+        expect(observed).toEqual([
+            {
+                phase: "background",
+                purpose: "keyword-authoring",
+                scope: "background",
+                classificationSource: "explicit",
+            },
+        ]);
+    });
+
+    it("keeps keyword authoring background under a foreground caller", async () => {
+        await withChatModelTelemetryContext(
+            { phase: "action", purpose: "action", scope: "foreground" },
+            () => distillKeywords(keywordInput, { createModel: keywordModel }),
+        );
+
+        expect(observed[0]).toEqual({
+            phase: "background",
+            purpose: "keyword-authoring",
+            scope: "background",
+            classificationSource: "explicit",
+        });
+    });
+});

--- a/ts/packages/dispatcher/dispatcher/test/optimizeLlmClassification.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/optimizeLlmClassification.spec.ts
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+    getChatModelTelemetryContext,
+    withChatModelTelemetryContext,
+    type ChatModel,
+    type ChatModelTelemetryContext,
+} from "@typeagent/aiclient";
+import type { ActionConfigProvider } from "../src/translation/actionConfigProvider.js";
+import type { Neighborhood } from "../src/neighborhoods/types.js";
+import type { TranslationProbeFile } from "../src/translation/translationProbeRunner.js";
+import type {
+    AttemptRecord,
+    CaseDescription,
+    Hypothesis,
+} from "../src/neighborhoods/optimize/types.js";
+import {
+    _clearRegistryForTest,
+    registerLever,
+    type LeverPlugin,
+    type ProposeContext,
+} from "../src/neighborhoods/optimize/registry.js";
+import { generateHypotheses } from "../src/neighborhoods/optimize/hypothesisGenerator.js";
+import { distillGuidelineCandidates } from "../src/neighborhoods/optimize/guidelineDistiller.js";
+import { analyzeCase } from "../src/neighborhoods/optimize/caseAnalyzer.js";
+
+function makeStubModel(observed: ChatModelTelemetryContext[]): ChatModel {
+    return {
+        complete: async () => {
+            observed.push(getChatModelTelemetryContext());
+            return {
+                success: true,
+                data: JSON.stringify({
+                    failurePattern: "unclassified",
+                    proposedText: "Prefer explicit action descriptions.",
+                }),
+            };
+        },
+    } as unknown as ChatModel;
+}
+
+function makeCaseDescription(): CaseDescription {
+    return {
+        schemaVersion: 1,
+        neighborhoodId: "n1",
+        members: [
+            { schemaName: "list", actionName: "addItems" },
+            { schemaName: "list", actionName: "removeItems" },
+        ],
+        severityTier: "leaky",
+        failurePattern: "unclassified",
+        failurePatternHeuristic: "unclassified",
+        misroutePhrases: [],
+        cleanPhrases: [],
+        reverseDirectionPhrases: [],
+        currentJSDoc: {},
+        currentManifestDescriptions: {},
+        currentPasDescriptions: {},
+        originalChecksum: {},
+    };
+}
+
+function makeProposeContext(model: ChatModel): ProposeContext {
+    return {
+        createModel: () => model,
+        pmap: async <T, R>(
+            items: readonly T[],
+            _concurrency: number,
+            fn: (item: T, index: number) => Promise<R>,
+        ) => Promise.all(items.map(fn)),
+        workdir: "test-workdir",
+        outDir: "test-outdir",
+        schemaGuidelines: "",
+    };
+}
+
+describe("optimize LLM classification", () => {
+    afterEach(() => {
+        _clearRegistryForTest();
+    });
+
+    it("classifies every lever and nested retry as background hypothesis generation", async () => {
+        const observed: ChatModelTelemetryContext[] = [];
+        const model = makeStubModel(observed);
+        const makeLever = (name: string): LeverPlugin => ({
+            name,
+            description: `${name} lever`,
+            consumes: ["neighborhoods"],
+            probeType: "translator",
+            proposeHypotheses: async (
+                _caseDescription: CaseDescription,
+                _priorAttempts: AttemptRecord[],
+                context: ProposeContext,
+            ): Promise<Hypothesis[]> => {
+                await context.createModel("propose").complete("prompt");
+                await context.createModel("retry").complete("retry prompt");
+                return [];
+            },
+            applyToSandbox: async () => ({ filesWritten: [] }),
+        });
+        registerLever(makeLever("a-lever"));
+        registerLever(makeLever("b-lever"));
+
+        await withChatModelTelemetryContext(
+            { phase: "action", purpose: "action", scope: "foreground" },
+            () =>
+                generateHypotheses({
+                    caseDesc: makeCaseDescription(),
+                    priorAttempts: [],
+                    ctx: makeProposeContext(model),
+                }),
+        );
+
+        expect(observed).toHaveLength(4);
+        for (const classification of observed) {
+            expect(classification).toEqual({
+                phase: "background",
+                purpose: "optimization-hypothesis-generation",
+                scope: "background",
+                classificationSource: "explicit",
+            });
+        }
+    });
+
+    it("classifies case analysis as background case classification", async () => {
+        const observed: ChatModelTelemetryContext[] = [];
+        const neighborhood: Neighborhood = {
+            id: "n1",
+            kind: "same-schema",
+            members: [
+                { schemaName: "list", actionName: "addItems" },
+                { schemaName: "list", actionName: "removeItems" },
+            ],
+            evidence: {},
+            sources: ["corpus"],
+        };
+        const translationResults = {
+            results: [],
+        } as unknown as TranslationProbeFile;
+        const provider = {
+            tryGetActionConfig: () => undefined,
+        } as unknown as ActionConfigProvider;
+
+        await analyzeCase({
+            neighborhood,
+            translationResults,
+            provider,
+            createModel: () => makeStubModel(observed),
+            schemaGuidelines: "guidelines",
+            skipChecksumValidation: true,
+        });
+
+        expect(observed).toEqual([
+            {
+                phase: "background",
+                purpose: "optimization-case-classification",
+                scope: "background",
+                classificationSource: "explicit",
+            },
+        ]);
+    });
+
+    it("classifies guideline distillation as background work", async () => {
+        const observed: ChatModelTelemetryContext[] = [];
+        const tempRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "optimize-distill-test-"),
+        );
+        const evalPathA = path.join(tempRoot, "attempt-a");
+        const evalPathB = path.join(tempRoot, "attempt-b");
+        fs.mkdirSync(evalPathA);
+        fs.mkdirSync(evalPathB);
+        try {
+            const patternsFile = path.join(tempRoot, "patterns.jsonl");
+            const row = (id: string, evaluationPath: string) => ({
+                runId: "r1",
+                caseId: `c-${id}`,
+                schemaName: "list",
+                actionName: "addItems",
+                neighborhoodId: `n-${id}`,
+                failurePattern: "unclassified",
+                failurePatternHeuristic: "unclassified",
+                lever: "jsdoc",
+                mechanism: "widen-identity",
+                guidelineHook: "schema-shape-work-with-llm-intent",
+                depth: 0,
+                rescues: 3,
+                regressions: 0,
+                netDelta: 3,
+                score: 3,
+                isWinner: true,
+                regressionPhrases: [],
+                evaluationPath,
+            });
+            fs.writeFileSync(
+                patternsFile,
+                `${JSON.stringify(row("1", evalPathA))}\n${JSON.stringify(
+                    row("2", evalPathB),
+                )}\n`,
+            );
+
+            await distillGuidelineCandidates({
+                patternsFile,
+                minAttempts: 1,
+                minPerGroup: 2,
+                schemaGuidelines: "guidelines",
+                createModel: () => makeStubModel(observed),
+            });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+
+        expect(observed).toEqual([
+            {
+                phase: "background",
+                purpose: "optimization-guideline-distillation",
+                scope: "background",
+                classificationSource: "explicit",
+            },
+        ]);
+    });
+});

--- a/ts/packages/telemetry/package.json
+++ b/ts/packages/telemetry/package.json
@@ -20,6 +20,10 @@
       "node": "./dist/otel/testing/inMemorySpanManager.js"
     },
     "./traceContext": {
+      "node": {
+        "types": "./dist/otel/traceContextNode.d.ts",
+        "default": "./dist/otel/traceContextNode.js"
+      },
       "types": "./dist/otel/traceContract.d.ts",
       "default": "./dist/otel/traceContract.js"
     },

--- a/ts/packages/telemetry/src/logger/structuredLogMessage.ts
+++ b/ts/packages/telemetry/src/logger/structuredLogMessage.ts
@@ -47,6 +47,8 @@ export function getStructuredLogMessage(
             return `LLM started: ${formatLlmOperation(data)}${formatScope(data)}${formatModel(data)}${booleanValue(data, "streaming") ? " (streaming)" : ""}`;
         case "aiclient:llm:completed":
             return formatLlmCompleted(data);
+        case "aiclient:llm:classification:default":
+            return `${numberValue(data, "count", 0)} foreground LLM call(s) ran with default (unclassified) phase/purpose`;
         default:
             return undefined;
     }
@@ -134,7 +136,10 @@ function formatLlmCompleted(data: Record<string, unknown>): string {
 function formatLlmOperation(data: Record<string, unknown>): string {
     const phase = stringValue(data, "phase", "unknown");
     const purpose = stringValue(data, "purpose", "unknown");
-    return phase === purpose ? phase : `${phase}.${purpose}`;
+    const operation = phase === purpose ? phase : `${phase}.${purpose}`;
+    return data.classificationSource === "default"
+        ? `${operation} (unclassified)`
+        : operation;
 }
 
 function formatScope(data: Record<string, unknown>): string {

--- a/ts/packages/telemetry/src/otel/index.ts
+++ b/ts/packages/telemetry/src/otel/index.ts
@@ -113,12 +113,17 @@ export {
     TYPEAGENT_SPAN_NAMES,
     TYPEAGENT_SPAN_ATTRIBUTES,
     getActiveTypeAgentSpanAttributes,
+    installAmbientTypeAgentAttributeStore,
+    runInTypeAgentTelemetryContext,
     setActiveTypeAgentSpanAttributes,
     setTypeAgentSpanAttributes,
+    type AmbientTypeAgentAttributeStore,
     type TypeAgentSpanName,
     type TypeAgentSpanAttributeKey,
     type TypeAgentSpanAttributes,
 } from "./traceContract.js";
+
+export { installNodeAmbientTelemetryContext } from "./traceContextNode.js";
 
 export {
     isStructuredLoggingEnabled,

--- a/ts/packages/telemetry/src/otel/traceContextNode.ts
+++ b/ts/packages/telemetry/src/otel/traceContextNode.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+    installAmbientTypeAgentAttributeStore,
+    type AmbientTypeAgentAttributeStore,
+    type TypeAgentSpanAttributes,
+} from "./traceContract.js";
+
+export * from "./traceContract.js";
+
+const ambientAttributes = new AsyncLocalStorage<TypeAgentSpanAttributes>();
+
+const nodeAmbientStore: AmbientTypeAgentAttributeStore = {
+    getActive: () => ambientAttributes.getStore(),
+    run: (attributes, body) => ambientAttributes.run(attributes, body),
+};
+
+export function installNodeAmbientTelemetryContext(): void {
+    installAmbientTypeAgentAttributeStore(nodeAmbientStore);
+}
+
+installNodeAmbientTelemetryContext();

--- a/ts/packages/telemetry/src/otel/traceContract.ts
+++ b/ts/packages/telemetry/src/otel/traceContract.ts
@@ -71,6 +71,7 @@ export const TYPEAGENT_SPAN_ATTRIBUTES = Object.freeze({
     LLM_PHASE: "typeagent.llm.phase",
     LLM_PURPOSE: "typeagent.llm.purpose",
     LLM_SCOPE: "typeagent.llm.scope",
+    LLM_CLASSIFICATION_SOURCE: "typeagent.llm.classification_source",
 } as const);
 
 /** Type of a well-known TypeAgent attribute-key value. */
@@ -109,18 +110,37 @@ export interface TypeAgentSpanAttributes {
     readonly llmPurpose?: string;
     /** Whether the LLM operation is foreground or background work. */
     readonly llmScope?: string;
+    /** Whether a call site explicitly classified the LLM operation. */
+    readonly llmClassificationSource?: string;
 }
 
 const ACTIVE_TYPEAGENT_ATTRIBUTES = createContextKey(
     "typeagent.active-span-attributes",
 );
 
+export interface AmbientTypeAgentAttributeStore {
+    getActive(): TypeAgentSpanAttributes | undefined;
+    run<T>(attributes: TypeAgentSpanAttributes, body: () => T): T;
+}
+
+let ambientStore: AmbientTypeAgentAttributeStore | undefined;
+
+export function installAmbientTypeAgentAttributeStore(
+    store: AmbientTypeAgentAttributeStore | undefined,
+): AmbientTypeAgentAttributeStore | undefined {
+    const previous = ambientStore;
+    ambientStore = store;
+    return previous;
+}
+
 export function getActiveTypeAgentSpanAttributes(
     activeContext: Context = context.active(),
 ): TypeAgentSpanAttributes | undefined {
-    return activeContext.getValue(ACTIVE_TYPEAGENT_ATTRIBUTES) as
-        | TypeAgentSpanAttributes
-        | undefined;
+    return (
+        (activeContext.getValue(ACTIVE_TYPEAGENT_ATTRIBUTES) as
+            | TypeAgentSpanAttributes
+            | undefined) ?? ambientStore?.getActive()
+    );
 }
 
 export function setActiveTypeAgentSpanAttributes(
@@ -134,6 +154,17 @@ export function setActiveTypeAgentSpanAttributes(
         ...current,
         ...attributes,
     });
+}
+
+export function runInTypeAgentTelemetryContext<T>(
+    activeContext: Context,
+    attributes: TypeAgentSpanAttributes,
+    body: () => T,
+): T {
+    const withContext = () => context.with(activeContext, body);
+    return ambientStore === undefined
+        ? withContext()
+        : ambientStore.run(attributes, withContext);
 }
 
 const ATTRIBUTE_KEY_FOR_FIELD: {
@@ -150,6 +181,8 @@ const ATTRIBUTE_KEY_FOR_FIELD: {
     llmPhase: TYPEAGENT_SPAN_ATTRIBUTES.LLM_PHASE,
     llmPurpose: TYPEAGENT_SPAN_ATTRIBUTES.LLM_PURPOSE,
     llmScope: TYPEAGENT_SPAN_ATTRIBUTES.LLM_SCOPE,
+    llmClassificationSource:
+        TYPEAGENT_SPAN_ATTRIBUTES.LLM_CLASSIFICATION_SOURCE,
 };
 
 /**

--- a/ts/packages/telemetry/src/otel/traceContract.ts
+++ b/ts/packages/telemetry/src/otel/traceContract.ts
@@ -110,7 +110,6 @@ export interface TypeAgentSpanAttributes {
     readonly llmPurpose?: string;
     /** Whether the LLM operation is foreground or background work. */
     readonly llmScope?: string;
-    /** Whether a call site explicitly classified the LLM operation. */
     readonly llmClassificationSource?: string;
 }
 

--- a/ts/packages/telemetry/test/otelTraceContract.spec.ts
+++ b/ts/packages/telemetry/test/otelTraceContract.spec.ts
@@ -3,11 +3,19 @@
 
 import { context, propagation, trace, TraceFlags } from "@opentelemetry/api";
 import { createSecretFilter } from "@typeagent/common-utils";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
+    getActiveTypeAgentSpanAttributes,
+    installAmbientTypeAgentAttributeStore,
+    runInTypeAgentTelemetryContext,
+    setActiveTypeAgentSpanAttributes,
     setTypeAgentSpanAttributes,
     TYPEAGENT_SPAN_ATTRIBUTES,
     TYPEAGENT_SPAN_NAMES,
 } from "../src/otel/traceContract.js";
+import { installNodeAmbientTelemetryContext } from "../src/otel/traceContextNode.js";
 import {
     createInMemorySpanManager,
     type CapturedSpan,
@@ -21,6 +29,7 @@ import {
 // `@typeagent/telemetry/testing/inMemorySpanManager` do not silently pick up
 // a stale build.
 import * as managerSubpath from "@typeagent/telemetry/testing/inMemorySpanManager";
+import * as traceContextSubpath from "@typeagent/telemetry/traceContext";
 
 describe("trace contract span-name and attribute-key constants", () => {
     it("uses the frozen typeagent.* span-name namespace the design doc calls out", () => {
@@ -47,6 +56,7 @@ describe("trace contract span-name and attribute-key constants", () => {
             LLM_PHASE: "typeagent.llm.phase",
             LLM_PURPOSE: "typeagent.llm.purpose",
             LLM_SCOPE: "typeagent.llm.scope",
+            LLM_CLASSIFICATION_SOURCE: "typeagent.llm.classification_source",
         });
         expect(Object.isFrozen(TYPEAGENT_SPAN_ATTRIBUTES)).toBe(true);
     });
@@ -385,5 +395,132 @@ describe("published testing subpath export", () => {
             // provider into whichever spec Jest schedules next.
             await manager.shutdown();
         }
+    });
+});
+
+describe("ambient TypeAgent attributes", () => {
+    const attributes = { sessionId: "session", requestId: "request" };
+
+    it("propagates across awaits without an OTel context manager", async () => {
+        const observed = await runInTypeAgentTelemetryContext(
+            setActiveTypeAgentSpanAttributes(context.active(), attributes),
+            attributes,
+            async () => {
+                await Promise.resolve();
+                return getActiveTypeAgentSpanAttributes();
+            },
+        );
+
+        expect(observed).toEqual(attributes);
+        expect(getActiveTypeAgentSpanAttributes()).toBeUndefined();
+    });
+
+    it("degrades without throwing when no ambient store or context manager exists", async () => {
+        const previous = installAmbientTypeAgentAttributeStore(undefined);
+        try {
+            const observed = await runInTypeAgentTelemetryContext(
+                setActiveTypeAgentSpanAttributes(context.active(), attributes),
+                attributes,
+                async () => {
+                    await Promise.resolve();
+                    return getActiveTypeAgentSpanAttributes();
+                },
+            );
+            expect(observed).toBeUndefined();
+        } finally {
+            installAmbientTypeAgentAttributeStore(previous);
+        }
+    });
+
+    it("restores Node ambient propagation after the browser fallback path", () => {
+        installNodeAmbientTelemetryContext();
+        expect(
+            runInTypeAgentTelemetryContext(
+                context.active(),
+                attributes,
+                getActiveTypeAgentSpanAttributes,
+            ),
+        ).toEqual(attributes);
+    });
+});
+
+describe("browser-safe traceContext boundary", () => {
+    const attributes = { sessionId: "session", requestId: "request" };
+    const otelSrcDir = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../src/otel",
+    );
+    const nodeBuiltins = new Set([
+        "async_hooks",
+        "buffer",
+        "child_process",
+        "crypto",
+        "events",
+        "fs",
+        "http",
+        "https",
+        "net",
+        "os",
+        "path",
+        "process",
+        "stream",
+        "timers",
+        "url",
+        "util",
+        "worker_threads",
+        "zlib",
+    ]);
+    const specifierPattern = /(?:\bfrom\s*|\bimport\s*\(?\s*)["']([^"']+)["']/g;
+
+    async function collectImports(entry: string): Promise<string[]> {
+        const visited = new Set<string>();
+        const external: string[] = [];
+        const queue = [entry];
+        while (queue.length > 0) {
+            const file = queue.shift();
+            if (file === undefined || visited.has(file)) {
+                continue;
+            }
+            visited.add(file);
+            const source = await readFile(path.join(otelSrcDir, file), "utf8");
+            for (const match of source.matchAll(specifierPattern)) {
+                const specifier = match[1];
+                if (specifier === undefined) {
+                    continue;
+                }
+                if (specifier.startsWith(".")) {
+                    queue.push(
+                        specifier.replace(/^\.\//, "").replace(/\.js$/, ".ts"),
+                    );
+                } else {
+                    external.push(specifier);
+                }
+            }
+        }
+        return external;
+    }
+
+    it("keeps the browser contract free of Node builtins", async () => {
+        const external = await collectImports("traceContract.ts");
+        expect(
+            external.filter(
+                (specifier) =>
+                    specifier.startsWith("node:") ||
+                    nodeBuiltins.has(specifier.split("/")[0] ?? ""),
+            ),
+        ).toEqual([]);
+    });
+
+    it("resolves the published Node subpath with ambient context installed", () => {
+        expect(
+            typeof traceContextSubpath.installNodeAmbientTelemetryContext,
+        ).toBe("function");
+        expect(
+            traceContextSubpath.runInTypeAgentTelemetryContext(
+                context.active(),
+                attributes,
+                () => traceContextSubpath.getActiveTypeAgentSpanAttributes(),
+            ),
+        ).toEqual(attributes);
     });
 });

--- a/ts/packages/telemetry/test/structuredLogMessage.spec.ts
+++ b/ts/packages/telemetry/test/structuredLogMessage.spec.ts
@@ -108,6 +108,7 @@ describe("getStructuredLogMessage", () => {
                 phase: "translation",
                 purpose: "schema-selection",
                 scope: "foreground",
+                classificationSource: "explicit",
             }),
         ).toBe(
             "LLM started: translation.schema-selection (azure/GPT_4_1) (streaming)",
@@ -122,9 +123,27 @@ describe("getStructuredLogMessage", () => {
                 phase: "explanation",
                 purpose: "cache-generation",
                 scope: "background",
+                classificationSource: "explicit",
             }),
         ).toBe(
             "LLM succeeded: explanation.cache-generation [background] (azure/GPT_4_1) in 1234 ms (456 tokens)",
+        );
+        expect(
+            getStructuredLogMessage("aiclient:llm:started", {
+                phase: "unknown",
+                purpose: "unknown",
+                scope: "foreground",
+                classificationSource: "default",
+            }),
+        ).toBe("LLM started: unknown (unclassified)");
+        expect(
+            getStructuredLogMessage("aiclient:llm:classification:default", {
+                scope: "foreground",
+                count: 7,
+                windowMs: 60_000,
+            }),
+        ).toBe(
+            "7 foreground LLM call(s) ran with default (unclassified) phase/purpose",
         );
     });
 


### PR DESCRIPTION
## Stack

**Position:** 2/3

**Parent:** #2916 (`georgengmsft-failure-semantics-layer` at `3aa146995b3167351422d6b536c90f4c50bd6e9c`)

## Scope

- Add explicit/default LLM classification semantics for phase, purpose, and foreground/background scope.
- Preserve attribution and correlation in logs-only, traces-disabled Node processes through browser-safe trace-context composition.
- Classify identifiable foreground and offline/background model calls, including optimize case classification, nested/retry hypothesis generation, and guideline distillation.
- Add a bounded, rate-limited diagnostic for default foreground classification.
- Make LLM lifecycle body messages readable without JSON inspection, including attribution, background scope, outcome, elapsed time, token count, and bounded failure details.
- Document the contract and add focused telemetry, aiclient, dispatcher, browser-boundary, and logs-only tests.

## Exclusions

This layer intentionally excludes layer 3 RPC lifecycle work: RPC started/completed structured events, `RpcOptions` logger injection, RPC lifecycle docs/tests/browser-safety tests, `cancelCommandByClientId` queue ordering/events, and secondary queue body-message additions.

## Invariants

- Preserves all behavior from parent PR #2916 and reuses its shared error classification and cancellation semantics without duplication.
- Browser-shared trace-context code imports no Node builtins.
- No prompts, responses, provider messages, stacks, model/provider identifiers, or call-site identities enter the default-classification diagnostic.
- Statically identifiable offline calls are explicitly attributed as background work.

## Validation

- `pnpm run build agent-dispatcher`
- Telemetry focused tests: 34 passed
- Aiclient focused tests: 23 passed
- Dispatcher attribution tests: 6 passed
- `pnpm run prettier:changed`
- `pnpm run code-lint -- --ratchet --base origin/main`
- `git diff --check`