### PR TITLE
Harden automatic coding workflow validation

### DIFF
--- a/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
+++ b/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
@@ -79,18 +79,14 @@ function isWithinRoot(candidate: string, root: string): boolean {
 export function loadWorkingDirectoryPolicy(
     env: NodeJS.ProcessEnv = process.env,
 ): WorkingDirectoryPolicy {
-    const configuredAllowedRoots = env.TYPEAGENT_CODE_ALLOWED_ROOTS;
-    const configuredRoots = (configuredAllowedRoots ?? "")
+    const configuredRoots = (env.TYPEAGENT_CODE_ALLOWED_ROOTS ?? "")
         .split(path.delimiter)
         .map((entry) => entry.trim())
         .filter(Boolean);
     const allowedRoots = configuredRoots
         .map(canonicalDirectory)
         .filter((entry): entry is string => entry !== undefined);
-    if (
-        configuredAllowedRoots !== undefined &&
-        (configuredRoots.length === 0 || allowedRoots.length === 0)
-    ) {
+    if (configuredRoots.length > 0 && allowedRoots.length === 0) {
         throw new Error(
             "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
         );

--- a/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
+++ b/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
@@ -79,12 +79,18 @@ function isWithinRoot(candidate: string, root: string): boolean {
 export function loadWorkingDirectoryPolicy(
     env: NodeJS.ProcessEnv = process.env,
 ): WorkingDirectoryPolicy {
-    const allowedRoots = (env.TYPEAGENT_CODE_ALLOWED_ROOTS ?? "")
+    const configuredRoots = (env.TYPEAGENT_CODE_ALLOWED_ROOTS ?? "")
         .split(path.delimiter)
         .map((entry) => entry.trim())
-        .filter(Boolean)
+        .filter(Boolean);
+    const allowedRoots = configuredRoots
         .map(canonicalDirectory)
         .filter((entry): entry is string => entry !== undefined);
+    if (configuredRoots.length > 0 && allowedRoots.length === 0) {
+        throw new Error(
+            "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
+        );
+    }
     const defaultRoot = canonicalDirectory(
         env.TYPEAGENT_CODE_DEFAULT_WORKING_DIRECTORY ?? process.cwd(),
     );

--- a/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
+++ b/ts/packages/agentServer/server/src/workingDirectoryPolicy.ts
@@ -79,14 +79,18 @@ function isWithinRoot(candidate: string, root: string): boolean {
 export function loadWorkingDirectoryPolicy(
     env: NodeJS.ProcessEnv = process.env,
 ): WorkingDirectoryPolicy {
-    const configuredRoots = (env.TYPEAGENT_CODE_ALLOWED_ROOTS ?? "")
+    const configuredAllowedRoots = env.TYPEAGENT_CODE_ALLOWED_ROOTS;
+    const configuredRoots = (configuredAllowedRoots ?? "")
         .split(path.delimiter)
         .map((entry) => entry.trim())
         .filter(Boolean);
     const allowedRoots = configuredRoots
         .map(canonicalDirectory)
         .filter((entry): entry is string => entry !== undefined);
-    if (configuredRoots.length > 0 && allowedRoots.length === 0) {
+    if (
+        configuredAllowedRoots !== undefined &&
+        (configuredRoots.length === 0 || allowedRoots.length === 0)
+    ) {
         throw new Error(
             "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
         );

--- a/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
+++ b/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
@@ -81,15 +81,16 @@ describe("agent-server working-directory policy", () => {
     });
 
     test.each(["", " ", path.delimiter])(
-        "rejects an explicitly configured empty allowlist",
+        "treats an explicitly configured empty allowlist as unrestricted",
         (configuredRoots) => {
-            expect(() =>
+            expect(
                 loadWorkingDirectoryPolicy({
                     TYPEAGENT_CODE_ALLOWED_ROOTS: configuredRoots,
                 }),
-            ).toThrow(
-                "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
-            );
+            ).toEqual({
+                allowedRoots: [],
+                defaultRoot: fs.realpathSync(process.cwd()),
+            });
         },
     );
 

--- a/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
+++ b/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
@@ -80,6 +80,19 @@ describe("agent-server working-directory policy", () => {
         );
     });
 
+    test.each(["", " ", path.delimiter])(
+        "rejects an explicitly configured empty allowlist",
+        (configuredRoots) => {
+            expect(() =>
+                loadWorkingDirectoryPolicy({
+                    TYPEAGENT_CODE_ALLOWED_ROOTS: configuredRoots,
+                }),
+            ).toThrow(
+                "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
+            );
+        },
+    );
+
     test("infers the parent directory of a quoted file path", () => {
         const file = path.join(child, "releaseNotes.ts");
         fs.writeFileSync(file, "export {};\n");

--- a/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
+++ b/ts/packages/agentServer/server/test/workingDirectoryPolicy.spec.ts
@@ -70,6 +70,16 @@ describe("agent-server working-directory policy", () => {
         });
     });
 
+    test("rejects an allowlist with no valid roots", () => {
+        expect(() =>
+            loadWorkingDirectoryPolicy({
+                TYPEAGENT_CODE_ALLOWED_ROOTS: path.join(root, "does-not-exist"),
+            }),
+        ).toThrow(
+            "TYPEAGENT_CODE_ALLOWED_ROOTS does not contain an existing directory",
+        );
+    });
+
     test("infers the parent directory of a quoted file path", () => {
         const file = path.join(child, "releaseNotes.ts");
         fs.writeFileSync(file, "export {};\n");

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/codingCompletion.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/codingCompletion.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import type { CodingTaskOutcome } from "@typeagent/dispatcher-types";
+import { isMutatingCodingRequest } from "./codingRequestClassification.js";
 
-const MUTATION_REQUEST_PATTERN =
-    /\b(add|build|create|delete|edit|fix|format|implement|migrate|modify|refactor|remove|rename|update|write)\b/i;
+export { isMutatingCodingRequest } from "./codingRequestClassification.js";
 const DOCUMENTATION_TARGET_PATTERN =
     /\b(docs?|documentation|markdown|readme)\b|\.(?:md|mdx)\b/i;
 const VALIDATED_TARGET_PATTERN =
@@ -23,10 +23,6 @@ function serializedArgs(args: unknown): string {
     } catch {
         return String(args);
     }
-}
-
-export function isMutatingCodingRequest(request: string): boolean {
-    return MUTATION_REQUEST_PATTERN.test(request);
 }
 
 export function requiresCodingValidation(request: string): boolean {
@@ -79,6 +75,8 @@ export function createCodingCompletionTracker(request: string) {
         onToolSuccess(toolName: string, args: unknown): void {
             if (isWriteToolUse(toolName, args)) {
                 filesChanged = true;
+                validationSucceeded = false;
+                stopBlockIssued = false;
             }
             if (isValidationToolUse(toolName, args)) {
                 validationAttempted = true;

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/codingCompletion.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/codingCompletion.ts
@@ -66,6 +66,12 @@ export function createCodingCompletionTracker(request: string) {
     let validationSucceeded = false;
     let stopBlockIssued = false;
 
+    const recordWriteEvidence = (): void => {
+        filesChanged = true;
+        validationSucceeded = false;
+        stopBlockIssued = false;
+    };
+
     return {
         onToolStart(toolName: string, args: unknown): void {
             if (isValidationToolUse(toolName, args)) {
@@ -74,9 +80,7 @@ export function createCodingCompletionTracker(request: string) {
         },
         onToolSuccess(toolName: string, args: unknown): void {
             if (isWriteToolUse(toolName, args)) {
-                filesChanged = true;
-                validationSucceeded = false;
-                stopBlockIssued = false;
+                recordWriteEvidence();
             }
             if (isValidationToolUse(toolName, args)) {
                 validationAttempted = true;
@@ -84,6 +88,9 @@ export function createCodingCompletionTracker(request: string) {
             }
         },
         onToolFailure(toolName: string, args: unknown): void {
+            if (isWriteToolUse(toolName, args)) {
+                recordWriteEvidence();
+            }
             if (isValidationToolUse(toolName, args)) {
                 validationAttempted = true;
                 validationSucceeded = false;

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/codingRequestClassification.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/codingRequestClassification.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const MUTATION_ACTION_PATTERN =
+    /\b(add|build|change|create|delete|edit|fix|format|implement|migrate|modify|refactor|remove|rename|update|write)\b/i;
+
+export function isMutatingCodingRequest(request: string): boolean {
+    return MUTATION_ACTION_PATTERN.test(request);
+}

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/codingRouting.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/codingRouting.ts
@@ -9,6 +9,7 @@ import {
     DispatcherClarifyName,
     isUnknownAction,
 } from "../context/dispatcher/dispatcherUtils.js";
+import { isMutatingCodingRequest } from "./codingRequestClassification.js";
 
 export type CodingRouteDecision = "coding" | "notCoding";
 
@@ -43,8 +44,8 @@ export function isCodeAgentRequest(requestAction: RequestAction): boolean {
     );
 }
 
-const ACTION_PATTERN =
-    /\b(add|build|compile|create|debug|delete|edit|fix|format|implement|lint|migrate|modify|refactor|remove|rename|run|test|typecheck|update|write)\b/i;
+const NON_MUTATING_ACTION_PATTERN =
+    /\b(compile|debug|lint|run|test|typecheck)\b/i;
 const ANALYSIS_PATTERN =
     /\b(analyze|explain|find|inspect|review|search|trace|understand)\b/i;
 const CODE_TARGET_PATTERN =
@@ -77,7 +78,8 @@ export function classifyCodingRequest(
     if (CODING_COMMAND_PATTERN.test(text)) {
         return "coding";
     }
-    const hasAction = ACTION_PATTERN.test(text);
+    const hasAction =
+        isMutatingCodingRequest(text) || NON_MUTATING_ACTION_PATTERN.test(text);
     const hasTarget =
         CODE_TARGET_PATTERN.test(text) ||
         FILE_PATTERN.test(text) ||

--- a/ts/packages/dispatcher/dispatcher/test/codingCompletion.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/codingCompletion.spec.ts
@@ -83,6 +83,22 @@ describe("coding completion evidence", () => {
         });
     });
 
+    test("invalidates validation when a write tool fails", () => {
+        const tracker = createCodingCompletionTracker("change the module");
+        tracker.onToolSuccess("edit", { path: "module.ts" });
+        tracker.onToolSuccess("shell", { command: "pnpm test" });
+        tracker.onToolFailure("shell", {
+            command: "Set-Content module.ts broken; exit 1",
+        });
+
+        expect(tracker.onAgentStop(false)?.decision).toBe("block");
+        expect(tracker.outcome("session-4")).toMatchObject({
+            status: "unvalidated",
+            filesChanged: true,
+            validationSucceeded: false,
+        });
+    });
+
     test("does not require validation for read-only analysis", () => {
         const tracker = createCodingCompletionTracker("review parser.ts");
         expect(tracker.onAgentStop(false)).toBeUndefined();

--- a/ts/packages/dispatcher/dispatcher/test/codingCompletion.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/codingCompletion.spec.ts
@@ -13,6 +13,7 @@ describe("coding completion evidence", () => {
     test("distinguishes analysis from mutation requests", () => {
         expect(isMutatingCodingRequest("explain parser.ts")).toBe(false);
         expect(isMutatingCodingRequest("fix parser.ts")).toBe(true);
+        expect(isMutatingCodingRequest("change parser.ts")).toBe(true);
     });
 
     test("does not require code validation for documentation-only mutations", () => {
@@ -65,6 +66,20 @@ describe("coding completion evidence", () => {
             status: "completed",
             validationAttempted: true,
             validationSucceeded: true,
+        });
+    });
+
+    test("requires validation after the most recent write", () => {
+        const tracker = createCodingCompletionTracker("change the module");
+        tracker.onToolSuccess("edit", { path: "module.ts" });
+        tracker.onToolSuccess("shell", { command: "pnpm test" });
+        tracker.onToolSuccess("edit", { path: "module.ts" });
+
+        expect(tracker.onAgentStop(false)?.decision).toBe("block");
+        expect(tracker.outcome("session-3")).toMatchObject({
+            status: "unvalidated",
+            validationAttempted: true,
+            validationSucceeded: false,
         });
     });
 

--- a/ts/packages/dispatcher/dispatcher/test/codingRouting.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/codingRouting.spec.ts
@@ -15,6 +15,7 @@ import fs from "node:fs";
 describe("coding request classification", () => {
     test.each([
         "fix the error in parser.ts",
+        "change parser.ts to reject empty input",
         "create a README.md for this project",
         "run pnpm test",
         "implement the missing function",


### PR DESCRIPTION
Follow-up to #2904 addressing review findings in the automatic coding workflow.

## Summary
- Fail agent-server startup when `TYPEAGENT_CODE_ALLOWED_ROOTS` contains nonempty entries but none resolve to valid directories, instead of silently falling back to unrestricted access. Empty, whitespace-only, or delimiter-only configuration remains intentionally unrestricted.
- Invalidate successful validation evidence after every subsequent successful or failed write-capable tool so completion reflects the final file state, including possible partial writes.
- Share mutation intent classification between coding routing and completion, including common `change` requests.
- Add focused regression coverage for each behavior.

## Validation
- Built `agent-dispatcher` and `agent-server`.
- Ran focused coding completion, coding routing, and working-directory policy tests.
- Passed complexity and lint ratchets against `origin/main`.