### PR TITLE
Fix XSS in chat message rendering

### DIFF
--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -31,6 +31,40 @@ const ansiUpMarkdownToHtml = new AnsiUp();
 ansiUpMarkdownToHtml.use_classes = true;
 ansiUpMarkdownToHtml.escape_html = false;
 
+// Schemes a link or image in message content may use. `typeagent-browser` and
+// `typeagent-file` are the app's own link schemes (see fileLink.ts); `cid`
+// covers inline mail attachments. Note `file:` is deliberately absent - local
+// files are linked with `typeagent-file:` precisely because `file:` hrefs are
+// sanitized away here and are inert in Electron and webview hosts.
+const ALLOWED_URI_REGEXP =
+    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+// The single DOMPurify configuration for every message-content sink.
+//
+// Message content is NOT trusted: an agent can relay text it got from the
+// outside world (an email body, a web page, a file), so anything rendered
+// here may be attacker-controlled. Two rules follow from that, and both were
+// previously violated:
+//
+//   1. Never add event-handler attributes (`onclick`, `onerror`, ...) to
+//      ADD_ATTR. Doing so re-permits exactly what DOMPurify strips by default
+//      and lets `<img src=x onerror=...>` execute.
+//   2. Never list `href`/`src` in ADD_URI_SAFE_ATTR. That marks them as not
+//      needing URI checks, which skips ALLOWED_URI_REGEXP entirely and lets
+//      `javascript:` URLs through.
+//
+// `target` is the only addition needed: the markdown `link_open` rule sets
+// `target="_blank"`. `href`, `src` and `style` are already allowed by
+// DOMPurify's defaults, so they do not need to be listed.
+//
+// Agent content that genuinely needs to run script uses `type: "iframe"`
+// instead, which renders in a sandboxed iframe and never reaches this config.
+const sanitizeConfig = {
+    ADD_ATTR: ["target"],
+    ADD_DATA_URI_TAGS: ["img"],
+    ALLOWED_URI_REGEXP,
+};
+
 // ---------------------------------------------------------------------------
 // Structured-content HTML renderer (Phase 3a)
 // Converts a StructuredContent block document to an HTML string. DOMPurify
@@ -560,13 +594,7 @@ function processContent(
         case "iframe":
             return content;
         case "html":
-            return DOMPurify.sanitize(content, {
-                ADD_ATTR: ["target", "onclick", "onerror", "href"],
-                ADD_DATA_URI_TAGS: ["img"],
-                ADD_URI_SAFE_ATTR: ["src", "href"],
-                ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-            });
+            return DOMPurify.sanitize(content, sanitizeConfig);
         case "markdown": {
             const md = createMarkdownRenderer();
             const renderedMarkdown = inline
@@ -575,13 +603,7 @@ function processContent(
             const withAnsi =
                 ansiUpMarkdownToHtml.ansi_to_html(renderedMarkdown);
 
-            return DOMPurify.sanitize(withAnsi, {
-                ADD_ATTR: ["target", "onclick", "onerror", "href"],
-                ADD_DATA_URI_TAGS: ["img"],
-                ADD_URI_SAFE_ATTR: ["src", "href", "style"],
-                ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-            });
+            return DOMPurify.sanitize(withAnsi, sanitizeConfig);
         }
         case "text":
             return enableText2Html
@@ -973,13 +995,12 @@ export function setContent(
         // `processContent` already sanitizes html/markdown, but the data
         // flow through messageContentToHTML breaks the static analysis
         // chain).
-        contentElm.innerHTML += DOMPurify.sanitize(contentHtml, {
-            ADD_ATTR: ["target", "onclick", "onerror", "href"],
-            ADD_DATA_URI_TAGS: ["img"],
-            ADD_URI_SAFE_ATTR: ["src", "href", "style"],
-            ALLOWED_URI_REGEXP:
-                /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|typeagent-browser|typeagent-file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-        });
+        // vanilla, sanitized HTML only — re-run DOMPurify at the sink so
+        // CodeQL js/xss can recognize sanitization (the upstream
+        // `processContent` already sanitizes html/markdown, but the data
+        // flow through messageContentToHTML breaks the static analysis
+        // chain).
+        contentElm.innerHTML += DOMPurify.sanitize(contentHtml, sanitizeConfig);
 
         // Plain-text content authors no links of its own, so bare URLs would
         // otherwise render as dead text. Wrap them in anchors here (markdown
@@ -1087,6 +1108,14 @@ export function swapContent(
         targetElement.classList.add("chat-message-action-data");
     }
 
-    sourceElement.setAttribute("action-data", originalMessage);
-    targetElement.innerHTML = data;
+    // Both halves of the swap are sanitized. `action-data` is an attribute on
+    // a DOM node, so it is reachable by anything that can already write to the
+    // document, and `originalMessage` is re-serialized message content that is
+    // swapped back in on the next toggle. Sanitizing both keeps this toggle
+    // from becoming a way to reintroduce markup that the render sink rejected.
+    sourceElement.setAttribute(
+        "action-data",
+        DOMPurify.sanitize(originalMessage, sanitizeConfig),
+    );
+    targetElement.innerHTML = DOMPurify.sanitize(data, sanitizeConfig);
 }

--- a/ts/packages/chat-ui/src/setContent.ts
+++ b/ts/packages/chat-ui/src/setContent.ts
@@ -990,12 +990,7 @@ export function setContent(
 
         contentElm.appendChild(iframe);
     } else {
-        // vanilla, sanitized HTML only — re-run DOMPurify at the sink so
-        // CodeQL js/xss can recognize sanitization (the upstream
-        // `processContent` already sanitizes html/markdown, but the data
-        // flow through messageContentToHTML breaks the static analysis
-        // chain).
-        // vanilla, sanitized HTML only — re-run DOMPurify at the sink so
+        // vanilla, sanitized HTML only: re-run DOMPurify at the sink so
         // CodeQL js/xss can recognize sanitization (the upstream
         // `processContent` already sanitizes html/markdown, but the data
         // flow through messageContentToHTML breaks the static analysis

--- a/ts/packages/chat-ui/test/setContent.spec.ts
+++ b/ts/packages/chat-ui/test/setContent.spec.ts
@@ -295,3 +295,112 @@ describe("setContent plain-text linkification", () => {
         expect(elm.querySelector("a[href]")).toBeNull();
     });
 });
+
+// Message content can carry text an agent relayed from the outside world (an
+// email body, a fetched page), so it is treated as untrusted. These pin the
+// sanitizer: the config previously allow-listed `onclick`/`onerror` via
+// ADD_ATTR and marked `href`/`src` as URI-safe, which let event handlers and
+// `javascript:` URLs reach the DOM.
+describe("setContent sanitizes untrusted message content", () => {
+    // Serialized markup, so an attribute that survived sanitization is
+    // visible even when jsdom would not fire the handler.
+    const html = (elm: HTMLElement) => elm.innerHTML.toLowerCase();
+
+    describe.each(["html", "markdown"] as const)("%s content", (type) => {
+        it("strips inline event handlers", () => {
+            const elm = render({
+                type,
+                content: `<img src="x" onerror="alert(1)">`,
+            });
+            expect(html(elm)).not.toContain("onerror");
+            // The element itself is kept; only the handler is removed.
+            expect(elm.querySelector("img")).not.toBeNull();
+        });
+
+        it("strips onclick handlers", () => {
+            const elm = render({
+                type,
+                content: `<div onclick="alert(1)">click me</div>`,
+            });
+            expect(html(elm)).not.toContain("onclick");
+        });
+
+        it("drops javascript: URLs", () => {
+            const elm = render({
+                type,
+                content: `<a href="javascript:alert(1)">link</a>`,
+            });
+            expect(html(elm)).not.toContain("javascript:");
+        });
+
+        it("drops javascript: URLs that dodge a naive scheme check", () => {
+            const elm = render({
+                type,
+                content: [
+                    `<a href="JaVaScRiPt:alert(1)">a</a>`,
+                    `<a href="&#106;avascript:alert(1)">b</a>`,
+                    `<a href=" javascript:alert(1)">c</a>`,
+                    `<img src="javascript:alert(1)">`,
+                ].join(""),
+            });
+            expect(html(elm)).not.toContain("javascript:");
+        });
+
+        it("removes script elements", () => {
+            const elm = render({
+                type,
+                content: `<script>alert(1)</script><p>after</p>`,
+            });
+            expect(elm.querySelector("script")).toBeNull();
+        });
+
+        it("survives markup that tries to break out of a parent element", () => {
+            const elm = render({
+                type,
+                content:
+                    `<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>` +
+                    `<template><img src=y onerror=alert(2)></template>`,
+            });
+            expect(html(elm)).not.toContain("onerror");
+        });
+    });
+
+    // The allow-list existed to keep these working. They must survive, or the
+    // fix would be traded for a rendering regression.
+    describe("keeps legitimate content intact", () => {
+        it("keeps links to the app's own schemes", () => {
+            const elm = render({
+                type: "html",
+                content: [
+                    `<a href="https://example.com/a">https</a>`,
+                    `<a href="mailto:a@b.com">mail</a>`,
+                    `<a href="typeagent-file:/c/tmp/a.txt">file</a>`,
+                    `<a href="typeagent-browser://open">browser</a>`,
+                ].join(""),
+            });
+            expect(elm.querySelectorAll("a[href]")).toHaveLength(4);
+        });
+
+        it("keeps image sources the renderer relies on", () => {
+            const elm = render({
+                type: "html",
+                content: [
+                    `<img src="https://example.com/a.png">`,
+                    `<img src="data:image/png;base64,iVBORw0KGgo=">`,
+                    `<img src="cid:attachment-1">`,
+                ].join(""),
+            });
+            expect(elm.querySelectorAll("img[src]")).toHaveLength(3);
+        });
+
+        it("keeps target on markdown links so they open in a new tab", () => {
+            const elm = render({
+                type: "markdown",
+                content: "[docs](https://example.org/guide)",
+            });
+            expect(
+                elm.querySelector<HTMLAnchorElement>("a[href]")!.target,
+            ).toBe("_blank");
+        });
+    });
+});


### PR DESCRIPTION
# Fix XSS in chat message rendering

## Summary

`chat-ui`'s message sanitizer re-permitted the exact things DOMPurify strips by
default, so markup in agent output could execute script in the renderer.

Two independent problems in one config:

- `ADD_ATTR: ["onclick", "onerror"]` re-enabled inline event handlers -
  `<img src=x onerror=...>` passed through byte-for-byte.
- `ADD_URI_SAFE_ATTR: ["src", "href", "style"]` exempted those attributes from
  URI validation, which skips `ALLOWED_URI_REGEXP` entirely and let
  `javascript:` URLs through. This one is independent of the handler list, so
  fixing only the handlers would still leave an exec path.

## Changes

- One shared `sanitizeConfig` replaces three duplicated copies;
  `ALLOWED_URI_REGEXP` extracted to a single constant.
- Removed the handler allow-list and `ADD_URI_SAFE_ATTR`. `href`/`src`/`style`
  are already permitted by DOMPurify's defaults; only `target` was genuinely
  needed (markdown `link_open`).
- `swapContent()` now sanitizes both writes - one had no sanitizer at all.
- Both rules documented inline so the config isn't widened back.

## Compatibility

Agent content that needs script uses `type: "iframe"`
(`createActionResultFromHtmlDisplayWithScript`), which renders sandboxed and
never touches this config - the image carousel and video agent both use that
path. DOMPurify strips `<script>` regardless of `ADD_ATTR`, so anything relying
on an inline handler plus a helper function was already broken through this
sink.

Verified intact: https/mailto/`typeagent-file:`/`typeagent-browser:` links,
cid/data/https images, `target="_blank"`, code blocks, tables. `file:` and
`blob:` are now stripped, which matches the documented intent behind
`typeagent-file:` (`fileLink.ts`).

## Tests

15 regression tests across the html and markdown paths. Negative control:
restoring the previous config fails 8 of them.
