### PR TITLE
[Telemetry] Reduce agent-server startup telemetry noise

### DIFF
--- a/ts/docs/architecture/telemetry/opentelemetry.md
+++ b/ts/docs/architecture/telemetry/opentelemetry.md
@@ -133,6 +133,10 @@ TypeAgent-owned Node hosts call `initTelemetry()` once and
 per enabled signal and exports directly. Libraries, agents, requests, and
 sessions do not create providers.
 
+Agent subprocesses are trace-only. They install a trace provider for RPC span
+continuity, but do not duplicate the agent-server's metrics, structured logs,
+debug bridge, local JSONL writer, or retention scan.
+
 The bridge includes `typeagent:*` namespaces by default. TypeAgent-owned hosts
 may explicitly include a stable legacy prefix that they own. Agent server hosts
 include `agent-server:*` this way rather than renaming existing namespaces and
@@ -372,7 +376,7 @@ omit unavailable values.
 
 ## Configuration and Local Files
 
-TypeAgent-owned processes support:
+TypeAgent-owned host processes support:
 
 ```yaml
 telemetry:
@@ -476,11 +480,11 @@ Expand `~` before `path.resolve()`. Sanitize `{service}`, `{process}`,
 `{timestamp}`, and `{pid}`. The timestamp is the UTC process-start time and
 changes once per telemetry initialization, not per record. TypeAgent-owned
 hosts identify their process role as `agent-server`, `api-server`, `shell`,
-`cli`, or `agent-<name>`. Insert missing process, timestamp, and PID components
-before the extension so filenames remain identifiable and concurrent processes
-never share a writer. Create parent directories and report the
-resolved path once through a status or diagnostic path that cannot recurse into
-the exporter.
+or `cli`. Agent subprocesses do not create local log files. Insert missing
+process, timestamp, and PID components before the extension so filenames remain
+identifiable and concurrent host processes never share a writer. Create parent
+directories and report the resolved path once through a status or diagnostic
+path that cannot recurse into the exporter.
 
 Rotation is left to the OS or external tools. Retention is managed by
 TypeAgent for its own JSONL directory: on telemetry startup, an asynchronous
@@ -601,7 +605,7 @@ pnpm run start:agent-server
 The environment settings enable:
 
 - OTLP export for configured signals.
-- One local JSONL file per process.
+- One local JSONL file for the agent-server host.
 - Copies of enabled `debug` namespaces in the OTel logs pipeline.
 - Privacy-filtered dispatcher Structured Logger events.
 - Full local trace sampling so every generated trace can be inspected.

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcess.ts
@@ -11,6 +11,7 @@ import {
 import { createChannelProvider } from "@typeagent/agent-rpc/channel";
 import { otel } from "@typeagent/telemetry";
 import { loadAgentDebug } from "./agentDebug.js";
+import { selectAgentProcessTelemetry } from "./agentProcessTelemetry.js";
 
 //=================================================================
 // Get arguments from command line
@@ -41,14 +42,9 @@ let exitPromise: Promise<void> | undefined;
 
 function exitAgentProcess(exitCode: number, message: string): Promise<void> {
     debug(message);
-    exitPromise ??= otel
-        .shutdownTelemetry()
-        .catch((error) => {
-            debug(`Telemetry shutdown failed: ${error}`);
-        })
-        .then(() => {
-            process.exit(exitCode);
-        });
+    exitPromise ??= otel.shutdownTelemetry().finally(() => {
+        process.exit(exitCode);
+    });
     return exitPromise;
 }
 
@@ -80,13 +76,9 @@ async function startAgentProcess(): Promise<void> {
             `'${agentName}': Agent debug trace loaded. ${loadedAgentDebug.path}`,
         );
     }
-    const debugModules =
-        agentDebug === undefined
-            ? [registerDebug]
-            : [registerDebug, agentDebug];
     await otel.initTelemetry({
         processName: `agent-${agentName}`,
-        debugModules,
+        config: selectAgentProcessTelemetry(otel.resolveTelemetryConfig()),
     });
 
     //=================================================================

--- a/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessTelemetry.ts
+++ b/ts/packages/dispatcher/nodeProviders/src/agentProvider/process/agentProcessTelemetry.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { otel } from "@typeagent/telemetry";
+
+/**
+ * Agent workers emit RPC spans, while host-level metrics and logs are emitted
+ * by agent-server. Avoid creating idle exporters in every worker process.
+ */
+export function selectAgentProcessTelemetry(
+    config: otel.TelemetryConfig,
+): otel.TelemetryConfig {
+    return config.traces === undefined ? {} : { traces: config.traces };
+}

--- a/ts/packages/dispatcher/nodeProviders/test/agentProcessTelemetryConfig.spec.ts
+++ b/ts/packages/dispatcher/nodeProviders/test/agentProcessTelemetryConfig.spec.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { otel } from "@typeagent/telemetry";
+import { selectAgentProcessTelemetry } from "../src/agentProvider/process/agentProcessTelemetry.js";
+
+describe("agent process telemetry configuration", () => {
+    it("keeps traces without starting worker metrics or log exporters", () => {
+        const traces: otel.TraceConfig = {
+            otlp: { endpoint: "http://localhost:4318/v1/traces" },
+            sampler: "always_on",
+        };
+        const config: otel.TelemetryConfig = {
+            traces,
+            metrics: {
+                otlp: { endpoint: "http://localhost:4318/v1/metrics" },
+            },
+            logs: {
+                otlp: { endpoint: "http://localhost:4318/v1/logs" },
+                logFile: "worker.jsonl",
+            },
+            debugBridge: true,
+            structuredLogs: true,
+        };
+
+        expect(selectAgentProcessTelemetry(config)).toEqual({ traces });
+    });
+
+    it("returns an unconfigured telemetry pipeline when traces are disabled", () => {
+        expect(
+            selectAgentProcessTelemetry({
+                logs: { logFile: "worker.jsonl" },
+                debugBridge: true,
+            }),
+        ).toEqual({});
+    });
+});

--- a/ts/packages/telemetry/src/otel/jsonlLogExporter.ts
+++ b/ts/packages/telemetry/src/otel/jsonlLogExporter.ts
@@ -93,7 +93,6 @@ export class JsonlLogExporter implements LogRecordExporter {
         }
         this.diagnostic = options.diagnostic ?? writeDiagnostic;
         activePaths.add(pathIdentity);
-        this.reportDiagnostic(`OpenTelemetry JSONL logs: ${this.filePath}`);
     }
 
     public export(
@@ -231,6 +230,7 @@ export class JsonlLogExporter implements LogRecordExporter {
                     file.chmod(0o600),
                 ]);
             }
+            this.reportDiagnostic(`OpenTelemetry JSONL logs: ${this.filePath}`);
             return file;
         } catch (error) {
             await file.close();

--- a/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
+++ b/ts/packages/telemetry/test/otelLocalDiagnostics.spec.ts
@@ -150,6 +150,29 @@ describe("JsonlLogExporter", () => {
         expect(lines.map((line) => line.body)).toEqual(["first", "second"]);
     });
 
+    it("creates and announces the file only when the first record is written", async () => {
+        const dir = makeTempDir();
+        tempDirs.push(dir);
+        const diagnostics: string[] = [];
+        const exporter = new JsonlLogExporter({
+            filePath: path.join(dir, "lazy-{pid}.jsonl"),
+            serviceName: "test",
+            pid: 1010,
+            diagnostic: (message) => diagnostics.push(message),
+        });
+
+        expect(fs.existsSync(exporter.filePath)).toBe(false);
+        expect(diagnostics).toEqual([]);
+
+        await exportRecords(exporter, [createRecord("first")]);
+
+        expect(fs.existsSync(exporter.filePath)).toBe(true);
+        expect(diagnostics).toEqual([
+            `OpenTelemetry JSONL logs: ${exporter.filePath}`,
+        ]);
+        await exporter.shutdown();
+    });
+
     it("writes the reduced local envelope", async () => {
         const dir = makeTempDir();
         tempDirs.push(dir);


### PR DESCRIPTION
## Summary
Remove startup log noise, only print logfiles during actual creation in the lazy load. Consolidate agent runtime logs in agent-server

- keep agent subprocess telemetry trace-only for RPC span continuity
- leave metrics, structured logs, debug bridging, JSONL output, and retention in the agent-server host
- remove redundant per-agent telemetry shutdown diagnostics
- document the host/worker telemetry ownership boundary