### PR TITLE
[GHCP Plugin] Fix Copilot plugin registration on Windows

### DIFF
--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -244,28 +244,25 @@ The current Copilot CLI (>= 1.0) does **not** accept a local path for
 subdirs, or git URLs. However, `copilot plugin marketplace add <path>` **does**
 accept a local path. So `pnpm run register` (`scripts/install-plugin.mjs`):
 
-1. Registers the `ts` workspace root as a local marketplace named
-   `typeagent-local`. The CLI discovers the marketplace manifest at
-   `ts/.github/plugin/marketplace.json`, whose plugin `source` points at
-   `./packages/copilot-plugin` (resolved relative to the marketplace root).
-2. Installs `typeagent@typeagent-local`, which **copies** the plugin dir into
-   `~/.copilot/installed-plugins/`.
-
-> The CLI searches several locations for the marketplace manifest, in order:
-> `marketplace.json` (root), `.plugin/marketplace.json`,
-> `.github/plugin/marketplace.json`, then `.claude-plugin/marketplace.json`.
-> We use `.github/plugin/` since the workspace already has a `.github` folder.
+1. Stages only the bundled runtime files under
+   `~/.typeagent-copilot/plugin-stage`. This deliberately excludes the
+   workspace's pnpm `node_modules` junctions, which Copilot cannot copy on
+   Windows.
+2. Creates and registers a local marketplace at
+   `~/.copilot/marketplaces/typeagent-local`.
+3. Installs `typeagent@typeagent-local`, which copies the staged snapshot into
+   `~/.copilot/installed-plugins/`, and verifies that it appears in
+   `copilot plugin list`.
 
 ### Why the build must bundle
 
-Installing copies the plugin directory into `~/.copilot/installed-plugins/`.
-Because this is a pnpm workspace, the plugin's runtime deps (the MCP SDK and the
-`workspace:*` packages) are symlinks/junctions into the central `.pnpm` store —
-the copy breaks them, and the MCP server crashes on launch with
-`ERR_MODULE_NOT_FOUND`. To fix this, `pnpm run build` runs an esbuild bundle
-step (`scripts/bundle.mjs`) that inlines every dependency into the hook and MCP
-entry points, so the copied `dist/` is self-contained and needs no
-`node_modules` at runtime.
+Installing copies a plugin snapshot into `~/.copilot/installed-plugins/`.
+Because this is a pnpm workspace, the package's runtime dependencies are
+symlinks/junctions into the central `.pnpm` store. Copying those links can fail
+with `Access is denied` on Windows, and copied links would not be portable.
+`pnpm run build` therefore runs `scripts/bundle.mjs` to inline every dependency,
+and registration stages only that self-contained runtime without
+`node_modules`.
 
 ### Updating after a code change
 
@@ -274,7 +271,7 @@ the plugin, rebuild and refresh the global copy:
 
 ```powershell
 pnpm run build       # re-bundle
-pnpm run register    # re-copies the fresh build (runs `copilot plugin update`)
+pnpm run register    # stages and installs a fresh snapshot
 ```
 
 > For rapid local development with live edits, prefer `pnpm copilot`

--- a/ts/packages/copilot-plugin/scripts/install-plugin.mjs
+++ b/ts/packages/copilot-plugin/scripts/install-plugin.mjs
@@ -23,20 +23,17 @@ const pluginRoot = path.resolve(scriptDir, "..");
 const workspaceRoot = path.resolve(pluginRoot, "..", "..");
 const marketplaceName = "typeagent-local";
 const pluginName = "typeagent";
+const copilotHome = path.resolve(
+    process.env.COPILOT_HOME ?? path.join(os.homedir(), ".copilot"),
+);
 const stagingRoot = path.join(
     os.homedir(),
     ".typeagent-copilot",
     "plugin-stage",
 );
-const marketplaceRoot = path.join(
-    os.homedir(),
-    ".copilot",
-    "marketplaces",
-    marketplaceName,
-);
+const marketplaceRoot = path.join(copilotHome, "marketplaces", marketplaceName);
 const installedMarketplaceRoot = path.join(
-    os.homedir(),
-    ".copilot",
+    copilotHome,
     "installed-plugins",
     marketplaceName,
 );
@@ -56,7 +53,27 @@ function warn(message) {
     process.stderr.write(`[copilot-plugin] ${message}\n`);
 }
 
+function quoteCmdArgument(value) {
+    return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+}
+
 function run(command, args) {
+    if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command)) {
+        const commandLine = [
+            "call",
+            quoteCmdArgument(command),
+            ...args.map(quoteCmdArgument),
+        ].join(" ");
+        return spawnSync(
+            process.env.ComSpec ?? "cmd.exe",
+            ["/d", "/s", "/c", commandLine],
+            {
+                encoding: "utf8",
+                shell: false,
+                windowsVerbatimArguments: true,
+            },
+        );
+    }
     return spawnSync(command, args, {
         encoding: "utf8",
         shell: false,
@@ -73,6 +90,13 @@ function findCopilotCli() {
     const result = spawnSync(command, ["copilot"], { encoding: "utf8" });
     if (result.status !== 0 || !result.stdout.trim()) return undefined;
     return result.stdout.split(/\r?\n/)[0].trim();
+}
+
+function hasListedEntry(output, identifier) {
+    return output.split(/\r?\n/).some((line) => {
+        const entry = line.trim().replace(/^[^A-Za-z0-9_.@-]+/, "");
+        return entry.split(/\s+/, 1)[0] === identifier;
+    });
 }
 
 if (
@@ -111,13 +135,14 @@ const marketplaceOutput = `${marketplaces.stdout || ""}\n${
     marketplaces.stderr || ""
 }`;
 if (
-    marketplaceOutput.includes(marketplaceName) &&
+    hasListedEntry(marketplaceOutput, marketplaceName) &&
     !marketplaceOutput.toLowerCase().includes(marketplaceRoot.toLowerCase())
 ) {
     log("Replacing the legacy workspace-backed marketplace registration.");
     const plugins = run(copilotPath, ["plugin", "list"]);
     if (
-        `${plugins.stdout || ""}\n${plugins.stderr || ""}`.includes(
+        hasListedEntry(
+            `${plugins.stdout || ""}\n${plugins.stderr || ""}`,
             `${pluginName}@${marketplaceName}`,
         )
     ) {
@@ -175,7 +200,7 @@ const verification = run(copilotPath, ["plugin", "list"]);
 const verificationOutput = `${verification.stdout || ""}\n${
     verification.stderr || ""
 }`;
-if (!verificationOutput.includes(`${pluginName}@${marketplaceName}`)) {
+if (!hasListedEntry(verificationOutput, `${pluginName}@${marketplaceName}`)) {
     printResult(verification);
     warn(
         "Plugin registration returned success, but the plugin is not installed.",

--- a/ts/packages/copilot-plugin/scripts/install-plugin.mjs
+++ b/ts/packages/copilot-plugin/scripts/install-plugin.mjs
@@ -3,51 +3,76 @@
 // Licensed under the MIT License.
 
 /**
- * Install this plugin into GitHub Copilot CLI *globally*, so it loads in every
- * `copilot` session regardless of the directory you launch from (no
- * `--plugin-dir` and no `pnpm copilot` wrapper needed).
+ * Install this plugin globally through a local Copilot marketplace.
  *
- * Mechanism (Copilot CLI >= 1.0):
- *   `copilot plugin install <path>` is NOT supported — the install source must
- *   be a marketplace, a GitHub repo, or a git URL. However,
- *   `copilot plugin marketplace add <path>` DOES accept a local path. So we:
- *     1. Register the `ts` workspace root as a local marketplace
- *        ("typeagent-local"). The CLI discovers the marketplace manifest at
- *        `ts/.github/plugin/marketplace.json`, whose plugin `source` points at
- *        `./packages/copilot-plugin` (relative to the marketplace root).
- *     2. Install (or refresh) the "typeagent" plugin from that marketplace.
- *
- *   Installing COPIES the plugin (including dist/ and node_modules/) into
- *   ~/.copilot/installed-plugins/. It is a snapshot, not a live reference, so
- *   after you rebuild the plugin you must re-run this script (which calls
- *   `copilot plugin update`) to refresh the global copy.
- *
- *  - If `copilot` is not on PATH, we warn and exit 0 (don't fail the build).
- *  - Pass `--skip-install` (or set `TYPEAGENT_SKIP_PLUGIN_INSTALL=1`) to opt out.
+ * The workspace package cannot be used as the marketplace source directly:
+ * its pnpm node_modules contains Windows junctions that Copilot tries to copy,
+ * which fails with access denied. Stage only the self-contained runtime files,
+ * then use the same registration implementation as the TypeAgent installer.
  */
 
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { stageCopilotPlugin } from "../../../tools/scripts/stageCopilotPlugin.mjs";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const pluginRoot = resolve(__dirname, "..");
-// The marketplace manifest lives at <workspaceRoot>/.github/plugin/
-// marketplace.json, so the marketplace source we register is the `ts`
-// workspace root (packages/copilot-plugin -> ../..).
-const workspaceRoot = resolve(pluginRoot, "..", "..");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.resolve(scriptDir, "..");
+const workspaceRoot = path.resolve(pluginRoot, "..", "..");
+const marketplaceName = "typeagent-local";
+const pluginName = "typeagent";
+const stagingRoot = path.join(
+    os.homedir(),
+    ".typeagent-copilot",
+    "plugin-stage",
+);
+const marketplaceRoot = path.join(
+    os.homedir(),
+    ".copilot",
+    "marketplaces",
+    marketplaceName,
+);
+const installedMarketplaceRoot = path.join(
+    os.homedir(),
+    ".copilot",
+    "installed-plugins",
+    marketplaceName,
+);
+const registerScript = path.join(
+    workspaceRoot,
+    "tools",
+    "installers",
+    "common",
+    "register-plugin.mjs",
+);
 
-const MARKETPLACE_NAME = "typeagent-local";
-const PLUGIN_NAME = "typeagent";
-
-function log(msg) {
-    process.stdout.write(`[copilot-plugin] ${msg}\n`);
+function log(message) {
+    process.stdout.write(`[copilot-plugin] ${message}\n`);
 }
 
-function warn(msg) {
-    process.stderr.write(`[copilot-plugin] ${msg}\n`);
+function warn(message) {
+    process.stderr.write(`[copilot-plugin] ${message}\n`);
+}
+
+function run(command, args) {
+    return spawnSync(command, args, {
+        encoding: "utf8",
+        shell: false,
+    });
+}
+
+function printResult(result) {
+    process.stdout.write(result.stdout || "");
+    process.stderr.write(result.stderr || "");
+}
+
+function findCopilotCli() {
+    const command = process.platform === "win32" ? "where" : "which";
+    const result = spawnSync(command, ["copilot"], { encoding: "utf8" });
+    if (result.status !== 0 || !result.stdout.trim()) return undefined;
+    return result.stdout.split(/\r?\n/)[0].trim();
 }
 
 if (
@@ -58,8 +83,7 @@ if (
     process.exit(0);
 }
 
-// Sanity check: built output must exist.
-const distHook = resolve(pluginRoot, "dist", "hooks", "hook-router.js");
+const distHook = path.join(pluginRoot, "dist", "hooks", "hook-router.js");
 if (!existsSync(distHook)) {
     warn(
         `Built output not found at ${distHook}. Run \`pnpm run build\` first.`,
@@ -67,78 +91,96 @@ if (!existsSync(distHook)) {
     process.exit(1);
 }
 
-// Locate copilot CLI. spawnSync with shell:false; resolve via which/where.
-function findCopilotCli() {
-    const cmd = process.platform === "win32" ? "where" : "which";
-    const result = spawnSync(cmd, ["copilot"], { encoding: "utf-8" });
-    if (result.status === 0 && result.stdout.trim()) {
-        return result.stdout.split(/\r?\n/)[0].trim();
-    }
-    return null;
-}
-
 const copilotPath = findCopilotCli();
 if (!copilotPath) {
     warn(
         "GitHub Copilot CLI (`copilot`) not found on PATH. " +
-            "Skipping global plugin registration. " +
-            "Install Copilot CLI and rerun `pnpm run register` if you want " +
-            "to use the plugin outside this repo.",
+            "Skipping global plugin registration.",
     );
     process.exit(0);
-}
-
-// Run a copilot subcommand, returning { status, stdout, stderr }.
-function copilot(args) {
-    return spawnSync("copilot", args, {
-        encoding: "utf-8",
-        shell: process.platform === "win32",
-    });
 }
 
 log(`Found copilot at ${copilotPath}`);
+const metrics = stageCopilotPlugin(stagingRoot);
+log(`Staged ${metrics.files} runtime files without workspace node_modules.`);
 
-// 1. Register the local marketplace if not already registered.
-const mpList = copilot(["plugin", "marketplace", "list"]);
-if ((mpList.stdout || "").includes(MARKETPLACE_NAME)) {
-    log(`Marketplace "${MARKETPLACE_NAME}" already registered.`);
-} else {
-    log(`Registering local marketplace from ${workspaceRoot}`);
-    const add = copilot(["plugin", "marketplace", "add", workspaceRoot]);
-    process.stdout.write(add.stdout || "");
-    process.stderr.write(add.stderr || "");
-    if (add.status !== 0) {
-        warn("Failed to register marketplace. Aborting.");
-        process.exit(0);
+// Migrate registrations created by the old script, which pointed directly at
+// the pnpm workspace and caused Copilot to traverse package junctions.
+const marketplaces = run(copilotPath, ["plugin", "marketplace", "list"]);
+const marketplaceOutput = `${marketplaces.stdout || ""}\n${
+    marketplaces.stderr || ""
+}`;
+if (
+    marketplaceOutput.includes(marketplaceName) &&
+    !marketplaceOutput.toLowerCase().includes(marketplaceRoot.toLowerCase())
+) {
+    log("Replacing the legacy workspace-backed marketplace registration.");
+    const plugins = run(copilotPath, ["plugin", "list"]);
+    if (
+        `${plugins.stdout || ""}\n${plugins.stderr || ""}`.includes(
+            `${pluginName}@${marketplaceName}`,
+        )
+    ) {
+        printResult(run(copilotPath, ["plugin", "uninstall", pluginName]));
+    }
+    const remove = run(copilotPath, [
+        "plugin",
+        "marketplace",
+        "remove",
+        marketplaceName,
+    ]);
+    printResult(remove);
+    if (remove.status !== 0) {
+        warn("Failed to remove the legacy marketplace registration.");
+        process.exit(1);
     }
 }
 
-// 2. Install the plugin, or update it if it's already installed (refresh the
-//    global snapshot from the freshly built local source).
-const pluginList = copilot(["plugin", "list"]);
-const alreadyInstalled = (pluginList.stdout || "").includes(
-    `${PLUGIN_NAME}@${MARKETPLACE_NAME}`,
-);
-
-const op = alreadyInstalled
-    ? ["plugin", "update", PLUGIN_NAME]
-    : ["plugin", "install", `${PLUGIN_NAME}@${MARKETPLACE_NAME}`];
-
-log(alreadyInstalled ? "Refreshing global plugin copy…" : "Installing plugin…");
-const result = copilot(op);
-process.stdout.write(result.stdout || "");
-process.stderr.write(result.stderr || "");
-
-if (result.status === 0) {
-    log(
-        "Done. The plugin is now available in every `copilot` session. " +
-            "After rebuilding, re-run `pnpm run register` to refresh it.",
-    );
-    process.exit(0);
+// Clean up partial directories left by the old workspace-backed installation.
+if (existsSync(installedMarketplaceRoot)) {
+    for (const entry of readdirSync(installedMarketplaceRoot)) {
+        if (entry.startsWith(`.${pluginName}.tmp-`)) {
+            log(`Removing stale failed-install artifact ${entry}.`);
+            rmSync(path.join(installedMarketplaceRoot, entry), {
+                recursive: true,
+                force: true,
+            });
+        }
+    }
 }
 
-warn(
-    `copilot ${op.join(" ")} exited with code ${result.status}. ` +
-        "Re-run manually with `pnpm run register` if needed.",
-);
-process.exit(0);
+const registration = run(process.execPath, [
+    registerScript,
+    "--install-dir",
+    workspaceRoot,
+    "--plugin-source-dir",
+    stagingRoot,
+    "--marketplace-name",
+    marketplaceName,
+    "--marketplace-root",
+    marketplaceRoot,
+    "--plugin-name",
+    pluginName,
+    "--copilot-path",
+    copilotPath,
+]);
+printResult(registration);
+
+if (registration.status !== 0) {
+    warn(`Plugin registration failed with exit code ${registration.status}.`);
+    process.exit(registration.status ?? 1);
+}
+
+const verification = run(copilotPath, ["plugin", "list"]);
+const verificationOutput = `${verification.stdout || ""}\n${
+    verification.stderr || ""
+}`;
+if (!verificationOutput.includes(`${pluginName}@${marketplaceName}`)) {
+    printResult(verification);
+    warn(
+        "Plugin registration returned success, but the plugin is not installed.",
+    );
+    process.exit(1);
+}
+
+log("Done. The plugin is available in every `copilot` session.");

--- a/ts/packages/copilot-plugin/scripts/install-plugin.mjs
+++ b/ts/packages/copilot-plugin/scripts/install-plugin.mjs
@@ -3,15 +3,14 @@
 // Licensed under the MIT License.
 
 /**
- * Install this plugin globally through a local Copilot marketplace.
+ * Stage and install this plugin through the shared TypeAgent registrar.
  *
  * The workspace package cannot be used as the marketplace source directly:
  * its pnpm node_modules contains Windows junctions that Copilot tries to copy,
- * which fails with access denied. Stage only the self-contained runtime files,
- * then use the same registration implementation as the TypeAgent installer.
+ * which fails with access denied.
  */
 
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -22,7 +21,6 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(scriptDir, "..");
 const workspaceRoot = path.resolve(pluginRoot, "..", "..");
 const marketplaceName = "typeagent-local";
-const pluginName = "typeagent";
 const copilotHome = path.resolve(
     process.env.COPILOT_HOME ?? path.join(os.homedir(), ".copilot"),
 );
@@ -32,11 +30,6 @@ const stagingRoot = path.join(
     "plugin-stage",
 );
 const marketplaceRoot = path.join(copilotHome, "marketplaces", marketplaceName);
-const installedMarketplaceRoot = path.join(
-    copilotHome,
-    "installed-plugins",
-    marketplaceName,
-);
 const registerScript = path.join(
     workspaceRoot,
     "tools",
@@ -53,50 +46,14 @@ function warn(message) {
     process.stderr.write(`[copilot-plugin] ${message}\n`);
 }
 
-function quoteCmdArgument(value) {
-    return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
-}
-
-function run(command, args) {
-    if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(command)) {
-        const commandLine = [
-            "call",
-            quoteCmdArgument(command),
-            ...args.map(quoteCmdArgument),
-        ].join(" ");
-        return spawnSync(
-            process.env.ComSpec ?? "cmd.exe",
-            ["/d", "/s", "/c", commandLine],
-            {
-                encoding: "utf8",
-                shell: false,
-                windowsVerbatimArguments: true,
-            },
-        );
-    }
-    return spawnSync(command, args, {
-        encoding: "utf8",
-        shell: false,
-    });
-}
-
-function printResult(result) {
-    process.stdout.write(result.stdout || "");
-    process.stderr.write(result.stderr || "");
-}
-
 function findCopilotCli() {
+    if (process.env.COPILOT_CLI_PATH) {
+        return process.env.COPILOT_CLI_PATH;
+    }
     const command = process.platform === "win32" ? "where" : "which";
     const result = spawnSync(command, ["copilot"], { encoding: "utf8" });
     if (result.status !== 0 || !result.stdout.trim()) return undefined;
     return result.stdout.split(/\r?\n/)[0].trim();
-}
-
-function hasListedEntry(output, identifier) {
-    return output.split(/\r?\n/).some((line) => {
-        const entry = line.trim().replace(/^[^A-Za-z0-9_.@-]+/, "");
-        return entry.split(/\s+/, 1)[0] === identifier;
-    });
 }
 
 if (
@@ -128,84 +85,35 @@ log(`Found copilot at ${copilotPath}`);
 const metrics = stageCopilotPlugin(stagingRoot);
 log(`Staged ${metrics.files} runtime files without workspace node_modules.`);
 
-// Migrate registrations created by the old script, which pointed directly at
-// the pnpm workspace and caused Copilot to traverse package junctions.
-const marketplaces = run(copilotPath, ["plugin", "marketplace", "list"]);
-const marketplaceOutput = `${marketplaces.stdout || ""}\n${
-    marketplaces.stderr || ""
-}`;
-if (
-    hasListedEntry(marketplaceOutput, marketplaceName) &&
-    !marketplaceOutput.toLowerCase().includes(marketplaceRoot.toLowerCase())
-) {
-    log("Replacing the legacy workspace-backed marketplace registration.");
-    const plugins = run(copilotPath, ["plugin", "list"]);
-    if (
-        hasListedEntry(
-            `${plugins.stdout || ""}\n${plugins.stderr || ""}`,
-            `${pluginName}@${marketplaceName}`,
-        )
-    ) {
-        printResult(run(copilotPath, ["plugin", "uninstall", pluginName]));
-    }
-    const remove = run(copilotPath, [
-        "plugin",
-        "marketplace",
-        "remove",
+const registration = spawnSync(
+    process.execPath,
+    [
+        registerScript,
+        "--install-dir",
+        workspaceRoot,
+        "--plugin-source-dir",
+        stagingRoot,
+        "--marketplace-name",
         marketplaceName,
-    ]);
-    printResult(remove);
-    if (remove.status !== 0) {
-        warn("Failed to remove the legacy marketplace registration.");
-        process.exit(1);
-    }
+        "--marketplace-root",
+        marketplaceRoot,
+        "--plugin-name",
+        "typeagent",
+        "--copilot-path",
+        copilotPath,
+    ],
+    { encoding: "utf8", shell: false },
+);
+process.stdout.write(registration.stdout || "");
+process.stderr.write(registration.stderr || "");
+
+if (registration.error) {
+    warn(`Plugin registration could not start: ${registration.error.message}`);
+    process.exit(1);
 }
-
-// Clean up partial directories left by the old workspace-backed installation.
-if (existsSync(installedMarketplaceRoot)) {
-    for (const entry of readdirSync(installedMarketplaceRoot)) {
-        if (entry.startsWith(`.${pluginName}.tmp-`)) {
-            log(`Removing stale failed-install artifact ${entry}.`);
-            rmSync(path.join(installedMarketplaceRoot, entry), {
-                recursive: true,
-                force: true,
-            });
-        }
-    }
-}
-
-const registration = run(process.execPath, [
-    registerScript,
-    "--install-dir",
-    workspaceRoot,
-    "--plugin-source-dir",
-    stagingRoot,
-    "--marketplace-name",
-    marketplaceName,
-    "--marketplace-root",
-    marketplaceRoot,
-    "--plugin-name",
-    pluginName,
-    "--copilot-path",
-    copilotPath,
-]);
-printResult(registration);
-
 if (registration.status !== 0) {
     warn(`Plugin registration failed with exit code ${registration.status}.`);
     process.exit(registration.status ?? 1);
-}
-
-const verification = run(copilotPath, ["plugin", "list"]);
-const verificationOutput = `${verification.stdout || ""}\n${
-    verification.stderr || ""
-}`;
-if (!hasListedEntry(verificationOutput, `${pluginName}@${marketplaceName}`)) {
-    printResult(verification);
-    warn(
-        "Plugin registration returned success, but the plugin is not installed.",
-    );
-    process.exit(1);
 }
 
 log("Done. The plugin is available in every `copilot` session.");

--- a/ts/tools/installers/common/register-plugin.mjs
+++ b/ts/tools/installers/common/register-plugin.mjs
@@ -97,12 +97,49 @@ function createLogger(logPath) {
     return { write, logPath: resolvedLog };
 }
 
-function runCopilot(copilotPath, args, logger, allowFailure = false) {
-    logger.write(`Running: ${copilotPath} ${args.join(" ")}`);
-    const res = spawnSync(copilotPath, args, {
+function getCopilotHome() {
+    return path.resolve(
+        process.env.COPILOT_HOME ?? path.join(os.homedir(), ".copilot"),
+    );
+}
+
+function hasListedEntry(output, identifier) {
+    return output.split(/\r?\n/).some((line) => {
+        const entry = line.trim().replace(/^[^A-Za-z0-9_.@-]+/, "");
+        return entry.split(/\s+/, 1)[0] === identifier;
+    });
+}
+
+function quoteCmdArgument(value) {
+    return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
+}
+
+function spawnCopilot(copilotPath, args) {
+    if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(copilotPath)) {
+        const commandLine = [
+            "call",
+            quoteCmdArgument(copilotPath),
+            ...args.map(quoteCmdArgument),
+        ].join(" ");
+        return spawnSync(
+            process.env.ComSpec ?? "cmd.exe",
+            ["/d", "/s", "/c", commandLine],
+            {
+                encoding: "utf8",
+                shell: false,
+                windowsVerbatimArguments: true,
+            },
+        );
+    }
+    return spawnSync(copilotPath, args, {
         encoding: "utf8",
         shell: false,
     });
+}
+
+function runCopilot(copilotPath, args, logger, allowFailure = false) {
+    logger.write(`Running: ${copilotPath} ${args.join(" ")}`);
+    const res = spawnCopilot(copilotPath, args);
 
     if (res.error) {
         if (allowFailure) {
@@ -121,7 +158,11 @@ function runCopilot(copilotPath, args, logger, allowFailure = false) {
         if (line.trim()) logger.write(`copilot! ${line}`);
     }
 
-    if (!allowFailure && res.status !== 0) {
+    const reportedFailure =
+        /(?:^|\n)(?:Failed to|Error: Request .* failed)/im.test(
+            `${stdout}\n${stderr}`,
+        );
+    if (!allowFailure && (res.status !== 0 || reportedFailure)) {
         throw new Error(
             `Copilot command exited with code ${res.status}: ${copilotPath} ${args.join(" ")}`,
         );
@@ -277,7 +318,7 @@ function installPlugin(opts, logger) {
         logger,
         true,
     );
-    if (!marketplaceList.output.includes(opts.marketplaceName)) {
+    if (!hasListedEntry(marketplaceList.output, opts.marketplaceName)) {
         runCopilot(
             opts.copilotPath,
             ["plugin", "marketplace", "add", opts.marketplaceRoot],
@@ -298,7 +339,8 @@ function installPlugin(opts, logger) {
         true,
     );
     if (
-        pluginListResult.output.includes(
+        hasListedEntry(
+            pluginListResult.output,
             `${opts.pluginName}@${opts.marketplaceName}`,
         )
     ) {
@@ -307,8 +349,7 @@ function installPlugin(opts, logger) {
             // own snapshot. Removing this one snapshot first avoids traversing
             // or replacing files from inside the Copilot process.
             const installedSnapshot = path.join(
-                os.homedir(),
-                ".copilot",
+                getCopilotHome(),
                 "installed-plugins",
                 opts.marketplaceName,
                 opts.pluginName,
@@ -345,7 +386,8 @@ function installPlugin(opts, logger) {
         true,
     );
     if (
-        !verifyListResult.output.includes(
+        !hasListedEntry(
+            verifyListResult.output,
             `${opts.pluginName}@${opts.marketplaceName}`,
         )
     ) {

--- a/ts/tools/installers/common/register-plugin.mjs
+++ b/ts/tools/installers/common/register-plugin.mjs
@@ -101,7 +101,7 @@ function runCopilot(copilotPath, args, logger, allowFailure = false) {
     logger.write(`Running: ${copilotPath} ${args.join(" ")}`);
     const res = spawnSync(copilotPath, args, {
         encoding: "utf8",
-        shell: process.platform === "win32",
+        shell: false,
     });
 
     if (res.error) {
@@ -271,20 +271,17 @@ function installPlugin(opts, logger) {
     });
     logger.write(`Marketplace manifest updated: ${manifestPath}`);
 
-    const addResult = runCopilot(
+    const marketplaceList = runCopilot(
         opts.copilotPath,
-        ["plugin", "marketplace", "add", opts.marketplaceRoot],
+        ["plugin", "marketplace", "list"],
         logger,
         true,
     );
-
-    if (
-        addResult.status !== 0 &&
-        !/already/i.test(addResult.output) &&
-        !/exists/i.test(addResult.output)
-    ) {
-        throw new Error(
-            `Failed to register marketplace '${opts.marketplaceName}' from '${opts.marketplaceRoot}'.`,
+    if (!marketplaceList.output.includes(opts.marketplaceName)) {
+        runCopilot(
+            opts.copilotPath,
+            ["plugin", "marketplace", "add", opts.marketplaceRoot],
+            logger,
         );
     }
 
@@ -305,12 +302,34 @@ function installPlugin(opts, logger) {
             `${opts.pluginName}@${opts.marketplaceName}`,
         )
     ) {
-        runCopilot(
-            opts.copilotPath,
-            ["plugin", "uninstall", opts.pluginName],
-            logger,
-            true,
-        );
+        if (process.platform === "win32") {
+            // Copilot CLI 1.0.81 can fail with os error 5 while replacing its
+            // own snapshot. Removing this one snapshot first avoids traversing
+            // or replacing files from inside the Copilot process.
+            const installedSnapshot = path.join(
+                os.homedir(),
+                ".copilot",
+                "installed-plugins",
+                opts.marketplaceName,
+                opts.pluginName,
+            );
+            if (fs.existsSync(installedSnapshot)) {
+                logger.write(
+                    `Removing previous plugin snapshot: ${installedSnapshot}`,
+                );
+                fs.rmSync(installedSnapshot, {
+                    recursive: true,
+                    force: true,
+                });
+            }
+        } else {
+            runCopilot(
+                opts.copilotPath,
+                ["plugin", "uninstall", opts.pluginName],
+                logger,
+                true,
+            );
+        }
     }
 
     runCopilot(

--- a/ts/tools/installers/common/register-plugin.mjs
+++ b/ts/tools/installers/common/register-plugin.mjs
@@ -13,8 +13,7 @@ function parseArgs(argv) {
         pluginSourceDir: "",
         marketplaceName: "typeagent-local",
         marketplaceRoot: path.join(
-            os.homedir(),
-            ".copilot",
+            getCopilotHome(),
             "marketplaces",
             "typeagent-local",
         ),
@@ -103,11 +102,15 @@ function getCopilotHome() {
     );
 }
 
-function hasListedEntry(output, identifier) {
-    return output.split(/\r?\n/).some((line) => {
+function findListedEntry(output, identifier) {
+    return output.split(/\r?\n/).find((line) => {
         const entry = line.trim().replace(/^[^A-Za-z0-9_.@-]+/, "");
         return entry.split(/\s+/, 1)[0] === identifier;
     });
+}
+
+function hasListedEntry(output, identifier) {
+    return findListedEntry(output, identifier) !== undefined;
 }
 
 function quoteCmdArgument(value) {
@@ -144,7 +147,7 @@ function runCopilot(copilotPath, args, logger, allowFailure = false) {
     if (res.error) {
         if (allowFailure) {
             logger.write(`Copilot invocation failed: ${res.error.message}`);
-            return { output: "", status: 1 };
+            return { output: "", status: 1, failed: true };
         }
         throw new Error(`Copilot invocation failed: ${res.error.message}`);
     }
@@ -168,7 +171,11 @@ function runCopilot(copilotPath, args, logger, allowFailure = false) {
         );
     }
 
-    return { output: `${stdout}\n${stderr}`, status: res.status ?? 1 };
+    return {
+        output: `${stdout}\n${stderr}`,
+        status: res.status ?? 1,
+        failed: res.status !== 0 || reportedFailure,
+    };
 }
 
 function ensureLocalPluginMarketplace({
@@ -293,6 +300,84 @@ function resolvePluginMetadata(opts) {
     return { pluginVersion, pluginDescription };
 }
 
+function getInstalledMarketplaceRoot(opts) {
+    return path.join(
+        getCopilotHome(),
+        "installed-plugins",
+        opts.marketplaceName,
+    );
+}
+
+function removeInstalledSnapshot(opts, logger) {
+    const installedSnapshot = path.join(
+        getInstalledMarketplaceRoot(opts),
+        opts.pluginName,
+    );
+    if (!fs.existsSync(installedSnapshot)) return;
+    logger.write(`Removing previous plugin snapshot: ${installedSnapshot}`);
+    fs.rmSync(installedSnapshot, { recursive: true, force: true });
+}
+
+function cleanFailedInstallArtifacts(opts, logger) {
+    const installedRoot = getInstalledMarketplaceRoot(opts);
+    if (!fs.existsSync(installedRoot)) return;
+    for (const entry of fs.readdirSync(installedRoot)) {
+        if (!entry.startsWith(`.${opts.pluginName}.tmp-`)) continue;
+        logger.write(`Removing failed-install artifact: ${entry}`);
+        fs.rmSync(path.join(installedRoot, entry), {
+            recursive: true,
+            force: true,
+        });
+    }
+}
+
+function migrateMarketplaceRegistration(opts, logger) {
+    const marketplaces = runCopilot(
+        opts.copilotPath,
+        ["plugin", "marketplace", "list"],
+        logger,
+    );
+    const registeredMarketplace = findListedEntry(
+        marketplaces.output,
+        opts.marketplaceName,
+    );
+    if (!registeredMarketplace) return false;
+    if (
+        registeredMarketplace
+            .toLowerCase()
+            .includes(opts.marketplaceRoot.toLowerCase())
+    ) {
+        return true;
+    }
+
+    logger.write(
+        `Replacing marketplace '${opts.marketplaceName}' with ${opts.marketplaceRoot}.`,
+    );
+    const plugins = runCopilot(opts.copilotPath, ["plugin", "list"], logger);
+    if (
+        hasListedEntry(
+            plugins.output,
+            `${opts.pluginName}@${opts.marketplaceName}`,
+        )
+    ) {
+        if (process.platform === "win32") {
+            removeInstalledSnapshot(opts, logger);
+        }
+        runCopilot(
+            opts.copilotPath,
+            ["plugin", "uninstall", opts.pluginName],
+            logger,
+            true,
+        );
+    }
+    runCopilot(
+        opts.copilotPath,
+        ["plugin", "marketplace", "remove", opts.marketplaceName],
+        logger,
+    );
+    return false;
+}
+
 function ensureCopilotAvailable(copilotPath, logger) {
     runCopilot(copilotPath, ["--version"], logger);
 }
@@ -300,6 +385,8 @@ function ensureCopilotAvailable(copilotPath, logger) {
 function installPlugin(opts, logger) {
     const { pluginVersion, pluginDescription } = resolvePluginMetadata(opts);
     logger.write(`Plugin source ready: ${opts.pluginSourceDir}`);
+    cleanFailedInstallArtifacts(opts, logger);
+    const marketplaceRegistered = migrateMarketplaceRegistration(opts, logger);
 
     const manifestPath = ensureLocalPluginMarketplace({
         marketplaceRoot: opts.marketplaceRoot,
@@ -312,13 +399,7 @@ function installPlugin(opts, logger) {
     });
     logger.write(`Marketplace manifest updated: ${manifestPath}`);
 
-    const marketplaceList = runCopilot(
-        opts.copilotPath,
-        ["plugin", "marketplace", "list"],
-        logger,
-        true,
-    );
-    if (!hasListedEntry(marketplaceList.output, opts.marketplaceName)) {
+    if (!marketplaceRegistered) {
         runCopilot(
             opts.copilotPath,
             ["plugin", "marketplace", "add", opts.marketplaceRoot],
@@ -336,63 +417,49 @@ function installPlugin(opts, logger) {
         opts.copilotPath,
         ["plugin", "list"],
         logger,
-        true,
     );
-    if (
-        hasListedEntry(
-            pluginListResult.output,
-            `${opts.pluginName}@${opts.marketplaceName}`,
-        )
-    ) {
-        if (process.platform === "win32") {
-            // Copilot CLI 1.0.81 can fail with os error 5 while replacing its
-            // own snapshot. Removing this one snapshot first avoids traversing
-            // or replacing files from inside the Copilot process.
-            const installedSnapshot = path.join(
-                getCopilotHome(),
-                "installed-plugins",
-                opts.marketplaceName,
-                opts.pluginName,
-            );
-            if (fs.existsSync(installedSnapshot)) {
-                logger.write(
-                    `Removing previous plugin snapshot: ${installedSnapshot}`,
-                );
-                fs.rmSync(installedSnapshot, {
-                    recursive: true,
-                    force: true,
-                });
+    const pluginIdentifier = `${opts.pluginName}@${opts.marketplaceName}`;
+    if (hasListedEntry(pluginListResult.output, pluginIdentifier)) {
+        const update = runCopilot(
+            opts.copilotPath,
+            ["plugin", "update", opts.pluginName],
+            logger,
+            true,
+        );
+        if (update.failed) {
+            const windowsAccessDenied =
+                process.platform === "win32" &&
+                /(?:Access is denied|os error 5)/i.test(update.output);
+            if (!windowsAccessDenied) {
+                throw new Error(`Plugin update failed: '${pluginIdentifier}'.`);
             }
-        } else {
+            logger.write(
+                "Copilot could not replace its Windows snapshot; retrying from a clean snapshot.",
+            );
+            removeInstalledSnapshot(opts, logger);
+            cleanFailedInstallArtifacts(opts, logger);
             runCopilot(
                 opts.copilotPath,
-                ["plugin", "uninstall", opts.pluginName],
+                ["plugin", "install", pluginIdentifier],
                 logger,
-                true,
             );
         }
+    } else {
+        runCopilot(
+            opts.copilotPath,
+            ["plugin", "install", pluginIdentifier],
+            logger,
+        );
     }
-
-    runCopilot(
-        opts.copilotPath,
-        ["plugin", "install", `${opts.pluginName}@${opts.marketplaceName}`],
-        logger,
-    );
 
     const verifyListResult = runCopilot(
         opts.copilotPath,
         ["plugin", "list"],
         logger,
-        true,
     );
-    if (
-        !hasListedEntry(
-            verifyListResult.output,
-            `${opts.pluginName}@${opts.marketplaceName}`,
-        )
-    ) {
+    if (!hasListedEntry(verifyListResult.output, pluginIdentifier)) {
         throw new Error(
-            `Plugin verification failed: '${opts.pluginName}@${opts.marketplaceName}' not found in copilot plugin list.`,
+            `Plugin verification failed: '${pluginIdentifier}' not found in copilot plugin list.`,
         );
     }
 

--- a/ts/tools/installers/common/register-plugin.mjs
+++ b/ts/tools/installers/common/register-plugin.mjs
@@ -118,10 +118,17 @@ function quoteCmdArgument(value) {
 }
 
 function spawnCopilot(copilotPath, args) {
-    if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(copilotPath)) {
+    let launcherPath = copilotPath;
+    if (process.platform === "win32" && path.extname(launcherPath) === "") {
+        launcherPath =
+            [".exe", ".cmd", ".bat"]
+                .map((extension) => `${launcherPath}${extension}`)
+                .find((candidate) => fs.existsSync(candidate)) ?? launcherPath;
+    }
+    if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(launcherPath)) {
         const commandLine = [
             "call",
-            quoteCmdArgument(copilotPath),
+            quoteCmdArgument(launcherPath),
             ...args.map(quoteCmdArgument),
         ].join(" ");
         return spawnSync(
@@ -134,7 +141,7 @@ function spawnCopilot(copilotPath, args) {
             },
         );
     }
-    return spawnSync(copilotPath, args, {
+    return spawnSync(launcherPath, args, {
         encoding: "utf8",
         shell: false,
     });

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -346,7 +346,7 @@
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
                   Execute="deferred"
-                  Return="check"
+                  Return="ignore"
                   Impersonate="yes" />
 
     <!-- Unregister on uninstall -->

--- a/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
+++ b/ts/tools/installers/wix/TypeAgent-AgentServer.wxs
@@ -346,7 +346,7 @@
                   BinaryKey="WixCA"
                   DllEntry="WixQuietExec64"
                   Execute="deferred"
-                  Return="ignore"
+                  Return="check"
                   Impersonate="yes" />
 
     <!-- Unregister on uninstall -->


### PR DESCRIPTION
This fixes `pnpm run register` on Windows by staging only the bundled TypeAgent plugin files instead of copying the workspace’s pnpm-linked `node_modules`. The command still registers the local marketplace and installs or updates the plugin, but now handles the Windows access-denied case and verifies the plugin was actually installed before reporting success.