### PR TITLE
[GHCP Plugin] Improve plugin installer/updates

### DIFF
--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -250,9 +250,14 @@ accept a local path. So `pnpm run register` (`scripts/install-plugin.mjs`):
    Windows.
 2. Creates and registers a local marketplace at
    `~/.copilot/marketplaces/typeagent-local`.
-3. Installs `typeagent@typeagent-local`, which copies the staged snapshot into
-   `~/.copilot/installed-plugins/`, and verifies that it appears in
-   `copilot plugin list`.
+3. Installs or updates `typeagent@typeagent-local`, which copies the staged
+   snapshot into `~/.copilot/installed-plugins/`, and verifies that it appears
+   in `copilot plugin list`.
+
+On Windows, VS Code may hold a directory watcher on the installed snapshot that
+blocks Copilot CLI's normal directory replacement with `Access is denied`. The
+registrar preserves the previous snapshot, removes the locked directory, and
+retries `plugin update`. If the retry fails, it restores the previous snapshot.
 
 ### Why the build must bundle
 

--- a/ts/tools/installers/common/register-plugin.mjs
+++ b/ts/tools/installers/common/register-plugin.mjs
@@ -117,14 +117,36 @@ function quoteCmdArgument(value) {
     return `"${value.replace(/%/g, "%%").replace(/"/g, '""')}"`;
 }
 
-function spawnCopilot(copilotPath, args) {
-    let launcherPath = copilotPath;
-    if (process.platform === "win32" && path.extname(launcherPath) === "") {
-        launcherPath =
-            [".exe", ".cmd", ".bat"]
-                .map((extension) => `${launcherPath}${extension}`)
-                .find((candidate) => fs.existsSync(candidate)) ?? launcherPath;
+function resolveWindowsLauncher(copilotPath) {
+    const resolveCandidate = (candidate) => {
+        if (path.extname(candidate) !== "") return candidate;
+        return (
+            [".exe", ".cmd", ".bat", ".ps1"]
+                .map((extension) => `${candidate}${extension}`)
+                .find((withExtension) => fs.existsSync(withExtension)) ??
+            candidate
+        );
+    };
+
+    const directCandidate = resolveCandidate(copilotPath);
+    if (directCandidate !== copilotPath || path.isAbsolute(copilotPath)) {
+        return directCandidate;
     }
+
+    const where = spawnSync("where.exe", [copilotPath], { encoding: "utf8" });
+    if (where.status !== 0) return copilotPath;
+    for (const line of where.stdout.split(/\r?\n/)) {
+        const candidate = line.trim();
+        if (candidate) return resolveCandidate(candidate);
+    }
+    return copilotPath;
+}
+
+function spawnCopilot(copilotPath, args) {
+    const launcherPath =
+        process.platform === "win32"
+            ? resolveWindowsLauncher(copilotPath)
+            : copilotPath;
     if (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(launcherPath)) {
         const commandLine = [
             "call",
@@ -138,6 +160,23 @@ function spawnCopilot(copilotPath, args) {
                 encoding: "utf8",
                 shell: false,
                 windowsVerbatimArguments: true,
+            },
+        );
+    }
+    if (process.platform === "win32" && /\.ps1$/i.test(launcherPath)) {
+        return spawnSync(
+            "powershell.exe",
+            [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                launcherPath,
+                ...args,
+            ],
+            {
+                encoding: "utf8",
+                shell: false,
             },
         );
     }
@@ -315,14 +354,50 @@ function getInstalledMarketplaceRoot(opts) {
     );
 }
 
+function getInstalledSnapshot(opts) {
+    return path.join(getInstalledMarketplaceRoot(opts), opts.pluginName);
+}
+
 function removeInstalledSnapshot(opts, logger) {
-    const installedSnapshot = path.join(
-        getInstalledMarketplaceRoot(opts),
-        opts.pluginName,
-    );
+    const installedSnapshot = getInstalledSnapshot(opts);
     if (!fs.existsSync(installedSnapshot)) return;
     logger.write(`Removing previous plugin snapshot: ${installedSnapshot}`);
     fs.rmSync(installedSnapshot, { recursive: true, force: true });
+}
+
+function retryUpdateFromCleanSnapshot(opts, logger, pluginIdentifier) {
+    const installedSnapshot = getInstalledSnapshot(opts);
+    const backupRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), `${opts.pluginName}-plugin-backup-`),
+    );
+    const backupSnapshot = path.join(backupRoot, opts.pluginName);
+    fs.cpSync(installedSnapshot, backupSnapshot, { recursive: true });
+
+    try {
+        removeInstalledSnapshot(opts, logger);
+        cleanFailedInstallArtifacts(opts, logger);
+        try {
+            runCopilot(
+                opts.copilotPath,
+                ["plugin", "update", pluginIdentifier],
+                logger,
+            );
+        } catch (error) {
+            logger.write(
+                "The clean-snapshot update failed; restoring the previous plugin snapshot.",
+            );
+            if (fs.existsSync(installedSnapshot)) {
+                fs.rmSync(installedSnapshot, {
+                    recursive: true,
+                    force: true,
+                });
+            }
+            fs.cpSync(backupSnapshot, installedSnapshot, { recursive: true });
+            throw error;
+        }
+    } finally {
+        fs.rmSync(backupRoot, { recursive: true, force: true });
+    }
 }
 
 function cleanFailedInstallArtifacts(opts, logger) {
@@ -429,7 +504,7 @@ function installPlugin(opts, logger) {
     if (hasListedEntry(pluginListResult.output, pluginIdentifier)) {
         const update = runCopilot(
             opts.copilotPath,
-            ["plugin", "update", opts.pluginName],
+            ["plugin", "update", pluginIdentifier],
             logger,
             true,
         );
@@ -441,15 +516,9 @@ function installPlugin(opts, logger) {
                 throw new Error(`Plugin update failed: '${pluginIdentifier}'.`);
             }
             logger.write(
-                "Copilot could not replace its Windows snapshot; retrying from a clean snapshot.",
+                "Copilot could not replace its Windows snapshot; removing the locked snapshot and retrying the update.",
             );
-            removeInstalledSnapshot(opts, logger);
-            cleanFailedInstallArtifacts(opts, logger);
-            runCopilot(
-                opts.copilotPath,
-                ["plugin", "install", pluginIdentifier],
-                logger,
-            );
+            retryUpdateFromCleanSnapshot(opts, logger, pluginIdentifier);
         }
     } else {
         runCopilot(


### PR DESCRIPTION
Follow-up to #2947. This keeps TypeAgent's Copilot plugin update working when VS Code holds a watcher on the installed snapshot: registration preserves the current snapshot, removes it, retries the marketplace-qualified update, and restores the previous copy if the retry fails. It also resolves Windows Copilot launchers consistently from PATH, including `.exe`, `.cmd`, `.bat`, and `.ps1`, and documents the recovery behavior.

Accidentally left this change out in the previous PR