### PR TITLE
Bind local servers to loopback and gate browser-driven requests

### DIFF
--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -84,6 +84,17 @@ WORKDIR /prod/api
 
 EXPOSE 80:3000
 
+# The API server binds loopback by default so a local run isn't reachable from
+# the network. In the container the published port is the whole point and the
+# container boundary is the isolation, so bind all interfaces here.
+ENV TYPEAGENT_API_HOST=0.0.0.0
+
+# Browser clients are still gated on Origin, and a hosted deployment serves the
+# chat view from its own hostname rather than localhost. Set
+# TYPEAGENT_API_ALLOWED_ORIGINS to that public origin when running this image,
+# e.g. TYPEAGENT_API_ALLOWED_ORIGINS=https://typeagent.example.com, or the
+# browser's dispatcher WebSocket will be refused with 403.
+
 # start actions
 # az login
 RUN echo az login --identity >> start.sh

--- a/ts/examples/cacheRESTEndpoint/src/index.ts
+++ b/ts/examples/cacheRESTEndpoint/src/index.ts
@@ -23,7 +23,7 @@ type SchemaEntry = {
 const app = express();
 
 // Define the port number
-const port = `10482`;
+const port = 10482;
 
 // The cache file to serve
 const cacheFile = "data/v5_sample.json";
@@ -80,8 +80,10 @@ app.get(`/test`, async (req: Request, res: Response) => {
     res.sendFile(path.resolve("src/test.html"));
 });
 
-// Start the server and listen on the specified port
-app.listen(port, async () => {
+// Start the server and listen on the specified port. Bind loopback-only: the
+// endpoint has no authentication and serves cache contents plus a file read
+// from disk, so an all-interfaces bind would expose both to any LAN peer.
+app.listen(port, "127.0.0.1", async () => {
     console.log(`Server is running at http://localhost:${port}`);
     console.log(`Serving cache file from: ${cacheFile}`);
 

--- a/ts/packages/agentServer/server/README.md
+++ b/ts/packages/agentServer/server/README.md
@@ -29,11 +29,29 @@ node --disable-warning=DEP0190 packages/agentServer/server/dist/server.js --conf
 
 Listens on `ws://localhost:8999`. The server also starts automatically when clients call `ensureAgentServer()`.
 
+### Network exposure
+
+The listener binds loopback (`127.0.0.1`), so only this machine can reach it,
+and refuses WebSocket upgrades whose `Origin` is neither a loopback page nor a
+TypeAgent browser extension. This matters because the server has no
+authentication: a client that connects can join conversations, read the signed-in
+user's identity, and run agent commands with the local user's permissions.
+
+For cross-device access use the [dev tunnel](#dev-tunnel-cross-device-access) -
+the tunnel host runs on this machine and reaches the server over loopback, so it
+works unchanged.
+
+`--host <address>` (or `AGENT_SERVER_HOST`) widens the bind for deployments that
+must publish the port, such as a container that isolates the workspace. The
+server prints a warning banner whenever it binds anything but loopback; only do
+this behind a network boundary you control.
+
 ### Server flags
 
 | Flag                       | Description                                                                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `--port <port>`            | Port to listen on (default: 8999)                                                                                                       |
+| `--host <address>`         | Address to bind (default: `127.0.0.1`). Also settable via `AGENT_SERVER_HOST`.                                                          |
 | `--config <name>`          | Load `config.<name>.json` instead of the default config                                                                                 |
 | `--idle-timeout <seconds>` | Exit after this many seconds with no connected clients (default: disabled). The CLI passes 600 (10 min) when it auto-spawns the server. |
 

--- a/ts/packages/agentServer/server/package.json
+++ b/ts/packages/agentServer/server/package.json
@@ -55,6 +55,7 @@
     "@typeagent/telemetry": "workspace:*",
     "@typeagent/typechat-utils": "workspace:*",
     "@typeagent/websocket-channel-server": "workspace:*",
+    "@typeagent/websocket-utils": "workspace:*",
     "agent-dispatcher": "workspace:*",
     "better-sqlite3": "12.8.0",
     "debug": "^4.4.0",

--- a/ts/packages/agentServer/server/src/listenHost.ts
+++ b/ts/packages/agentServer/server/src/listenHost.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
+
+/**
+ * Resolve the address the agent server listens on: `--host` wins over
+ * `AGENT_SERVER_HOST`, and both fall back to loopback.
+ *
+ * Values are trimmed, and a blank one is treated as absent. Binding the empty
+ * string publishes the listener on every interface, which is the opposite of
+ * the default this function exists to enforce. An untrimmed value is worse
+ * than useless: it fails to resolve at bind time, yet `isLoopbackHost` trims
+ * before comparing, so it would read as loopback and suppress the
+ * network-exposure warning for a host that never binds at all.
+ */
+export function resolveAgentServerHost(
+    argv: readonly string[],
+    env: NodeJS.ProcessEnv,
+): string {
+    const idx = argv.indexOf("--host");
+    const fromArgv = idx !== -1 ? argv[idx + 1]?.trim() : undefined;
+    const fromEnv = env.AGENT_SERVER_HOST?.trim();
+    return fromArgv || fromEnv || LOOPBACK_HOST;
+}

--- a/ts/packages/agentServer/server/src/server.ts
+++ b/ts/packages/agentServer/server/src/server.ts
@@ -8,7 +8,9 @@ import {
 } from "./conversationManager.js";
 import { createAgentServerConnectionHandler } from "./connectionHandler.js";
 import { startStaleBuildWatcher, isStaleBuild } from "./staleBuild.js";
-import { printConfigDriftBanner } from "./banner.js";
+import { printConfigDriftBanner, printWarningBanner } from "./banner.js";
+import { isLoopbackHost } from "@typeagent/websocket-utils/loopback";
+import { resolveAgentServerHost } from "./listenHost.js";
 import {
     getInstanceDirAsync,
     getTraceIdAsync,
@@ -397,6 +399,27 @@ async function main() {
               ? parseInt(process.env.AGENT_SERVER_PORT, 10)
               : AGENT_SERVER_DEFAULT_PORT;
 
+    // The listener is unauthenticated: anyone who can reach the port can join
+    // a conversation and drive the dispatcher with the local user's
+    // permissions. Bind loopback so only this machine can reach it. Remote
+    // access goes through the dev tunnel, whose host process also connects
+    // over loopback, so tunneling still works. `--host` / AGENT_SERVER_HOST
+    // exists for deployments that must publish the port (a container that
+    // isolates the workspace, for example) and warns when it widens the bind.
+    const host = resolveAgentServerHost(process.argv, process.env);
+    if (!isLoopbackHost(host)) {
+        printWarningBanner(
+            [
+                `Agent server is binding ${host}:${port}, not loopback.`,
+                "The server has no authentication: any host that can reach",
+                "this port can join conversations, read your identity, and",
+                "run agent commands as you. Only do this behind a network",
+                "boundary you control.",
+            ],
+            "agent-server",
+        );
+    }
+
     const idleShutdownIdx = process.argv.indexOf("--idle-timeout");
     const idleShutdownMs =
         idleShutdownIdx !== -1
@@ -519,7 +542,7 @@ async function main() {
             },
         });
 
-    wss = await createWebSocketChannelServer({ port }, connectionHandler);
+    wss = await createWebSocketChannelServer({ port, host }, connectionHandler);
 
     // Register the agent-server's own listen port as a regular
     // allocation under the well-known AGENT_SERVER_DISCOVERY_NAME with
@@ -537,7 +560,11 @@ async function main() {
         SYSTEM_SESSION_CONTEXT_ID,
     );
 
-    console.log(`Agent server started at ws://localhost:${port}`);
+    console.log(
+        isLoopbackHost(host)
+            ? `Agent server started at ws://localhost:${port}`
+            : `Agent server started at ws://${host}:${port}`,
+    );
     writeServerPid(port, process.pid);
     // Publish our own listen URL into the process environment so in-process
     // consumers (e.g. the reasoning loop's subagent manager, which spawns

--- a/ts/packages/agentServer/server/test/listenHost.spec.ts
+++ b/ts/packages/agentServer/server/test/listenHost.spec.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { resolveAgentServerHost } from "../src/listenHost.js";
+
+const LOOPBACK = "127.0.0.1";
+
+describe("resolveAgentServerHost", () => {
+    test("defaults to loopback with no override", () => {
+        expect(resolveAgentServerHost(["node", "server.js"], {})).toBe(
+            LOOPBACK,
+        );
+    });
+
+    test("honors --host", () => {
+        expect(
+            resolveAgentServerHost(
+                ["node", "server.js", "--host", "0.0.0.0"],
+                {},
+            ),
+        ).toBe("0.0.0.0");
+    });
+
+    test("honors AGENT_SERVER_HOST", () => {
+        expect(
+            resolveAgentServerHost(["node", "server.js"], {
+                AGENT_SERVER_HOST: "0.0.0.0",
+            }),
+        ).toBe("0.0.0.0");
+    });
+
+    test("--host wins over the environment", () => {
+        expect(
+            resolveAgentServerHost(["node", "server.js", "--host", "::1"], {
+                AGENT_SERVER_HOST: "0.0.0.0",
+            }),
+        ).toBe("::1");
+    });
+
+    test("trims surrounding whitespace", () => {
+        // An untrimmed value fails to resolve at bind time, yet isLoopbackHost
+        // trims before comparing, so it would read as loopback and suppress the
+        // exposure warning for a host that never binds.
+        expect(
+            resolveAgentServerHost(
+                ["node", "server.js", "--host", "  localhost  "],
+                {},
+            ),
+        ).toBe("localhost");
+        expect(
+            resolveAgentServerHost(["node", "server.js"], {
+                AGENT_SERVER_HOST: "  0.0.0.0  ",
+            }),
+        ).toBe("0.0.0.0");
+    });
+
+    test("treats a blank --host as absent rather than binding every interface", () => {
+        // listen(port, "") binds all interfaces, the opposite of the default.
+        expect(
+            resolveAgentServerHost(["node", "server.js", "--host", ""], {}),
+        ).toBe(LOOPBACK);
+        expect(
+            resolveAgentServerHost(["node", "server.js", "--host", "   "], {}),
+        ).toBe(LOOPBACK);
+    });
+
+    test("falls back to the environment when --host has no value", () => {
+        expect(
+            resolveAgentServerHost(["node", "server.js", "--host"], {
+                AGENT_SERVER_HOST: "0.0.0.0",
+            }),
+        ).toBe("0.0.0.0");
+    });
+
+    test("falls back to loopback when --host is the last argument", () => {
+        expect(
+            resolveAgentServerHost(["node", "server.js", "--host"], {}),
+        ).toBe(LOOPBACK);
+    });
+});

--- a/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
+++ b/ts/packages/agents/browser/src/agent/agentWebSocketServer.mts
@@ -5,6 +5,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import { IncomingMessage } from "http";
 import { AddressInfo } from "net";
 import { isAllowedAgentOrigin } from "./originAllowlist.mjs";
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
 import {
     createChannelProviderAdapter,
     type ChannelProviderAdapter,
@@ -98,6 +99,11 @@ export class AgentWebSocketServer {
         return new Promise((resolve, reject) => {
             const server = new WebSocketServer({
                 port,
+                // Bind loopback: the origin gate below accepts clients that
+                // send no Origin header at all (native `ws` callers), so an
+                // all-interfaces bind would let any LAN peer connect as one
+                // and drive privileged browser-control RPC.
+                host: LOOPBACK_HOST,
                 verifyClient: (info, cb) => {
                     // `info.req.headers.origin` is `string | string[] |
                     // undefined`; coerce arrays to the first element so

--- a/ts/packages/agents/browser/src/views/server/core/baseServer.ts
+++ b/ts/packages/agents/browser/src/views/server/core/baseServer.ts
@@ -3,6 +3,7 @@
 
 import express, { Express, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
 import path from "path";
 import { fileURLToPath } from "url";
 import { FeatureConfig, ServerConfig, SSEManager } from "./types.js";
@@ -168,25 +169,38 @@ export class BaseServer {
     }
 
     /**
-     * Start the server
+     * Start the server.
+     *
+     * Binds loopback: these view servers front local user content and agent
+     * state with no authentication, and the origin checks they apply let
+     * through requests that carry no Origin header at all, so an
+     * all-interfaces bind would make them reachable by any LAN peer.
      */
     start(): Promise<void> {
         return new Promise((resolve, reject) => {
-            const server = this.app.listen(this.config.port, () => {
-                this.boundPort = (server.address() as { port: number }).port;
-                debug(`Server running at http://localhost:${this.boundPort}`);
-                debug(
-                    `Registered features: ${Array.from(this.features.keys()).join(", ")}`,
-                );
-                server.removeListener("error", onStartupError);
-                server.on("error", (err: NodeJS.ErrnoException) => {
-                    console.error(
-                        `Server runtime error on port ${this.boundPort}:`,
-                        err,
+            const server = this.app.listen(
+                this.config.port,
+                LOOPBACK_HOST,
+                () => {
+                    this.boundPort = (
+                        server.address() as { port: number }
+                    ).port;
+                    debug(
+                        `Server running at http://localhost:${this.boundPort}`,
                     );
-                });
-                resolve();
-            });
+                    debug(
+                        `Registered features: ${Array.from(this.features.keys()).join(", ")}`,
+                    );
+                    server.removeListener("error", onStartupError);
+                    server.on("error", (err: NodeJS.ErrnoException) => {
+                        console.error(
+                            `Server runtime error on port ${this.boundPort}:`,
+                            err,
+                        );
+                    });
+                    resolve();
+                },
+            );
             const onStartupError = (err: NodeJS.ErrnoException) => {
                 if (err.code === "EADDRINUSE") {
                     reject(

--- a/ts/packages/agents/code/src/codeAgentWebSocketServer.ts
+++ b/ts/packages/agents/code/src/codeAgentWebSocketServer.ts
@@ -6,6 +6,7 @@ import { AddressInfo } from "net";
 import registerDebug from "debug";
 import { isAllowedAgentOrigin } from "./originAllowlist.js";
 import { attachHeartbeat } from "@typeagent/websocket-channel-server";
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
 
 const debug = registerDebug("typeagent:code:websocket");
 
@@ -57,6 +58,11 @@ export class CodeAgentWebSocketServer {
         return new Promise((resolve, reject) => {
             const server = new WebSocketServer({
                 port,
+                // Bind loopback: the origin gate below accepts clients that
+                // send no Origin header at all (native `ws` callers), so an
+                // all-interfaces bind would let any LAN peer connect as one
+                // and drive privileged code-agent RPC.
+                host: LOOPBACK_HOST,
                 // Gate every upgrade on Origin so a random web page on
                 // the same host can't dial the ephemeral port assigned
                 // by the OS. `verifyClient` is invoked synchronously

--- a/ts/packages/agents/montage/src/route/route.ts
+++ b/ts/packages/agents/montage/src/route/route.ts
@@ -4,6 +4,7 @@
 //import Server from "webpack-dev-server";
 import express, { Express, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
 import bodyParser from "body-parser";
 import { fileURLToPath } from "url";
 import path from "path";
@@ -288,8 +289,9 @@ process.on("disconnect", () => {
     process.exit(1);
 });
 
-// Start the server
-const server = app.listen(port, () => {
+// Start the server. Bind loopback: this server serves indexed local files and
+// forwards updates to the agent process without authenticating callers.
+const server = app.listen(port, LOOPBACK_HOST, () => {
     const boundPort = (server.address() as { port: number }).port;
     debug(`Montage server started on port ${boundPort}`);
     process.send?.({ success: true, port: boundPort });

--- a/ts/packages/agents/onboarding/src/scaffolder/templateLoader.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/templateLoader.ts
@@ -39,6 +39,17 @@ function templatePath(filename: string): string {
 // template at scaffold time.
 const RESERVED_TEMPLATE_NAMES = new Set<string>(["__agentName__Schema.ts"]);
 
+// Values every template can reference without the caller supplying them.
+//
+// `LOOPBACK_HOST` is the bind address emitted into each scaffolded listener.
+// It is substituted as a literal rather than imported by the generated code:
+// scaffolded agents do not depend on `@typeagent/websocket-utils`, so an
+// import would not resolve in the new package. Keeping it here gives the
+// three templates that bind a socket one definition to change.
+const DEFAULT_TEMPLATE_VARS: Record<string, string> = {
+    LOOPBACK_HOST: "127.0.0.1",
+};
+
 /**
  * Load `filename` from `src/scaffolder/templates/` and substitute every
  * `__TOKEN__` with `vars[TOKEN]`. Throws if any `__TOKEN__` placeholder
@@ -65,6 +76,9 @@ export function loadTemplate(
         );
     }
     const tpl = fs.readFileSync(templatePath(filename), "utf-8");
+    // Caller-supplied values win, so a template can still be given an
+    // explicit host where that ever makes sense.
+    const allVars = { ...DEFAULT_TEMPLATE_VARS, ...vars };
     // Single-pass regex replacement so a substituted value that happens
     // to contain a `__KEY__` token is NOT re-processed by a later
     // iteration -- important if a future caller ever passes a var
@@ -75,7 +89,7 @@ export function loadTemplate(
     // `__agentName__` but leaves Node's `__filename` (no trailing `__`)
     // and `____` (empty body) alone.
     const out = tpl.replace(/__([A-Za-z_][A-Za-z0-9_]*)__/g, (match, key) =>
-        key in vars ? vars[key] : match,
+        key in allVars ? allVars[key] : match,
     );
     const leftover = out.match(/__[A-Za-z_][A-Za-z0-9_]*__/g);
     if (leftover && leftover.length > 0) {

--- a/ts/packages/agents/onboarding/src/scaffolder/templates/viewUiHandler.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/templates/viewUiHandler.ts
@@ -118,7 +118,9 @@ function startViewServer(
         };
         server.once("error", onError);
         server.once("listening", onListening);
-        server.listen(port);
+        // Loopback only: the view is unauthenticated, so binding every
+        // interface would let any peer on the network reach it.
+        server.listen(port, "__LOOPBACK_HOST__");
     });
 }
 

--- a/ts/packages/agents/onboarding/src/scaffolder/templates/websocketBridgeHandler.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/templates/websocketBridgeHandler.ts
@@ -114,7 +114,14 @@ class __AgentName__Bridge {
      */
     public static start(port: number = 0): Promise<__AgentName__Bridge> {
         return new Promise((resolve, reject) => {
-            const server = new WebSocketServer({ port });
+            const server = new WebSocketServer({
+                port,
+                // Bind loopback. The bridge carries agent RPC with the local
+                // user's permissions and authenticates nothing, so an
+                // all-interfaces bind would let any LAN peer impersonate the
+                // plugin, intercept requests, and forge responses.
+                host: "__LOOPBACK_HOST__",
+            });
             let settled = false;
             const onError = (e: Error) => {
                 if (settled) return;

--- a/ts/packages/agents/onboarding/src/scaffolder/templates/websocketBridgeTemplate.ts
+++ b/ts/packages/agents/onboarding/src/scaffolder/templates/websocketBridgeTemplate.ts
@@ -95,7 +95,14 @@ export class __AgentName__Bridge {
      */
     public static start(port: number = 0): Promise<__AgentName__Bridge> {
         return new Promise((resolve, reject) => {
-            const server = new WebSocketServer({ port });
+            const server = new WebSocketServer({
+                port,
+                // Bind loopback. The bridge carries agent RPC with the local
+                // user's permissions and authenticates nothing, so an
+                // all-interfaces bind would let any LAN peer impersonate the
+                // plugin, intercept requests, and forge responses.
+                host: "__LOOPBACK_HOST__",
+            });
             let settled = false;
             const onError = (e: Error) => {
                 if (settled) return;

--- a/ts/packages/api/README.md
+++ b/ts/packages/api/README.md
@@ -12,9 +12,41 @@ After setting up and building at the workspace root, there are several ways to s
 
 The server can be started with `npm run start` in this package's directory. Then connect to `http://localhost:3000` using a web browser. If you want to load the Shell interface in the browser window you want to open `http://localhost:3000/chatView.html`
 
+It binds loopback (`127.0.0.1`) so a local run isn't reachable from the network.
+The server has no authentication: anything that can reach the port can dispatch
+actions with your permissions - send mail from your account, read your files,
+drive your browser. Set `host` in `data/config.json`, or `TYPEAGENT_API_HOST`
+(which wins), to bind another address, and only do so behind a network boundary
+you control.
+
+The `/action/` endpoint and the dispatcher WebSocket also refuse requests that a
+web page could have caused (checked via the `Origin` and `Sec-Fetch-Site`
+headers), so a site the user visits can't drive the server through the browser.
+A hosted deployment serves the chat view from its own hostname, so set
+`TYPEAGENT_API_ALLOWED_ORIGINS` (comma separated, e.g.
+`https://typeagent.example.com`) to the origins browsers will load it from -
+otherwise only loopback origins are accepted and the browser client gets a 403.
+
+Static files are served with `Access-Control-Allow-Origin` echoing the request's
+origin, but only when that origin passes the same allowlist; every other request
+gets no CORS header. The clients that need these files load them from the page
+this server itself served, so they are same-origin and need no header. (This
+previously went out as `*`, which let any site on the web read them.)
+
+`/action/` accepts GET so simple clients such as IOT devices can submit an
+action as a URL. That keeps one gap: the checks above identify a browser
+request by its headers, and browsers released before fetch metadata support
+(roughly Firefox 90 and Safari 16.4) send neither `Origin` nor
+`Sec-Fetch-Site` on an image or script load. On those browsers a page the user
+visits can still reach `/action/` on loopback with a tag like
+`<img src="http://localhost:3000/action/?a=...">`, because a request with no
+headers at all is indistinguishable from a non-browser client. Current
+browsers label that request `cross-site` and it is refused. Use a current
+browser, or drop GET support locally if you need to close this off entirely.
+
 ### Docker Image
 
-It is possible to use the [docker image](../../Dockerfile) to host TypeAgent either locally or in a cloud hosted environment such as [Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/quickstart-custom-container?tabs=dotnet&pivots=container-linux-vscode).
+It is possible to use the [docker image](../../Dockerfile) to host TypeAgent either locally or in a cloud hosted environment such as [Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/quickstart-custom-container?tabs=dotnet&pivots=container-linux-vscode). The image sets `TYPEAGENT_API_HOST=0.0.0.0` because the published port is the point there and the container is the isolation boundary. Set `TYPEAGENT_API_ALLOWED_ORIGINS` to the public origin the chat view is served from so browser clients pass the Origin gate.
 
 ### Trademarks
 

--- a/ts/packages/api/package.json
+++ b/ts/packages/api/package.json
@@ -40,6 +40,7 @@
     "@typeagent/dispatcher-rpc": "workspace:*",
     "@typeagent/telemetry": "workspace:*",
     "@typeagent/typechat-utils": "workspace:*",
+    "@typeagent/websocket-utils": "workspace:*",
     "agent-dispatcher": "workspace:*",
     "chalk": "^5.4.1",
     "debug": "^4.4.0",

--- a/ts/packages/api/src/originPolicy.ts
+++ b/ts/packages/api/src/originPolicy.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    createConfiguredOriginAllowlist,
+    normalizeOrigin,
+    parseAllowedOrigins,
+} from "@typeagent/websocket-utils/originAllowlist";
+
+export { parseAllowedOrigins };
+
+/**
+ * Origins this server accepts browser clients from, beyond the loopback
+ * baseline. Comma separated, each an exact scheme://host[:port] with no path
+ * (for example `https://typeagent.example.com`).
+ *
+ * A deployment that widens the bind with TYPEAGENT_API_HOST serves the chat
+ * view from its own public hostname, so the browser sends that hostname as
+ * `Origin` and the loopback-only baseline would refuse it. Naming the origins
+ * explicitly reopens exactly those deployments while keeping the gate closed
+ * to every other site - in particular it still refuses a DNS rebinding
+ * attacker, whose Origin is its own domain rather than one listed here.
+ */
+const ALLOWED_ORIGINS_ENV = "TYPEAGENT_API_ALLOWED_ORIGINS";
+
+/**
+ * Origin gate shared by the `/action/` endpoint and the dispatcher
+ * WebSocket. Both reach the dispatcher with the local user's permissions, so
+ * both apply the same policy: the loopback baseline, plus any origin the
+ * operator named in {@link ALLOWED_ORIGINS_ENV}.
+ *
+ * `Origin: null` is refused. It is the opaque-origin sentinel sent by
+ * `file://` pages and sandboxed iframes, neither of which is a legitimate
+ * client here, and honoring it would hand a hostile page an iframe-shaped way
+ * in. A missing Origin header is a different case and stays allowed for
+ * non-browser callers (IoT devices, curl), which the bind address governs.
+ */
+export function createOriginAllowlist(
+    allowedOrigins: readonly string[],
+): (origin: string | string[] | undefined) => boolean {
+    return createConfiguredOriginAllowlist(
+        { allowNullOrigin: false },
+        allowedOrigins,
+    );
+}
+
+/**
+ * The gate the servers actually install, reading the operator's configuration
+ * from the environment.
+ *
+ * Resolved per call rather than once at module load: `loadConfig` merges YAML
+ * and Key Vault layers into `process.env` during startup, which happens after
+ * this module is first imported, so a value configured that way would be
+ * missed by an allowlist captured at import time. The derived predicate is
+ * cached against the raw string, so repeated requests do no extra work and a
+ * config reload is still picked up.
+ */
+let cachedRaw: string | undefined;
+let cachedAllowlist:
+    | ((origin: string | string[] | undefined) => boolean)
+    | undefined;
+
+export function isAllowedApiOrigin(
+    origin: string | string[] | undefined,
+): boolean {
+    const raw = process.env[ALLOWED_ORIGINS_ENV];
+    if (cachedAllowlist === undefined || raw !== cachedRaw) {
+        cachedRaw = raw;
+        cachedAllowlist = createOriginAllowlist(parseAllowedOrigins(raw));
+    }
+    return cachedAllowlist(origin);
+}
+
+/**
+ * The value to send back as `Access-Control-Allow-Origin` for a request, or
+ * undefined to send no CORS header at all.
+ *
+ * Static assets used to go out with `*`, which let any page on the web read
+ * them cross-origin. The clients that actually need these files load them from
+ * the page this server itself served, so they are same-origin and need no CORS
+ * header; only an operator-named origin needs one. Requests with no Origin are
+ * therefore answered without the header rather than with a wildcard.
+ *
+ * The normalized origin is echoed rather than the raw header, so a caller
+ * cannot smuggle control characters or trailing data into the response.
+ */
+export function resolveCorsOrigin(
+    origin: string | string[] | undefined,
+): string | undefined {
+    if (origin === undefined || Array.isArray(origin)) {
+        return undefined;
+    }
+    const normalized = normalizeOrigin(origin);
+    if (normalized === undefined || !isAllowedApiOrigin(normalized)) {
+        return undefined;
+    }
+    return normalized;
+}

--- a/ts/packages/api/src/webServer.ts
+++ b/ts/packages/api/src/webServer.ts
@@ -2,31 +2,101 @@
 // Licensed under the MIT License.
 
 import { getMimeType } from "@typeagent/typechat-utils";
+import { isAllowedApiOrigin, resolveCorsOrigin } from "./originPolicy.js";
+import {
+    LOOPBACK_HOST,
+    isLoopbackHost,
+} from "@typeagent/websocket-utils/loopback";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { createServer, Server } from "node:http";
+import {
+    createServer,
+    IncomingHttpHeaders,
+    OutgoingHttpHeaders,
+    Server,
+} from "node:http";
 import {
     createServer as createSecureServer,
     Server as SecureServer,
 } from "node:https";
 import path from "node:path";
 
+const DEFAULT_PORT = 3000;
+const SECURE_PORT = 3443;
+
 export type TypeAgentAPIServerConfig = {
     wwwroot: string;
     port: number;
+    /**
+     * Address to bind. Defaults to loopback so the unauthenticated
+     * `/action/` endpoint and dispatcher WebSocket are reachable only from
+     * this machine. Set it (or TYPEAGENT_API_HOST, which wins) to
+     * `0.0.0.0` when hosting the container image, where the port is
+     * published deliberately and the container is the isolation boundary.
+     */
+    host?: string;
     broadcast: boolean;
     blobBackupEnabled: boolean;
     storageProvider?: "azure" | "aws";
 };
 
+/**
+ * Address the servers bind to. TYPEAGENT_API_HOST overrides the config file
+ * so the container image can widen the bind without editing `data/config.json`.
+ */
+export function resolveListenHost(config: TypeAgentAPIServerConfig): string {
+    return (
+        process.env.TYPEAGENT_API_HOST?.trim() ||
+        config.host?.trim() ||
+        LOOPBACK_HOST
+    );
+}
+
+/**
+ * Whether a request is allowed to submit an action. `/action/` runs the
+ * request through the dispatcher with the local user's permissions - it can
+ * send mail, write files, and drive the browser - and carries no
+ * authentication, so a request that a web page could have caused must be
+ * refused.
+ *
+ * Two header checks, because neither covers every case on its own:
+ *  - `Origin` is sent by fetch/XHR and by form posts, and identifies the page
+ *    that made the request. Only the served loopback origins are honored.
+ *  - `Sec-Fetch-Site` is sent by current browsers on *every* request,
+ *    including `<img src=...>` and top-level navigations that carry no
+ *    Origin. `cross-site` and `same-site` (another loopback port counts as
+ *    same-site) are refused; `same-origin` (the chat view this server
+ *    serves) and `none` (the user typed the URL) are allowed.
+ *
+ * Non-browser clients (curl, an IoT device) send neither header and are
+ * allowed - the loopback bind is what keeps them local. That is also the
+ * limit of this check: browsers without fetch metadata support (before
+ * roughly Firefox 90 and Safari 16.4) send neither header on an image load
+ * either, so on those a cross-site `<img>` to `/action/` is indistinguishable
+ * from an IoT client and still gets through. Current browsers label it
+ * `cross-site` and are refused. Closing that off completely means dropping
+ * GET or requiring a secret, both of which break existing callers.
+ */
+export function isTrustedActionRequest(headers: IncomingHttpHeaders): boolean {
+    const origin = headers.origin;
+    if (origin !== undefined && !isAllowedApiOrigin(origin)) {
+        return false;
+    }
+    const site = headers["sec-fetch-site"];
+    return site === undefined || site === "same-origin" || site === "none";
+}
+
 export class TypeAgentAPIWebServer {
     public server: Server<any, any>;
     private secureServer: SecureServer<any, any> | undefined;
     private actionHandler: (action: any) => any;
+    private config: TypeAgentAPIServerConfig;
 
     constructor(
         config: TypeAgentAPIServerConfig,
         actionHandler: (action: any) => any,
     ) {
+        this.config = config;
+
         // web server
         this.server = createServer((request: any, response: any) => {
             this.serve(config, request, response);
@@ -77,6 +147,15 @@ export class TypeAgentAPIWebServer {
             url.pathname == "/action/" &&
             (request.method === "PUT" || request.method === "GET")
         ) {
+            if (!isTrustedActionRequest(request.headers)) {
+                console.warn(
+                    `Refused action request from origin '${request.headers.origin}' (${request.socket.remoteAddress})`,
+                );
+                response.writeHead(403, { "Content-Type": "application/json" });
+                response.end(JSON.stringify({ error: "Forbidden" }));
+                return;
+            }
+
             let data: string | null = "";
             if (request.method === "PUT") {
                 data = request.read();
@@ -116,11 +195,17 @@ export class TypeAgentAPIWebServer {
 
             // serve requested file
             if (existsSync(requestedFile)) {
-                response.writeHead(200, {
+                const headers: OutgoingHttpHeaders = {
                     "Content-Type": getMimeType(path.extname(requestedFile)),
-                    "Access-Control-Allow-Origin": "*",
+                    // Responses differ by Origin, so caches must key on it.
+                    Vary: "Origin",
                     //"Permissions-Policy": "camera=(self)", // allow access to getUserMedia() for the camera
-                });
+                };
+                const corsOrigin = resolveCorsOrigin(request.headers?.origin);
+                if (corsOrigin !== undefined) {
+                    headers["Access-Control-Allow-Origin"] = corsOrigin;
+                }
+                response.writeHead(200, headers);
                 response.end(readFileSync(requestedFile).toString());
 
                 console.log(`Served '${requestedFile}' as '${request.url}'`);
@@ -139,12 +224,20 @@ export class TypeAgentAPIWebServer {
     }
 
     start() {
-        this.server.listen(3000, () => {
-            console.log("Listening on all local IPs at port 3000");
+        const host = resolveListenHost(this.config);
+        const port = this.config.port ?? DEFAULT_PORT;
+        if (!isLoopbackHost(host)) {
+            console.warn(
+                `WARNING: binding ${host} exposes this server to the network. It has no authentication - anyone who can reach the port can dispatch actions as you (send mail, read files, drive the browser).`,
+            );
+        }
+
+        this.server.listen(port, host, () => {
+            console.log(`Listening at http://${host}:${port}`);
         });
 
-        this.secureServer?.listen(3443, () => {
-            console.log("Listening securely on all local IPs at port 3443");
+        this.secureServer?.listen(SECURE_PORT, host, () => {
+            console.log(`Listening securely at https://${host}:${SECURE_PORT}`);
         });
     }
 

--- a/ts/packages/api/src/webSocketServer.ts
+++ b/ts/packages/api/src/webSocketServer.ts
@@ -3,6 +3,17 @@
 
 import WebSocket, { WebSocketServer } from "ws";
 import { IncomingMessage, Server } from "node:http";
+import { isAllowedApiOrigin } from "./originPolicy.js";
+
+/**
+ * Origin gate for the dispatcher WebSocket. A client that completes the
+ * upgrade gets full dispatcher RPC with the local user's permissions, so
+ * only the chat view this server serves (a loopback origin, or one named in
+ * TYPEAGENT_API_ALLOWED_ORIGINS for a hosted deployment) and non-browser
+ * clients (no Origin header) are let through. Everything else is refused
+ * with HTTP 403 before the `connection` event fires, which keeps a web page
+ * the user happens to visit from dialing the port.
+ */
 
 export class TypeAgentAPIWebSocketServer {
     private server: WebSocketServer;
@@ -14,6 +25,16 @@ export class TypeAgentAPIWebSocketServer {
     ) {
         this.server = new WebSocketServer({
             server: webServer,
+            verifyClient: (info, cb) => {
+                if (isAllowedApiOrigin(info.origin)) {
+                    cb(true);
+                    return;
+                }
+                console.warn(
+                    `Rejected WebSocket upgrade from origin '${info.origin}'`,
+                );
+                cb(false, 403, "Origin not allowed");
+            },
         });
 
         this.server.on("listening", () => {

--- a/ts/packages/api/test/api.test.ts
+++ b/ts/packages/api/test/api.test.ts
@@ -42,7 +42,7 @@ describe("api web server", () => {
         server = new TypeAgentAPIWebServer(config, () => undefined);
 
         // Bind an ephemeral loopback port instead of calling start(), which
-        // hardcodes 3000 (and 3443) and would conflict / bind all interfaces.
+        // uses the configured port (and the secure 3443) and would conflict.
         await new Promise<void>((resolve, reject) => {
             server.server.once("error", reject);
             server.server.listen(0, "127.0.0.1", resolve);

--- a/ts/packages/api/test/originPolicy.spec.ts
+++ b/ts/packages/api/test/originPolicy.spec.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    createOriginAllowlist,
+    isAllowedApiOrigin,
+    parseAllowedOrigins,
+    resolveCorsOrigin,
+} from "../src/originPolicy.js";
+
+function buildAllowlist(configured?: string) {
+    return createOriginAllowlist(parseAllowedOrigins(configured));
+}
+
+describe("createOriginAllowlist", () => {
+    test("allows the loopback origins the chat view is served from", () => {
+        const isAllowed = buildAllowlist();
+        expect(isAllowed("http://localhost:3000")).toBe(true);
+        expect(isAllowed("http://127.0.0.1:3000")).toBe(true);
+        expect(isAllowed("https://[::1]:3443")).toBe(true);
+    });
+
+    test("allows a missing Origin so non-browser callers still work", () => {
+        expect(buildAllowlist()(undefined)).toBe(true);
+    });
+
+    test("refuses the opaque origin a sandboxed iframe sends", () => {
+        expect(buildAllowlist()("null")).toBe(false);
+    });
+
+    test("refuses an arbitrary site", () => {
+        expect(buildAllowlist()("https://evil.example.com")).toBe(false);
+    });
+
+    test("allows an operator-configured hosted origin", () => {
+        const isAllowed = buildAllowlist("https://typeagent.example.com");
+        expect(isAllowed("https://typeagent.example.com")).toBe(true);
+    });
+
+    test("configuring one origin does not open up others", () => {
+        const isAllowed = buildAllowlist("https://typeagent.example.com");
+        expect(isAllowed("https://evil.example.com")).toBe(false);
+        // A DNS rebinding attacker reaches the port but still sends its own
+        // domain as Origin, so naming a hosted origin does not admit it.
+        expect(isAllowed("http://rebind.example.com")).toBe(false);
+    });
+
+    test("accepts a list and tolerates spacing and a trailing slash", () => {
+        const isAllowed = buildAllowlist(
+            " https://a.example.com/ , https://b.example.com ",
+        );
+        expect(isAllowed("https://a.example.com")).toBe(true);
+        expect(isAllowed("https://b.example.com")).toBe(true);
+        expect(isAllowed("https://c.example.com")).toBe(false);
+    });
+
+    test("a port mismatch on a configured origin is still refused", () => {
+        const isAllowed = buildAllowlist("https://typeagent.example.com");
+        expect(isAllowed("https://typeagent.example.com:8443")).toBe(false);
+    });
+
+    test("refuses ambiguous repeated Origin headers", () => {
+        const isAllowed = buildAllowlist("https://typeagent.example.com");
+        expect(
+            isAllowed(["https://typeagent.example.com", "https://evil.test"]),
+        ).toBe(false);
+    });
+});
+
+describe("parseAllowedOrigins", () => {
+    test("returns nothing when unset", () => {
+        expect(parseAllowedOrigins(undefined)).toEqual([]);
+    });
+
+    test("drops entries that aren't absolute http(s) origins", () => {
+        expect(
+            parseAllowedOrigins(
+                "https://ok.example.com, not-a-url, ftp://x.example.com, ,",
+            ),
+        ).toEqual(["https://ok.example.com"]);
+    });
+});
+
+describe("isAllowedApiOrigin", () => {
+    const ENV = "TYPEAGENT_API_ALLOWED_ORIGINS";
+
+    afterEach(() => {
+        delete process.env[ENV];
+    });
+
+    test("reads the environment per call, not once at import", () => {
+        // Startup merges YAML and Key Vault config into process.env after
+        // this module is imported, so a value that appears later still has
+        // to take effect.
+        delete process.env[ENV];
+        expect(isAllowedApiOrigin("https://late.example.com")).toBe(false);
+
+        process.env[ENV] = "https://late.example.com";
+        expect(isAllowedApiOrigin("https://late.example.com")).toBe(true);
+    });
+
+    test("stops honoring an origin once it is removed", () => {
+        process.env[ENV] = "https://late.example.com";
+        expect(isAllowedApiOrigin("https://late.example.com")).toBe(true);
+
+        delete process.env[ENV];
+        expect(isAllowedApiOrigin("https://late.example.com")).toBe(false);
+    });
+
+    test("keeps the loopback baseline regardless of configuration", () => {
+        delete process.env[ENV];
+        expect(isAllowedApiOrigin("http://127.0.0.1:3000")).toBe(true);
+        expect(isAllowedApiOrigin("null")).toBe(false);
+    });
+});
+
+describe("resolveCorsOrigin", () => {
+    const ENV = "TYPEAGENT_API_ALLOWED_ORIGINS";
+    const saved = process.env[ENV];
+
+    afterEach(() => {
+        if (saved === undefined) {
+            delete process.env[ENV];
+        } else {
+            process.env[ENV] = saved;
+        }
+    });
+
+    test("sends no CORS header when the request has no Origin", () => {
+        delete process.env[ENV];
+        // Same-origin loads of the chat view need no header, and answering
+        // them with a wildcard would hand every other site read access.
+        expect(resolveCorsOrigin(undefined)).toBeUndefined();
+    });
+
+    test("refuses to echo an arbitrary site", () => {
+        delete process.env[ENV];
+        expect(resolveCorsOrigin("https://evil.example.com")).toBeUndefined();
+    });
+
+    test("refuses to echo the opaque origin", () => {
+        delete process.env[ENV];
+        expect(resolveCorsOrigin("null")).toBeUndefined();
+    });
+
+    test("echoes an operator configured origin", () => {
+        process.env[ENV] = "https://typeagent.example.com";
+        expect(resolveCorsOrigin("https://typeagent.example.com")).toBe(
+            "https://typeagent.example.com",
+        );
+    });
+
+    test("echoes the loopback origins the chat view is served from", () => {
+        delete process.env[ENV];
+        expect(resolveCorsOrigin("http://localhost:3000")).toBe(
+            "http://localhost:3000",
+        );
+    });
+
+    test("echoes the normalized origin, never the raw header", () => {
+        process.env[ENV] = "https://typeagent.example.com";
+        // A trailing path or odd casing must not reach the response header.
+        expect(resolveCorsOrigin("https://TypeAgent.Example.com/")).toBe(
+            "https://typeagent.example.com",
+        );
+    });
+
+    test("refuses a header that repeats, which cannot be a real origin", () => {
+        delete process.env[ENV];
+        expect(
+            resolveCorsOrigin(["http://localhost:3000", "https://evil.test"]),
+        ).toBeUndefined();
+    });
+});

--- a/ts/packages/api/test/webServer.spec.ts
+++ b/ts/packages/api/test/webServer.spec.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    isTrustedActionRequest,
+    resolveListenHost,
+    type TypeAgentAPIServerConfig,
+} from "../src/webServer.js";
+import { isLoopbackHost } from "@typeagent/websocket-utils/loopback";
+
+const baseConfig: TypeAgentAPIServerConfig = {
+    wwwroot: "../shell/out/renderer",
+    port: 3000,
+    broadcast: true,
+    blobBackupEnabled: false,
+};
+
+afterEach(() => {
+    delete process.env.TYPEAGENT_API_HOST;
+});
+
+describe("resolveListenHost", () => {
+    test("defaults to loopback so a local run isn't on the network", () => {
+        expect(resolveListenHost(baseConfig)).toBe("127.0.0.1");
+    });
+
+    test("honors a configured host", () => {
+        expect(resolveListenHost({ ...baseConfig, host: "0.0.0.0" })).toBe(
+            "0.0.0.0",
+        );
+    });
+
+    test("TYPEAGENT_API_HOST wins over the config file", () => {
+        process.env.TYPEAGENT_API_HOST = "0.0.0.0";
+        expect(resolveListenHost({ ...baseConfig, host: "127.0.0.1" })).toBe(
+            "0.0.0.0",
+        );
+    });
+
+    test("ignores a blank override", () => {
+        process.env.TYPEAGENT_API_HOST = "   ";
+        expect(resolveListenHost(baseConfig)).toBe("127.0.0.1");
+    });
+});
+
+describe("isTrustedActionRequest", () => {
+    test("allows non-browser clients that send neither header", () => {
+        expect(isTrustedActionRequest({})).toBe(true);
+    });
+
+    test("allows the chat view this server serves", () => {
+        expect(
+            isTrustedActionRequest({
+                origin: "http://localhost:3000",
+                "sec-fetch-site": "same-origin",
+            }),
+        ).toBe(true);
+    });
+
+    test("allows a URL the user typed", () => {
+        expect(isTrustedActionRequest({ "sec-fetch-site": "none" })).toBe(true);
+    });
+
+    test("rejects a cross-origin fetch", () => {
+        expect(
+            isTrustedActionRequest({
+                origin: "https://evil.example.com",
+                "sec-fetch-site": "cross-site",
+            }),
+        ).toBe(false);
+    });
+
+    test("rejects an img-tag request that carries no Origin", () => {
+        // <img src="http://localhost:3000/action/?a=..."> on an attacker page:
+        // no Origin header, but browsers still label the fetch cross-site.
+        expect(isTrustedActionRequest({ "sec-fetch-site": "cross-site" })).toBe(
+            false,
+        );
+    });
+
+    test("rejects another page on a different loopback port", () => {
+        // Ports don't distinguish sites, so a malicious page served from
+        // another local port is same-site, not same-origin.
+        expect(
+            isTrustedActionRequest({
+                origin: "http://localhost:5173",
+                "sec-fetch-site": "same-site",
+            }),
+        ).toBe(false);
+    });
+
+    test("rejects an opaque origin", () => {
+        expect(isTrustedActionRequest({ origin: "null" })).toBe(false);
+    });
+});
+
+describe("isLoopbackHost", () => {
+    test("recognizes the loopback forms a listener can bind", () => {
+        expect(isLoopbackHost("127.0.0.1")).toBe(true);
+        expect(isLoopbackHost("127.1.2.3")).toBe(true);
+        expect(isLoopbackHost("localhost")).toBe(true);
+        expect(isLoopbackHost("::1")).toBe(true);
+        expect(isLoopbackHost("[::1]")).toBe(true);
+        expect(isLoopbackHost(" LocalHost ")).toBe(true);
+    });
+
+    test("treats a public bind as exposed so the warning still fires", () => {
+        expect(isLoopbackHost("0.0.0.0")).toBe(false);
+        expect(isLoopbackHost("192.168.1.10")).toBe(false);
+        expect(isLoopbackHost("::")).toBe(false);
+    });
+
+    test("a hostname that merely starts with 127. is not loopback", () => {
+        // Node resolves these through DNS, so they can land on a public or
+        // wildcard address. Accepting them would silence the exposure warning.
+        expect(isLoopbackHost("127.example.com")).toBe(false);
+        expect(isLoopbackHost("127.0.0.1.evil.test")).toBe(false);
+        expect(isLoopbackHost("127.0.0")).toBe(false);
+        expect(isLoopbackHost("1270.0.0.1")).toBe(false);
+    });
+});

--- a/ts/packages/security/mcpValidation/demo/run-demo.ts
+++ b/ts/packages/security/mcpValidation/demo/run-demo.ts
@@ -419,7 +419,9 @@ async function main() {
         res.end("Not found");
     });
 
-    httpServer.listen(PORT, () => {
+    // Loopback only: the dashboard is unauthenticated and exposes live server
+    // state, so it must not be reachable from other machines.
+    httpServer.listen(PORT, "127.0.0.1", () => {
         console.error(`
 ╔══════════════════════════════════════════════════════════════╗
 ║           Plan Validation — Live Demo Dashboard              ║

--- a/ts/packages/security/mcpValidation/demo/server.ts
+++ b/ts/packages/security/mcpValidation/demo/server.ts
@@ -174,7 +174,9 @@ async function main() {
         res.end("Not found");
     });
 
-    httpServer.listen(PORT, () => {
+    // Loopback only: the dashboard is unauthenticated and exposes live server
+    // state, so it must not be reachable from other machines.
+    httpServer.listen(PORT, "127.0.0.1", () => {
         console.error(`\n  Dashboard: http://localhost:${PORT}\n`);
         console.error(
             "  The dashboard polls the MCP server state every second.",

--- a/ts/packages/shell/README.md
+++ b/ts/packages/shell/README.md
@@ -85,6 +85,12 @@ In local mode (no agent server), only a single default conversation is available
 
 In local mode, the shell also hosts an in-process port-discovery WebSocket on `ws://localhost:8999/` (the same default the standalone `agentServer` uses) so external clients like the Chrome extension can find in-process agents — e.g. the browser agent's dynamically assigned WebSocket port — through the same discovery channel they would use against a real `agentServer`. If port 8999 is already in use (a real `agentServer` running, another local-mode shell, etc.) the bind fails loudly and the shell continues without discovery; external clients won't be able to find in-process agents until you restart the shell with no conflict.
 
+### Read-only chat view server
+
+Setting `localHostPort` starts a small HTTP/WebSocket server that serves a read-only view of the current conversation. It pushes the full chat log to every client that connects and has no authentication, so it listens on `127.0.0.1` only. Upgrades are additionally restricted to TypeAgent origins, which keeps unrelated pages in your browser from opening a socket to the port.
+
+To read the chat view from another device, such as a phone on a trusted home network, set `TYPEAGENT_SHELL_CHAT_SERVER_HOST` to the interface to bind (`0.0.0.0` for all of them), and set `TYPEAGENT_SHELL_CHAT_SERVER_ALLOWED_ORIGINS` to the address the device loads the page from (for example `http://192.168.1.5:8080`). Both are needed: the page connects back to whatever host it was loaded from, so widening the bind without naming the origin leaves the page loading but its socket refused. Anyone who can reach that port can then read your conversation, so only do this on a network you control.
+
 ### Azure Speech to Text service (Optional)
 
 Currently, TypeAgent Shell optionally supports voice input via Azure Speech Services or [Local Whisper Service](../../../python/stt/whisperService/) in addition to keyboard input.

--- a/ts/packages/shell/src/main/chatServer.ts
+++ b/ts/packages/shell/src/main/chatServer.ts
@@ -6,14 +6,62 @@ import registerDebug from "debug";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import WebSocket, { WebSocketServer } from "ws";
 import { getMimeType } from "@typeagent/typechat-utils";
+import {
+    isLoopbackHost,
+    LOOPBACK_HOST,
+} from "@typeagent/websocket-utils/loopback";
+import {
+    createConfiguredOriginAllowlist,
+    parseAllowedOrigins,
+} from "@typeagent/websocket-utils/originAllowlist";
 import path from "node:path";
 
 const debug = registerDebug("typeagent:shell:chatServer");
+
+/**
+ * Origins allowed to open the chat socket, beyond the loopback baseline.
+ * Comma separated, each an exact scheme://host[:port].
+ *
+ * The page connects back to whatever host it was loaded from, so widening the
+ * bind alone is not enough: a phone loading the view from `http://192.168.1.5:port`
+ * sends that as its `Origin`, which the loopback baseline refuses. Naming the
+ * origin here reopens exactly that case while still refusing a DNS rebinding
+ * attacker, whose Origin is its own domain.
+ */
+const ALLOWED_ORIGINS_ENV = "TYPEAGENT_SHELL_CHAT_SERVER_ALLOWED_ORIGINS";
+
+/**
+ * Rejects upgrades from web pages that are not part of TypeAgent. Without this
+ * any page the user happens to have open could open a socket to the chat view
+ * port and read the conversation. A sandboxed frame sends "Origin: null", which
+ * carries no useful identity, so it is refused too.
+ */
+function createChatOriginAllowlist() {
+    return createConfiguredOriginAllowlist(
+        { allowNullOrigin: false },
+        parseAllowedOrigins(process.env[ALLOWED_ORIGINS_ENV]),
+    );
+}
+
+/**
+ * Resolves the interface the chat view server listens on.
+ *
+ * Loopback is the default because the server is unauthenticated and pushes the
+ * whole chat log to every client that connects. Binding all interfaces would
+ * let any peer on the same network read the conversation. Set
+ * TYPEAGENT_SHELL_CHAT_SERVER_HOST to expose it deliberately, for instance to
+ * read the chat view from a phone on a trusted home network.
+ */
+export function resolveChatServerHost(): string {
+    const host = process.env.TYPEAGENT_SHELL_CHAT_SERVER_HOST?.trim();
+    return host !== undefined && host !== "" ? host : LOOPBACK_HOST;
+}
 
 export class ChatServer {
     private server: Server<any, any>;
     private socketServer: WebSocketServer;
     private port: number;
+    private host: string;
 
     onConnection(callback: (ws: WebSocket, req: IncomingMessage) => void) {
         this.socketServer.on(
@@ -28,14 +76,20 @@ export class ChatServer {
 
     constructor(port: number) {
         this.port = port;
+        this.host = resolveChatServerHost();
 
         // web server for HTML page
         this.server = createServer((request: any, response: any) => {
             this.serve(request, response);
         });
 
-        // socket server for web page IPC calls
-        this.socketServer = new WebSocketServer({ server: this.server });
+        // socket server for web page IPC calls. Built per instance so the
+        // allowlist reflects configuration loaded after module import.
+        const isOriginAllowed = createChatOriginAllowlist();
+        this.socketServer = new WebSocketServer({
+            server: this.server,
+            verifyClient: ({ origin }) => isOriginAllowed(origin),
+        });
 
         this.server.on("listening", () => {
             console.log(`WebSocket server started!`);
@@ -59,8 +113,13 @@ export class ChatServer {
     }
 
     async start() {
-        this.server.listen(this.port, () => {
-            console.log(`ChatServer is listening on port ${this.port}`);
+        if (!isLoopbackHost(this.host)) {
+            console.warn(
+                `WARNING: binding ${this.host} exposes the chat view to the network. It has no authentication - anyone who can reach the port can read your conversation.`,
+            );
+        }
+        this.server.listen(this.port, this.host, () => {
+            console.log(`ChatServer is listening on ${this.host}:${this.port}`);
         });
     }
 

--- a/ts/packages/utils/webSocketChannelServer/src/server.ts
+++ b/ts/packages/utils/webSocketChannelServer/src/server.ts
@@ -8,6 +8,11 @@ import {
 import WebSocket, { WebSocketServer } from "ws";
 import registerDebug from "debug";
 import { createPromiseWithResolvers } from "@typeagent/common-utils";
+import {
+    createConfiguredOriginAllowlist,
+    VISUAL_STUDIO_WEBVIEW_ORIGIN,
+} from "@typeagent/websocket-utils/originAllowlist";
+import { LOOPBACK_HOST } from "@typeagent/websocket-utils/loopback";
 import { attachHeartbeat } from "./heartbeat.js";
 
 const debugWss = registerDebug("typeagent:transport:wss");
@@ -30,17 +35,52 @@ type WebSocketChannelServer = {
 };
 
 /**
- * Extra options layered on top of `ws.ServerOptions` for our transport.
+ * Origin policy applied when the caller doesn't supply one. The channels
+ * served here reach the dispatcher, so the only legitimate clients are
+ * same-machine ones: Node `ws` callers (CLI, shell, VS Code extension host),
+ * which send no Origin, loopback web pages, the TypeAgent browser
+ * extension, and the Visual Studio chat panel. A web page the user happens
+ * to visit is not on that list and gets a 403 during the handshake.
+ *
+ * The Visual Studio panel is a WebView2 serving bundled content from a
+ * virtual host, so it sends {@link VISUAL_STUDIO_WEBVIEW_ORIGIN} rather than
+ * a loopback origin. It is allowed by exact match. Reaching this listener
+ * still requires the ability to run code on the loopback interface, since
+ * that origin resolves to a folder mapping inside the WebView2 host rather
+ * than to anything a remote page can be served from.
+ *
+ * `Origin: null` is refused: it is the opaque-origin sentinel a sandboxed
+ * iframe sends, so accepting it would let a hostile page reach the
+ * dispatcher through an iframe it controls. Native clients send no Origin
+ * header at all, which is a separate case and still allowed.
  */
-export type WebSocketChannelServerOptions = WebSocket.ServerOptions & {
+const defaultIsOriginAllowed = createConfiguredOriginAllowlist(
+    {
+        extensionSchemes: ["chrome-extension://", "moz-extension://"],
+        allowNullOrigin: false,
+    },
+    [VISUAL_STUDIO_WEBVIEW_ORIGIN],
+);
+
+/**
+ * Extra options layered on top of `ws.ServerOptions` for our transport.
+ *
+ * `verifyClient` is not accepted: this factory installs its own, built from
+ * {@link WebSocketChannelServerOptions.isOriginAllowed}. Taking one here would
+ * silently discard it and drop the caller's access check.
+ */
+export type WebSocketChannelServerOptions = Omit<
+    WebSocket.ServerOptions,
+    "verifyClient"
+> & {
     /**
-     * Optional Origin gate. When provided, an upgrade whose `Origin` header
-     * is rejected by the predicate is refused with HTTP 403 during the
-     * handshake, so denied clients never allocate a channel or send frames.
-     * Build one with `createAgentOriginAllowlist` from
-     * `@typeagent/websocket-utils` (it allows missing-Origin native clients
-     * and loopback web origins by default). When omitted, the upgrade is
-     * accepted regardless of Origin (current default behavior).
+     * Optional Origin gate. An upgrade whose `Origin` header is rejected by
+     * the predicate is refused with HTTP 403 during the handshake, so denied
+     * clients never allocate a channel or send frames. Defaults to an
+     * allowlist of no-Origin native clients, loopback web origins, and the
+     * TypeAgent browser extension schemes; pass `() => true` to accept every
+     * Origin. Build a different policy with `createAgentOriginAllowlist` from
+     * `@typeagent/websocket-utils`.
      */
     isOriginAllowed?: (origin: string | string[] | undefined) => boolean;
 };
@@ -52,26 +92,31 @@ export async function createWebSocketChannelServer(
         closeFn: () => void,
     ) => void,
 ): Promise<WebSocketChannelServer> {
-    const { isOriginAllowed, ...wsOptions } = options;
+    const { isOriginAllowed = defaultIsOriginAllowed, ...wsOptions } = options;
+    // `ws` binds every interface when given a `port` with no `host`, which
+    // would put this unauthenticated RPC surface on the LAN. Callers here
+    // serve same-machine clients, so bind loopback unless one names a host
+    // explicitly (a container publishing the port, for example).
+    const listenOptions: WebSocket.ServerOptions =
+        wsOptions.port !== undefined && wsOptions.host === undefined
+            ? { ...wsOptions, host: LOOPBACK_HOST }
+            : wsOptions;
     // verifyClient runs synchronously during the HTTP upgrade; using it
     // (rather than rejecting after `connection`) means denied clients
     // never get to allocate a channelProvider or send any frames.
-    const wssOptions: WebSocket.ServerOptions =
-        isOriginAllowed !== undefined
-            ? {
-                  ...wsOptions,
-                  verifyClient: (info, cb) => {
-                      if (isOriginAllowed(info.origin)) {
-                          cb(true);
-                          return;
-                      }
-                      debugWssError(
-                          `rejecting upgrade: origin '${info.origin}' not allowed`,
-                      );
-                      cb(false, 403, "Origin not allowed");
-                  },
-              }
-            : wsOptions;
+    const wssOptions: WebSocket.ServerOptions = {
+        ...listenOptions,
+        verifyClient: (info, cb) => {
+            if (isOriginAllowed(info.origin)) {
+                cb(true);
+                return;
+            }
+            debugWssError(
+                `rejecting upgrade: origin '${info.origin}' not allowed`,
+            );
+            cb(false, 403, "Origin not allowed");
+        },
+    };
     const wss = new WebSocketServer(wssOptions);
     attachHeartbeat(wss);
     wss.on("connection", (ws) => {

--- a/ts/packages/utils/webSocketChannelServer/test/server.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/server.spec.ts
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { afterEach, describe, expect, test } from "@jest/globals";
+import WebSocket from "ws";
+import os from "node:os";
+
+import { createWebSocketChannelServer } from "../src/server.js";
+
+const openServers: Array<{ close: () => void }> = [];
+const openClients: WebSocket[] = [];
+
+// Fixed high ports (one per case) rather than port 0: the server object
+// doesn't surface the bound port, and these tests need to dial a specific
+// address to prove what the listener is reachable on.
+let nextPort = 39411;
+function takePort(): number {
+    return nextPort++;
+}
+
+/** First non-internal IPv4 address of this machine, if it has one. */
+function lanAddress(): string | undefined {
+    for (const addresses of Object.values(os.networkInterfaces())) {
+        for (const address of addresses ?? []) {
+            if (address.family === "IPv4" && !address.internal) {
+                return address.address;
+            }
+        }
+    }
+    return undefined;
+}
+
+async function start(
+    options: Parameters<typeof createWebSocketChannelServer>[0],
+): Promise<void> {
+    const server = await createWebSocketChannelServer(options, () => {});
+    openServers.push(server);
+}
+
+function connect(
+    host: string,
+    port: number,
+    origin?: string,
+): Promise<"open" | "refused"> {
+    return new Promise((resolve) => {
+        const ws = new WebSocket(
+            `ws://${host}:${port}`,
+            origin === undefined ? undefined : { origin },
+        );
+        openClients.push(ws);
+        ws.once("open", () => resolve("open"));
+        ws.once("error", () => resolve("refused"));
+    });
+}
+
+afterEach(() => {
+    for (const ws of openClients.splice(0)) {
+        ws.removeAllListeners();
+        ws.close();
+    }
+    for (const server of openServers.splice(0)) {
+        server.close();
+    }
+});
+
+describe("createWebSocketChannelServer binding", () => {
+    test("a port with no host binds loopback, not every interface", async () => {
+        const port = takePort();
+        await start({ port });
+
+        await expect(connect("127.0.0.1", port)).resolves.toBe("open");
+
+        // The channels served here are unauthenticated, so the listener must
+        // not answer on this machine's network address.
+        const lan = lanAddress();
+        if (lan !== undefined) {
+            await expect(connect(lan, port)).resolves.toBe("refused");
+        }
+    });
+
+    test("an explicit host is passed through", async () => {
+        const port = takePort();
+        await start({ port, host: "localhost" });
+
+        await expect(connect("localhost", port)).resolves.toBe("open");
+    });
+});
+
+describe("createWebSocketChannelServer origin gate", () => {
+    test("accepts native clients that send no Origin", async () => {
+        const port = takePort();
+        await start({ port });
+
+        await expect(connect("127.0.0.1", port)).resolves.toBe("open");
+    });
+
+    test("accepts loopback and browser-extension origins", async () => {
+        const port = takePort();
+        await start({ port });
+
+        await expect(
+            connect("127.0.0.1", port, "http://localhost:3000"),
+        ).resolves.toBe("open");
+        await expect(
+            connect("127.0.0.1", port, "chrome-extension://abcdef"),
+        ).resolves.toBe("open");
+    });
+
+    test("accepts the Visual Studio chat panel's virtual-host origin", async () => {
+        // The VS extension serves its WebView2 content from a virtual host
+        // mapping and navigates to https://typeagent.local/index.html, so the
+        // panel's upgrade carries that Origin instead of a loopback one.
+        const port = takePort();
+        await start({ port });
+
+        await expect(
+            connect("127.0.0.1", port, "https://typeagent.local"),
+        ).resolves.toBe("open");
+    });
+
+    test("matches the Visual Studio origin exactly, not as a prefix", async () => {
+        // A prefix test would accept this domain, which an attacker can
+        // register.
+        const port = takePort();
+        await start({ port });
+
+        await expect(
+            connect("127.0.0.1", port, "https://typeagent.local.evil.example"),
+        ).resolves.toBe("refused");
+    });
+
+    test("rejects a foreign web origin by default", async () => {
+        const port = takePort();
+        await start({ port });
+
+        await expect(
+            connect("127.0.0.1", port, "https://evil.example.com"),
+        ).resolves.toBe("refused");
+    });
+
+    test("rejects the opaque origin a sandboxed iframe sends", async () => {
+        // A hostile page can host a script-enabled sandboxed iframe, whose
+        // handshake carries `Origin: null`. Honoring it would give that page
+        // a way through to the dispatcher.
+        const port = takePort();
+        await start({ port });
+
+        await expect(connect("127.0.0.1", port, "null")).resolves.toBe(
+            "refused",
+        );
+    });
+
+    test("an explicit predicate replaces the default policy", async () => {
+        const port = takePort();
+        await start({ port, isOriginAllowed: () => true });
+
+        await expect(
+            connect("127.0.0.1", port, "https://evil.example.com"),
+        ).resolves.toBe("open");
+    });
+});

--- a/ts/packages/utils/webSocketUtils/package.json
+++ b/ts/packages/utils/webSocketUtils/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./originAllowlist": "./dist/originAllowlist.js",
+    "./loopback": "./dist/loopback.js",
     "./heartbeat": "./dist/heartbeat.js",
     "./rpcChannel": "./dist/rpcChannel.js",
     "./backoff": "./dist/backoff.js"

--- a/ts/packages/utils/webSocketUtils/src/loopback.ts
+++ b/ts/packages/utils/webSocketUtils/src/loopback.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Address every same-machine listener in this repo should bind to.
+ *
+ * Node's `net.Server.listen(port)` and `new WebSocketServer({ port })` bind
+ * `0.0.0.0` when no host is given, which publishes the listener on every
+ * interface (LAN, corporate wifi, hotspot). TypeAgent's local listeners are
+ * unauthenticated RPC surfaces that drive the dispatcher, so they must be
+ * restricted to this machine at the socket level.
+ */
+export const LOOPBACK_HOST = "127.0.0.1";
+
+/**
+ * True when `host` names the local machine, so a listener bound to it is
+ * only reachable from this machine. Used to decide whether an explicit
+ * host override needs a "this is exposed to the network" warning.
+ *
+ * IPv6 loopback is accepted in both the bracketed (`[::1]`, as it appears
+ * in URLs) and bare (`::1`, as it appears in listen options) forms.
+ */
+export function isLoopbackHost(host: string): boolean {
+    const normalized = host.trim().toLowerCase();
+    return (
+        normalized === "localhost" ||
+        normalized === "::1" ||
+        normalized === "[::1]" ||
+        // 127.0.0.0/8 is entirely loopback, not just 127.0.0.1. Match the
+        // dotted-quad literal exactly: a prefix test would also accept
+        // hostnames like "127.example.com", which resolve wherever DNS says
+        // and would suppress the network-exposure warning on a public bind.
+        isLoopbackIPv4(normalized)
+    );
+}
+
+function isLoopbackIPv4(host: string): boolean {
+    const octets = host.split(".");
+    if (octets.length !== 4) {
+        return false;
+    }
+    if (!octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255)) {
+        return false;
+    }
+    return octets[0] === "127";
+}

--- a/ts/packages/utils/webSocketUtils/src/originAllowlist.ts
+++ b/ts/packages/utils/webSocketUtils/src/originAllowlist.ts
@@ -63,6 +63,85 @@ export type OriginAllowlistOptions = {
 };
 
 /**
+ * Origin of the Visual Studio chat panel. The extension maps its bundled
+ * WebView2 content to a virtual host
+ * (`SetVirtualHostNameToFolderMapping("typeagent.local", ...)` in
+ * `dotnet/visualStudioTypeAgent/ChatToolWindowControl.xaml.cs`) and navigates
+ * to `https://typeagent.local/index.html`, so the panel's WebSocket upgrade
+ * carries this Origin rather than a loopback one.
+ *
+ * It is matched exactly, never as a prefix: a prefix test would also accept
+ * `https://typeagent.local.example.com`, a domain an attacker can register.
+ */
+export const VISUAL_STUDIO_WEBVIEW_ORIGIN = "https://typeagent.local";
+
+/**
+ * Reduce an origin to the `scheme://host[:port]` form browsers send, so a
+ * configured entry with a trailing slash or stray case still matches.
+ * Returns undefined for anything that isn't a usable absolute http(s)
+ * origin.
+ */
+export function normalizeOrigin(value: string): string | undefined {
+    const trimmed = value.trim();
+    if (trimmed === "") {
+        return undefined;
+    }
+    try {
+        const url = new URL(trimmed);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+            return undefined;
+        }
+        return url.origin.toLowerCase();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Split a comma separated configuration value into normalized origins,
+ * dropping entries that aren't usable absolute http(s) origins.
+ */
+export function parseAllowedOrigins(raw: string | undefined): string[] {
+    if (raw === undefined) {
+        return [];
+    }
+    return raw
+        .split(",")
+        .map((entry) => normalizeOrigin(entry))
+        .filter((entry): entry is string => entry !== undefined);
+}
+
+/**
+ * The baseline allowlist widened by origins an operator named explicitly.
+ *
+ * A server that binds beyond loopback serves its page from some other
+ * hostname, so the browser sends that hostname as `Origin` and the loopback
+ * baseline alone would refuse it. Naming the origins reopens exactly those
+ * deployments while still refusing a DNS rebinding attacker, whose Origin is
+ * its own domain rather than one listed here. Comparing `Origin` against the
+ * request's `Host` would not: a rebinding attacker's request has the two
+ * agree.
+ */
+export function createConfiguredOriginAllowlist(
+    options: OriginAllowlistOptions,
+    allowedOrigins: readonly string[],
+): (origin: string | string[] | undefined) => boolean {
+    const baseline = createAgentOriginAllowlist(options);
+    const configured = new Set(allowedOrigins);
+    return (origin: string | string[] | undefined): boolean => {
+        if (baseline(origin)) {
+            return true;
+        }
+        if (configured.size === 0 || Array.isArray(origin)) {
+            return false;
+        }
+        const normalized =
+            origin === undefined ? undefined : normalizeOrigin(origin);
+        return normalized !== undefined && configured.has(normalized);
+    };
+}
+
+/**
  * Returns a predicate that decides whether an incoming WebSocket
  * upgrade's `Origin` header should be accepted. See
  * {@link OriginAllowlistOptions} for the shared policy.

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -1796,6 +1796,9 @@ importers:
       '@typeagent/websocket-channel-server':
         specifier: workspace:*
         version: link:../../utils/webSocketChannelServer
+      '@typeagent/websocket-utils':
+        specifier: workspace:*
+        version: link:../../utils/webSocketUtils
       agent-dispatcher:
         specifier: workspace:*
         version: link:../../dispatcher/dispatcher
@@ -3970,6 +3973,9 @@ importers:
       '@typeagent/typechat-utils':
         specifier: workspace:*
         version: link:../utils/typechatUtils
+      '@typeagent/websocket-utils':
+        specifier: workspace:*
+        version: link:../utils/webSocketUtils
       agent-dispatcher:
         specifier: workspace:*
         version: link:../dispatcher/dispatcher


### PR DESCRIPTION
## Problem

TypeAgent's servers were reachable from the network. `new WebSocketServer({ port })`
and `server.listen(port)` bind `0.0.0.0` when no host is given, so every one of these
listened on all interfaces even though logs and comments claimed localhost. None of
them authenticate, so any host that could reach the port could drive them:

- **agent server** - `shutdown()`, `joinConversation()`, `getUserIdentity()`. Joining a
  conversation hands back a dispatcher channel, which reaches the file system, mail,
  calendar and browser agents with the local user's permissions.
- **api server** - the `/action/` endpoint dispatches any action from an unauthenticated
  request, including `sendEmail` from the signed-in account.
- **markdown view** - file read/write plus `/agent/execute`. (Fixed separately by #2938;
  this branch no longer touches it.)
- **browser agent bridge, code agent bridge, browser views, montage view** - agent control
  surfaces.
- **shell chat view** - pushed the full conversation to every client that connected.

The api server additionally served static files with `Access-Control-Allow-Origin: *`,
letting any site on the web read them, and ignored the configured `port` entirely.

Two vectors survive a loopback bind, so binding alone was not enough: a page the user
visits can reach `http://localhost:<port>`, and a DNS rebinding attacker can make a
public hostname resolve to loopback.

## Change

Loopback by default, everywhere, with an explicit opt-in where network exposure is a
real deployment need.

- `createWebSocketChannelServer` now binds `127.0.0.1` when given a bare `port` and always
  installs an origin gate. This covers the agent server and the shell discovery server.
- The api server binds loopback unless `TYPEAGENT_API_HOST` (or `host` in config) says
  otherwise, and now honors the configured port. The Dockerfile sets that variable, so
  hosted deployments are unaffected.
- `/action/` and the dispatcher WebSocket refuse requests a web page could have caused,
  checked through `Origin` and `Sec-Fetch-Site`. `TYPEAGENT_API_ALLOWED_ORIGINS` names the
  origins a hosted deployment serves its UI from. An explicit allowlist is used rather than
  comparing `Origin` to `Host`, because a rebinding attacker's request has those two agree.
- Static files echo the request origin only when it passes that same allowlist, and set
  `Vary: Origin`. Same-origin clients need no header at all.
- The remaining listeners bind loopback: montage, browser views, both agent
  bridges, the shell chat view (opt-in via `TYPEAGENT_SHELL_CHAT_SERVER_HOST`), the
  validation demo dashboards, and the `cacheRESTEndpoint` example. The markdown view is
  not included here — #2938 landed the
  same loopback bind for it while this branch was in review, so this branch rebases onto
  that fix rather than duplicating it.
- The onboarding scaffolder templates generate loopback binds, so new agents are not born
  exposed.
- The agent server's `--host` / `AGENT_SERVER_HOST` override trims its value and treats a
  blank one as absent. `--host ""` previously bound every interface, because `??` falls
  through only on `null`/`undefined` and `listen(port, "")` means "all interfaces" — the
  opposite of the default this change establishes.
- `WebSocketChannelServerOptions` no longer accepts `verifyClient`. The factory builds its
  own from `isOriginAllowed`, so one passed in was silently discarded along with the
  caller's access check; it is now a compile error. No existing caller passes one.

Origin gates refuse `Origin: null`, the opaque value a sandboxed iframe sends. A missing
`Origin` stays allowed for non-browser callers such as IoT devices and curl, where the bind
address is the control.

The Visual Studio chat panel is a WebView2 whose content is mapped to a virtual host, so it
sends `Origin: https://typeagent.local` rather than a loopback origin. That origin is
allowed by exact match, alongside the browser-extension schemes. It is deliberately not a
prefix match, which would also accept `https://typeagent.local.evil.example`.

## Known gap

`/action/` accepts GET so simple clients can submit an action as a URL. Browsers older than
roughly Firefox 90 and Safari 16.4 send neither `Origin` nor `Sec-Fetch-Site` on an image
load, and a request carrying neither header is indistinguishable from a non-browser client.
On those browsers a visited page can still reach `/action/` over loopback. Current browsers
label the request `cross-site` and it is refused. This is documented in the api README.

## Validation

New tests cover host resolution, the request gate, the origin allowlist and the CORS
reflection: 35 in the api package (was 28), 13 for the channel server (was 4), and 8 for
agent-server host resolution, including the blank-`--host` case. All three suites pass on
the rebased branch, as does the `agentServer/server` build, which exercises the new
`@typeagent/websocket-utils/loopback` dependency edge.

The three VS Code extensions (`coda`, `vscode-chat`, `vscode-shell`) and the Visual Studio
panel were checked as clients rather than by reading the code. The extensions all run in
the Node extension host, send no `Origin`, and default to `ws://localhost:8999`; driving
the real `connectAgentServer()` against a hardened server connects and lists conversations.
Because the bind is IPv4-only while those clients dial a hostname, `localhost` resolution
was tested explicitly, including with IPv6 forced first — `autoSelectFamily` falls back and
the connection succeeds.

The Visual Studio panel was the one client this broke, and the tests above are what caught
it. Its WebView2 origin now round-trips, its look-alike domain is refused, and both cases
are covered by unit tests.

Binding was confirmed at runtime with `netstat` for the api server, channel server, both
agent bridges, the browser view server, the chat server and the `cacheRESTEndpoint`
example, each of which reported
`127.0.0.1` where it previously reported `0.0.0.0`. Cross-site `/action/` returns 403 and
same-origin returns 200. Static files return a CORS header only for allowlisted origins.

The Electron shell was run in both connect and standalone mode; all 10 listeners bound
loopback and none were reachable from an off-box peer (a WSL2 VM on a separate NAT
network). `@help` round-trips end to end.

The agent-server origin gate was checked against a live server on a confirmed
`127.0.0.1`-only bind:

| Origin | Result |
|---|---|
| *(none)* — native clients (`coda`, `vscode-chat`, CLI) | 101 |
| `http://localhost:8999`, `http://127.0.0.1:5173` | 101 |
| `chrome-extension://…`, `moz-extension://…` | 101 |
| LAN page, `https://evil.example.com`, `null` | 403 |

The cross-origin case was also confirmed in a real browser rather than with a synthetic
header. The same page served from a LAN origin could not open a WebSocket to the agent
server, while the identical page served from loopback could — the loopback case acting as a
positive control so that a blanket failure could not be mistaken for a successful block.
That is the DNS-rebinding vector from the report.

Conversation lifecycle (`listConversations` → `createConversation` → `joinConversation` →
`leaveConversation` → `deleteConversation`) was exercised over the real RPC to confirm
legitimate loopback clients are unaffected.

Scaffolder output was verified end to end: templates were generated through the real
`loadTemplate()`, compiled with `tsc`, and the resulting bridge started and reported a bound
address of `127.0.0.1`.

Lint counts were compared per file against `origin/main` and are unchanged; the new files
add no violations.

### Not covered

Hardware- and service-dependent paths were not exercised: the Android app, Dev Tunnel,
the Docker image, hosted Azure deployment, and the browser extension end to end. The
Visual Studio panel's origin was verified against a live server and in unit tests, but the
panel itself was not driven, since that needs a Visual Studio install. The loopback bind is
IPv4-only, so a client that hard-prefers `::1` would fail; this was not observed here but
was not exhaustively ruled out across all platforms.

For VS Code Remote, both extensions already default to `localhost` and connect from the
extension host with no `Origin`, so the common configurations are unaffected. The one
behavior change is for a client explicitly pointed at a non-localhost address, which is the
exposure this change closes; `AGENT_SERVER_HOST` / `--host` is the documented opt-in. Note
that inside a dev container VS Code's own port forwarding still works, but Docker `-p`
publishing does not, since it can only forward an externally-bound socket.