### PR TITLE
fix(action-grammar): support optional rule references

### DIFF
--- a/ts/docs/architecture/core/actionGrammar.md
+++ b/ts/docs/architecture/core/actionGrammar.md
@@ -82,19 +82,26 @@ separated by `|`:
 
 #### Expression types
 
-| Syntax              | Meaning                                |
-| ------------------- | -------------------------------------- |
-| `word`              | Literal token (case-insensitive match) |
-| `$(var:wildcard)`   | Capture any tokens as string           |
-| `$(var:number)`     | Capture numeric token                  |
-| `$(var:EntityType)` | Capture with entity validation         |
-| `$(var:<RuleName>)` | Capture via sub-rule match             |
-| `<RuleName>`        | Reference another rule (no capture)    |
-| `( expr )`          | Grouping                               |
-| `expr?`             | Optional (zero or one)                 |
-| `expr*`             | Zero or more                           |
-| `expr+`             | One or more                            |
-| `alt1 \| alt2`      | Alternation                            |
+| Syntax               | Meaning                                |
+| -------------------- | -------------------------------------- |
+| `word`               | Literal token (case-insensitive match) |
+| `$(var:wildcard)`    | Capture any tokens as string           |
+| `$(var:number)`      | Capture numeric token                  |
+| `$(var:EntityType)`  | Capture with entity validation         |
+| `$(var:type)?`       | Optional captured variable             |
+| `$(var:<RuleName>)`  | Capture via sub-rule match             |
+| `$(var:<RuleName>)?` | Optional captured sub-rule             |
+| `<RuleName>`         | Reference another rule (no capture)    |
+| `<RuleName>?`        | Optional rule reference                |
+| `( expr )`           | Grouping                               |
+| `( expr )?`          | Optional group (zero or one)           |
+| `( expr )*`          | Zero or more                           |
+| `( expr )+`          | One or more                            |
+| `alt1 \| alt2`       | Alternation                            |
+
+The `?` suffix must immediately follow the closing `)` or `>`. A literal
+question mark immediately after a rule reference must be escaped as `\?`;
+a question mark separated by whitespace remains literal.
 
 #### Value expressions
 

--- a/ts/packages/actionGrammar/src/grammarCompiler.ts
+++ b/ts/packages/actionGrammar/src/grammarCompiler.ts
@@ -1325,22 +1325,42 @@ function createGrammarRule(
                     !isLocallyDefined &&
                     globalPhraseSetRegistry.isPhraseSetName(expr.refName.name)
                 ) {
+                    const partId = allocPartId(
+                        context,
+                        expr.pos,
+                        `<${expr.refName.name}>${expr.optional ? "?" : ""}`,
+                    );
                     parts.push(
-                        createPhraseSetPart(
-                            expr.refName.name,
-                            undefined,
-                            allocPartId(
-                                context,
-                                expr.pos,
-                                `<${expr.refName.name}>`,
-                            ),
-                        ),
+                        expr.optional
+                            ? createRulesPart(
+                                  [
+                                      {
+                                          parts: [
+                                              createPhraseSetPart(
+                                                  expr.refName.name,
+                                              ),
+                                          ],
+                                          value: undefined,
+                                          spacingMode,
+                                      },
+                                  ],
+                                  {
+                                      optional: true,
+                                      name: expr.refName.name,
+                                      partId,
+                                  },
+                              )
+                            : createPhraseSetPart(
+                                  expr.refName.name,
+                                  undefined,
+                                  partId,
+                              ),
                     );
                     // Phrase sets don't produce a captured value on their own.
                     // Use defaultValue=true so single-part rules using a phrase set
                     // don't trip the "Start rule does not produce a value" check.
                     defaultValue = true;
-                    consumedInput(); // phrase sets always consume input
+                    if (!expr.optional) consumedInput();
                     break;
                 }
                 const record = createNamedGrammarRules(
@@ -1354,22 +1374,24 @@ function createGrammarRule(
                 defaultValue = record.hasValue;
                 parts.push(
                     createRulesPart(record.grammarRules, {
+                        optional: expr.optional,
                         name: expr.refName.name,
                         partId: allocPartId(
                             context,
                             expr.pos,
-                            `<${expr.refName.name}>`,
+                            `<${expr.refName.name}>${expr.optional ? "?" : ""}`,
                         ),
                     }),
                 );
-                // RuleRefExpr has no optional modifier; it is always non-optional.
-                // === false: only clear when *definitely* non-nullable (same
-                // asymmetry as the variable ruleRef case above).
-                if (record.nullable === false) {
-                    currentEpr = new Set();
+                if (!expr.optional) {
+                    // === false: only clear when *definitely* non-nullable (same
+                    // asymmetry as the variable ruleRef case above).
+                    if (record.nullable === false) {
+                        currentEpr = new Set();
+                    }
+                    // ?? false: treat undefined (back-ref) as non-nullable.
+                    ruleNullable = ruleNullable && (record.nullable ?? false);
                 }
-                // ?? false: treat undefined (back-ref) as non-nullable.
-                ruleNullable = ruleNullable && (record.nullable ?? false);
                 break;
             }
             case "rules": {

--- a/ts/packages/actionGrammar/src/grammarRuleParser.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleParser.ts
@@ -87,7 +87,7 @@ const debugParse = registerDebug("typeagent:grammar:parse");
  *
  *   <VariableSpecifier> ::= <VarName> (":" (<TypeName> | <RuleName>))?
  *
- *   <RuleRefExpr> ::= <RuleName>
+ *   <RuleRefExpr> ::= <RuleName> (immediately followed by "?")?
  *   <GroupExpr> ::= "(" <Rules> ( ")" | ")?" | ")*" | ")+" )
  *
  *   // ── Value (basic mode: enableValueExpressions=false) ──────────────────────────
@@ -232,6 +232,7 @@ export type CommentedName = {
 export type RuleRefExpr = {
     type: "ruleReference";
     refName: CommentedName;
+    optional?: boolean | undefined;
     pos?: number | undefined;
     leadingComments?: Comment[] | undefined;
 };
@@ -753,7 +754,7 @@ class GrammarRuleParser implements ValueExprParserContext {
             refPos = this.pos;
             if (this.isAt("<")) {
                 ruleReference = true;
-                bracketedName = this.parseRuleName();
+                bracketedName = this.parseRuleName().name;
             } else {
                 bracketedName = this.parseNameWithComments("Type name");
             }
@@ -798,11 +799,17 @@ class GrammarRuleParser implements ValueExprParserContext {
 
             if (this.isAt("<")) {
                 const pos = this.pos;
+                const { name: refName, end } = this.parseRuleName();
                 const node: RuleRefExpr = {
                     type: "ruleReference",
-                    refName: this.parseRuleName(),
+                    refName,
                     pos,
                 };
+                if (this.content.startsWith("?", end)) {
+                    node.optional = true;
+                    this.curr = end;
+                    this.skipWhitespace(1);
+                }
                 attach(node);
                 expNodes.push(node);
                 continue;
@@ -1171,11 +1178,12 @@ class GrammarRuleParser implements ValueExprParserContext {
         return { name, leadingComments, trailingComments };
     }
 
-    private parseRuleName(): CommentedName {
+    private parseRuleName(): { name: CommentedName; end: number } {
         this.consume("<", "at start of rule name");
-        const result = this.parseNameWithComments("Rule identifier");
+        const name = this.parseNameWithComments("Rule identifier");
+        const end = this.curr + 1;
         this.consume(">", "at end of rule name");
-        return result;
+        return { name, end };
     }
 
     private parseRules(): Rule[] {
@@ -1238,7 +1246,7 @@ class GrammarRuleParser implements ValueExprParserContext {
         afterExportComments?: Comment[],
     ): RuleDefinition {
         const pos = this.pos;
-        const rn = this.parseRuleName();
+        const rn = this.parseRuleName().name;
         let spacingMode: SpacingMode;
         let spacingAnnotationComments: SpacingAnnotationComments | undefined;
         let beforeEqualsComments: Comment[] | undefined;

--- a/ts/packages/actionGrammar/src/grammarRuleWriter.ts
+++ b/ts/packages/actionGrammar/src/grammarRuleWriter.ts
@@ -925,6 +925,7 @@ function writeSingleExpr(
         }
         case "ruleReference":
             writeBracketedName(result, expr.refName);
+            if (expr.optional) result.write("?");
             break;
         case "rules": {
             result.write("(");

--- a/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleParser.spec.ts
@@ -88,6 +88,37 @@ describe("Grammar Rule Parser", () => {
                 value: ["world"],
             });
         });
+
+        it("rule with optional rule reference", () => {
+            const grammar = "<sentence> = <greeting>? world;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions).toHaveLength(2);
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "ruleReference",
+                refName: { name: "greeting" },
+                optional: true,
+            });
+            expect(result[0].rules[0].expressions[1]).toEqual({
+                type: "string",
+                value: ["world"],
+            });
+        });
+
+        it("requires the optional suffix to be adjacent", () => {
+            const grammar = "<sentence> = <greeting> ? world;";
+            const result = testParamGrammarRules("test.agr", grammar);
+
+            expect(result[0].rules[0].expressions).toHaveLength(2);
+            expect(result[0].rules[0].expressions[0]).toEqual({
+                type: "ruleReference",
+                refName: { name: "greeting" },
+            });
+            expect(result[0].rules[0].expressions[1]).toEqual({
+                type: "string",
+                value: ["?", "world"],
+            });
+        });
     });
 
     describe("Expression Parsing", () => {

--- a/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
+++ b/ts/packages/actionGrammar/test/grammarRuleWriter.spec.ts
@@ -35,6 +35,24 @@ function validateRoundTrip(grammar: string) {
 }
 
 describe("Formatting layout", () => {
+    describe("rule references", () => {
+        it("preserves an optional rule-reference suffix", () => {
+            const source = "<test> = <greeting>? world;";
+
+            expect(fmt(source)).toBe(`${source}\n`);
+            roundTrip(source);
+        });
+
+        it("does not turn a separated question mark into a suffix", () => {
+            roundTrip("<test> = <greeting> ? world;");
+            roundTrip("<test> = <greeting> /* comment */ ? world;");
+        });
+
+        it("keeps an adjacent escaped question mark literal", () => {
+            roundTrip("<test> = <greeting>\\? world;");
+        });
+    });
+
     describe("rule alternatives — flat vs broken", () => {
         it("single alt always flat", () => {
             // No alternates — always stays on one line

--- a/ts/packages/actionGrammar/test/nfaDfaParity.spec.ts
+++ b/ts/packages/actionGrammar/test/nfaDfaParity.spec.ts
@@ -485,6 +485,88 @@ describe("NFA/DFA Parity", () => {
         });
     });
 
+    describe("optional rule reference", () => {
+        const { grammar, nfa, dfa } = compile(
+            "optionalRuleReference",
+            `
+            <Start> = add $(item:wildcard) to <Owner>? $(playlist:wildcard) playlist
+                -> { actionName: "add", parameters: { item, playlist } };
+            <Owner> = the | my;
+            `,
+        );
+
+        it.each([
+            ["add track to the favorites playlist"],
+            ["add track to my favorites playlist"],
+            ["add track to favorites playlist"],
+        ])("matches '%s' in both matchers", (request) => {
+            assertMatchParity(grammar, nfa, dfa, request);
+            expect(matchGrammarWithNFA(grammar, nfa, request)).not.toHaveLength(
+                0,
+            );
+            expect(
+                matchDFAWithSplitting(dfa, tokenizeRequest(request)).matched,
+            ).toBe(true);
+        });
+
+        it("does not make an unsuffixed rule reference optional", () => {
+            const required = compile(
+                "requiredRuleReference",
+                `
+                <Start> = add $(item:wildcard) to <Owner> $(playlist:wildcard) playlist
+                    -> { actionName: "add", parameters: { item, playlist } };
+                <Owner> = the | my;
+                `,
+            );
+
+            expect(
+                matchGrammarWithNFA(
+                    required.grammar,
+                    required.nfa,
+                    "add track to favorites playlist",
+                ),
+            ).toHaveLength(0);
+            expect(
+                matchDFAWithSplitting(
+                    required.dfa,
+                    tokenizeRequest("add track to favorites playlist"),
+                ).matched,
+            ).toBe(false);
+        });
+
+        it.each(["the play", "play"])(
+            "keeps AST evaluation in parity for '%s'",
+            (request) => {
+                const noCaptures = compile(
+                    "optionalRuleReferenceAST",
+                    `
+                    <Start> = <Owner>? play -> { actionName: "play" };
+                    <Owner> = the | my;
+                    `,
+                );
+
+                assertASTMatchParity(
+                    noCaptures.grammar,
+                    noCaptures.nfa,
+                    noCaptures.dfa,
+                    request,
+                );
+            },
+        );
+
+        it("offers both the optional rule and the following wildcard", () => {
+            const completions = getDFACompletions(dfa, ["add", "track", "to"]);
+
+            expect(completions.completions).toEqual(
+                expect.arrayContaining(["the", "my"]),
+            );
+            expect(completions.properties).toContainEqual({
+                actionName: "add",
+                propertyPath: "parameters.playlist",
+            });
+        });
+    });
+
     // -----------------------------------------------------------------------
     // 7. Kleene plus (one-or-more)
     // -----------------------------------------------------------------------
@@ -1812,6 +1894,53 @@ describe("PhraseSet Completion Parity", () => {
         <Start> = <schedule> | <find>;
         `,
     );
+
+    const optionalPhraseSet = compile(
+        "optionalPhraseSetReference",
+        `
+        <Start> = <Polite>? schedule $(desc:wildcard)
+            -> { actionName: "scheduleEvent", parameters: { desc } };
+        `,
+    );
+
+    it.each(["please schedule meeting", "schedule meeting"])(
+        "matches an optional phrase-set reference in '%s'",
+        (request) => {
+            assertMatchParity(
+                optionalPhraseSet.grammar,
+                optionalPhraseSet.nfa,
+                optionalPhraseSet.dfa,
+                request,
+            );
+            assertASTMatchParity(
+                optionalPhraseSet.grammar,
+                optionalPhraseSet.nfa,
+                optionalPhraseSet.dfa,
+                request,
+            );
+            expect(
+                matchGrammarWithNFA(
+                    optionalPhraseSet.grammar,
+                    optionalPhraseSet.nfa,
+                    request,
+                ),
+            ).not.toHaveLength(0);
+            expect(
+                matchDFAWithSplitting(
+                    optionalPhraseSet.dfa,
+                    tokenizeRequest(request),
+                ).matched,
+            ).toBe(true);
+        },
+    );
+
+    it("suggests both the optional phrase set and the following token", () => {
+        const completions = getDFACompletions(optionalPhraseSet.dfa, []);
+
+        expect(completions.completions).toEqual(
+            expect.arrayContaining(["please", "schedule"]),
+        );
+    });
 
     it("empty prefix: DFA suggests phraseSet first-tokens", () => {
         const comp = getDFACompletions(dfa, []);


### PR DESCRIPTION
## Summary

- parse an adjacent `?` after a named rule reference as an optional suffix
- preserve required references and literal question marks when `?` is separated or escaped
- carry optionality through local, imported, and built-in phrase-set references
- keep formatter round-trips, source metadata, spacing modes, and grammar docs in sync

## Why

`<Owner>?` was previously compiled as a required `<Owner>` followed by a literal `?` token. That made the optional reference fail to match even though the equivalent inline group worked. The same suffix form is already used by grammars such as `<TimeSpec>?` and `<PanelRef>?`.

The suffix is intentionally adjacency-only, matching `$(...)?` and `(...)?`, so `<Rule> ?` remains a required reference followed by literal punctuation.

## Validation

- action grammar build
- 76 action grammar test suites: 16,188 passed, 2 skipped
- parser/writer round-trip, NFA/DFA, AST evaluation, and completion regressions
- Prettier and `git diff --check`
- repository policy checks: 9,532 passed
- code-lint ratchet: no new violations

Fixes #2461