### PR TITLE
[Installer] Add MSI failure diagnostics

### DIFF
--- a/ts/tools/installers/wix/README.md
+++ b/ts/tools/installers/wix/README.md
@@ -261,6 +261,16 @@ msiexec /i "$env:TEMP\typeagent-msi-stage\out\TypeAgent-0.0.1-local-win32-x64.ms
 Get-Item "$env:LOCALAPPDATA\TypeAgent\agent-server" -ErrorAction SilentlyContinue
 ```
 
+Payload extraction failures always write the complete exception and PowerShell
+stack trace to
+`$env:LOCALAPPDATA\TypeAgent\logs\msi-extract-payload.log`. For interactive
+debugging, select **Show full error details if setup fails** on the endpoint
+providers page. The installer displays those details before rollback instead of
+leaving the underlying exception only in the log. The equivalent command-line
+property is `SHOWSTACKTRACE=1`. Error details are suppressed for quiet or basic
+UI installs so unattended deployment cannot block on the dialog; the full
+exception remains available in the log.
+
 ## Native VS Code Chat integration
 
 `VSCODECHAT=1` is enabled by default. During install, the MSI runs the shared

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -75,6 +75,7 @@
     <Property Id="STARTSERVER" Value="1" Secure="yes" />
     <Property Id="AUTOSTART" Value="1" Secure="yes" />
     <Property Id="VSCODECHAT" Value="1" Secure="yes" />
+    <Property Id="SHOWSTACKTRACE" Secure="yes" />
 
     <!-- ═══════════════════════════════════════════════
          Optional TypeAgent Shell install (Electron app)
@@ -274,7 +275,7 @@
     <SetProperty Id="ExtractAgentServerPayload"
            Before="ExtractAgentServerPayload"
            Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -Payload &quot;agent-server&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot;" />
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -Payload &quot;agent-server&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot; -ShowStackTrace &quot;[SHOWSTACKTRACE]&quot; -InstallerUiLevel &quot;[UILevel]&quot;" />
 
     <CustomAction Id="ExtractAgentServerPayload"
                   BinaryKey="WixCA"
@@ -286,7 +287,7 @@
     <SetProperty Id="ExtractCopilotPluginPayload"
            Before="ExtractCopilotPluginPayload"
            Sequence="execute"
-                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -Payload &quot;copilot-plugin&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot;" />
+                 Value="&quot;[WindowsFolder]System32\WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;[TYPEAGENTROOT]extract-payload.ps1&quot; -Root &quot;[TYPEAGENTROOT].&quot; -Payload &quot;copilot-plugin&quot; -LogPath &quot;[LocalAppDataFolder]TypeAgent\logs\msi-extract-payload.log&quot; -ShowStackTrace &quot;[SHOWSTACKTRACE]&quot; -InstallerUiLevel &quot;[UILevel]&quot;" />
 
     <CustomAction Id="ExtractCopilotPluginPayload"
                   BinaryKey="WixCA"
@@ -692,7 +693,7 @@
       <DialogRef Id="UserExit" />
 
       <!-- ═══ Provider / embedding selection dialog ═══ -->
-      <Dialog Id="ProviderDlg" Width="370" Height="290" Title="[ProductName] Setup">
+      <Dialog Id="ProviderDlg" Width="370" Height="310" Title="[ProductName] Setup">
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
                  TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
@@ -762,12 +763,16 @@
                  Property="SHELL" CheckBoxValue="1"
                  Text="Also install the TypeAgent Shell desktop app" />
 
-        <Control Id="BottomLine" Type="Line" X="0" Y="254" Width="370" Height="0" />
-        <Control Id="Back" Type="PushButton" X="180" Y="263" Width="56" Height="17"
+        <Control Id="StackTraceCheckBox" Type="CheckBox" X="20" Y="253" Width="340" Height="12"
+                 Property="SHOWSTACKTRACE" CheckBoxValue="1"
+                 Text="Show full error details if setup fails" />
+
+        <Control Id="BottomLine" Type="Line" X="0" Y="274" Width="370" Height="0" />
+        <Control Id="Back" Type="PushButton" X="180" Y="283" Width="56" Height="17"
                  Text="!(loc.WixUIBack)" />
-        <Control Id="Next" Type="PushButton" X="236" Y="263" Width="56" Height="17"
+        <Control Id="Next" Type="PushButton" X="236" Y="283" Width="56" Height="17"
                  Default="yes" Text="!(loc.WixUINext)" />
-        <Control Id="Cancel" Type="PushButton" X="304" Y="263" Width="56" Height="17"
+        <Control Id="Cancel" Type="PushButton" X="304" Y="283" Width="56" Height="17"
                  Cancel="yes" Text="!(loc.WixUICancel)">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>

--- a/ts/tools/installers/wix/extract-payload.ps1
+++ b/ts/tools/installers/wix/extract-payload.ps1
@@ -20,11 +20,19 @@
 
 .PARAMETER Uninstall
   Remove the extracted directories instead of creating them.
+
+.PARAMETER ShowStackTrace
+  Set to "1" to display full error details before Windows Installer rolls back.
+
+.PARAMETER InstallerUiLevel
+  Windows Installer UI level. Error details are displayed only for full UI.
 #>
 param(
     [Parameter(Mandatory = $true)][string]$Root,
     [ValidateSet("agent-server", "copilot-plugin")][string]$Payload,
     [string]$LogPath,
+    [string]$ShowStackTrace = "0",
+    [int]$InstallerUiLevel = 0,
     [switch]$Uninstall
 )
 
@@ -42,6 +50,40 @@ function Write-Log([string]$message) {
             Add-Content -Path $LogPath -Value $line
         } catch {
             # Logging must never fail the install.
+        }
+    }
+}
+
+function Format-ErrorDetails([System.Management.Automation.ErrorRecord]$errorRecord) {
+    $details = @($errorRecord.Exception.ToString())
+    if ($errorRecord.ScriptStackTrace) {
+        $details += "PowerShell stack trace:"
+        $details += $errorRecord.ScriptStackTrace
+    }
+    return $details -join [Environment]::NewLine
+}
+
+function Show-ErrorDetails([string]$details) {
+    $owner = $null
+    try {
+        Add-Type -AssemblyName System.Windows.Forms
+        $owner = New-Object System.Windows.Forms.Form
+        $owner.Opacity = 0
+        $owner.ShowInTaskbar = $false
+        $owner.TopMost = $true
+        $owner.Show()
+        [System.Windows.Forms.MessageBox]::Show(
+            $owner,
+            $details,
+            "TypeAgent setup error details",
+            [System.Windows.Forms.MessageBoxButtons]::OK,
+            [System.Windows.Forms.MessageBoxIcon]::Error
+        ) | Out-Null
+    } catch {
+        Write-Log "ERROR: Unable to display setup error details: $($_.Exception)"
+    } finally {
+        if ($owner) {
+            $owner.Dispose()
         }
     }
 }
@@ -143,6 +185,14 @@ try {
     Write-Log "Payload extraction complete: $($payloads.Name -join ', ')."
     exit 0
 } catch {
-    Write-Log "ERROR: $($_.Exception.Message)"
+    $errorDetails = Format-ErrorDetails $_
+    Write-Log "ERROR: $errorDetails"
+    if (
+        $ShowStackTrace -eq "1" -and
+        $InstallerUiLevel -eq 5 -and
+        [Environment]::UserInteractive
+    ) {
+        Show-ErrorDetails $errorDetails
+    }
     exit 1
 }


### PR DESCRIPTION
## Summary
- log complete payload extraction exceptions and PowerShell stack traces on installer failures
- add an opt-in **Show full error details if setup fails** installer option and `SHOWSTACKTRACE=1` public property
- suppress the blocking diagnostic dialog outside full, interactive MSI UI while retaining full file logs
- document the diagnostic workflow and log location

<img width="593" height="520" alt="image" src="https://github.com/user-attachments/assets/5d2bd2a3-b1c5-4f5b-b02a-0c62c006345a" />
<img width="590" height="553" alt="image" src="https://github.com/user-attachments/assets/aaf6d2ea-d65b-407b-bcc4-0a96d90ab406" />