### PR TITLE
[OTEL] Use fixed ports for local telemetry

### DIFF
--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -428,11 +428,13 @@ typeagent:
 #
 # Local Grafana LGTM sink (managed by `pnpm run telemetry:grafana`).
 #
-# You normally do not edit this section — `pnpm run telemetry:grafana` sets
-# `enabled: "true"` once Grafana is healthy and preserves any custom values
-# you have added. When enabled it runs alongside any standard backend above
-# (deduplicated when they resolve to the same URL); it becomes the primary
-# exporter when no standard backend is configured.
+# You normally do not edit this section - `pnpm run telemetry:grafana` sets
+# `enabled: "true"` and the stable loopback endpoint while preserving other
+# custom values. The setting remains enabled when LGTM stops, so TypeAgent
+# can start first and export as soon as LGTM becomes available. When enabled
+# it runs alongside any standard backend above (deduplicated when they
+# resolve to the same URL); it becomes the primary exporter when no standard
+# backend is configured.
 #
 # `enabled` is a STRING because the flat env layer drops YAML booleans whose
 # value is `false` — a plain boolean would silently "stick" once enabled.
@@ -440,7 +442,7 @@ typeagent:
 # telemetry:
 #   local:
 #     enabled: "true"
-#     otlpEndpoint: http://localhost:4318
+#     otlpEndpoint: http://127.0.0.1:24318
 #     logFile: ~/.typeagent/logs/{process}-{timestamp}-p{pid}.jsonl
 #     logRetentionBytes: 524288000
 #     debugBridge: "true"

--- a/ts/docs/architecture/telemetry/local-telemetry-debugging.md
+++ b/ts/docs/architecture/telemetry/local-telemetry-debugging.md
@@ -9,7 +9,8 @@ instrumentation contracts, see [OpenTelemetry in TypeAgent](./opentelemetry.md).
 
 ## Quick Start
 
-This assumes TypeAgent is already running.
+TypeAgent may already be running if `telemetry.local` was configured by an
+earlier run.
 
 From `ts`, run:
 
@@ -21,8 +22,9 @@ If Docker Desktop is missing on Windows or macOS, the command asks whether to
 install it. Otherwise, it starts Docker when needed, starts the local Grafana
 stack, and enables local telemetry in `config.local.yaml`.
 
-Restart TypeAgent so it picks up the new configuration, send a request, then
-open [Grafana](http://localhost:3000) to inspect traces and logs.
+If the command changes `telemetry.local`, restart TypeAgent once so it picks
+up the configuration. Send a request, then open
+[Grafana](http://127.0.0.1:24319) to inspect traces and logs.
 
 For setup details, queries, cleanup, and troubleshooting, continue below.
 
@@ -34,9 +36,8 @@ You need:
 
 - A configured TypeAgent checkout.
 - Docker Desktop or Docker Engine.
-- Port `3000` available on `localhost` for Grafana. The OTLP/gRPC and
-  OTLP/HTTP receiver ports are assigned dynamically on the loopback
-  interface, so no specific port needs to be free for them.
+- Loopback ports `24317` (OTLP/gRPC), `24318` (OTLP/HTTP), and `24319`
+  (Grafana) available. The command reports which occupied port must be freed.
 
 If this is a fresh checkout, run `pnpm run setup` from `ts`.
 
@@ -51,22 +52,22 @@ pnpm run telemetry:grafana
 The command starts the local Grafana LGTM container. It includes Grafana,
 Loki, Tempo, Prometheus, and an OpenTelemetry collector.
 
-Once Grafana reports healthy, the command also enables the local sink in
-`config.local.yaml` — no `OTEL_*` / `TYPEAGENT_OTEL_*` environment variables
-are required. The block includes the Docker-assigned endpoint:
+Before starting Docker, the command enables the local sink in
+`config.local.yaml` - no `OTEL_*` / `TYPEAGENT_OTEL_*` environment variables
+are required. The block includes the stable endpoint:
 
 ```yaml
 telemetry:
   local:
     enabled: "true"
-    otlpEndpoint: http://127.0.0.1:<assigned-port>
+    otlpEndpoint: http://127.0.0.1:24318
     logFile: ~/.typeagent/logs/{process}-{timestamp}-p{pid}.jsonl
     debugBridge: "true"
     structuredLogs: "true"
 ```
 
-`otlpEndpoint` is owned by `pnpm run telemetry:grafana`: the command discovers
-and writes the current endpoint automatically. Other local settings you have customized
+`otlpEndpoint` is owned by `pnpm run telemetry:grafana`: the command writes
+the fixed endpoint automatically. Other local settings you have customized
 (`logFile`, `logRetentionBytes`, `debugBridge`, `structuredLogs`) are left
 alone.
 
@@ -75,16 +76,18 @@ configured in `telemetry.otlpEndpoint`, TypeAgent exports to both the
 standard backend and the local Grafana LGTM stack in parallel (deduplicated
 when they resolve to the same URL).
 
-> TypeAgent reads `config.local.yaml` at process startup, so **restart the
-> agent-server after enabling the local sink** — otherwise the running
-> process will not pick up the new configuration.
+> TypeAgent reads `config.local.yaml` at process startup. Restart the
+> agent-server only when the command changes the local configuration. Once
+> configured, the agent-server can start while LGTM is absent and begins
+> exporting when LGTM starts.
 
-Open Grafana at [http://localhost:3000](http://localhost:3000).
+Open Grafana at
+[http://127.0.0.1:24319](http://127.0.0.1:24319).
 
 Check that Grafana is ready:
 
 ```powershell
-Invoke-RestMethod http://localhost:3000/api/health
+Invoke-RestMethod http://127.0.0.1:24319/api/health
 ```
 
 The response should report that the database is `ok`.
@@ -252,11 +255,9 @@ Then stop the local stack:
 pnpm run telemetry:grafana --stop
 ```
 
-`--stop` also flips `telemetry.local.enabled` to `"false"` in
-`config.local.yaml`. Other local values (`logFile`, `logRetentionBytes`,
-`debugBridge`, `structuredLogs`) are preserved for the next start;
-`otlpEndpoint` is refreshed automatically the next time you start the stack,
-since Docker may assign a different host port.
+`--stop` stops only the LGTM sink. It leaves `telemetry.local` enabled at the
+stable endpoint, so a running agent-server can resume exporting the next time
+LGTM starts without being restarted.
 
 ### Log Retention and Manual Cleanup
 
@@ -310,7 +311,7 @@ Run:
 
 ```powershell
 docker ps --filter "name=typeagent-otel"
-Invoke-RestMethod http://localhost:3000/api/health
+Invoke-RestMethod http://127.0.0.1:24319/api/health
 ```
 
 If Docker is stopped, start it and run `pnpm run telemetry:grafana` again.
@@ -323,8 +324,8 @@ Check that:
   `Enabled telemetry.local in ...config.local.yaml`.
 - `config.local.yaml` contains `telemetry.local.enabled: "true"` (the value
   must be the string `"true"`, not the YAML boolean `true`).
-- The agent server was restarted **after** the sink was enabled — config is
-  read at process startup.
+- The agent server was restarted after the sink was first enabled or migrated
+  from an older endpoint. Config is read at process startup.
 - Nothing in the environment sets `OTEL_TRACES_EXPORTER=none` for the shell
   that started the agent server (that explicitly opts out of the traces
   signal even when the local sink is enabled).

--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -380,15 +380,14 @@ telemetry:
   tracesSampler: always_on
   local:
     enabled: "true"
-    otlpEndpoint: http://127.0.0.1:54321
+    otlpEndpoint: http://127.0.0.1:24318
     debugBridge: "true"
     structuredLogs: "true"
 ```
 
-`telemetry.local.otlpEndpoint` above (`54321` is just an example) is written
-by `pnpm run telemetry:grafana`: Docker assigns the local container's
-OTLP/HTTP host port dynamically on every start, so the script owns this
-value and overwrites it on every run instead of preserving a stale one.
+`telemetry.local.otlpEndpoint` is written by
+`pnpm run telemetry:grafana`. The script owns this value and uses the stable
+OTLP/HTTP loopback port `24318`.
 
 Standard `OTEL_*` variables override YAML. Relevant settings include:
 
@@ -410,10 +409,12 @@ Partner libraries use host configuration and do not read TypeAgent YAML.
 with the standard exporter; it does not replace or rewrite the backend
 endpoint (`telemetry.otlpEndpoint`). Identical resolved endpoints are
 deduplicated. The script does, however, own `telemetry.local.otlpEndpoint`
-itself: it discovers the container's dynamically-assigned OTLP/HTTP host
-port on every start and overwrites the local endpoint with it, so a stale or
-hand-edited value never lingers. TypeAgent reads this configuration at
-process startup, so processes must restart after the script changes it.
+itself: it writes the stable `http://127.0.0.1:24318` endpoint, so a stale or
+hand-edited value never lingers. The setting remains enabled when LGTM stops.
+This lets a configured TypeAgent process start while LGTM is absent and begin
+exporting when the collector becomes available. TypeAgent reads this
+configuration at process startup, so processes must restart only after the
+script changes it from an older configuration.
 
 Local development samples all traces by default when trace export is enabled.
 Deployments may configure standard OTel sampling. Partner hosts own sampling.
@@ -555,21 +556,24 @@ The helper:
   engine.
 - Pulls `grafana/otel-lgtm:latest` when it is not already installed.
 - Starts or reuses the `typeagent-otel` container.
+- Recreates an existing container if its port mappings are stale.
 - Waits for Grafana to become healthy.
-- Publishes Grafana and both collector receivers on `127.0.0.1` only.
+- Publishes fixed loopback ports for OTLP/gRPC (`24317`), OTLP/HTTP (`24318`),
+  and Grafana (`24319`).
+- Fails with an actionable error when a required host port is unavailable.
 
 The loopback binding keeps the services inaccessible from other machines on
 the network. Do not publish these ports on all interfaces unless remote access
 is intentional and protected separately.
 
-Grafana always listens on `3000`. Docker assigns the collector ports on the
-loopback interface, and the helper writes the current OTLP/HTTP endpoint into
-`telemetry.local.otlpEndpoint`; no collector-port configuration is needed.
+The fixed host ports are below the OS ephemeral range. The helper writes
+`http://127.0.0.1:24318` into `telemetry.local.otlpEndpoint` before starting
+Docker, and `--stop` leaves that configuration enabled.
 
 Verify that Grafana is ready:
 
 ```powershell
-Invoke-RestMethod http://localhost:3000/api/health
+Invoke-RestMethod http://127.0.0.1:24319/api/health
 ```
 
 ### 2. Configure and Start TypeAgent
@@ -580,10 +584,8 @@ From `ts/`, build the agent server and configure its process environment:
 pnpm run build agent-server
 
 $env:OTEL_SERVICE_NAME = "typeagent-local"
-# Use the OTLP/HTTP address `pnpm run telemetry:grafana` printed (or
-# `docker port typeagent-otel 4318/tcp`): Docker assigns this port
-# dynamically, so it is not always 4318.
-$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:54321"
+# `pnpm run telemetry:grafana` provisions telemetry.local with the stable
+# http://127.0.0.1:24318 endpoint. No OTLP endpoint env var is required.
 $env:OTEL_TRACES_SAMPLER = "always_on"
 $env:TYPEAGENT_OTEL_LOG_FILE = "$HOME\.typeagent\logs\{process}-{timestamp}-p{pid}.jsonl"
 $env:TYPEAGENT_OTEL_DEBUG_BRIDGE = "true"
@@ -734,7 +736,7 @@ the model.
 
 ### 5. Inspect the Same Logs in Grafana
 
-Open [http://localhost:3000](http://localhost:3000), select **Explore**, choose
+Open [http://127.0.0.1:24319](http://127.0.0.1:24319), select **Explore**, choose
 the **Loki** data source, and switch the query editor to **Code** mode. Do not
 use Logs Drilldown or its search box; those use a different search API rather
 than executing the LogQL below. Query all records from this validation run:
@@ -789,6 +791,10 @@ Grafana LGTM:
 ```powershell
 pnpm run telemetry:grafana --stop
 ```
+
+Stopping LGTM leaves `telemetry.local` enabled at the stable endpoint. A
+configured TypeAgent process can remain running and resumes export when LGTM
+starts again.
 
 ## Privacy and Reliability
 

--- a/ts/packages/telemetry/src/otel/config.ts
+++ b/ts/packages/telemetry/src/otel/config.ts
@@ -177,6 +177,7 @@ export interface ResolveTelemetryConfigOptions {
  * backend is configured for a signal, the local exporter becomes that
  * signal's primary. Local defaults for `logFile`, `debugBridge`, and
  * `structuredLogs` only apply when the standard YAML/env values are unset.
+ * The default local OTLP/HTTP endpoint is `http://127.0.0.1:24318`.
  * `enabled` is intentionally a string because the flat env layer drops YAML
  * booleans whose value is `false`, which would silently "stick" once turned
  * on.
@@ -461,7 +462,7 @@ function resolveLocalSink(yaml: Readonly<Record<string, string | undefined>>): {
         debugBridge?: boolean;
         structuredLogs?: boolean;
     } = {
-        endpoint: endpoint ?? "http://localhost:4318",
+        endpoint: endpoint ?? "http://127.0.0.1:24318",
         logFile:
             logFile ?? "~/.typeagent/logs/{process}-{timestamp}-p{pid}.jsonl",
         debugBridge: debugBridge ?? true,

--- a/ts/packages/telemetry/test/otelConfig.spec.ts
+++ b/ts/packages/telemetry/test/otelConfig.spec.ts
@@ -843,7 +843,7 @@ describe("resolveTelemetryConfig", () => {
             );
             const cfg = resolve(root);
             expect(cfg.traces?.otlp?.endpoint).toBe(
-                "http://localhost:4318/v1/traces",
+                "http://127.0.0.1:24318/v1/traces",
             );
             expect(cfg.logs?.logFile).toContain(
                 "/.typeagent/logs/{process}-{timestamp}-p{pid}.jsonl",

--- a/ts/tools/scripts/lib/telemetryLocalYaml.mjs
+++ b/ts/tools/scripts/lib/telemetryLocalYaml.mjs
@@ -9,13 +9,11 @@
 //   - `enabled` is written as the string "true" / "false". The flat env
 //     layer used by `@typeagent/config` drops YAML booleans whose value is
 //     `false`, so a plain boolean would silently "stick" once enabled.
-//   - `startLocalTelemetry.mjs` owns `otlpEndpoint`: Docker assigns the
-//     container's OTLP/HTTP host port dynamically on every start, so
-//     enabling always overwrites `otlpEndpoint` with the caller-supplied
-//     value instead of preserving a stale/customized one. Defaults are
-//     otherwise only inserted for keys the user has NOT set; existing
+//   - `startLocalTelemetry.mjs` owns `otlpEndpoint` and always writes the
+//     stable local OTLP/HTTP endpoint. Defaults are otherwise only inserted
+//     for keys the user has NOT set; existing
 //     `logFile` / `logRetentionBytes` / `debugBridge` / `structuredLogs`
-//     values are preserved so a customized local sink survives a toggle.
+//     values are preserved so a customized local sink survives setup.
 //   - The document is parsed with js-yaml before and after the edit. If
 //     either parse fails, or if `telemetry` / `telemetry.local` uses an
 //     ambiguous / unsupported shape (flow style, sequence, scalar, custom
@@ -24,6 +22,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
+
+export const LOCAL_OTLP_ENDPOINT = "http://127.0.0.1:24318";
 
 /**
  * Default values written by `pnpm run telemetry:grafana` when the user has
@@ -59,35 +59,15 @@ export function resolveLocalConfigPath(workspaceTsRoot) {
 }
 
 /**
- * Enable the local telemetry sink in `config.local.yaml` and point it at
- * `otlpEndpoint`. `startLocalTelemetry.mjs` owns this value: Docker assigns
- * the container's OTLP/HTTP host port dynamically on every start, so a
- * stale or hand-customized endpoint is overwritten rather than preserved.
- * The caller must provide the endpoint discovered from Docker. Writes the
- * file only when its content actually changes.
+ * Enable the local telemetry sink in `config.local.yaml` and point it at the
+ * stable local OTLP/HTTP endpoint. Writes the file only when its content
+ * actually changes.
  */
-export function enableTelemetryLocal(filePath, otlpEndpoint) {
-    return applyTelemetryLocalEdit(filePath, true, otlpEndpoint);
+export function enableTelemetryLocal(filePath) {
+    return applyTelemetryLocalEdit(filePath);
 }
 
-/**
- * Disable the local telemetry sink in `config.local.yaml`. Preserves any
- * customized local defaults (including `otlpEndpoint`) so re-enabling does
- * not lose them.
- */
-export function disableTelemetryLocal(filePath) {
-    return applyTelemetryLocalEdit(filePath, false, undefined);
-}
-
-function applyTelemetryLocalEdit(filePath, enable, otlpEndpoint) {
-    if (
-        enable &&
-        (typeof otlpEndpoint !== "string" || otlpEndpoint.trim() === "")
-    ) {
-        throw new Error(
-            "otlpEndpoint must be a non-empty string when enabling telemetry.local.",
-        );
-    }
+function applyTelemetryLocalEdit(filePath) {
     const originalText = fs.existsSync(filePath)
         ? fs.readFileSync(filePath, "utf8")
         : "";
@@ -97,7 +77,7 @@ function applyTelemetryLocalEdit(filePath, enable, otlpEndpoint) {
     const existingLocal = getExistingLocal(parsed);
     const previouslyEnabled = existingLocal?.enabled === "true";
 
-    const desiredLocal = buildDesiredLocal(existingLocal, enable, otlpEndpoint);
+    const desiredLocal = buildDesiredLocal(existingLocal);
     const newText = rewriteTelemetryLocalBlock(originalText, desiredLocal);
 
     // Re-parse to guarantee we did not corrupt the document. If it fails,
@@ -193,15 +173,10 @@ function getExistingLocal(parsed) {
     return local;
 }
 
-function buildDesiredLocal(existingLocal, enable, otlpEndpoint) {
+function buildDesiredLocal(existingLocal) {
     const merged = { ...LOCAL_DEFAULTS, ...(existingLocal ?? {}) };
-    merged.enabled = enable ? "true" : "false";
-    if (enable) {
-        // The local launcher owns this value: Docker assigns a new
-        // ephemeral host port on every start, so a stale/customized
-        // endpoint left over from a previous toggle must not survive.
-        merged.otlpEndpoint = otlpEndpoint;
-    }
+    merged.enabled = "true";
+    merged.otlpEndpoint = LOCAL_OTLP_ENDPOINT;
     for (const key of ["debugBridge", "structuredLogs"]) {
         if (typeof merged[key] === "boolean") {
             merged[key] = merged[key] ? "true" : "false";

--- a/ts/tools/scripts/startLocalTelemetry.mjs
+++ b/ts/tools/scripts/startLocalTelemetry.mjs
@@ -3,13 +3,14 @@
 // Licensed under the MIT License.
 
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 import readline from "node:readline/promises";
 import {
-    disableTelemetryLocal,
     enableTelemetryLocal,
+    LOCAL_OTLP_ENDPOINT,
     resolveLocalConfigPath,
 } from "./lib/telemetryLocalYaml.mjs";
 
@@ -17,6 +18,9 @@ const containerName = "typeagent-otel";
 const imageName = "grafana/otel-lgtm:latest";
 const dockerReadyTimeoutMs = 120_000;
 const grafanaReadyTimeoutMs = 120_000;
+const otlpGrpcPort = 24317;
+const otlpHttpPort = 24318;
+const grafanaPort = 24319;
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const workspaceTsRoot = path.resolve(scriptDir, "../..");
@@ -27,25 +31,24 @@ if (args.has("--help") || args.has("-h")) {
 
 Starts Docker Desktop when needed on Windows or macOS, then starts the local
 Grafana LGTM OpenTelemetry stack:
-  Grafana: http://localhost:3000
+  OTLP/gRPC: http://127.0.0.1:24317
+  OTLP/HTTP: http://127.0.0.1:24318
+  Grafana:   http://127.0.0.1:24319
 
-The collector ports are assigned dynamically on the loopback interface and
-configured automatically in config.local.yaml (path resolved with the same
-precedence as getKeys):
+The fixed loopback ports are configured automatically in config.local.yaml
+(path resolved with the same precedence as getKeys):
   TYPEAGENT_CONFIG_LOCAL > TYPEAGENT_CONFIG_DIR/config.local.yaml >
   ts/config.local.yaml
 
 Starting sets telemetry.local.enabled to the string "true" and
-telemetry.local.otlpEndpoint to the discovered OTLP/HTTP address, only AFTER
-Grafana reports healthy. This script owns otlpEndpoint: any stale or
-hand-customized value is overwritten on every start, since the assigned
-port can differ from one run to the next. Stopping sets enabled to "false"
-after the container is confirmed stopped (or already not running); other
-local settings (logFile/logRetentionBytes/debugBridge/structuredLogs) are
-left untouched.
+telemetry.local.otlpEndpoint to the fixed OTLP/HTTP address before starting
+Docker. The setting remains enabled when LGTM is stopped, so TypeAgent can
+start without LGTM and begin exporting when LGTM becomes available. This
+script owns otlpEndpoint; other local settings
+(logFile/logRetentionBytes/debugBridge/structuredLogs) are left untouched.
 
-TypeAgent reads config.local.yaml at process startup, so RESTART TypeAgent
-after each toggle for the change to take effect.
+TypeAgent reads config.local.yaml at process startup. Restart TypeAgent only
+when this command changes telemetry.local from an older configuration.
 
 Options:
   --stop     Stop the local Grafana LGTM container.
@@ -253,17 +256,13 @@ function isLoopbackBinding(entries) {
     );
 }
 
-function isDynamicLoopbackBinding(entries) {
-    return isLoopbackBinding(entries) && entries[0].HostPort === "";
+function isFixedLoopbackBinding(entries, hostPort) {
+    return (
+        isLoopbackBinding(entries) && entries[0].HostPort === String(hostPort)
+    );
 }
 
-// `HostConfig.PortBindings` holds the *requested* binding spec and is
-// available whether the container is running or stopped, but for a
-// dynamically-assigned port (empty host port) it never reflects the actual
-// host port Docker chose. It only tells us the port is bound to loopback,
-// which is what we need to decide whether an existing container is
-// compatible with the current (loopback-only) scheme.
-function hasLoopbackBindings() {
+function hasFixedLoopbackBindings() {
     const result = runDocker(
         [
             "inspect",
@@ -275,48 +274,43 @@ function hasLoopbackBindings() {
     );
     const bindings = JSON.parse(result.stdout);
     return (
-        isLoopbackBinding(bindings["3000/tcp"]) &&
-        bindings["3000/tcp"][0].HostPort === "3000" &&
-        ["4317/tcp", "4318/tcp"].every((port) =>
-            isDynamicLoopbackBinding(bindings[port]),
-        )
+        isFixedLoopbackBinding(bindings["3000/tcp"], grafanaPort) &&
+        isFixedLoopbackBinding(bindings["4317/tcp"], otlpGrpcPort) &&
+        isFixedLoopbackBinding(bindings["4318/tcp"], otlpHttpPort)
     );
 }
 
-// `NetworkSettings.Ports` reflects the *actual* live port assignment and is
-// only populated while the container is running. Docker picks a fresh
-// ephemeral host port for the OTLP receivers on every start, so this must
-// be re-queried each time rather than cached across runs.
-function getRuntimeOtlpPorts() {
-    const result = runDocker(
-        [
-            "inspect",
-            "--format",
-            "{{json .NetworkSettings.Ports}}",
-            containerName,
-        ],
-        { capture: true },
-    );
-    const bindings = JSON.parse(result.stdout);
-    const otlpHttpPort = getLoopbackHostPort(bindings, 4318);
-    const otlpGrpcPort = getLoopbackHostPort(bindings, 4317);
-    if (otlpHttpPort === undefined || otlpGrpcPort === undefined) {
-        throw new Error(
-            "Docker did not report loopback host ports for the OTLP endpoints.",
+async function assertPortAvailable(port, label) {
+    await new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.unref();
+        server.once("error", (error) => {
+            reject(
+                new Error(
+                    `${label} port ${port} is unavailable on 127.0.0.1 (${error.code ?? error.message}). Stop the process or container using this port, then run \`pnpm run telemetry:grafana\` again.`,
+                ),
+            );
+        });
+        server.listen({ host: "127.0.0.1", port, exclusive: true }, () =>
+            server.close(resolve),
         );
-    }
-    return { otlpHttpPort, otlpGrpcPort };
+    });
 }
 
-function getLoopbackHostPort(bindings, containerPort) {
-    const entries = bindings[`${containerPort}/tcp`];
-    return isLoopbackBinding(entries) ? entries[0].HostPort : undefined;
+async function assertFixedPortsAvailable() {
+    await Promise.all([
+        assertPortAvailable(otlpGrpcPort, "OTLP/gRPC"),
+        assertPortAvailable(otlpHttpPort, "OTLP/HTTP"),
+        assertPortAvailable(grafanaPort, "Grafana"),
+    ]);
 }
 
 async function waitForGrafana() {
     await waitFor("Grafana", grafanaReadyTimeoutMs, async () => {
         try {
-            const response = await fetch("http://127.0.0.1:3000/api/health");
+            const response = await fetch(
+                `http://127.0.0.1:${grafanaPort}/api/health`,
+            );
             return response.ok;
         } catch {
             return false;
@@ -327,29 +321,22 @@ async function waitForGrafana() {
 async function stop() {
     if (!isDockerInstalled()) {
         console.log("[telemetry:grafana] Docker CLI was not found.");
-        toggleTelemetryLocal(false);
         return;
     }
     if (!isDockerReady()) {
         console.log("[telemetry:grafana] Docker is not running.");
-        // Container is definitely not exporting; safe to flip the sink off.
-        toggleTelemetryLocal(false);
         return;
     }
     if (getContainerId(true) === "") {
         console.log("[telemetry:grafana] Grafana LGTM is not running.");
-        toggleTelemetryLocal(false);
         return;
     }
-    // Only flip the sink off after `docker stop` succeeds. If it fails, we
-    // leave config.local.yaml alone: TypeAgent may still be exporting to a
-    // partially-alive container, and a stale "enabled: false" would be
-    // misleading on the next start attempt.
     runDocker(["stop", containerName]);
-    toggleTelemetryLocal(false);
 }
 
 async function start() {
+    enableLocalTelemetryConfig();
+
     if (!isDockerInstalled()) {
         if (process.platform === "win32" || process.platform === "darwin") {
             await promptToInstallDockerDesktop();
@@ -366,21 +353,23 @@ async function start() {
         await waitFor("Docker Desktop", dockerReadyTimeoutMs, isDockerReady);
     }
 
-    if (getContainerId(true) !== "" && !hasLoopbackBindings()) {
+    if (getContainerId(true) !== "" && !hasFixedLoopbackBindings()) {
         console.log(
-            "[telemetry:grafana] Recreating the container with loopback-only ports...",
+            "[telemetry:grafana] Recreating the container with the fixed loopback ports...",
         );
         runDocker(["rm", "--force", containerName]);
     }
 
     if (getContainerId(false) !== "") {
         console.log(
-            "[telemetry:grafana] Grafana LGTM is already running at http://localhost:3000",
+            `[telemetry:grafana] Grafana LGTM is already running at http://127.0.0.1:${grafanaPort}`,
         );
     } else if (getContainerId(true) !== "") {
+        await assertFixedPortsAvailable();
         console.log("[telemetry:grafana] Starting the existing container...");
         runDocker(["start", containerName]);
     } else {
+        await assertFixedPortsAvailable();
         console.log(
             "[telemetry:grafana] Pulling and starting Grafana LGTM as needed...",
         );
@@ -391,52 +380,35 @@ async function start() {
             "--name",
             containerName,
             "-p",
-            "127.0.0.1:3000:3000",
-            // Let Docker pick the host port for the OTLP receivers (empty
-            // host port) so they never collide with something else already
-            // listening on 4317/4318. The chosen ports are discovered below
-            // and written into config.local.yaml.
+            `127.0.0.1:${grafanaPort}:3000`,
             "-p",
-            "127.0.0.1::4317",
+            `127.0.0.1:${otlpGrpcPort}:4317`,
             "-p",
-            "127.0.0.1::4318",
+            `127.0.0.1:${otlpHttpPort}:4318`,
             imageName,
         ]);
     }
 
     await waitForGrafana();
-    // Grafana is healthy: safe to advertise the local sink to TypeAgent.
-    // We intentionally discover ports and toggle AFTER health passes so a
-    // failed startup does not leave the config claiming a working sink is
-    // available. Re-discover the ports even when the container was already
-    // running: Docker may have assigned different ephemeral ports than the
-    // last time this script ran, and this script owns otlpEndpoint, so any
-    // stale/customized value must not survive.
-    const { otlpHttpPort, otlpGrpcPort } = getRuntimeOtlpPorts();
-    const otlpEndpoint = `http://127.0.0.1:${otlpHttpPort}`;
-    toggleTelemetryLocal(true, otlpEndpoint);
-    console.log("[telemetry:grafana] Grafana:   http://localhost:3000");
-    console.log(`[telemetry:grafana] OTLP/HTTP: ${otlpEndpoint}`);
+    console.log(
+        `[telemetry:grafana] Grafana:   http://127.0.0.1:${grafanaPort}`,
+    );
+    console.log(`[telemetry:grafana] OTLP/HTTP: ${LOCAL_OTLP_ENDPOINT}`);
     console.log(
         `[telemetry:grafana] OTLP/gRPC: http://127.0.0.1:${otlpGrpcPort}`,
     );
-    console.log(
-        "[telemetry:grafana] Restart TypeAgent so it picks up the new telemetry config.",
-    );
 }
 
-function toggleTelemetryLocal(enable, otlpEndpoint) {
+function enableLocalTelemetryConfig() {
     const filePath = resolveLocalConfigPath(workspaceTsRoot);
-    const result = enable
-        ? enableTelemetryLocal(filePath, otlpEndpoint)
-        : disableTelemetryLocal(filePath);
+    const result = enableTelemetryLocal(filePath);
     if (result.changed) {
         console.log(
-            `[telemetry:grafana] ${enable ? "Enabled" : "Disabled"} telemetry.local in ${result.path}. Restart TypeAgent for the change to take effect.`,
+            `[telemetry:grafana] Enabled telemetry.local at ${LOCAL_OTLP_ENDPOINT} in ${result.path}. Restart TypeAgent once to load this configuration.`,
         );
     } else {
         console.log(
-            `[telemetry:grafana] telemetry.local already ${enable ? "enabled" : "disabled"} in ${result.path}; no change.`,
+            `[telemetry:grafana] telemetry.local already uses ${LOCAL_OTLP_ENDPOINT} in ${result.path}; no change.`,
         );
     }
 }

--- a/ts/tools/scripts/test/telemetryLocalYaml.spec.mjs
+++ b/ts/tools/scripts/test/telemetryLocalYaml.spec.mjs
@@ -8,9 +8,9 @@ import path from "node:path";
 import test from "node:test";
 import yaml from "js-yaml";
 import {
-    disableTelemetryLocal,
     enableTelemetryLocal,
     LOCAL_DEFAULTS,
+    LOCAL_OTLP_ENDPOINT,
 } from "../lib/telemetryLocalYaml.mjs";
 
 function makeTempFile(initial) {
@@ -28,7 +28,7 @@ test("enable creates a fresh block when the file does not exist", () => {
     const file = makeTempFile(undefined);
     fs.rmSync(file, { force: true });
 
-    const result = enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    const result = enableTelemetryLocal(file);
 
     assert.equal(result.changed, true);
     assert.equal(result.previouslyEnabled, false);
@@ -36,7 +36,7 @@ test("enable creates a fresh block when the file does not exist", () => {
     const parsed = yaml.load(written);
     assert.deepEqual(parsed.telemetry.local, {
         enabled: "true",
-        otlpEndpoint: "http://127.0.0.1:54321",
+        otlpEndpoint: LOCAL_OTLP_ENDPOINT,
         logFile: LOCAL_DEFAULTS.logFile,
         logRetentionBytes: LOCAL_DEFAULTS.logRetentionBytes,
         debugBridge: "true",
@@ -59,7 +59,7 @@ test("enable preserves comments and unrelated sections when telemetry is absent"
     ].join("\n");
     const file = makeTempFile(initial);
 
-    enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    enableTelemetryLocal(file);
 
     const written = fs.readFileSync(file, "utf8");
     assert.ok(written.includes("# Top-of-file comment."));
@@ -84,7 +84,7 @@ test("enable adds the local block under an existing telemetry section without to
     ].join("\n");
     const file = makeTempFile(initial);
 
-    enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    enableTelemetryLocal(file);
 
     const written = fs.readFileSync(file, "utf8");
     assert.ok(
@@ -100,81 +100,38 @@ test("enable adds the local block under an existing telemetry section without to
     assert.equal(parsed.telemetry.local.enabled, "true");
 });
 
-test("enable overwrites a customized otlpEndpoint but preserves other customized values", () => {
+test("enable writes the stable otlpEndpoint and preserves other customized values", () => {
     const initial = [
         "telemetry:",
         "  local:",
-        '    enabled: "false"',
+        '    enabled: "true"',
         "    otlpEndpoint: http://my-lgtm:4318",
         "    debugBridge: false",
         "",
     ].join("\n");
     const file = makeTempFile(initial);
 
-    const result = enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    const result = enableTelemetryLocal(file);
 
     const parsed = yaml.load(fs.readFileSync(file, "utf8"));
     assert.equal(parsed.telemetry.local.enabled, "true");
-    // startLocalTelemetry.mjs owns otlpEndpoint: Docker assigns the OTLP
-    // host port dynamically on every start, so a stale/custom value must
-    // not survive a toggle.
-    assert.equal(parsed.telemetry.local.otlpEndpoint, "http://127.0.0.1:54321");
+    assert.equal(parsed.telemetry.local.otlpEndpoint, LOCAL_OTLP_ENDPOINT);
     // Unrelated customized values are still preserved.
     assert.equal(parsed.telemetry.local.debugBridge, "false");
     // Missing defaults filled in.
     assert.equal(parsed.telemetry.local.logFile, LOCAL_DEFAULTS.logFile);
     assert.equal(parsed.telemetry.local.structuredLogs, "true");
-    assert.equal(result.previouslyEnabled, false);
-});
-
-test("enable requires a discovered otlpEndpoint instead of writing a broken config", () => {
-    const file = makeTempFile(undefined);
-    fs.rmSync(file, { force: true });
-
-    assert.throws(
-        () => enableTelemetryLocal(file),
-        /otlpEndpoint must be a non-empty string/,
-    );
-    assert.equal(
-        fs.existsSync(file),
-        false,
-        "must not create the file when validation fails",
-    );
-});
-
-test('disable flips enabled to "false" and preserves all other local values', () => {
-    const initial = [
-        "telemetry:",
-        "  local:",
-        '    enabled: "true"',
-        "    otlpEndpoint: http://my-lgtm:4318",
-        "    logFile: ~/logs/x.jsonl",
-        "    debugBridge: true",
-        "    structuredLogs: true",
-        "",
-    ].join("\n");
-    const file = makeTempFile(initial);
-
-    const result = disableTelemetryLocal(file);
-
-    assert.equal(result.changed, true);
     assert.equal(result.previouslyEnabled, true);
-    const parsed = yaml.load(fs.readFileSync(file, "utf8"));
-    assert.equal(parsed.telemetry.local.enabled, "false");
-    assert.equal(parsed.telemetry.local.otlpEndpoint, "http://my-lgtm:4318");
-    assert.equal(parsed.telemetry.local.logFile, "~/logs/x.jsonl");
-    assert.equal(parsed.telemetry.local.debugBridge, "true");
-    assert.equal(parsed.telemetry.local.structuredLogs, "true");
 });
 
 test("second identical enable is a no-op that does not rewrite the file", () => {
     const file = makeTempFile("");
-    const first = enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    const first = enableTelemetryLocal(file);
     assert.equal(first.changed, true);
     const contents = fs.readFileSync(file, "utf8");
     const mtimeBefore = fs.statSync(file).mtimeMs;
 
-    const second = enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    const second = enableTelemetryLocal(file);
     assert.equal(second.changed, false);
     assert.equal(fs.readFileSync(file, "utf8"), contents);
     // File was not touched.
@@ -184,33 +141,27 @@ test("second identical enable is a no-op that does not rewrite the file", () => 
 test("rejects flow-style telemetry.local instead of corrupting the document", () => {
     const file = makeTempFile('telemetry: { local: { enabled: "true" } }\n');
     assert.throws(
-        () => enableTelemetryLocal(file, "http://127.0.0.1:54321"),
+        () => enableTelemetryLocal(file),
         /telemetry:.*must open a block mapping/,
     );
 });
 
 test("rejects telemetry as a sequence", () => {
     const file = makeTempFile("telemetry:\n  - not: a-map\n");
-    assert.throws(
-        () => enableTelemetryLocal(file, "http://127.0.0.1:54321"),
-        /telemetry must be a map/,
-    );
+    assert.throws(() => enableTelemetryLocal(file), /telemetry must be a map/);
 });
 
 test("rejects telemetry.local as a sequence", () => {
     const file = makeTempFile("telemetry:\n  local:\n    - enabled: true\n");
     assert.throws(
-        () => enableTelemetryLocal(file, "http://127.0.0.1:54321"),
+        () => enableTelemetryLocal(file),
         /telemetry\.local must be a map/,
     );
 });
 
 test("rejects invalid YAML", () => {
     const file = makeTempFile("telemetry: local: broken:\n  bad\n");
-    assert.throws(
-        () => enableTelemetryLocal(file, "http://127.0.0.1:54321"),
-        /Failed to parse/,
-    );
+    assert.throws(() => enableTelemetryLocal(file), /Failed to parse/);
 });
 
 test("enable preserves unrelated custom local keys", () => {
@@ -224,7 +175,7 @@ test("enable preserves unrelated custom local keys", () => {
     ].join("\n");
     const file = makeTempFile(initial);
 
-    enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    enableTelemetryLocal(file);
 
     const parsed = yaml.load(fs.readFileSync(file, "utf8"));
     assert.equal(parsed.telemetry.local.customExperimental, "hello");
@@ -240,7 +191,7 @@ test("enable preserves a custom logRetentionBytes value instead of overwriting i
     ].join("\n");
     const file = makeTempFile(initial);
 
-    enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    enableTelemetryLocal(file);
 
     const parsed = yaml.load(fs.readFileSync(file, "utf8"));
     // Custom retention value kept — this is a value key, not a toggle.
@@ -250,7 +201,7 @@ test("enable preserves a custom logRetentionBytes value instead of overwriting i
 
 test("enable inserts the default logRetentionBytes as an unquoted YAML number", () => {
     const file = makeTempFile("");
-    enableTelemetryLocal(file, "http://127.0.0.1:54321");
+    enableTelemetryLocal(file);
     const written = fs.readFileSync(file, "utf8");
     // The resolver's parseNonNegativeInteger rejects quoted numbers except
     // as plain decimal digits, but YAML numbers must not be quoted for
@@ -264,7 +215,7 @@ test("enable inserts the default logRetentionBytes as an unquoted YAML number", 
     assert.equal(parsed.telemetry.local.logRetentionBytes, 524288000);
 });
 
-test("toggle preserves local comments and comments before the next sibling", () => {
+test("enable preserves local comments and comments before the next sibling", () => {
     const initial = [
         "telemetry:",
         "  local:",
@@ -277,20 +228,20 @@ test("toggle preserves local comments and comments before the next sibling", () 
     ].join("\n");
     const file = makeTempFile(initial);
 
-    enableTelemetryLocal(file, "http://127.0.0.1:61234");
+    enableTelemetryLocal(file);
 
     const written = fs.readFileSync(file, "utf8");
     assert.ok(written.includes('enabled: "true" # managed toggle'));
     assert.ok(written.includes("# Keep this local explanation."));
-    // otlpEndpoint's value is overwritten (this launcher owns it) but its
-    // inline comment survives the rewrite.
+    // The launcher-owned endpoint is stabilized but its inline comment
+    // survives the rewrite.
     assert.ok(
         written.includes(
-            "otlpEndpoint: http://127.0.0.1:61234 # custom tunnel",
+            `otlpEndpoint: ${LOCAL_OTLP_ENDPOINT} # custom tunnel`,
         ),
     );
     assert.ok(written.includes("  # Production backend."));
     const parsed = yaml.load(written);
     assert.equal(parsed.telemetry.otlpEndpoint, "https://backend.example");
-    assert.equal(parsed.telemetry.local.otlpEndpoint, "http://127.0.0.1:61234");
+    assert.equal(parsed.telemetry.local.otlpEndpoint, LOCAL_OTLP_ENDPOINT);
 });


### PR DESCRIPTION
Decided to go with fixed ports for simplicity (this is only for local testing anyway) and also allow agent-server to just export telemetry without needing it running in advance (to inform it of it's dynamic ports).

## Summary

- use fixed loopback ports for the local Grafana LGTM stack: OTLP/gRPC `24317`, OTLP/HTTP `24318`, and Grafana `24319`
- keep `telemetry.local` enabled at the stable endpoint when LGTM stops, allowing agent-server to start first and export when LGTM becomes available
- remove dynamic port discovery and runtime endpoint rewriting
- recreate containers with stale mappings and fail clearly when a required port is occupied
- update focused tests, sample configuration, launcher help, and local telemetry documentation

## Validation

- `node --test tools/scripts/test/telemetryLocalYaml.spec.mjs`
- `pnpm run build @typeagent/telemetry`
- `pnpm run jest-esm --testPathPattern="otelConfig.spec.js"`
- `pnpm run prettier:changed`
- `pnpm run code-complexity:ci`
- `pnpm run code-lint -- --ratchet --base origin/main`
- `git diff --check`