### PR TITLE
[Security] WebSocket empty-host binding

### DIFF
--- a/.github/workflows/build-ts.yml
+++ b/.github/workflows/build-ts.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y libsecret-1-dev
       - name: Setup Git LF
         run: |

--- a/ts/packages/utils/webSocketChannelServer/src/server.ts
+++ b/ts/packages/utils/webSocketChannelServer/src/server.ts
@@ -98,7 +98,8 @@ export async function createWebSocketChannelServer(
     // serve same-machine clients, so bind loopback unless one names a host
     // explicitly (a container publishing the port, for example).
     const listenOptions: WebSocket.ServerOptions =
-        wsOptions.port !== undefined && wsOptions.host === undefined
+        wsOptions.port !== undefined &&
+        (wsOptions.host === undefined || wsOptions.host.trim() === "")
             ? { ...wsOptions, host: LOOPBACK_HOST }
             : wsOptions;
     // verifyClient runs synchronously during the HTTP upgrade; using it

--- a/ts/packages/utils/webSocketChannelServer/test/server.spec.ts
+++ b/ts/packages/utils/webSocketChannelServer/test/server.spec.ts
@@ -78,6 +78,18 @@ describe("createWebSocketChannelServer binding", () => {
         }
     });
 
+    test("an empty host binds loopback, not every interface", async () => {
+        const port = takePort();
+        await start({ port, host: "" });
+
+        await expect(connect("127.0.0.1", port)).resolves.toBe("open");
+
+        const lan = lanAddress();
+        if (lan !== undefined) {
+            await expect(connect(lan, port)).resolves.toBe("refused");
+        }
+    });
+
     test("an explicit host is passed through", async () => {
         const port = takePort();
         await start({ port, host: "localhost" });


### PR DESCRIPTION
## Summary

- Treat empty and whitespace-only WebSocket `host` values like an omitted host.
- Preserve the secure loopback default instead of allowing `ws` to interpret an empty host as an all-interface bind.
- Add a regression test proving an empty host remains reachable on loopback but not through the machine's LAN address.

## Security context

The agent server exposes unauthenticated local RPC over WebSocket. The existing Origin gate blocks hostile browser pages and the shared server defaults omitted hosts to loopback. However, `ws` treats `host: ""` as an all-interface bind, while the shared wrapper previously defaulted to loopback only when `host` was `undefined`. An empty or whitespace-only host could therefore bypass the loopback-safe default.

This change closes that binding edge case. Explicit non-empty hosts remain supported for intentional container or remote deployments.

Follow PR to https://github.com/microsoft/TypeAgent/pull/2944