### PR TITLE
[OTEL] Add RPC lifecycle telemetry

### DIFF
--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -751,11 +751,44 @@ other fields are present only for decisions the code actually observed. The
 reduced local message appends `+llm` when a cache/grammar strategy still reached
 the model.
 
+### RPC lifecycle events
+
+`agentRpc` optionally emits `rpc:started` and `rpc:completed` at each `invoke`
+boundary: once for the outbound client call and once for inbound server handler
+dispatch. A logger is supplied structurally through `RpcOptions.logger`; when it
+is omitted, RPC behavior is unchanged and no events are emitted. Logger failures
+cannot fail an invocation.
+
+The events contain only bounded operational fields. Arguments, results, raw
+error messages, stacks, and transport payloads are never included.
+
+- `role` - `client` or `server`.
+- `channel` and `method` - validated labels capped at 256 characters. Invalid,
+  oversized, or secret-shaped values become `invalid_channel` or
+  `invalid_method`.
+- `callId` - the per-RPC-instance monotonic identifier.
+- `status` - `succeeded`, `failed`, or `cancelled` on `rpc:completed`.
+- `success`, optional `cancelled`, and `elapsedMs` on `rpc:completed`.
+- `errorCategory` and optional bounded `errorCode`, `httpStatus`, and
+  `retryable` only for real failures.
+
+Client and server spans and events use the same shared cancellation classifier,
+including its bounded `cause` walk. A wrapped `AbortError` therefore produces
+`cancelled` consistently and carries no failure classification. Each started
+event is paired with exactly one completed event, including local setup errors,
+handler failures, disconnect/rebind cancellation, and logger failure.
+
+`agentRpc` imports the classifier from the browser-safe
+`@typeagent/telemetry/errorClassification` subpath rather than the Node-only
+package root. Reduced local messages render role, method, channel, status,
+elapsed time, and bounded classification without consulting payload content.
+
 ### Failure classification
 
 Structured failure events use a small, shared classification instead of
 exporting error messages or stacks. This makes failures useful in telemetry
-without exposing user or provider content.
+without exposing user or provider content. The same classifier is used for
+failed `rpc:completed` events.
 
 The classification can include:
 

--- a/ts/packages/agentRpc/README.md
+++ b/ts/packages/agentRpc/README.md
@@ -121,7 +121,8 @@ parenting.
 Code shared with browser RPC consumers must import active TypeAgent trace
 metadata from `@typeagent/telemetry/traceContext`. The main
 `@typeagent/telemetry` entry point is Node-only because it includes provider and
-exporter lifecycle support.
+exporter lifecycle support. Failure classification is likewise available
+through the browser-safe `@typeagent/telemetry/errorClassification` subpath.
 
 Cancellation continues to use each application protocol's existing mechanism.
 For example, agent actions send `cancelAction`, abort the server handler, and
@@ -135,6 +136,25 @@ RPC spans use enqueue-time completion: a SERVER span ends after its terminal
 response is handed to `RpcChannel.send`. The callback is optional in the channel
 contract, so later transport-delivery failures are debug diagnostics rather than
 changes to an already-ended span.
+
+## Structured lifecycle events
+
+Pass a structural logger through `RpcOptions.logger` to emit exactly one
+`rpc:started` and one `rpc:completed` event for each client and server `invoke`
+boundary. Omitting the logger preserves existing behavior and emits nothing.
+Logger failures are isolated from the invocation.
+
+Events contain only bounded operational fields: `role`, `channel`, `method`,
+`callId`, and, on completion, `status`, `success`, `elapsedMs`, optional
+`cancelled`, and normalized failure classification. Invalid or oversized
+channel and method labels become `invalid_channel` and `invalid_method`.
+Arguments, results, raw error messages, stacks, and transport payloads are never
+included.
+
+Completion status is `succeeded`, `failed`, or `cancelled`. Both RPC spans and
+events use the shared cancellation classifier, including its bounded `cause`
+walk, so wrapped cancellation is reported consistently. Only real failures
+carry normalized classification fields.
 
 ## Trademarks
 

--- a/ts/packages/agentRpc/src/client.ts
+++ b/ts/packages/agentRpc/src/client.ts
@@ -35,6 +35,7 @@ import {
     type RpcCorrelationFields,
     type RpcInvocation,
     type RpcOptions,
+    type RpcStructuredLogger,
 } from "./rpc.js";
 import { ChannelProvider } from "./common.js";
 import { getObjectProperty, uint8ArrayToBase64 } from "@typeagent/common-utils";
@@ -44,6 +45,7 @@ import { getActiveTypeAgentSpanAttributes } from "@typeagent/telemetry/traceCont
 
 export type AgentRpcOptions = {
     trustedContextPropagation?: boolean;
+    logger?: RpcStructuredLogger;
 };
 
 /**
@@ -881,17 +883,26 @@ function getTrustedRpcOptions(
         invocation: RpcInvocation,
     ) => RpcCorrelationFields | undefined,
 ): RpcOptions | undefined {
-    return options?.trustedContextPropagation === true
-        ? {
-              tracing: {
-                  propagateContext: true,
-                  trustRemoteContext: true,
-                  ...(getCorrelationFields === undefined
-                      ? undefined
-                      : { getCorrelationFields }),
-              },
-          }
-        : undefined;
+    if (
+        options?.trustedContextPropagation !== true &&
+        options?.logger === undefined
+    ) {
+        return undefined;
+    }
+    return {
+        ...(options.trustedContextPropagation === true
+            ? {
+                  tracing: {
+                      propagateContext: true,
+                      trustRemoteContext: true,
+                      ...(getCorrelationFields === undefined
+                          ? undefined
+                          : { getCorrelationFields }),
+                  },
+              }
+            : {}),
+        ...(options.logger === undefined ? {} : { logger: options.logger }),
+    };
 }
 
 function getAgentRpcCorrelation(

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -557,7 +557,7 @@ export function createRpc<
     let nextCallId = 0;
     const disconnectedInvoke = (
         methodName: keyof InvokeTargetFunctions,
-        ..._args: any[]
+        ..._args: unknown[]
     ): never => {
         const lifecycle = createLifecycleFields(
             "client",

--- a/ts/packages/agentRpc/src/rpc.ts
+++ b/ts/packages/agentRpc/src/rpc.ts
@@ -15,6 +15,11 @@ import {
 } from "@opentelemetry/api";
 import registerDebug from "debug";
 import { filterSecrets } from "@typeagent/common-utils";
+import {
+    classifyTelemetryError,
+    isTelemetryCancellation,
+    type TelemetryErrorClassification,
+} from "@typeagent/telemetry/errorClassification";
 
 import { RpcChannel } from "./common.js";
 
@@ -92,7 +97,29 @@ export type RpcOptions = {
     // intact so the rpc can be reattached to a fresh channel via rebind().
     rebindable?: boolean;
     tracing?: RpcTracingOptions;
+    /**
+     * Optional structured-event logger for `rpc:started` and `rpc:completed`.
+     * The structural type keeps browser callers independent of the Node-only
+     * telemetry package entry point.
+     */
+    logger?: RpcStructuredLogger;
 };
+
+export interface RpcStructuredLogger {
+    logEvent(
+        eventName: string,
+        entry: Record<string, unknown>,
+        severity?: "info" | "warning" | "error",
+    ): void;
+}
+
+export const RPC_STRUCTURED_EVENTS = {
+    started: "rpc:started",
+    completed: "rpc:completed",
+} as const;
+
+type RpcRole = "client" | "server";
+type RpcStatus = "succeeded" | "failed" | "cancelled";
 
 const RPC_SPAN_NAME = "typeagent.rpc.invoke";
 const RPC_INSTRUMENTATION_SCOPE = "@typeagent/agent-rpc";
@@ -100,6 +127,7 @@ const RPC_INSTRUMENTATION_VERSION = "0.0.1";
 const MAX_TRACEPARENT_LENGTH = 512;
 const MAX_TRACESTATE_LENGTH = 512;
 const MAX_CORRELATION_LENGTH = 256;
+const MAX_RPC_CHANNEL_LENGTH = 256;
 const MAX_RPC_METHOD_LENGTH = 256;
 const MAX_TRACESTATE_MEMBERS = 32;
 const CORRELATION_VALUE_PATTERN = /^[A-Za-z0-9._:@/-]+$/;
@@ -234,57 +262,76 @@ export function createRpc<
             remote.parentContext,
             async (span) => {
                 setCorrelationAttributes(span, remote.correlation);
+                const lifecycle = createLifecycleFields(
+                    "server",
+                    name,
+                    message.name,
+                    message.callId,
+                );
+                const startedAt = Date.now();
+                emitStructuredStarted(options?.logger, lifecycle);
+                let outcome: RpcCompletion = {
+                    ...lifecycle,
+                    status: "failed",
+                };
                 let cancelServerInvoke:
                     | ((reason: ServerCancellation) => void)
                     | undefined;
-                const cancellation = new Promise<{
-                    kind: "cancelled";
-                    reason: ServerCancellation;
-                }>((resolve) => {
-                    cancelServerInvoke = (reason) =>
-                        resolve({ kind: "cancelled", reason });
-                });
-                const serverInvoke: ServerInvoke = {
-                    cancel(reason) {
-                        cancelServerInvoke?.(reason);
-                    },
-                };
-                serverInvokes.set(message.callId, serverInvoke);
-
-                const handler = invokeHandlers?.[message.name];
-                const handlerResult = context.with(
-                    context
-                        .active()
-                        .setValue(ACTIVE_RPC_CORRELATION, remote.correlation),
-                    () =>
-                        handler === undefined
-                            ? Promise.resolve({
-                                  kind: "error" as const,
-                                  error: new Error(
-                                      `No invoke handler ${message.name}`,
-                                  ),
-                              })
-                            : Promise.resolve()
-                                  .then(() => handler(...message.args))
-                                  .then(
-                                      (result) => ({
-                                          kind: "result" as const,
-                                          result,
-                                      }),
-                                      (error) => ({
-                                          kind: "error" as const,
-                                          error,
-                                      }),
-                                  ),
-                );
-
+                let serverInvoke: ServerInvoke | undefined;
                 try {
+                    const cancellation = new Promise<{
+                        kind: "cancelled";
+                        reason: ServerCancellation;
+                    }>((resolve) => {
+                        cancelServerInvoke = (reason) =>
+                            resolve({ kind: "cancelled", reason });
+                    });
+                    serverInvoke = {
+                        cancel(reason) {
+                            cancelServerInvoke?.(reason);
+                        },
+                    };
+                    serverInvokes.set(message.callId, serverInvoke);
+
+                    const handler = invokeHandlers?.[message.name];
+                    const handlerResult = context.with(
+                        context
+                            .active()
+                            .setValue(
+                                ACTIVE_RPC_CORRELATION,
+                                remote.correlation,
+                            ),
+                        () =>
+                            handler === undefined
+                                ? Promise.resolve({
+                                      kind: "error" as const,
+                                      error: new Error(
+                                          `No invoke handler ${message.name}`,
+                                      ),
+                                  })
+                                : Promise.resolve()
+                                      .then(() => handler(...message.args))
+                                      .then(
+                                          (result) => ({
+                                              kind: "result" as const,
+                                              result,
+                                          }),
+                                          (error) => ({
+                                              kind: "error" as const,
+                                              error,
+                                          }),
+                                      ),
+                    );
                     const result = await Promise.race([
                         handlerResult,
                         cancellation,
                     ]);
                     if (result.kind === "cancelled") {
                         recordServerCancellation(span);
+                        outcome = {
+                            ...lifecycle,
+                            status: "cancelled",
+                        };
                         return;
                     }
                     serverInvokes.delete(message.callId);
@@ -297,10 +344,16 @@ export function createRpc<
                             },
                             message.name,
                         );
+                        outcome = {
+                            ...lifecycle,
+                            status: "succeeded",
+                        };
                         return;
                     }
 
-                    const cancellationError = isAbortError(result.error);
+                    const cancellationError = isTelemetryCancellation(
+                        result.error,
+                    );
                     recordServerError(span, cancellationError);
                     sendResponse(
                         {
@@ -320,8 +373,18 @@ export function createRpc<
                         },
                         message.name,
                     );
+                    outcome = {
+                        ...lifecycle,
+                        status: cancellationError ? "cancelled" : "failed",
+                        error: cancellationError ? undefined : result.error,
+                    };
                 } catch (error) {
                     recordLocalRpcError(span);
+                    outcome = {
+                        ...lifecycle,
+                        status: "failed",
+                        error,
+                    };
                     debugError("invoke response processing failed", {
                         agent: name,
                         method: message.name,
@@ -331,9 +394,16 @@ export function createRpc<
                         stack: getErrorStack(error),
                     });
                 } finally {
-                    if (serverInvokes.get(message.callId) === serverInvoke) {
+                    if (
+                        serverInvoke !== undefined &&
+                        serverInvokes.get(message.callId) === serverInvoke
+                    ) {
                         serverInvokes.delete(message.callId);
                     }
+                    emitStructuredCompleted(options?.logger, {
+                        ...outcome,
+                        elapsedMs: Date.now() - startedAt,
+                    });
                     span.end();
                 }
             },
@@ -478,21 +548,37 @@ export function createRpc<
             rejectAllPending("Agent channel disconnected");
             cancelAllServerInvokes("disconnect");
             if (!rebindable) {
-                rpc.invoke = errorFunc;
+                rpc.invoke = disconnectedInvoke;
                 rpc.send = errorFunc;
             }
         });
     };
 
     let nextCallId = 0;
+    const disconnectedInvoke = (
+        methodName: keyof InvokeTargetFunctions,
+        ..._args: any[]
+    ): never => {
+        const lifecycle = createLifecycleFields(
+            "client",
+            name,
+            methodName as string,
+            nextCallId++,
+        );
+        const error = new Error("Agent channel disconnected");
+        emitStructuredStarted(options?.logger, lifecycle);
+        emitStructuredCompleted(options?.logger, {
+            ...lifecycle,
+            status: "failed",
+            elapsedMs: 0,
+            error,
+        });
+        throw error;
+    };
     const invoke = async (
         methodName: keyof InvokeTargetFunctions,
         args: any[],
     ): Promise<any> => {
-        if (!connected) {
-            throw new Error("Agent channel disconnected");
-        }
-
         return tracer.startActiveSpan(
             RPC_SPAN_NAME,
             {
@@ -504,20 +590,36 @@ export function createRpc<
                     method: methodName as string,
                     args,
                 };
-                const correlation = getOutboundCorrelation(
-                    options?.tracing,
-                    invocation,
+                const callId = nextCallId++;
+                const lifecycle = createLifecycleFields(
+                    "client",
+                    name,
+                    invocation.method,
+                    callId,
                 );
-                setCorrelationAttributes(span, correlation);
+                const startedAt = Date.now();
+                emitStructuredStarted(options?.logger, lifecycle);
+                let outcome: RpcCompletion = {
+                    ...lifecycle,
+                    status: "succeeded",
+                };
                 try {
+                    if (!connected) {
+                        throw new Error("Agent channel disconnected");
+                    }
+                    const correlation = getOutboundCorrelation(
+                        options?.tracing,
+                        invocation,
+                    );
+                    setCorrelationAttributes(span, correlation);
                     const metadata =
                         options?.tracing?.propagateContext === true
                             ? createMetadataEnvelope(correlation)
                             : undefined;
                     const message: InvokeMessage = {
                         type: "invoke",
-                        callId: nextCallId++,
-                        name: methodName as string,
+                        callId,
+                        name: invocation.method,
                         args,
                         ...(metadata === undefined ? undefined : { metadata }),
                     };
@@ -546,9 +648,19 @@ export function createRpc<
                         }
                     });
                 } catch (error) {
+                    const cancelled = isTelemetryCancellation(error);
+                    outcome = {
+                        ...lifecycle,
+                        status: cancelled ? "cancelled" : "failed",
+                        error: cancelled ? undefined : error,
+                    };
                     recordClientError(span, error);
                     throw error;
                 } finally {
+                    emitStructuredCompleted(options?.logger, {
+                        ...outcome,
+                        elapsedMs: Date.now() - startedAt,
+                    });
                     span.end();
                 }
             },
@@ -600,18 +712,25 @@ export function createRpc<
 function createSpanAttributes(methodName: string) {
     return {
         "rpc.system": "typeagent",
-        "rpc.method": isValidRpcMethod(methodName)
-            ? methodName
-            : "invalid_method",
+        "rpc.method": boundedRpcIdentifier(
+            methodName,
+            MAX_RPC_METHOD_LENGTH,
+            "invalid_method",
+        ),
     };
 }
 
-function isValidRpcMethod(value: string): boolean {
-    return (
-        value.length > 0 &&
-        value.length <= MAX_RPC_METHOD_LENGTH &&
-        RPC_METHOD_PATTERN.test(value)
-    );
+function boundedRpcIdentifier(
+    value: string,
+    maxLength: number,
+    fallback: string,
+): string {
+    return value.length > 0 &&
+        value.length <= maxLength &&
+        RPC_METHOD_PATTERN.test(value) &&
+        filterSecrets(value) === value
+        ? value
+        : fallback;
 }
 
 function setCorrelationAttributes(
@@ -859,7 +978,7 @@ function validateTracestate(value: unknown): value is string {
 
 function recordClientError(span: Span, error: unknown): void {
     const failureKind = (error as RpcFailure | undefined)?.rpcFailureKind;
-    if (failureKind === "cancelled" || isAbortError(error)) {
+    if (failureKind === "cancelled" || isTelemetryCancellation(error)) {
         span.recordException({ name: "AbortError", message: "cancelled" });
         span.setStatus({
             code: SpanStatusCode.ERROR,
@@ -880,7 +999,7 @@ function recordServerError(span: Span, cancelled: boolean): void {
 }
 
 function recordServerCancellation(span: Span): void {
-    recordLocalRpcError(span);
+    recordServerError(span, true);
 }
 
 function recordLocalRpcError(span: Span): void {
@@ -888,12 +1007,83 @@ function recordLocalRpcError(span: Span): void {
     span.setStatus({ code: SpanStatusCode.ERROR, message: "rpc failed" });
 }
 
-function isAbortError(error: unknown): boolean {
-    return (
-        error !== null &&
-        typeof error === "object" &&
-        (error as { name?: unknown }).name === "AbortError"
-    );
+type RpcLifecycleFields = {
+    role: RpcRole;
+    channel: string;
+    method: string;
+    callId: number;
+};
+
+type RpcCompletion = RpcLifecycleFields & {
+    status: RpcStatus;
+    error?: unknown;
+};
+
+function createLifecycleFields(
+    role: RpcRole,
+    channel: string,
+    method: string,
+    callId: number,
+): RpcLifecycleFields {
+    return {
+        role,
+        channel: boundedRpcIdentifier(
+            channel,
+            MAX_RPC_CHANNEL_LENGTH,
+            "invalid_channel",
+        ),
+        method: boundedRpcIdentifier(
+            method,
+            MAX_RPC_METHOD_LENGTH,
+            "invalid_method",
+        ),
+        callId,
+    };
+}
+
+function emitStructuredStarted(
+    logger: RpcStructuredLogger | undefined,
+    fields: RpcLifecycleFields,
+): void {
+    try {
+        logger?.logEvent(RPC_STRUCTURED_EVENTS.started, { ...fields });
+    } catch {
+        // Logging must not change RPC behavior.
+    }
+}
+
+function emitStructuredCompleted(
+    logger: RpcStructuredLogger | undefined,
+    data: RpcCompletion & { elapsedMs: number },
+): void {
+    if (logger === undefined) {
+        return;
+    }
+    try {
+        const classification: TelemetryErrorClassification | undefined =
+            data.status === "failed" && data.error !== undefined
+                ? classifyTelemetryError(data.error)
+                : undefined;
+        const success = data.status === "succeeded";
+        const cancelled = data.status === "cancelled";
+        logger.logEvent(
+            RPC_STRUCTURED_EVENTS.completed,
+            {
+                role: data.role,
+                channel: data.channel,
+                method: data.method,
+                callId: data.callId,
+                status: data.status,
+                success,
+                ...(cancelled ? { cancelled: true } : {}),
+                elapsedMs: data.elapsedMs,
+                ...(classification ?? {}),
+            },
+            success ? "info" : cancelled ? "warning" : "error",
+        );
+    } catch {
+        // Logging must not change RPC behavior.
+    }
 }
 
 function getErrorMessage(error: unknown): string {

--- a/ts/packages/agentRpc/src/server.ts
+++ b/ts/packages/agentRpc/src/server.ts
@@ -31,7 +31,7 @@ import {
     ContextParams,
     OptionsFunctionCallBack,
 } from "./types.js";
-import { createRpc, type RpcOptions } from "./rpc.js";
+import { createRpc, type RpcOptions, type RpcStructuredLogger } from "./rpc.js";
 import { ChannelProvider, RpcChannel } from "./common.js";
 import {
     base64ToUint8Array,
@@ -42,19 +42,29 @@ import {
 
 export type AgentRpcServerOptions = {
     trustedContextPropagation?: boolean;
+    logger?: RpcStructuredLogger;
 };
 
 function getTrustedRpcOptions(
     options: AgentRpcServerOptions | undefined,
 ): RpcOptions | undefined {
-    return options?.trustedContextPropagation === true
-        ? {
-              tracing: {
-                  propagateContext: true,
-                  trustRemoteContext: true,
-              },
-          }
-        : undefined;
+    if (
+        options?.trustedContextPropagation !== true &&
+        options?.logger === undefined
+    ) {
+        return undefined;
+    }
+    return {
+        ...(options.trustedContextPropagation === true
+            ? {
+                  tracing: {
+                      propagateContext: true,
+                      trustRemoteContext: true,
+                  },
+              }
+            : {}),
+        ...(options.logger === undefined ? {} : { logger: options.logger }),
+    };
 }
 
 function createOptionsRpc(

--- a/ts/packages/agentRpc/test/browserSafety.spec.ts
+++ b/ts/packages/agentRpc/test/browserSafety.spec.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("agentRpc browser safety", () => {
+    const packageRoot = resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "..",
+    );
+
+    function readSource(path: string): string {
+        return readFileSync(resolve(packageRoot, path), "utf8");
+    }
+
+    it("uses only browser-safe telemetry subpaths", () => {
+        const source = readSource("src/rpc.ts");
+        const imports = Array.from(
+            source.matchAll(/from\s+["']([^"']+)["']/g),
+            (match) => match[1]!,
+        ).filter((specifier) => specifier.startsWith("@typeagent/telemetry"));
+
+        expect(imports).toEqual(["@typeagent/telemetry/errorClassification"]);
+    });
+
+    it.each(["src/rpc.ts", "src/common.ts"])(
+        "%s imports no Node builtins",
+        (path) => {
+            const source = readSource(path);
+            expect(source).not.toMatch(/from\s+["']node:/);
+            expect(source).not.toMatch(/from\s+["'](crypto|fs|path|os)["']/);
+        },
+    );
+});

--- a/ts/packages/agentRpc/test/rpc.spec.ts
+++ b/ts/packages/agentRpc/test/rpc.spec.ts
@@ -19,7 +19,9 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import {
     createRpc,
     RPC_METADATA_VERSION,
+    RPC_STRUCTURED_EVENTS,
     type RpcOptions,
+    type RpcStructuredLogger,
 } from "../src/rpc.js";
 import type { RpcChannel } from "../src/common.js";
 
@@ -99,6 +101,27 @@ function createFakeChannel(): FakeChannel {
 function connect(a: FakeChannel, b: FakeChannel) {
     a.setPeer(b);
     b.setPeer(a);
+}
+
+type CapturedEvent = {
+    eventName: string;
+    entry: Record<string, unknown>;
+    severity: "info" | "warning" | "error" | undefined;
+};
+
+function createRecordingLogger(): {
+    logger: RpcStructuredLogger;
+    events: CapturedEvent[];
+} {
+    const events: CapturedEvent[] = [];
+    return {
+        events,
+        logger: {
+            logEvent(eventName, entry, severity) {
+                events.push({ eventName, entry, severity });
+            },
+        },
+    };
 }
 
 type EchoInvoke = { echo: (x: number) => Promise<number> };
@@ -723,7 +746,7 @@ describe("createRpc OpenTelemetry propagation", () => {
         expect(serverSpans).toHaveLength(1);
         expect(serverSpans[0]!.status).toEqual({
             code: SpanStatusCode.ERROR,
-            message: "rpc failed",
+            message: "cancelled",
         });
     });
 
@@ -803,6 +826,55 @@ describe("createRpc OpenTelemetry propagation", () => {
         }
     });
 
+    it("reports wrapped cancellation consistently in spans and events", async () => {
+        const clientLogger = createRecordingLogger();
+        const serverLogger = createRecordingLogger();
+        const { clientRpc } = createTracingPair(
+            {
+                tracing: { trustRemoteContext: true },
+                logger: serverLogger.logger,
+            },
+            {
+                tracing: { propagateContext: true },
+                logger: clientLogger.logger,
+            },
+            async () => {
+                const cause = new DOMException("private detail", "AbortError");
+                const wrapper = new Error("private wrapper") as Error & {
+                    cause: unknown;
+                };
+                wrapper.cause = cause;
+                throw wrapper;
+            },
+        );
+
+        await expect(clientRpc.invoke("echo", 1)).rejects.toMatchObject({
+            name: "AbortError",
+        });
+
+        for (const span of fixture!.exporter.getFinishedSpans()) {
+            expect(span.status).toEqual({
+                code: SpanStatusCode.ERROR,
+                message: "cancelled",
+            });
+        }
+        for (const events of [clientLogger.events, serverLogger.events]) {
+            expect(events.map((event) => event.eventName)).toEqual([
+                RPC_STRUCTURED_EVENTS.started,
+                RPC_STRUCTURED_EVENTS.completed,
+            ]);
+            expect(events[1]).toMatchObject({
+                entry: {
+                    status: "cancelled",
+                    success: false,
+                    cancelled: true,
+                },
+                severity: "warning",
+            });
+            expect(events[1]!.entry).not.toHaveProperty("errorCategory");
+        }
+    });
+
     it("records stable statuses for remote errors and ends both spans", async () => {
         const { clientRpc } = createTracingPair(
             { tracing: { trustRemoteContext: true } },
@@ -826,6 +898,215 @@ describe("createRpc OpenTelemetry propagation", () => {
         expect(serverSpan.status).toEqual({
             code: SpanStatusCode.ERROR,
             message: "request failed",
+        });
+    });
+
+    describe("RPC structured lifecycle events", () => {
+        function assertSafeEvent(entry: Record<string, unknown>): void {
+            expect(Object.keys(entry)).toEqual(
+                expect.arrayContaining(["role", "channel", "method", "callId"]),
+            );
+            for (const forbidden of [
+                "args",
+                "result",
+                "error",
+                "message",
+                "stack",
+            ]) {
+                expect(entry).not.toHaveProperty(forbidden);
+            }
+        }
+
+        it("emits exactly one bounded pair per client and server success", async () => {
+            const client = createFakeChannel();
+            const server = createFakeChannel();
+            connect(client, server);
+            const clientLogger = createRecordingLogger();
+            const serverLogger = createRecordingLogger();
+            const clientRpc = createRpc<EchoInvoke>(
+                "client-a",
+                client,
+                undefined,
+                undefined,
+                { logger: clientLogger.logger },
+            );
+            createRpc<{}, {}, EchoInvoke>(
+                "server-a",
+                server,
+                { echo: async (value) => value * 2 },
+                undefined,
+                { logger: serverLogger.logger },
+            );
+
+            await expect(clientRpc.invoke("echo", 21)).resolves.toBe(42);
+
+            for (const [role, events] of [
+                ["client", clientLogger.events],
+                ["server", serverLogger.events],
+            ] as const) {
+                expect(events.map((event) => event.eventName)).toEqual([
+                    RPC_STRUCTURED_EVENTS.started,
+                    RPC_STRUCTURED_EVENTS.completed,
+                ]);
+                expect(events[0]!.entry).toMatchObject({
+                    role,
+                    method: "echo",
+                    callId: 0,
+                });
+                expect(events[1]).toMatchObject({
+                    entry: {
+                        role,
+                        method: "echo",
+                        callId: 0,
+                        status: "succeeded",
+                        success: true,
+                    },
+                    severity: "info",
+                });
+                expect(typeof events[1]!.entry.elapsedMs).toBe("number");
+                for (const event of events) {
+                    assertSafeEvent(event.entry);
+                }
+            }
+        });
+
+        it("classifies only the server's original failure", async () => {
+            const client = createFakeChannel();
+            const server = createFakeChannel();
+            connect(client, server);
+            const clientLogger = createRecordingLogger();
+            const serverLogger = createRecordingLogger();
+            const clientRpc = createRpc<EchoInvoke>(
+                "client-b",
+                client,
+                undefined,
+                undefined,
+                { logger: clientLogger.logger },
+            );
+            createRpc<{}, {}, EchoInvoke>(
+                "server-b",
+                server,
+                {
+                    echo: async () => {
+                        const error = new Error(
+                            "private provider detail",
+                        ) as Error & {
+                            code: string;
+                        };
+                        error.code = "ECONNREFUSED";
+                        throw error;
+                    },
+                },
+                undefined,
+                { logger: serverLogger.logger },
+            );
+
+            await expect(clientRpc.invoke("echo", 1)).rejects.toThrow(
+                "private provider detail",
+            );
+
+            expect(serverLogger.events[1]).toMatchObject({
+                entry: {
+                    status: "failed",
+                    success: false,
+                    errorCategory: "network",
+                    errorCode: "ECONNREFUSED",
+                    retryable: true,
+                },
+                severity: "error",
+            });
+            expect(clientLogger.events[1]!.entry).toMatchObject({
+                status: "failed",
+                success: false,
+                errorCategory: "internal",
+            });
+            for (const event of [
+                ...clientLogger.events,
+                ...serverLogger.events,
+            ]) {
+                assertSafeEvent(event.entry);
+            }
+        });
+
+        it("bounds invalid channel and method labels", async () => {
+            const client = createFakeChannel();
+            const logger = createRecordingLogger();
+            const rpc = createRpc<
+                Record<string, (...args: any[]) => Promise<unknown>>
+            >("x".repeat(257), client, undefined, undefined, {
+                logger: logger.logger,
+            });
+
+            const result = rpc.invoke("y".repeat(257));
+            client.deliver({
+                type: "invokeError",
+                callId: 0,
+                error: "remote failure",
+            });
+            await expect(result).rejects.toThrow("remote failure");
+
+            for (const event of logger.events) {
+                expect(event.entry).toMatchObject({
+                    channel: "invalid_channel",
+                    method: "invalid_method",
+                });
+            }
+        });
+
+        it("does not let a throwing logger change RPC behavior", async () => {
+            const client = createFakeChannel();
+            const server = createFakeChannel();
+            connect(client, server);
+            const logger: RpcStructuredLogger = {
+                logEvent() {
+                    throw new Error("logger failed");
+                },
+            };
+            const clientRpc = createRpc<EchoInvoke>(
+                "client-c",
+                client,
+                undefined,
+                undefined,
+                { logger },
+            );
+            createRpc<{}, {}, EchoInvoke>(
+                "server-c",
+                server,
+                { echo: async (value) => value + 1 },
+                undefined,
+                { logger },
+            );
+
+            await expect(clientRpc.invoke("echo", 41)).resolves.toBe(42);
+        });
+
+        it("pairs lifecycle events for an invoke attempted while disconnected", async () => {
+            const channel = createFakeChannel();
+            const recording = createRecordingLogger();
+            const rpc = createRpc<EchoInvoke>(
+                "client-disconnected",
+                channel,
+                undefined,
+                undefined,
+                { rebindable: true, logger: recording.logger },
+            );
+            channel.fireDisconnect();
+
+            await expect(rpc.invoke("echo", 1)).rejects.toThrow(
+                "Agent channel disconnected",
+            );
+            expect(recording.events.map((event) => event.eventName)).toEqual([
+                RPC_STRUCTURED_EVENTS.started,
+                RPC_STRUCTURED_EVENTS.completed,
+            ]);
+            expect(recording.events[1]).toMatchObject({
+                entry: {
+                    status: "failed",
+                    success: false,
+                    errorCategory: "internal",
+                },
+                severity: "error",
+            });
         });
     });
 });

--- a/ts/packages/dispatcher/dispatcher/src/dispatcher.ts
+++ b/ts/packages/dispatcher/dispatcher/src/dispatcher.ts
@@ -406,28 +406,51 @@ export function createDispatcherFromContext(
             return context.requestQueue.promote(requestId);
         },
         cancelCommandByClientId(clientRequestId: unknown) {
-            const controller =
-                context.activeRequestsByClientId.get(clientRequestId);
-            if (controller) {
-                controller.abort();
-                return;
-            }
-            // Entry may still be sitting in the queue (no AbortController yet).
-            // Walk the snapshot to find a matching clientRequestId and cancel
-            // it via the queue. Check the running head too — it's normally
-            // already in activeRequestsByClientId, but cover the race anyway.
-            const snap = context.requestQueue.getSnapshot();
-            const running = snap.running;
-            if (running && running.clientRequestId === clientRequestId) {
+            const cancelRunning = (): boolean => {
+                const running = context.requestQueue.getSnapshot().running;
+                if (
+                    running === null ||
+                    running.clientRequestId !== clientRequestId
+                ) {
+                    return false;
+                }
                 context.requestQueue.cancelRunning(running.requestId, "user");
+                const controller =
+                    context.activeRequests.get(running.requestId) ??
+                    context.activeRequestsByClientId.get(clientRequestId);
+                controller?.abort();
+                return true;
+            };
+
+            // Record a running cancellation before aborting so queue observers
+            // see the initiating event before command unwinding completes.
+            if (cancelRunning()) {
                 return;
             }
+
+            // A queued entry has no active controller. If it promotes between
+            // the snapshot and cancelQueued, retry through the running path.
+            const snap = context.requestQueue.getSnapshot();
             for (const entry of snap.queued) {
                 if (entry.clientRequestId === clientRequestId) {
-                    context.requestQueue.cancelQueued(entry.requestId, "user");
+                    if (
+                        !context.requestQueue.cancelQueued(
+                            entry.requestId,
+                            "user",
+                        )
+                    ) {
+                        cancelRunning();
+                    }
                     return;
                 }
             }
+
+            // Cover the race where the request starts after the first running
+            // check but before the queued snapshot is read.
+            if (cancelRunning()) {
+                return;
+            }
+            context.activeRequestsByClientId.get(clientRequestId)?.abort();
         },
         async recordUserHide(
             requestId: RequestId,

--- a/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
+++ b/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
@@ -621,30 +621,37 @@ export class RequestQueue {
                 let result: CommandResult | undefined;
                 let error: unknown = undefined;
                 try {
-                    const ctx: QueueExecutionContext = {
-                        requestId: entry.requestId,
-                        originatorConnectionId: entry.originatorConnectionId,
-                        text: entry.text,
-                    };
-                    if (entry.clientRequestId !== undefined)
-                        ctx.clientRequestId = entry.clientRequestId;
-                    if (entry.attachments !== undefined)
-                        ctx.attachments = entry.attachments;
-                    if (entry.options !== undefined)
-                        ctx.options = entry.options;
-                    if (entry.traceContext !== undefined)
-                        ctx.traceContext = entry.traceContext;
-                    result = await this.innerProcessCommand(ctx);
-                    if (result?.cancelled) {
+                    if (entry.cancelReason !== undefined) {
                         entry.state = "cancelled";
-                        if (entry.error === undefined) {
-                            entry.error = `cancelled:${entry.cancelReason ?? "user"}`;
-                        }
-                    } else if (result?.disposition?.status === "failed") {
-                        entry.state = "failed";
-                        entry.error = "command failed";
+                        entry.error = `cancelled:${entry.cancelReason}`;
+                        result = { cancelled: true };
                     } else {
-                        entry.state = "succeeded";
+                        const ctx: QueueExecutionContext = {
+                            requestId: entry.requestId,
+                            originatorConnectionId:
+                                entry.originatorConnectionId,
+                            text: entry.text,
+                        };
+                        if (entry.clientRequestId !== undefined)
+                            ctx.clientRequestId = entry.clientRequestId;
+                        if (entry.attachments !== undefined)
+                            ctx.attachments = entry.attachments;
+                        if (entry.options !== undefined)
+                            ctx.options = entry.options;
+                        if (entry.traceContext !== undefined)
+                            ctx.traceContext = entry.traceContext;
+                        result = await this.innerProcessCommand(ctx);
+                        if (result?.cancelled) {
+                            entry.state = "cancelled";
+                            if (entry.error === undefined) {
+                                entry.error = `cancelled:${entry.cancelReason ?? "user"}`;
+                            }
+                        } else if (result?.disposition?.status === "failed") {
+                            entry.state = "failed";
+                            entry.error = "command failed";
+                        } else {
+                            entry.state = "succeeded";
+                        }
                     }
                 } catch (e) {
                     error = e;

--- a/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
+++ b/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
@@ -580,6 +580,97 @@ export class RequestQueue {
         }
     }
 
+    private broadcastRunningSnapshot(entry: InternalEntry): void {
+        // requestStarted can synchronously cancel the entry. In that case,
+        // cancelRunning already emitted the newer cancellation version; a
+        // running snapshot would resurrect it in client queue mirrors.
+        if (entry.cancelReason !== undefined) return;
+        this.safeBroadcast("queueStateChanged", () =>
+            this.broadcast.queueStateChanged(this.getSnapshot()),
+        );
+    }
+
+    private async processEntry(entry: InternalEntry): Promise<void> {
+        let result: CommandResult | undefined;
+        let error: unknown = undefined;
+        let state: "cancelled" | "failed" | "succeeded";
+        try {
+            if (entry.cancelReason !== undefined) {
+                state = "cancelled";
+                entry.error = `cancelled:${entry.cancelReason}`;
+                result = { cancelled: true };
+            } else {
+                const ctx: QueueExecutionContext = {
+                    requestId: entry.requestId,
+                    originatorConnectionId: entry.originatorConnectionId,
+                    text: entry.text,
+                };
+                if (entry.clientRequestId !== undefined)
+                    ctx.clientRequestId = entry.clientRequestId;
+                if (entry.attachments !== undefined)
+                    ctx.attachments = entry.attachments;
+                if (entry.options !== undefined) ctx.options = entry.options;
+                if (entry.traceContext !== undefined)
+                    ctx.traceContext = entry.traceContext;
+                result = await this.innerProcessCommand(ctx);
+                if (result?.cancelled) {
+                    state = "cancelled";
+                    if (entry.error === undefined) {
+                        entry.error = `cancelled:${entry.cancelReason ?? "user"}`;
+                    }
+                } else if (result?.disposition?.status === "failed") {
+                    state = "failed";
+                    entry.error = "command failed";
+                } else {
+                    state = "succeeded";
+                }
+            }
+        } catch (e) {
+            error = e;
+            const isAbort = e instanceof Error && e.name === "AbortError";
+            if (entry.cancelReason !== undefined && isAbort) {
+                state = "cancelled";
+                if (entry.error === undefined) {
+                    entry.error = `cancelled:${entry.cancelReason}`;
+                }
+                error = undefined;
+                result = { cancelled: true };
+            } else {
+                state = "failed";
+                entry.error = e instanceof Error ? e.message : String(e);
+            }
+        }
+        entry.state = state;
+        entry.finishedAt = Date.now();
+        if (entry.settled) {
+            this.head = null;
+            return;
+        }
+        entry.settled = true;
+        this.head = null;
+        ++this.snapshotVersion;
+
+        this.log(
+            "requestQueue:complete",
+            {
+                requestId: entry.requestId,
+                connectionId: entry.originatorConnectionId,
+                state: entry.state,
+                runMs: (entry.finishedAt ?? 0) - (entry.startedAt ?? 0),
+                totalMs: (entry.finishedAt ?? 0) - entry.submittedAt,
+            },
+            entry.state === "failed" ? "error" : "info",
+        );
+        this.safeBroadcast("queueStateChanged", () =>
+            this.broadcast.queueStateChanged(this.getSnapshot()),
+        );
+        if (error !== undefined) {
+            entry.rejectCompletion(error);
+        } else {
+            entry.resolveCompletion(result);
+        }
+    }
+
     private async maybeDrain(): Promise<void> {
         if (this.draining) return;
         if (this.head !== null) return;
@@ -609,100 +700,14 @@ export class RequestQueue {
                         startVersion,
                     ),
                 );
-                // requestStarted can synchronously cancel the entry. In that case,
-                // cancelRunning already emitted the newer cancellation version; a
-                // running snapshot would resurrect it in client queue mirrors.
-                if (entry.cancelReason === undefined) {
-                    this.safeBroadcast("queueStateChanged", () =>
-                        this.broadcast.queueStateChanged(this.getSnapshot()),
-                    );
-                }
+                this.broadcastRunningSnapshot(entry);
                 this.log("requestQueue:start", {
                     requestId: entry.requestId,
                     connectionId: entry.originatorConnectionId,
                     waitMs: entry.startedAt - entry.submittedAt,
                 });
 
-                let result: CommandResult | undefined;
-                let error: unknown = undefined;
-                try {
-                    if (entry.cancelReason !== undefined) {
-                        entry.state = "cancelled";
-                        entry.error = `cancelled:${entry.cancelReason}`;
-                        result = { cancelled: true };
-                    } else {
-                        const ctx: QueueExecutionContext = {
-                            requestId: entry.requestId,
-                            originatorConnectionId:
-                                entry.originatorConnectionId,
-                            text: entry.text,
-                        };
-                        if (entry.clientRequestId !== undefined)
-                            ctx.clientRequestId = entry.clientRequestId;
-                        if (entry.attachments !== undefined)
-                            ctx.attachments = entry.attachments;
-                        if (entry.options !== undefined)
-                            ctx.options = entry.options;
-                        if (entry.traceContext !== undefined)
-                            ctx.traceContext = entry.traceContext;
-                        result = await this.innerProcessCommand(ctx);
-                        if (result?.cancelled) {
-                            entry.state = "cancelled";
-                            if (entry.error === undefined) {
-                                entry.error = `cancelled:${entry.cancelReason ?? "user"}`;
-                            }
-                        } else if (result?.disposition?.status === "failed") {
-                            entry.state = "failed";
-                            entry.error = "command failed";
-                        } else {
-                            entry.state = "succeeded";
-                        }
-                    }
-                } catch (e) {
-                    error = e;
-                    const isAbort =
-                        e instanceof Error && e.name === "AbortError";
-                    if (entry.cancelReason !== undefined && isAbort) {
-                        entry.state = "cancelled";
-                        if (entry.error === undefined) {
-                            entry.error = `cancelled:${entry.cancelReason}`;
-                        }
-                        error = undefined;
-                        result = { cancelled: true };
-                    } else {
-                        entry.state = "failed";
-                        entry.error =
-                            e instanceof Error ? e.message : String(e);
-                    }
-                }
-                entry.finishedAt = Date.now();
-                if (entry.settled) {
-                    this.head = null;
-                    continue;
-                }
-                entry.settled = true;
-                this.head = null;
-                ++this.snapshotVersion;
-
-                this.log(
-                    "requestQueue:complete",
-                    {
-                        requestId: entry.requestId,
-                        connectionId: entry.originatorConnectionId,
-                        state: entry.state,
-                        runMs: (entry.finishedAt ?? 0) - (entry.startedAt ?? 0),
-                        totalMs: (entry.finishedAt ?? 0) - entry.submittedAt,
-                    },
-                    entry.state === "failed" ? "error" : "info",
-                );
-                this.safeBroadcast("queueStateChanged", () =>
-                    this.broadcast.queueStateChanged(this.getSnapshot()),
-                );
-                if (error !== undefined) {
-                    entry.rejectCompletion(error);
-                } else {
-                    entry.resolveCompletion(result);
-                }
+                await this.processEntry(entry);
             }
         } finally {
             this.draining = false;

--- a/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
+++ b/ts/packages/dispatcher/dispatcher/src/queue/requestQueue.ts
@@ -609,9 +609,14 @@ export class RequestQueue {
                         startVersion,
                     ),
                 );
-                this.safeBroadcast("queueStateChanged", () =>
-                    this.broadcast.queueStateChanged(this.getSnapshot()),
-                );
+                // requestStarted can synchronously cancel the entry. In that case,
+                // cancelRunning already emitted the newer cancellation version; a
+                // running snapshot would resurrect it in client queue mirrors.
+                if (entry.cancelReason === undefined) {
+                    this.safeBroadcast("queueStateChanged", () =>
+                        this.broadcast.queueStateChanged(this.getSnapshot()),
+                    );
+                }
                 this.log("requestQueue:start", {
                     requestId: entry.requestId,
                     connectionId: entry.originatorConnectionId,

--- a/ts/packages/dispatcher/dispatcher/test/cancelByClientIdOrdering.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/cancelByClientIdOrdering.spec.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { jest } from "@jest/globals";
+import type { AppAgent, AppAgentManifest } from "@typeagent/agent-sdk";
+import { getCommandInterface } from "@typeagent/agent-sdk/helpers/command";
+import { awaitCommand } from "@typeagent/dispatcher-types";
+import type {
+    ClientIO,
+    Dispatcher,
+    RequestId,
+} from "@typeagent/dispatcher-types";
+import type { LogEvent } from "@typeagent/telemetry";
+
+const captured: LogEvent[] = [];
+jest.unstable_mockModule("../src/otel/structuredLogSink.js", () => ({
+    createDispatcherOtelLoggerSink: () => ({
+        logEvent(event: LogEvent) {
+            captured.push(event);
+        },
+    }),
+}));
+
+const { createDispatcher } = await import("../src/dispatcher.js");
+
+const slowConfig: AppAgentManifest = {
+    emojiChar: "S",
+    description: "Slow test agent",
+};
+
+const slowAgent: AppAgent = {
+    ...getCommandInterface({
+        description: "Slow commands",
+        commands: {
+            slow: {
+                description: "Wait until cancelled",
+                run: async (): Promise<void> => {
+                    await new Promise<void>((resolve) =>
+                        setTimeout(resolve, 30_000),
+                    );
+                },
+            },
+        },
+    } as const),
+};
+
+const slowAgentProvider = {
+    getAppAgentNames: () => ["slow"],
+    getAppAgentManifest: async () => slowConfig,
+    loadAppAgent: async () => slowAgent,
+    unloadAppAgent: async () => {},
+};
+
+function createClientIO(): {
+    clientIO: ClientIO;
+    requestId: Promise<string>;
+    cancelOnStart(callback: (() => void) | undefined): void;
+} {
+    let resolveRequestId!: (id: string) => void;
+    let onStart: (() => void) | undefined;
+    const requestId = new Promise<string>((resolve) => {
+        resolveRequestId = resolve;
+    });
+    return {
+        requestId,
+        cancelOnStart(callback) {
+            onStart = callback;
+        },
+        clientIO: {
+            clear: () => {},
+            exit: () => process.exit(0),
+            shutdown: () => process.exit(0),
+            setUserRequest: (request: RequestId) =>
+                resolveRequestId(request.requestId),
+            setDisplayInfo: () => {},
+            setDisplay: () => {},
+            appendDisplay: () => {},
+            appendDiagnosticData: () => {},
+            setDynamicDisplay: () => {},
+            question: async (_r, _m, _c, defaultId) => defaultId ?? 0,
+            proposeAction: async () => undefined,
+            notify: () => {},
+            openLocalView: async () => {},
+            closeLocalView: async () => {},
+            requestChoice: () => {},
+            requestForm: () => {},
+            requestInteraction: () => {},
+            interactionResolved: () => {},
+            interactionCancelled: () => {},
+            requestStarted: () => onStart?.(),
+            takeAction: (_requestId, action) => {
+                throw new Error(`Action ${action} not supported`);
+            },
+        },
+    };
+}
+
+describe("cancelCommandByClientId ordering", () => {
+    let dispatcher: Dispatcher;
+    const { clientIO, requestId, cancelOnStart } = createClientIO();
+
+    beforeAll(async () => {
+        dispatcher = await createDispatcher("cancel-ordering", {
+            agents: { actions: false, schemas: false },
+            translation: { enabled: false },
+            explainer: { enabled: false },
+            cache: { enabled: false },
+            appAgentProviders: [slowAgentProvider],
+            collectCommandResult: true,
+            clientIO,
+            telemetry: { structuredLogs: true },
+        });
+    });
+
+    afterAll(async () => {
+        await dispatcher.close();
+    });
+
+    it("records the running cancellation before abort completion", async () => {
+        captured.length = 0;
+        const clientRequestId = "running-cancel";
+        const result = awaitCommand(
+            dispatcher,
+            "@slow slow",
+            undefined,
+            undefined,
+            clientRequestId,
+        );
+        await requestId;
+
+        dispatcher.cancelCommandByClientId(clientRequestId);
+
+        await expect(result).resolves.toMatchObject({ cancelled: true });
+        const cancelEvents = captured.filter(
+            (event) => event.eventName === "dispatcher:requestQueue:cancel",
+        );
+        expect(cancelEvents).toHaveLength(1);
+        expect(cancelEvents[0]!.event).toMatchObject({
+            phase: "running",
+            reason: "user",
+        });
+        const completed = captured.find(
+            (event) => event.eventName === "dispatcher:requestQueue:complete",
+        );
+        expect(completed).toBeDefined();
+        expect(captured.indexOf(cancelEvents[0]!)).toBeLessThan(
+            captured.indexOf(completed!),
+        );
+    }, 10_000);
+
+    it("preserves cancellation when requestStarted races controller setup", async () => {
+        const clientRequestId = "request-start-race";
+        cancelOnStart(() =>
+            dispatcher.cancelCommandByClientId(clientRequestId),
+        );
+        try {
+            await expect(
+                awaitCommand(
+                    dispatcher,
+                    "@slow slow",
+                    undefined,
+                    undefined,
+                    clientRequestId,
+                ),
+            ).resolves.toMatchObject({ cancelled: true });
+        } finally {
+            cancelOnStart(undefined);
+        }
+    }, 10_000);
+});

--- a/ts/packages/dispatcher/dispatcher/test/cancelByClientIdOrdering.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/cancelByClientIdOrdering.spec.ts
@@ -8,8 +8,10 @@ import { awaitCommand } from "@typeagent/dispatcher-types";
 import type {
     ClientIO,
     Dispatcher,
+    QueueSnapshot,
     RequestId,
 } from "@typeagent/dispatcher-types";
+import { QueueStateMirror } from "@typeagent/dispatcher-types";
 import type { LogEvent } from "@typeagent/telemetry";
 
 const captured: LogEvent[] = [];
@@ -54,15 +56,31 @@ const slowAgentProvider = {
 function createClientIO(): {
     clientIO: ClientIO;
     requestId: Promise<string>;
+    queueObservations: Array<{
+        event: "cancelled" | "snapshot";
+        running: string | null;
+    }>;
     cancelOnStart(callback: (() => void) | undefined): void;
 } {
     let resolveRequestId!: (id: string) => void;
     let onStart: (() => void) | undefined;
+    const mirror = new QueueStateMirror();
+    const queueObservations: Array<{
+        event: "cancelled" | "snapshot";
+        running: string | null;
+    }> = [];
+    const observe = (event: "cancelled" | "snapshot") => {
+        queueObservations.push({
+            event,
+            running: mirror.snapshot?.running?.requestId ?? null,
+        });
+    };
     const requestId = new Promise<string>((resolve) => {
         resolveRequestId = resolve;
     });
     return {
         requestId,
+        queueObservations,
         cancelOnStart(callback) {
             onStart = callback;
         },
@@ -87,7 +105,18 @@ function createClientIO(): {
             requestInteraction: () => {},
             interactionResolved: () => {},
             interactionCancelled: () => {},
-            requestStarted: () => onStart?.(),
+            requestStarted: (entry, version) => {
+                mirror.applyStarted(entry, version);
+                onStart?.();
+            },
+            requestCancelled: (id, _reason, version) => {
+                mirror.applyCancelled(id, version);
+                observe("cancelled");
+            },
+            queueStateChanged: (snapshot: QueueSnapshot) => {
+                mirror.applyQueueStateChanged(snapshot);
+                observe("snapshot");
+            },
             takeAction: (_requestId, action) => {
                 throw new Error(`Action ${action} not supported`);
             },
@@ -97,7 +126,8 @@ function createClientIO(): {
 
 describe("cancelCommandByClientId ordering", () => {
     let dispatcher: Dispatcher;
-    const { clientIO, requestId, cancelOnStart } = createClientIO();
+    const { clientIO, requestId, queueObservations, cancelOnStart } =
+        createClientIO();
 
     beforeAll(async () => {
         dispatcher = await createDispatcher("cancel-ordering", {
@@ -150,6 +180,7 @@ describe("cancelCommandByClientId ordering", () => {
 
     it("preserves cancellation when requestStarted races controller setup", async () => {
         const clientRequestId = "request-start-race";
+        queueObservations.length = 0;
         cancelOnStart(() =>
             dispatcher.cancelCommandByClientId(clientRequestId),
         );
@@ -163,6 +194,18 @@ describe("cancelCommandByClientId ordering", () => {
                     clientRequestId,
                 ),
             ).resolves.toMatchObject({ cancelled: true });
+            const cancelledIndex = queueObservations.findIndex(
+                ({ event }) => event === "cancelled",
+            );
+            expect(cancelledIndex).toBeGreaterThanOrEqual(0);
+            expect(
+                queueObservations
+                    .slice(cancelledIndex + 1)
+                    .some(
+                        ({ event, running }) =>
+                            event === "snapshot" && running !== null,
+                    ),
+            ).toBe(false);
         } finally {
             cancelOnStart(undefined);
         }

--- a/ts/packages/dispatcher/dispatcher/test/queue/requestQueue.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/queue/requestQueue.spec.ts
@@ -964,6 +964,26 @@ describe("RequestQueue", () => {
         ).toBeGreaterThan(snapsBefore);
     });
 
+    it("rejects cancellation after the inner command has settled", async () => {
+        const dispatcher = new ControllableDispatcher();
+        const { queue, events } = makeQueue(dispatcher);
+        const entry = queue.submit({
+            text: "a",
+            originatorConnectionId: "c1",
+        });
+        await flush();
+
+        const lateCancel = dispatcher.calls[0].promise.then(() =>
+            queue.cancelRunning(entry.requestId, "user"),
+        );
+        dispatcher.calls[0].resolve({});
+
+        await expect(lateCancel).resolves.toBe(false);
+        await expect(entry.completion).resolves.toEqual({});
+        expect(entry.state).toBe("succeeded");
+        expect(events.some((event) => event.type === "cancelled")).toBe(false);
+    });
+
     // Reason captured by cancelRunning must surface as `cancelled:<reason>`
     // on the wire `error` field so consumers can render the cause.
     it("cancelRunning reason is preserved on the wire as cancelled:<reason>", async () => {

--- a/ts/packages/dispatcher/rpc/src/dispatcherClient.ts
+++ b/ts/packages/dispatcher/rpc/src/dispatcherClient.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createRpc } from "@typeagent/agent-rpc/rpc";
+import {
+    createRpc,
+    type RpcOptions,
+    type RpcStructuredLogger,
+} from "@typeagent/agent-rpc/rpc";
 import type { RpcChannel } from "@typeagent/agent-rpc/channel";
 import type {
     ClientIO,
@@ -49,6 +53,7 @@ export interface DispatcherRpcOptions {
      * Enable only when the destination is the trusted agent-server endpoint.
      */
     trustedContextPropagation?: boolean;
+    logger?: RpcStructuredLogger;
 }
 
 type PendingEntry = {
@@ -65,18 +70,28 @@ export function createDispatcherRpcClient(
     connectionId?: ConnectionId,
     options?: DispatcherRpcOptions,
 ): DispatcherRpcClient {
+    const rpcOptions: RpcOptions | undefined =
+        options?.trustedContextPropagation === true ||
+        options?.logger !== undefined
+            ? {
+                  ...(options.trustedContextPropagation === true
+                      ? {
+                            tracing: {
+                                propagateContext: true,
+                            },
+                        }
+                      : {}),
+                  ...(options.logger === undefined
+                      ? {}
+                      : { logger: options.logger }),
+              }
+            : undefined;
     const rpc = createRpc<DispatcherInvokeFunctions, DispatcherCallFunctions>(
         "dispatcher",
         channel,
         undefined,
         undefined,
-        options?.trustedContextPropagation === true
-            ? {
-                  tracing: {
-                      propagateContext: true,
-                  },
-              }
-            : undefined,
+        rpcOptions,
     );
 
     // requestId → pending submitCommand awaiter (set on submit, resolved by

--- a/ts/packages/dispatcher/rpc/src/dispatcherServer.ts
+++ b/ts/packages/dispatcher/rpc/src/dispatcherServer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createRpc } from "@typeagent/agent-rpc/rpc";
+import { createRpc, type RpcOptions } from "@typeagent/agent-rpc/rpc";
 import type { RpcChannel } from "@typeagent/agent-rpc/channel";
 import type { Dispatcher, SubmitResult } from "@typeagent/dispatcher-types";
 import type {
@@ -29,6 +29,22 @@ export function createDispatcherRpcServer(
     channel: RpcChannel,
     options?: DispatcherRpcOptions,
 ) {
+    const rpcOptions: RpcOptions | undefined =
+        options?.trustedContextPropagation === true ||
+        options?.logger !== undefined
+            ? {
+                  ...(options.trustedContextPropagation === true
+                      ? {
+                            tracing: {
+                                trustRemoteContext: true,
+                            },
+                        }
+                      : {}),
+                  ...(options.logger === undefined
+                      ? {}
+                      : { logger: options.logger }),
+              }
+            : undefined;
     const dispatcherCallHandler: DispatcherCallFunctions = {
         cancelCommandByClientId(...args) {
             dispatcher.cancelCommandByClientId(...args);
@@ -109,12 +125,6 @@ export function createDispatcherRpcServer(
         channel,
         dispatcherInvokeHandler,
         dispatcherCallHandler,
-        options?.trustedContextPropagation === true
-            ? {
-                  tracing: {
-                      trustRemoteContext: true,
-                  },
-              }
-            : undefined,
+        rpcOptions,
     );
 }

--- a/ts/packages/dispatcher/rpc/test/dispatcherRpc.spec.ts
+++ b/ts/packages/dispatcher/rpc/test/dispatcherRpc.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { createChannelAdapter } from "@typeagent/agent-rpc/channel";
+import type { RpcStructuredLogger } from "@typeagent/agent-rpc/rpc";
 import { createDispatcherRpcClient } from "../src/dispatcherClient.js";
 import { createDispatcherRpcServer } from "../src/dispatcherServer.js";
 import type {
@@ -123,6 +124,31 @@ function makeResponse(interactionId = "id-1"): PendingInteractionResponse {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+describe("dispatcher RPC lifecycle options", () => {
+    it("forwards an optional logger on both client and server", async () => {
+        const { serverChannel, clientChannel } = createChannelPair();
+        const clientEvents: string[] = [];
+        const serverEvents: string[] = [];
+        const logger = (events: string[]): RpcStructuredLogger => ({
+            logEvent(eventName) {
+                events.push(eventName);
+            },
+        });
+        createDispatcherRpcServer(makeStubDispatcher(), serverChannel, {
+            logger: logger(serverEvents),
+        });
+        const { dispatcher } = createDispatcherRpcClient(
+            clientChannel,
+            undefined,
+            { logger: logger(clientEvents) },
+        );
+
+        await expect(dispatcher.restoreAllHidden()).resolves.toBe(0);
+        expect(clientEvents).toEqual(["rpc:started", "rpc:completed"]);
+        expect(serverEvents).toEqual(["rpc:started", "rpc:completed"]);
+    });
+});
+
 describe("dispatcher RPC — cancelInteraction (fire-and-forget)", () => {
     it("sends a call message and does not wait for a reply", () => {
         const { serverChannel, clientChannel } = createChannelPair();

--- a/ts/packages/telemetry/src/logger/structuredLogMessage.ts
+++ b/ts/packages/telemetry/src/logger/structuredLogMessage.ts
@@ -25,6 +25,12 @@ export function getStructuredLogMessage(
             return `Request queue rejected submission: ${stringValue(data, "reason", "unknown reason")}`;
         case "dispatcher:requestQueue:cancel":
             return `Request cancelled while ${stringValue(data, "phase", "queued")}`;
+        case "dispatcher:requestQueue:promote":
+            return "Queued request promoted to next";
+        case "dispatcher:requestQueue:abandoned":
+            return `Request queue abandoned ${numberValue(data, "count", 0)} entr${numberValue(data, "count", 0) === 1 ? "y" : "ies"}: ${stringValue(data, "reason", "unknown reason")}`;
+        case "dispatcher:requestQueue:broadcastFailed":
+            return "Request queue broadcast failed";
         case "dispatcher:request:received":
             return "Dispatcher began processing request";
         case "dispatcher:command:exception":
@@ -49,6 +55,12 @@ export function getStructuredLogMessage(
             return formatLlmCompleted(data);
         case "aiclient:llm:classification:default":
             return `${numberValue(data, "count", 0)} foreground LLM call(s) ran with default (unclassified) phase/purpose`;
+        case "rpc:started":
+        case "agentRpc:rpc:started":
+            return `RPC started: ${formatRpcInvocation(data)}`;
+        case "rpc:completed":
+        case "agentRpc:rpc:completed":
+            return `RPC ${stringValue(data, "status", "completed")}: ${formatRpcInvocation(data)}${formatElapsed(data)}${formatFailureNote(data)}`;
         default:
             return undefined;
     }
@@ -160,6 +172,17 @@ function formatAction(data: Record<string, unknown>): string {
     const schemaName = stringValue(data, "schemaName", "unknown");
     const actionName = stringValue(data, "actionName", "action");
     return `${schemaName}.${actionName}`;
+}
+
+function formatRpcInvocation(data: Record<string, unknown>): string {
+    const role = stringValue(data, "role", "");
+    const method = stringValue(data, "method", "unknown");
+    const channel = stringValue(data, "channel", "");
+    const direction = role === "client" ? "->" : role === "server" ? "<-" : "";
+    const suffix = channel === "" ? "" : ` on ${channel}`;
+    return direction === ""
+        ? `${method}${suffix}`
+        : `${direction} ${method}${suffix}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/ts/packages/telemetry/test/structuredLogMessage.spec.ts
+++ b/ts/packages/telemetry/test/structuredLogMessage.spec.ts
@@ -233,4 +233,65 @@ describe("getStructuredLogMessage", () => {
             getStructuredLogMessage("custom:event", { value: "detail" }),
         ).toBeUndefined();
     });
+
+    it("summarizes secondary queue lifecycle events", () => {
+        expect(
+            getStructuredLogMessage("dispatcher:requestQueue:promote", {}),
+        ).toBe("Queued request promoted to next");
+        expect(
+            getStructuredLogMessage("dispatcher:requestQueue:abandoned", {
+                count: 3,
+                reason: "server_stopping",
+            }),
+        ).toBe("Request queue abandoned 3 entries: server_stopping");
+        expect(
+            getStructuredLogMessage("dispatcher:requestQueue:abandoned", {
+                count: 1,
+                reason: "shutdown",
+            }),
+        ).toBe("Request queue abandoned 1 entry: shutdown");
+        expect(
+            getStructuredLogMessage(
+                "dispatcher:requestQueue:broadcastFailed",
+                {},
+            ),
+        ).toBe("Request queue broadcast failed");
+    });
+
+    it("summarizes RPC lifecycle events without payload content", () => {
+        expect(
+            getStructuredLogMessage("rpc:started", {
+                role: "client",
+                channel: "agent:calendar",
+                method: "executeAction",
+                callId: 3,
+            }),
+        ).toBe("RPC started: -> executeAction on agent:calendar");
+        expect(
+            getStructuredLogMessage("rpc:completed", {
+                role: "server",
+                channel: "agent:calendar",
+                method: "executeAction",
+                callId: 3,
+                status: "failed",
+                success: false,
+                elapsedMs: 12,
+                errorCategory: "network",
+                errorCode: "ECONNREFUSED",
+                retryable: true,
+                message: "private detail",
+            }),
+        ).toBe(
+            "RPC failed: <- executeAction on agent:calendar in 12 ms [network (ECONNREFUSED, retryable)]",
+        );
+        expect(
+            getStructuredLogMessage("agentRpc:rpc:completed", {
+                role: "client",
+                channel: "agent:calendar",
+                method: "executeAction",
+                status: "cancelled",
+                elapsedMs: 5,
+            }),
+        ).toBe("RPC cancelled: -> executeAction on agent:calendar in 5 ms");
+    });
 });


### PR DESCRIPTION
## Stack position

**3/3** in native stack #2918.

Parents:
1. #2916 — shared failure telemetry semantics
2. #2917 — LLM attribution telemetry

Base: `georgengmsft-llm-attribution-layer`

## Scope

- Emit paired `rpc:started` / `rpc:completed` events for client and server invoke boundaries.
- Add optional, browser-safe structured logger injection through low-level, agent, and dispatcher RPC options.
- Keep span and event outcomes aligned as `succeeded`, `failed`, or `cancelled`, including wrapped cancellation.
- Bound channel/method labels and export only role, channel, method, call ID, status, elapsed time, and normalized classification; never args, results, raw messages, stacks, or payloads.
- Preserve synchronous disconnected behavior while pairing lifecycle events, isolate logger failures, and add readable RPC/queue messages.
- Record running `cancelCommandByClientId` queue cancellation before abort, including request-start/promotion races.
- Add focused browser-safety, lifecycle, factory-forwarding, cancellation-ordering, and message-format tests plus related docs.

## Invariants

- Exactly one completion event follows each started event.
- Logging cannot change RPC behavior.
- Cancellation carries no failure classification.
- Browser RPC code imports only browser-safe telemetry subpaths.
- No unrelated lower-layer failure classification or LLM attribution behavior is changed.

## Validation

- Affected builds: `@typeagent/telemetry`, `@typeagent/agent-rpc`, `agent-dispatcher`, `@typeagent/dispatcher-rpc`
- Focused tests: 66 passed
- `pnpm run prettier:changed:fix`
- `pnpm run code-lint -- --ratchet --base origin/main`
- `git diff --check`
- Principal-level review and re-review completed with no remaining findings