### PR TITLE
Add isolated local MSI builds and payload cleanup diagnostics

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -16,6 +16,7 @@
     "api": "pnpm -C packages/api exec npm run start",
     "build": "fluid-build . -t build",
     "build:ext:vscode": "fluid-build . -t build:ext:vscode",
+    "build:msi:local": "node tools/scripts/build-msi-local.mjs",
     "build:shell": "fluid-build agent-shell -t build --dep",
     "bundle:agent-server": "node tools/scripts/bundleAgentServer.mjs",
     "bundle:copilot-plugin": "node tools/scripts/stageCopilotPlugin.mjs",

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -107,14 +107,35 @@ pnpm run build:msi:local -- --skip-build --version 0.0.1-local
 
 The equivalent individual steps are below for troubleshooting.
 
-#### 1. Build the workspace
+#### 1. Verify dependencies and build the workspace
 
 ```powershell
 cd D:\repos\TypeAgent\ts
+pnpm install --prod=false --frozen-lockfile
 pnpm run build
 ```
 
-#### 2. Stage agent-server
+The install command ensures the workspace has development dependencies such as
+`vsce`. It also repairs dependency state left by an interrupted production
+deploy. Omit `pnpm run build` when compiled outputs are already current (the
+equivalent of `--skip-build`).
+
+#### 2. Package VS Code Chat and stage the Copilot plugin
+
+Package tools that require development dependencies before staging the
+agent-server:
+
+```powershell
+pnpm --filter vscode-chat run package
+
+node tools/scripts/stageCopilotPlugin.mjs `
+  --out "$env:TEMP\typeagent-msi-stage\copilot-plugin"
+```
+
+`stageCopilotPlugin.mjs` copies only the runtime files used by the installer and
+writes `bundle-manifest.json`; do not copy the entire plugin `dist` directory.
+
+#### 3. Stage agent-server
 
 The MSI uses `bundleAgentServer.mjs`, matching the published CI artifact. It
 bundles server entry points and profile agents to minimize files and installed
@@ -125,32 +146,29 @@ intended for MSI packaging.
 
 ```powershell
 # From D:\repos\TypeAgent\ts
-node tools/scripts/bundleAgentServer.mjs `
-  --out "$env:TEMP\typeagent-msi-stage\agent-server" `
-  --platform win32 --arch x64 `
-  --profile inbox `
-  --external-cli
+$pnpmState = "$env:TEMP\typeagent-msi-stage\pnpm-state"
+Remove-Item -Recurse -Force $pnpmState -ErrorAction SilentlyContinue
+
+try {
+  node tools/scripts/bundleAgentServer.mjs `
+    --out "$env:TEMP\typeagent-msi-stage\agent-server" `
+    --platform win32 --arch x64 `
+    --profile inbox `
+    --external-cli `
+    --pnpm-state-dir $pnpmState
+} finally {
+  pnpm install --prod=false --frozen-lockfile
+  Remove-Item -Recurse -Force $pnpmState -ErrorAction SilentlyContinue
+}
 ```
 
-#### 3. Stage copilot-plugin
-
-```powershell
-$plugin = "packages/copilot-plugin"
-$out    = "$env:TEMP\typeagent-msi-stage\copilot-plugin"
-New-Item -ItemType Directory -Force $out | Out-Null
-Copy-Item -Recurse "$plugin/dist"       "$out/dist"
-Copy-Item          "$plugin/hooks.json" "$out/hooks.json"
-Copy-Item          "$plugin/.mcp.json"  "$out/.mcp.json"
-Copy-Item          "$plugin/plugin.json" "$out/plugin.json"
-Copy-Item -Recurse "$plugin/agents"     "$out/agents"
-Copy-Item -Recurse "$plugin/skills"     "$out/skills"
-```
+The isolated pnpm state keeps the production deploy out of the workspace. The
+`finally` block restores the frozen development install even if bundling fails,
+matching the wrapper's cleanup behavior.
 
 #### 4. Run the WiX build with local staged artifacts
 
 ```powershell
-pnpm --filter vscode-chat run package
-
 node tools/scripts/build-msi.mjs `
   --skip-download `
   --agent-dir  "$env:TEMP\typeagent-msi-stage\agent-server" `
@@ -159,8 +177,13 @@ node tools/scripts/build-msi.mjs `
   --version 0.0.1-local `
   --plugin-version 0.0.1-local `
   --vscode-chat-version 0.0.1-local `
+  --skip-shell-feed-resolution `
   --output "$env:TEMP\typeagent-msi-stage\out"
 ```
+
+The local wrapper skips shell feed resolution so this path does not require an
+Azure CLI login. Remove `--skip-shell-feed-resolution` to resolve and bake the
+latest shell fallback package version, which requires feed access.
 
 **Output:**
 

--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -84,6 +84,29 @@ Use the local source build to validate WiX changes before pushing to CI. This is
 
 ### Option A: Build from local repo (recommended for WiX development)
 
+Run the complete local build from `ts/`:
+
+```powershell
+pnpm run build:msi:local
+```
+
+The default output is
+`$env:TEMP\typeagent-msi-stage\out\TypeAgent-<version>-win32-x64.msi`.
+The wrapper builds the workspace, packages the VSIX, stages the Copilot plugin,
+creates the same bundled agent-server artifact used by CI, and runs WiX. Its
+temporary pnpm deployment state is kept out of the development workspace, and
+the wrapper restores development dependency status after pnpm's legacy deploy.
+By default it detects the installed TypeAgent MSI and increments its
+MSI-comparable version; when TypeAgent is not installed, it uses `0.0.1-local`.
+Pass `--skip-build` when compiled outputs are already current, or use
+`--version`, `--stage-dir`, and `--output` to override their defaults.
+
+```powershell
+pnpm run build:msi:local -- --skip-build --version 0.0.1-local
+```
+
+The equivalent individual steps are below for troubleshooting.
+
 #### 1. Build the workspace
 
 ```powershell
@@ -93,9 +116,16 @@ pnpm run build
 
 #### 2. Stage agent-server
 
+The MSI uses `bundleAgentServer.mjs`, matching the published CI artifact. It
+bundles server entry points and profile agents to minimize files and installed
+size. `deployAgentServer.mjs` is the unbundled variant: it preserves workspace
+package boundaries and a conventional production `node_modules` for debugging
+a repo-less deployment, but produces a substantially larger artifact and is not
+intended for MSI packaging.
+
 ```powershell
 # From D:\repos\TypeAgent\ts
-node tools/scripts/deployAgentServer.mjs `
+node tools/scripts/bundleAgentServer.mjs `
   --out "$env:TEMP\typeagent-msi-stage\agent-server" `
   --platform win32 --arch x64 `
   --profile inbox `
@@ -420,6 +450,18 @@ az artifacts universal download: ... (404 or auth error)
 1. Run `az login` and authenticate
 2. Verify artifact exists: `az artifacts universal list --feed typeagent`
 3. Check RID matches published artifacts (e.g., `agent-server.win32-x64`)
+
+### "Unable to clear payload directory"
+
+An upgrade cannot replace the agent-server while TypeAgent or another process
+is using a native module from the install directory. Setup reports the process
+ID and loaded module when Windows allows module inspection. Close TypeAgent,
+stop the agent server, and retry setup. Restart Windows if the file remains
+locked.
+
+Detailed extraction diagnostics are written to
+`%LOCALAPPDATA%\TypeAgent\logs\msi-extract-payload.log` and to the verbose MSI
+log when setup is run with `/L*V`.
 
 ### "Certificate not found"
 

--- a/ts/tools/installers/wix/extract-payload.ps1
+++ b/ts/tools/installers/wix/extract-payload.ps1
@@ -46,6 +46,40 @@ function Write-Log([string]$message) {
     }
 }
 
+function Write-PayloadCleanupDiagnostics([string]$target, [System.Exception]$exception) {
+    Write-Log "ERROR: Unable to clear payload directory '$target'."
+    Write-Log "ERROR: $($exception.GetType().FullName): $($exception.Message)"
+
+    $lockingProcesses = @{}
+    foreach ($process in Get-Process -ErrorAction SilentlyContinue) {
+        try {
+            foreach ($module in $process.Modules) {
+                if ($module.FileName.StartsWith($target, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $lockingProcesses[$process.Id] = @{
+                        Name = $process.ProcessName
+                        Module = $module.FileName
+                    }
+                    break
+                }
+            }
+        } catch {
+            # Some protected processes do not allow module enumeration.
+        }
+    }
+
+    if ($lockingProcesses.Count -gt 0) {
+        Write-Log "Processes using files from the payload directory:"
+        foreach ($processId in ($lockingProcesses.Keys | Sort-Object)) {
+            $details = $lockingProcesses[$processId]
+            Write-Log "  PID $processId ($($details.Name)): $($details.Module)"
+        }
+    } else {
+        Write-Log "No locking process could be identified. Antivirus or another protected process may be using the directory."
+    }
+
+    Write-Log "Close TypeAgent and stop its agent server, then retry setup. Restart Windows if the file remains locked."
+}
+
 # <target-dir-name> = <zip-file-name> under <Root>\payload
 $payloads = @(
     @{ Name = "agent-server";   Zip = "agent-server.zip" },
@@ -86,7 +120,12 @@ try {
         # Clean the target so upgrades don't leave stale files behind.
         if (Test-Path $target) {
             Write-Log "Clearing existing $target"
-            Remove-Item -Recurse -Force $target
+            try {
+                Remove-Item -Recurse -Force $target
+            } catch {
+                Write-PayloadCleanupDiagnostics $target $_.Exception
+                throw "Payload cleanup failed for '$target'. See '$LogPath' for process diagnostics."
+            }
         }
         New-Item -ItemType Directory -Force -Path $target | Out-Null
 

--- a/ts/tools/installers/wix/extract-payload.ps1
+++ b/ts/tools/installers/wix/extract-payload.ps1
@@ -50,11 +50,12 @@ function Write-PayloadCleanupDiagnostics([string]$target, [System.Exception]$exc
     Write-Log "ERROR: Unable to clear payload directory '$target'."
     Write-Log "ERROR: $($exception.GetType().FullName): $($exception.Message)"
 
+    $targetPrefix = $target + [System.IO.Path]::DirectorySeparatorChar
     $lockingProcesses = @{}
     foreach ($process in Get-Process -ErrorAction SilentlyContinue) {
         try {
             foreach ($module in $process.Modules) {
-                if ($module.FileName.StartsWith($target, [System.StringComparison]::OrdinalIgnoreCase)) {
+                if ($module.FileName.StartsWith($targetPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
                     $lockingProcesses[$process.Id] = @{
                         Name = $process.ProcessName
                         Module = $module.FileName
@@ -89,9 +90,10 @@ if ($Payload) {
     $payloads = @($payloads | Where-Object { $_.Name -eq $Payload })
 }
 
-$payloadDir = Join-Path $Root "payload"
-
 try {
+    $Root = [System.IO.Path]::GetFullPath($Root)
+    $payloadDir = Join-Path $Root "payload"
+
     if ($Uninstall) {
         foreach ($p in $payloads) {
             $target = Join-Path $Root $p.Name

--- a/ts/tools/scripts/build-msi-local.mjs
+++ b/ts/tools/scripts/build-msi-local.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const tsRoot = path.resolve(scriptsDir, "..", "..");
+const upgradeCode = "{12345678-1234-1234-1234-123456789012}";
+
+function getInstalledVersion() {
+    if (process.platform !== "win32") {
+        return undefined;
+    }
+
+    const script = [
+        "$ErrorActionPreference = 'Stop'",
+        "$installer = New-Object -ComObject WindowsInstaller.Installer",
+        `$products = @($installer.RelatedProducts('${upgradeCode}'))`,
+        "$versions = foreach ($product in $products) { $installer.ProductInfo($product, 'VersionString') }",
+        "$versions | Sort-Object { [version]$_ } -Descending | Select-Object -First 1",
+    ].join("; ");
+    const result = spawnSync(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", script],
+        { encoding: "utf8", windowsHide: true },
+    );
+    const installerVersion = result.stdout?.trim();
+    if (result.status === 0 && installerVersion) {
+        return installerVersion;
+    }
+
+    const registry = spawnSync(
+        "reg.exe",
+        ["query", "HKCU\\Software\\Microsoft\\TypeAgent", "/v", "Version"],
+        { encoding: "utf8", windowsHide: true },
+    );
+    return registry.stdout?.match(/Version\s+REG_\w+\s+(\S+)/i)?.[1];
+}
+
+function nextLocalVersion(installedVersion) {
+    if (!installedVersion) {
+        return "0.0.1-local";
+    }
+    const match = installedVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!match) {
+        return "0.0.1-local";
+    }
+
+    const parts = match.slice(1).map(Number);
+    parts[2]++;
+    for (let index = 2; index > 0; index--) {
+        if (parts[index] <= 65534) {
+            break;
+        }
+        parts[index] = 0;
+        parts[index - 1]++;
+    }
+    if (parts[0] > 65534) {
+        throw new Error(
+            `Installed TypeAgent version is too high to increment: ${installedVersion}`,
+        );
+    }
+    return `${parts.join(".")}-local`;
+}
+
+function parseArgs(argv) {
+    const args = {
+        stageDir: path.join(os.tmpdir(), "typeagent-msi-stage"),
+        skipBuild: false,
+    };
+    for (let i = 2; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === "--version") args.version = argv[++i];
+        else if (arg === "--stage-dir") args.stageDir = argv[++i];
+        else if (arg === "--output") args.output = argv[++i];
+        else if (arg === "--skip-build") args.skipBuild = true;
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    args.stageDir = path.resolve(args.stageDir);
+    args.output = path.resolve(args.output ?? path.join(args.stageDir, "out"));
+    if (!args.version) {
+        args.installedVersion = getInstalledVersion();
+        args.version = nextLocalVersion(args.installedVersion);
+    }
+    return args;
+}
+
+function run(command, commandArgs, cwd = tsRoot) {
+    console.log(`> ${command} ${commandArgs.join(" ")}`);
+    const result = spawnSync(command, commandArgs, {
+        cwd,
+        stdio: "inherit",
+        shell: process.platform === "win32",
+    });
+    if (result.status !== 0) {
+        throw new Error(`Command failed (${result.status}): ${command}`);
+    }
+}
+
+function requireWorkspaceDevDependencies() {
+    const executableSuffix = process.platform === "win32" ? ".cmd" : "";
+    const vsce = path.join(
+        tsRoot,
+        "packages",
+        "vscode-chat",
+        "node_modules",
+        ".bin",
+        `vsce${executableSuffix}`,
+    );
+    if (!fs.existsSync(vsce)) {
+        throw new Error(
+            "Workspace development dependencies are missing. A previous production deploy may have replaced node_modules. " +
+                "Run 'pnpm install' once from ts/, then rerun this command.",
+        );
+    }
+}
+
+const args = parseArgs(process.argv);
+const agentDir = path.join(args.stageDir, "agent-server");
+const pluginDir = path.join(args.stageDir, "copilot-plugin");
+const pnpmStateDir = path.join(args.stageDir, "pnpm-state");
+const vscodeChatVsix = path.join(
+    tsRoot,
+    "packages",
+    "vscode-chat",
+    "dist-pub",
+    "vscode-chat.vsix",
+);
+
+console.log(`Building local TypeAgent MSI ${args.version}`);
+if (args.installedVersion) {
+    console.log(`Installed TypeAgent: ${args.installedVersion}`);
+}
+console.log(`Staging: ${args.stageDir}`);
+console.log(`Output:  ${args.output}`);
+
+requireWorkspaceDevDependencies();
+
+if (!args.skipBuild) {
+    run("pnpm", ["run", "build"]);
+}
+
+// Package tools that require devDependencies before the production deploy.
+run("npm", ["run", "package"], path.join(tsRoot, "packages", "vscode-chat"));
+run("node", [
+    path.join(scriptsDir, "stageCopilotPlugin.mjs"),
+    "--out",
+    pluginDir,
+]);
+
+fs.rmSync(pnpmStateDir, { recursive: true, force: true });
+try {
+    run("node", [
+        path.join(scriptsDir, "bundleAgentServer.mjs"),
+        "--out",
+        agentDir,
+        "--platform",
+        "win32",
+        "--arch",
+        "x64",
+        "--profile",
+        "inbox",
+        "--external-cli",
+        "--pnpm-state-dir",
+        pnpmStateDir,
+    ]);
+} finally {
+    // pnpm's legacy deploy can leave workspace dependency status in production
+    // mode even when its modules directory is redirected. Match CI by restoring
+    // the frozen development install before this command exits.
+    run("pnpm", ["install", "--prod=false", "--frozen-lockfile"]);
+    fs.rmSync(pnpmStateDir, { recursive: true, force: true });
+}
+
+run("node", [
+    path.join(scriptsDir, "build-msi.mjs"),
+    "--skip-download",
+    "--agent-dir",
+    agentDir,
+    "--plugin-dir",
+    pluginDir,
+    "--vscode-chat-vsix",
+    vscodeChatVsix,
+    "--version",
+    args.version,
+    "--plugin-version",
+    args.version,
+    "--vscode-chat-version",
+    args.version,
+    "--skip-shell-feed-resolution",
+    "--output",
+    args.output,
+]);
+
+console.log(
+    `Local MSI ready: ${path.join(args.output, `TypeAgent-${args.version}-win32-x64.msi`)}`,
+);

--- a/ts/tools/scripts/build-msi.mjs
+++ b/ts/tools/scripts/build-msi.mjs
@@ -52,6 +52,7 @@ let shellPackage = "typeagent-shell.win32-x64";
 let shellFeedVersion = "";
 let shellOrg = "https://dev.azure.com/msctoproj";
 let shellProject = "AI_Systems";
+let skipShellFeedResolution = false;
 
 for (let i = 0; i < args.length; i++) {
     if (args[i] === "--rid") rid = args[++i];
@@ -72,6 +73,8 @@ for (let i = 0; i < args.length; i++) {
     else if (args[i] === "--shell-feed-version") shellFeedVersion = args[++i];
     else if (args[i] === "--shell-org") shellOrg = args[++i];
     else if (args[i] === "--shell-project") shellProject = args[++i];
+    else if (args[i] === "--skip-shell-feed-resolution")
+        skipShellFeedResolution = true;
 }
 if (vscodeChatVersion === "latest") vscodeChatVersion = version;
 
@@ -374,7 +377,12 @@ function downloadArtifact(packageName, ver, targetDir) {
     console.log(`✅ Downloaded ${packageName}: ${files.length} items`);
 }
 
-if (!shellFeedVersion && shellFeed && shellPackage) {
+if (
+    !skipShellFeedResolution &&
+    !shellFeedVersion &&
+    shellFeed &&
+    shellPackage
+) {
     console.log(
         `\n🔎 Resolving latest ${shellPackage} version from feed ${shellFeed}...`,
     );

--- a/ts/tools/scripts/bundleAgentServer.mjs
+++ b/ts/tools/scripts/bundleAgentServer.mjs
@@ -33,6 +33,8 @@ function parseArgs(argv) {
         else if (arg === "--platform") args.platform = argv[++i];
         else if (arg === "--arch") args.arch = argv[++i];
         else if (arg === "--external-cli") args.externalCli = true;
+        else if (arg === "--pnpm-state-dir")
+            args.pnpmStateDir = path.resolve(argv[++i]);
         else throw new Error(`Unknown argument: ${arg}`);
     }
     if (!args.out) {
@@ -126,14 +128,20 @@ export async function bundleAgentServer(args) {
     const out = args.out;
     fs.rmSync(out, { recursive: true, force: true });
 
-    run("pnpm", [
+    const deployArgs = [
         "--filter",
         "agent-server-bundled-runtime",
         "--config.node-linker=hoisted",
-        "deploy",
-        "--prod",
-        out,
-    ]);
+    ];
+    if (args.pnpmStateDir) {
+        const modulesDir = path.join(args.pnpmStateDir, "node_modules");
+        deployArgs.push(
+            `--config.modules-dir=${modulesDir}`,
+            `--config.virtual-store-dir=${path.join(modulesDir, ".pnpm")}`,
+        );
+    }
+    deployArgs.push("deploy", "--prod", out);
+    run("pnpm", deployArgs);
     run("node", [
         path.join(scriptsDir, "pruneDeploy.mjs"),
         "--dir",

--- a/ts/tools/scripts/deployAgentServer.mjs
+++ b/ts/tools/scripts/deployAgentServer.mjs
@@ -21,7 +21,7 @@
  *
  * Usage (from ts/):
  *   node tools/scripts/deployAgentServer.mjs --out <dir> [--platform win32] [--arch x64]
- *        [--skip-deploy] [--skip-prune]
+ *        [--skip-deploy] [--skip-prune] [--pnpm-state-dir <dir>]
  */
 
 import { spawnSync } from "node:child_process";
@@ -41,6 +41,8 @@ function parseArgs(argv) {
         else if (a === "--arch") args.arch = argv[++i];
         else if (a === "--skip-deploy") args.skipDeploy = true;
         else if (a === "--skip-prune") args.skipPrune = true;
+        else if (a === "--pnpm-state-dir")
+            args.pnpmStateDir = path.resolve(argv[++i]);
         else if (a === "--profile") args.profile = argv[++i];
         else if (a === "--external-cli") args.externalCli = true;
         else throw new Error(`Unknown argument: ${a}`);
@@ -80,18 +82,20 @@ function main() {
     //    and yields a copied, self-contained node_modules).
     if (!args.skipDeploy) {
         fs.rmSync(args.out, { recursive: true, force: true });
-        run(
-            "pnpm",
-            [
-                "--filter",
-                "agent-server",
-                "--config.node-linker=hoisted",
-                "deploy",
-                "--prod",
-                args.out,
-            ],
-            tsRoot,
-        );
+        const deployArgs = [
+            "--filter",
+            "agent-server",
+            "--config.node-linker=hoisted",
+        ];
+        if (args.pnpmStateDir) {
+            const modulesDir = path.join(args.pnpmStateDir, "node_modules");
+            deployArgs.push(
+                `--config.modules-dir=${modulesDir}`,
+                `--config.virtual-store-dir=${path.join(modulesDir, ".pnpm")}`,
+            );
+        }
+        deployArgs.push("deploy", "--prod", args.out);
+        run("pnpm", deployArgs, tsRoot);
     } else {
         console.log("Skipping pnpm deploy (--skip-deploy).");
     }


### PR DESCRIPTION
## Summary
- add a `build:msi:local` workflow that creates an isolated staging workspace before producing the Windows installer
- make the agent-server deploy and bundle scripts accept explicit pnpm/state locations so local packaging does not depend on the source checkout's linked `node_modules`
- improve payload cleanup failures by logging the underlying error, identifying processes that hold payload files open, and providing recovery guidance
- update the WiX payload extraction helper and documentation for the local build flow

## Details
`build-msi-local.mjs` stages the required workspace files, performs an isolated pnpm install/deploy, builds the agent server and MSI, and verifies the resulting package. Shared scripts gained optional configuration while preserving their existing defaults.

During an MSI upgrade, payload cleanup failures now produce actionable diagnostics in the installer log. The extraction helper records the exception, scans process modules for files loaded from the payload directory, reports matching process names and IDs, and advises the user to close TypeAgent or restart Windows before retrying.
