### PR TITLE
fix(markdown): prevent path traversal outside document root

### DIFF
--- a/ts/packages/agents/markdown/jest.config.cjs
+++ b/ts/packages/agents/markdown/jest.config.cjs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const base = require("../../../jest.config.js");
+module.exports = {
+    ...base,
+    moduleNameMapper: {
+        "^../src/view/route/(.*)$": "<rootDir>/dist/view/route/$1",
+        ...base.moduleNameMapper,
+    },
+};

--- a/ts/packages/agents/markdown/package.json
+++ b/ts/packages/agents/markdown/package.json
@@ -28,8 +28,11 @@
     "clean": "rimraf --glob dist *.tsbuildinfo *.done.build.log .frontend-build-cache.json .tsc-cache-*.json && rimraf .tsbuildinfo .build.cache",
     "dev": "npm run tsc && node scripts/dev-viewer.js --hmr",
     "dev:frontend": "vite  --watch",
+    "jest-esm": "node --no-warnings --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "prettier": "prettier --check . --ignore-path ../../../.prettierignore",
     "prettier:fix": "prettier --write . --ignore-path ../../../.prettierignore",
+    "test": "npm run test:local",
+    "test:local": "pnpm run jest-esm --testPathPattern=\".*[.]spec[.]js\"",
     "tsc": "tsc -b"
   },
   "dependencies": {

--- a/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
+++ b/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
@@ -4,17 +4,21 @@
 import fs from "node:fs";
 import path from "node:path";
 
+function isFileNotFoundError(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+    );
+}
+
 function pathEntryExists(candidate: string): boolean {
     try {
         fs.lstatSync(candidate);
         return true;
     } catch (error) {
-        if (
-            typeof error === "object" &&
-            error !== null &&
-            "code" in error &&
-            error.code === "ENOENT"
-        ) {
+        if (isFileNotFoundError(error)) {
             return false;
         }
         throw error;
@@ -63,12 +67,7 @@ export function resolveExistingFileWithinRoot(
     try {
         canonicalPath = fs.realpathSync(resolvedPath);
     } catch (error) {
-        if (
-            typeof error === "object" &&
-            error !== null &&
-            "code" in error &&
-            error.code === "ENOENT"
-        ) {
+        if (isFileNotFoundError(error)) {
             return undefined;
         }
         throw error;

--- a/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
+++ b/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
@@ -4,6 +4,11 @@
 import fs from "node:fs";
 import path from "node:path";
 
+interface RootPaths {
+    resolvedRoot: string;
+    canonicalRoot: string;
+}
+
 function isFileNotFoundError(error: unknown): boolean {
     return (
         typeof error === "object" &&
@@ -13,25 +18,56 @@ function isFileNotFoundError(error: unknown): boolean {
     );
 }
 
-function pathEntryExists(candidate: string): boolean {
+function resolveRootPaths(root: string): RootPaths {
+    const resolvedRoot = path.resolve(root);
+    return {
+        resolvedRoot,
+        canonicalRoot: fs.realpathSync(resolvedRoot),
+    };
+}
+
+function resolveCandidateWithinRoot(
+    root: RootPaths,
+    requestedPath: string,
+): string | undefined {
+    const candidate = path.resolve(root.resolvedRoot, requestedPath);
+    if (isPathWithinRoot(root.resolvedRoot, candidate)) {
+        return path.resolve(
+            root.canonicalRoot,
+            path.relative(root.resolvedRoot, candidate),
+        );
+    }
+    return isPathWithinRoot(root.canonicalRoot, candidate)
+        ? candidate
+        : undefined;
+}
+
+function resolveExistingFile(
+    root: RootPaths,
+    candidate: string,
+): string | undefined {
+    let canonicalCandidate: string;
     try {
-        fs.lstatSync(candidate);
-        return true;
+        canonicalCandidate = fs.realpathSync(candidate);
     } catch (error) {
         if (isFileNotFoundError(error)) {
-            return false;
+            return undefined;
         }
         throw error;
     }
+
+    return isPathWithinRoot(root.canonicalRoot, canonicalCandidate) &&
+        fs.statSync(canonicalCandidate).isFile()
+        ? canonicalCandidate
+        : undefined;
 }
 
 export function isPathWithinRoot(root: string, candidate: string): boolean {
     const relative = path.relative(root, candidate);
     return (
-        relative === "" ||
-        (relative !== ".." &&
-            !relative.startsWith(`..${path.sep}`) &&
-            !path.isAbsolute(relative))
+        relative !== ".." &&
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative)
     );
 }
 
@@ -39,61 +75,44 @@ export function resolvePathWithinRoot(
     root: string,
     requestedPath: string,
 ): string | undefined {
-    const resolvedRoot = path.resolve(root);
-    const canonicalRoot = fs.realpathSync(resolvedRoot);
-    const resolvedPath = path.resolve(resolvedRoot, requestedPath);
-    if (isPathWithinRoot(resolvedRoot, resolvedPath)) {
-        return path.resolve(
-            canonicalRoot,
-            path.relative(resolvedRoot, resolvedPath),
-        );
-    }
-    return isPathWithinRoot(canonicalRoot, resolvedPath)
-        ? resolvedPath
-        : undefined;
+    return resolveCandidateWithinRoot(resolveRootPaths(root), requestedPath);
 }
 
 export function resolveExistingFileWithinRoot(
     root: string,
     requestedPath: string,
 ): string | undefined {
-    const resolvedPath = resolvePathWithinRoot(root, requestedPath);
-    if (resolvedPath === undefined || !pathEntryExists(resolvedPath)) {
+    const rootPaths = resolveRootPaths(root);
+    const candidate = resolveCandidateWithinRoot(rootPaths, requestedPath);
+    if (candidate === undefined) {
         return undefined;
     }
-
-    const canonicalRoot = fs.realpathSync(root);
-    let canonicalPath: string;
-    try {
-        canonicalPath = fs.realpathSync(resolvedPath);
-    } catch (error) {
-        if (isFileNotFoundError(error)) {
-            return undefined;
-        }
-        throw error;
-    }
-    return isPathWithinRoot(canonicalRoot, canonicalPath) &&
-        fs.statSync(canonicalPath).isFile()
-        ? canonicalPath
-        : undefined;
+    return resolveExistingFile(rootPaths, candidate);
 }
 
 export function resolveWritableFileWithinRoot(
     root: string,
     requestedPath: string,
 ): string | undefined {
-    const resolvedPath = resolvePathWithinRoot(root, requestedPath);
-    if (resolvedPath === undefined) {
+    const rootPaths = resolveRootPaths(root);
+    const candidate = resolveCandidateWithinRoot(rootPaths, requestedPath);
+    if (candidate === undefined) {
         return undefined;
     }
 
-    if (pathEntryExists(resolvedPath)) {
-        return resolveExistingFileWithinRoot(root, resolvedPath);
+    const canonicalParent = fs.realpathSync(path.dirname(candidate));
+    if (!isPathWithinRoot(rootPaths.canonicalRoot, canonicalParent)) {
+        return undefined;
     }
 
-    const canonicalRoot = fs.realpathSync(root);
-    const canonicalParent = fs.realpathSync(path.dirname(resolvedPath));
-    return isPathWithinRoot(canonicalRoot, canonicalParent)
-        ? path.join(canonicalParent, path.basename(resolvedPath))
-        : undefined;
+    const writablePath = path.join(canonicalParent, path.basename(candidate));
+    try {
+        fs.lstatSync(writablePath);
+    } catch (error) {
+        if (isFileNotFoundError(error)) {
+            return writablePath;
+        }
+        throw error;
+    }
+    return resolveExistingFile(rootPaths, writablePath);
 }

--- a/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
+++ b/ts/packages/agents/markdown/src/view/route/pathPolicy.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import path from "node:path";
+
+function pathEntryExists(candidate: string): boolean {
+    try {
+        fs.lstatSync(candidate);
+        return true;
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+        ) {
+            return false;
+        }
+        throw error;
+    }
+}
+
+export function isPathWithinRoot(root: string, candidate: string): boolean {
+    const relative = path.relative(root, candidate);
+    return (
+        relative === "" ||
+        (relative !== ".." &&
+            !relative.startsWith(`..${path.sep}`) &&
+            !path.isAbsolute(relative))
+    );
+}
+
+export function resolvePathWithinRoot(
+    root: string,
+    requestedPath: string,
+): string | undefined {
+    const resolvedRoot = path.resolve(root);
+    const canonicalRoot = fs.realpathSync(resolvedRoot);
+    const resolvedPath = path.resolve(resolvedRoot, requestedPath);
+    if (isPathWithinRoot(resolvedRoot, resolvedPath)) {
+        return path.resolve(
+            canonicalRoot,
+            path.relative(resolvedRoot, resolvedPath),
+        );
+    }
+    return isPathWithinRoot(canonicalRoot, resolvedPath)
+        ? resolvedPath
+        : undefined;
+}
+
+export function resolveExistingFileWithinRoot(
+    root: string,
+    requestedPath: string,
+): string | undefined {
+    const resolvedPath = resolvePathWithinRoot(root, requestedPath);
+    if (resolvedPath === undefined || !pathEntryExists(resolvedPath)) {
+        return undefined;
+    }
+
+    const canonicalRoot = fs.realpathSync(root);
+    let canonicalPath: string;
+    try {
+        canonicalPath = fs.realpathSync(resolvedPath);
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+        ) {
+            return undefined;
+        }
+        throw error;
+    }
+    return isPathWithinRoot(canonicalRoot, canonicalPath) &&
+        fs.statSync(canonicalPath).isFile()
+        ? canonicalPath
+        : undefined;
+}
+
+export function resolveWritableFileWithinRoot(
+    root: string,
+    requestedPath: string,
+): string | undefined {
+    const resolvedPath = resolvePathWithinRoot(root, requestedPath);
+    if (resolvedPath === undefined) {
+        return undefined;
+    }
+
+    if (pathEntryExists(resolvedPath)) {
+        return resolveExistingFileWithinRoot(root, resolvedPath);
+    }
+
+    const canonicalRoot = fs.realpathSync(root);
+    const canonicalParent = fs.realpathSync(path.dirname(resolvedPath));
+    return isPathWithinRoot(canonicalRoot, canonicalParent)
+        ? path.join(canonicalParent, path.basename(resolvedPath))
+        : undefined;
+}

--- a/ts/packages/agents/markdown/src/view/route/service.ts
+++ b/ts/packages/agents/markdown/src/view/route/service.ts
@@ -19,6 +19,11 @@ import * as decoding from "lib0/decoding";
 import registerDebug from "debug";
 import sanitizeFilename from "sanitize-filename";
 import { isAllowedViewOrigin } from "./originAllowlist.js";
+import {
+    resolveExistingFileWithinRoot,
+    resolvePathWithinRoot,
+    resolveWritableFileWithinRoot,
+} from "./pathPolicy.js";
 
 const debug = registerDebug("typeagent:markdown:service");
 
@@ -100,39 +105,52 @@ app.post(
             }
 
             // Construct and normalize file path
-            const documentPath = path.resolve(
+            const documentPath = resolvePathWithinRoot(
                 ROOT_DIR,
                 `${sanitizedDocumentName}.md`,
             );
 
             debug("Sanitized document path ", documentPath);
             // Verify that the file path is within the safe root directory
-            if (!documentPath.startsWith(ROOT_DIR)) {
+            if (documentPath === undefined) {
                 res.status(403).json({
                     error: "Access to the specified path is forbidden.",
                 });
                 return;
             }
 
-            if (!fs.existsSync(documentPath)) {
-                // Create new document if it doesn't exist
-                fs.writeFileSync(
-                    documentPath,
-                    `# ${documentName}\n\nThis is a new document.\n`,
-                );
+            let safeDocumentPath = resolveWritableFileWithinRoot(
+                ROOT_DIR,
+                documentPath,
+            );
+            if (safeDocumentPath === undefined) {
+                res.status(403).json({
+                    error: "Access to the specified path is forbidden.",
+                });
+                return;
             }
 
-            filePath = documentPath;
+            if (!fs.existsSync(safeDocumentPath)) {
+                // Create new document if it doesn't exist
+                fs.writeFileSync(
+                    safeDocumentPath,
+                    `# ${documentName}\n\nThis is a new document.\n`,
+                    { flag: "wx" },
+                );
+                safeDocumentPath = fs.realpathSync(safeDocumentPath);
+            }
+
+            filePath = safeDocumentPath;
 
             // Initialize collaboration for new document
             const documentId = sanitizedDocumentName;
             collaborationManager.initializeDocument(
                 sanitizedDocumentName,
-                documentPath,
+                safeDocumentPath,
             );
 
             // Load content into collaboration manager
-            const content = fs.readFileSync(documentPath, "utf-8");
+            const content = fs.readFileSync(safeDocumentPath, "utf-8");
             debug("Raw content: ", content);
             // collaborationManager.setDocumentContent(documentId, content);
 
@@ -147,7 +165,7 @@ app.post(
                 success: true,
                 documentName: documentName,
                 content: content,
-                documentPath: documentPath,
+                documentPath: safeDocumentPath,
             });
         } catch (error) {
             res.status(500).json({
@@ -559,8 +577,17 @@ app.post("/document", express.json(), (req: Request, res: Response) => {
     }
 
     try {
+        const writableFilePath = resolveWritableFileWithinRoot(
+            ROOT_DIR,
+            filePath,
+        );
+        if (writableFilePath === undefined) {
+            res.status(403).json({ error: "Access to the file is forbidden" });
+            return;
+        }
+
         // File mode: save to both authoritative document and file
-        const documentId = path.basename(filePath, ".md");
+        const documentId = path.basename(writableFilePath, ".md");
         const ydoc = getAuthoritativeDocument(documentId);
         const ytext = ydoc.getText("content");
 
@@ -569,10 +596,11 @@ app.post("/document", express.json(), (req: Request, res: Response) => {
         ytext.insert(0, markdownContent);
 
         // Then save to file
-        fs.writeFileSync(filePath, markdownContent, "utf-8");
+        fs.writeFileSync(writableFilePath, markdownContent, "utf-8");
+        filePath = writableFilePath;
 
         debug(
-            `Saved content to both Y.js doc and file: ${filePath}, ${markdownContent.length} chars`,
+            `Saved content to both Y.js doc and file: ${writableFilePath}, ${markdownContent.length} chars`,
         );
         res.json({ success: true });
     } catch (error) {
@@ -661,8 +689,11 @@ app.post("/autosave", express.json(), (req: Request, res: Response) => {
             sanitizedFilePath += ".md";
         }
 
-        const resolvedFilePath = path.resolve(ROOT_DIR, sanitizedFilePath);
-        if (!resolvedFilePath.startsWith(ROOT_DIR)) {
+        const resolvedFilePath = resolvePathWithinRoot(
+            ROOT_DIR,
+            sanitizedFilePath,
+        );
+        if (resolvedFilePath === undefined) {
             res.status(403).json({ error: "Invalid file path" });
             return;
         }
@@ -812,16 +843,16 @@ app.post("/file/load", express.json(), (req: Request, res: Response) => {
     try {
         const { filePath: newFilePath } = req.body;
 
-        if (!newFilePath) {
+        if (typeof newFilePath !== "string" || !newFilePath) {
             res.status(400).json({ error: "File path is required" });
             return;
         }
 
-        const resolvedPath = path.resolve(ROOT_DIR, newFilePath);
-        if (
-            !resolvedPath.startsWith(ROOT_DIR) ||
-            !fs.existsSync(resolvedPath)
-        ) {
+        const resolvedPath = resolveExistingFileWithinRoot(
+            ROOT_DIR,
+            newFilePath,
+        );
+        if (resolvedPath === undefined) {
             res.status(403).json({
                 error: "Access to the file is forbidden or file not found",
             });
@@ -1471,11 +1502,11 @@ process.on("message", async (message: any) => {
     if (message.type == "setFile") {
         if (message.filePath) {
             // Resolve and validate the file path
-            const resolvedFilePath = path.resolve(
+            const resolvedFilePath = resolveWritableFileWithinRoot(
                 ROOT_DIR,
                 path.basename(message.filePath),
             );
-            if (!resolvedFilePath.startsWith(ROOT_DIR)) {
+            if (resolvedFilePath === undefined) {
                 debug("Invalid file path provided in message");
                 return;
             }

--- a/ts/packages/agents/markdown/test/pathPolicy.spec.ts
+++ b/ts/packages/agents/markdown/test/pathPolicy.spec.ts
@@ -33,6 +33,7 @@ describe("markdown path policy", () => {
         expect(resolvePathWithinRoot(root, "notes/example.md")).toBe(
             path.join(fs.realpathSync(root), "notes", "example.md"),
         );
+        expect(resolvePathWithinRoot(root, ".")).toBe(fs.realpathSync(root));
     });
 
     test("allows names that begin with two dots inside the root", () => {
@@ -119,5 +120,12 @@ describe("markdown path policy", () => {
         expect(
             resolveWritableFileWithinRoot(root, path.join("linked", "new.md")),
         ).toBeUndefined();
+    });
+
+    test("rejects a dangling link as a writable target", () => {
+        const link = path.join(root, "dangling");
+        fs.symlinkSync(path.join(sibling, "missing"), link, "junction");
+
+        expect(resolveWritableFileWithinRoot(root, "dangling")).toBeUndefined();
     });
 });

--- a/ts/packages/agents/markdown/test/pathPolicy.spec.ts
+++ b/ts/packages/agents/markdown/test/pathPolicy.spec.ts
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+    resolveExistingFileWithinRoot,
+    resolvePathWithinRoot,
+    resolveWritableFileWithinRoot,
+} from "../src/view/route/pathPolicy.js";
+
+describe("markdown path policy", () => {
+    let temporaryDirectory: string;
+    let root: string;
+    let sibling: string;
+
+    beforeEach(() => {
+        temporaryDirectory = fs.mkdtempSync(
+            path.join(os.tmpdir(), "typeagent-markdown-path-"),
+        );
+        root = path.join(temporaryDirectory, "Documents");
+        sibling = path.join(temporaryDirectory, "Documents-backup");
+        fs.mkdirSync(root);
+        fs.mkdirSync(sibling);
+    });
+
+    afterEach(() => {
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    });
+
+    test("allows paths inside the root", () => {
+        expect(resolvePathWithinRoot(root, "notes/example.md")).toBe(
+            path.join(root, "notes", "example.md"),
+        );
+    });
+
+    test("allows names that begin with two dots inside the root", () => {
+        expect(resolvePathWithinRoot(root, "..notes.md")).toBe(
+            path.join(root, "..notes.md"),
+        );
+    });
+
+    test("rejects sibling directories that share the root prefix", () => {
+        expect(
+            resolvePathWithinRoot(
+                root,
+                path.join("..", "Documents-backup", "notes.md"),
+            ),
+        ).toBeUndefined();
+    });
+
+    test("rejects absolute paths outside the root", () => {
+        expect(
+            resolvePathWithinRoot(root, path.join(sibling, "notes.md")),
+        ).toBeUndefined();
+    });
+
+    test("canonicalizes and allows an existing file inside the root", () => {
+        const file = path.join(root, "notes.md");
+        fs.writeFileSync(file, "safe");
+
+        expect(resolveExistingFileWithinRoot(root, "notes.md")).toBe(
+            fs.realpathSync(file),
+        );
+    });
+
+    test("preserves load-then-write through a root junction", () => {
+        const canonicalRoot = path.join(temporaryDirectory, "Canonical");
+        const linkedRoot = path.join(temporaryDirectory, "Linked");
+        const file = path.join(canonicalRoot, "notes.md");
+        fs.mkdirSync(canonicalRoot);
+        fs.writeFileSync(file, "safe");
+        fs.symlinkSync(canonicalRoot, linkedRoot, "junction");
+
+        const loadedPath = resolveExistingFileWithinRoot(
+            linkedRoot,
+            "notes.md",
+        );
+        expect(loadedPath).toBe(fs.realpathSync(file));
+        if (loadedPath === undefined) {
+            throw new Error("Expected the file to resolve through the root");
+        }
+        expect(resolveWritableFileWithinRoot(linkedRoot, loadedPath)).toBe(
+            fs.realpathSync(file),
+        );
+    });
+
+    test("allows a new writable file only when its parent is inside the root", () => {
+        expect(resolveWritableFileWithinRoot(root, "new.md")).toBe(
+            path.join(fs.realpathSync(root), "new.md"),
+        );
+        expect(
+            resolveWritableFileWithinRoot(
+                root,
+                path.join("..", "Documents-backup", "new.md"),
+            ),
+        ).toBeUndefined();
+    });
+
+    test("rejects a symlink that resolves outside the root", () => {
+        const outsideFile = path.join(sibling, "notes.md");
+        const link = path.join(root, "linked");
+        fs.writeFileSync(outsideFile, "secret");
+        fs.symlinkSync(sibling, link, "junction");
+
+        expect(
+            resolveExistingFileWithinRoot(
+                root,
+                path.join("linked", "notes.md"),
+            ),
+        ).toBeUndefined();
+        expect(
+            resolveWritableFileWithinRoot(
+                root,
+                path.join("linked", "notes.md"),
+            ),
+        ).toBeUndefined();
+        expect(
+            resolveWritableFileWithinRoot(root, path.join("linked", "new.md")),
+        ).toBeUndefined();
+    });
+});

--- a/ts/packages/agents/markdown/test/pathPolicy.spec.ts
+++ b/ts/packages/agents/markdown/test/pathPolicy.spec.ts
@@ -31,13 +31,13 @@ describe("markdown path policy", () => {
 
     test("allows paths inside the root", () => {
         expect(resolvePathWithinRoot(root, "notes/example.md")).toBe(
-            path.join(root, "notes", "example.md"),
+            path.join(fs.realpathSync(root), "notes", "example.md"),
         );
     });
 
     test("allows names that begin with two dots inside the root", () => {
         expect(resolvePathWithinRoot(root, "..notes.md")).toBe(
-            path.join(root, "..notes.md"),
+            path.join(fs.realpathSync(root), "..notes.md"),
         );
     });
 

--- a/ts/packages/agents/markdown/test/tsconfig.json
+++ b/ts/packages/agents/markdown/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "../dist/test",
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*"],
+  "references": [{ "path": "../src/view/route" }]
+}

--- a/ts/packages/agents/markdown/tsconfig.json
+++ b/ts/packages/agents/markdown/tsconfig.json
@@ -7,7 +7,8 @@
   "references": [
     { "path": "./src/agent" },
     { "path": "./src/view/site" },
-    { "path": "./src/view/route" }
+    { "path": "./src/view/route" },
+    { "path": "./test" }
   ],
   "ts-node": {
     "esm": true


### PR DESCRIPTION
## Summary

Previously, the app checked whether a requested file path **started with** the allowed folder name.


For example, if the allowed folder was:


Plain text




```
C:\Documents

```





this unsafe path also passed the check because it starts with the same text:


Plain text




```
C:\Documents-backup\secret.md

```





An attacker could load that outside file and later overwrite it through the document-save endpoint.


The PR fixes this by:



1. Resolving and canonicalizing both the allowed root and requested path.

2. Checking actual directory containment rather than matching text prefixes.

3. Resolving symlinks and junctions so they cannot redirect outside the root.

4. Rechecking the selected path immediately before writing.



As a result, `C:\Documents\notes.md` remains allowed, while sibling directories, `..` traversal, and links pointing outside `C:\Documents` are rejected.

## Security context

https://portal.microsofticm.com/imp/v5/incidents/details/31000000567548/summary

Fixes MSRC 110439 / ICM 31000000567548. Previously, `/file/load` could accept a sibling directory sharing the `ROOT_DIR` prefix, allowing a subsequent `/document` request to overwrite the selected file outside the configured root.
