### PR TITLE
[OTEL] Fix debug log propagation for app-agents

### DIFF
--- a/ts/docs/architecture/telemetry/local-telemetry-debugging.md
+++ b/ts/docs/architecture/telemetry/local-telemetry-debugging.md
@@ -160,6 +160,25 @@ Useful fields include:
 
 Press `Ctrl+C` to stop following the file.
 
+#### Show Agent Debug Logs
+
+By default the local JSONL uses the `focused` profile, which records only
+structured lifecycle events - no agent `debug` records. To include agent debug
+logs, run these from the CLI (`pnpm cli`):
+
+```text
+@trace typeagent:*
+@log profile diagnostic
+```
+
+- `@trace typeagent:*` scopes which terminal `debug` namespaces are produced,
+  so the bridge only forwards matching agent logs (narrow the pattern, e.g.
+  `@trace typeagent:dispatcher:*`, to focus further).
+- `@log profile diagnostic` raises the local profile so bridged `error`,
+  `warn`, and `info` debug records are written to the JSONL. Use
+  `@log profile verbose` to admit every debug class, or `@log clear` to return
+  to `focused`.
+
 ### 5. Find the Trace
 
 The easiest lookup key is the trace ID. Copy it from:

--- a/ts/packages/dispatcher/dispatcher/src/command/command.ts
+++ b/ts/packages/dispatcher/dispatcher/src/command/command.ts
@@ -382,10 +382,14 @@ export async function processCommandNoLock(
     context: CommandHandlerContext,
     attachments?: string[],
 ) {
+    let errorSource = DispatcherName;
+    let mayHaveSideEffects = false;
     try {
         context.currentAbortSignal?.throwIfAborted();
         const result = await parseCommand(originalInput, context);
+        errorSource = result.appAgentName;
         context.currentAbortSignal?.throwIfAborted();
+        mayHaveSideEffects = true;
         return await executeCommand(
             result.command,
             result.params,
@@ -418,7 +422,7 @@ export async function processCommandNoLock(
                     kind: "error",
                 },
                 getRequestId(context),
-                DispatcherName,
+                errorSource,
                 undefined,
             ),
             "block",
@@ -427,7 +431,7 @@ export async function processCommandNoLock(
         ensureCommandResult(context).disposition = {
             status: "failed",
             path: "command",
-            mayHaveSideEffects: false,
+            mayHaveSideEffects,
         };
         logCommandException(context?.logger, {
             requestId: requestIdToString(getRequestId(context)),

--- a/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/execute/actionHandlers.ts
@@ -1145,12 +1145,6 @@ export async function executeCommand(
                     "AbortError",
                 );
             }
-            const errorDisplay = getErrorDisplayContent(e);
-            if (errorDisplay !== undefined) {
-                actionContext.actionIO.appendDisplay(errorDisplay, "block");
-            } else {
-                displayError(`ERROR: ${e.message}`, actionContext);
-            }
             debugCommandExecError("command execution exception", {
                 requestId: getRequestId(context).requestId,
                 agent: appAgentName,
@@ -1159,6 +1153,7 @@ export async function executeCommand(
                 error: e?.message,
                 stack: e?.stack,
             });
+            throw e;
         }
     } finally {
         actionContext.profiler?.stop();

--- a/ts/packages/dispatcher/dispatcher/test/command.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/command.spec.ts
@@ -40,11 +40,11 @@ const handlers = {
                     run: async () => {},
                 },
             },
-            throws: {
-                description: "Throwing test command",
-                run: async () => {
-                    throw new Error("handler boom");
-                },
+        },
+        throws: {
+            description: "Throwing test command",
+            run: async () => {
+                throw new Error("handler boom");
             },
         },
     },
@@ -273,6 +273,11 @@ describe("Command", () => {
             expect(result!.lastError).toContain(
                 "Command '@test test' does not accept parameters.",
             );
+            expect(result?.disposition).toEqual({
+                status: "failed",
+                path: "command",
+                mayHaveSideEffects: false,
+            });
         });
         it("resolves a default command with extra param error", async () => {
             const result = await awaitCommand(dispatcher, "@test param param");
@@ -296,7 +301,7 @@ describe("Command", () => {
             expect(result?.disposition).toEqual({
                 status: "failed",
                 path: "command",
-                mayHaveSideEffects: false,
+                mayHaveSideEffects: true,
             });
         });
         it("does not resolve command with extra param error", async () => {

--- a/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/structuredRequestIntegration.spec.ts
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 import { jest } from "@jest/globals";
+import type { AppAgent, AppAgentManifest } from "@typeagent/agent-sdk";
+import { getCommandInterface } from "@typeagent/agent-sdk/helpers/command";
 import type { LogEvent } from "@typeagent/telemetry";
 import { awaitCommand, type Dispatcher } from "@typeagent/dispatcher-types";
+import type { AppAgentProvider } from "../src/agentProvider/agentProvider.js";
 
 const captured: LogEvent[] = [];
 jest.unstable_mockModule("../src/otel/structuredLogSink.js", () => ({
@@ -16,6 +19,30 @@ jest.unstable_mockModule("../src/otel/structuredLogSink.js", () => ({
 
 const { createDispatcher } = await import("../src/dispatcher.js");
 
+const throwingAgentManifest: AppAgentManifest = {
+    emojiChar: "🧪",
+    description: "Structured event test agent",
+};
+const throwingAgent: AppAgent = {
+    ...getCommandInterface({
+        description: "Structured event test commands",
+        commands: {
+            fail: {
+                description: "Throw an error",
+                run: async () => {
+                    throw new Error("agent command failed");
+                },
+            },
+        },
+    }),
+};
+const throwingAgentProvider: AppAgentProvider = {
+    getAppAgentNames: () => ["throwing"],
+    getAppAgentManifest: async () => throwingAgentManifest,
+    loadAppAgent: async () => throwingAgent,
+    unloadAppAgent: async () => {},
+};
+
 describe("dispatcher structured request lifecycle", () => {
     let dispatcher: Dispatcher;
 
@@ -25,6 +52,7 @@ describe("dispatcher structured request lifecycle", () => {
             translation: { enabled: false },
             explainer: { enabled: false },
             cache: { enabled: false },
+            appAgentProviders: [throwingAgentProvider],
             collectCommandResult: true,
             telemetry: { structuredLogs: true },
         });
@@ -81,6 +109,30 @@ describe("dispatcher structured request lifecycle", () => {
         expect(exception?.event).toMatchObject({ errorCategory: "internal" });
         expect(exception?.event.httpStatus).toBeUndefined();
         expect(exception?.event.retryable).toBeUndefined();
+        expect(exception?.event.requestId).toBe(
+            captured.find(
+                (event) => event.eventName === "dispatcher:request:received",
+            )?.event.requestId,
+        );
+    });
+
+    it("records an app-agent command exception as a structured event", async () => {
+        captured.length = 0;
+
+        const result = await awaitCommand(dispatcher, "@throwing fail");
+
+        expect(result?.disposition).toEqual({
+            status: "failed",
+            path: "command",
+            mayHaveSideEffects: true,
+        });
+        const exception = captured.find(
+            (event) => event.eventName === "dispatcher:command:exception",
+        );
+        expect(exception?.severity).toBe("error");
+        expect(exception?.event).toMatchObject({
+            errorCategory: "internal",
+        });
         expect(exception?.event.requestId).toBe(
             captured.find(
                 (event) => event.eventName === "dispatcher:request:received",


### PR DESCRIPTION
**Summary**

App-agent command exceptions were caught and displayed inside the execution layer but not propagated to the dispatcher’s canonical failure handler. As a result, failures such as Spotify authentication errors depended on optional  @trace  debug output and were missing structured  command:exception  telemetry. After this fix, app-agent command exceptions are properly propagated.

• Propagate app-agent command exceptions to the dispatcher command boundary.
• Emit structured failure telemetry independently of debug namespace settings.
• Preserve the originating agent when displaying errors.
• Mark execution failures as potentially side-effecting while keeping parse failures safe to retry.
• Add regression coverage for throwing command handlers and correct an existing malformed test fixture.
• Document how to enable agent debug logs in local telemetry.