### PR TITLE
Honor the configured model for assistant selection

### DIFF
--- a/ts/packages/dispatcher/dispatcher/src/translation/translateRequest.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/translateRequest.ts
@@ -907,6 +907,7 @@ async function findAssistantForRequest(
         schemaNames,
         provider,
         systemContext.promptLogger,
+        systemContext.session.getConfig().translation.model,
     );
 
     const result = await withChatModelTelemetryPurpose("schema-selection", () =>

--- a/ts/packages/dispatcher/dispatcher/src/translation/unknownSwitcher.ts
+++ b/ts/packages/dispatcher/dispatcher/src/translation/unknownSwitcher.ts
@@ -205,6 +205,7 @@ export function loadAssistantSelectionJsonTranslator(
     schemaNames: Iterable<string>,
     provider: ActionConfigProvider,
     promptLogger?: PromptLogger,
+    model?: string,
 ) {
     const schemas = getAssistantSelectionSchemas(schemaNames, provider);
 
@@ -242,6 +243,7 @@ export function loadAssistantSelectionJsonTranslator(
                                 "Select the assistant to handle the request",
                         },
                     ],
+                    model,
                     promptLogger,
                 },
             );


### PR DESCRIPTION
Passes the session translation model to the assistant-selection translator so fallback routing uses the configured model.
