### PR TITLE
Update Copilot defaults to GPT-5.6

### DIFF
--- a/ts/config.defaults.yaml
+++ b/ts/config.defaults.yaml
@@ -13,4 +13,4 @@ azureOpenAI:
 
 reasoning:
   timeoutMs: 1200000
-  copilotModel: claude-opus-4.8
+  copilotModel: gpt-5.6-sol

--- a/ts/config.sample.yaml
+++ b/ts/config.sample.yaml
@@ -159,10 +159,11 @@ openAI:
 # --- Copilot (Copilot SDK chat + local embeddings) -------------------------
 # modelProvider: copilot
 # copilot:
-#   defaultModel: claude-haiku-4.5   # requires an authenticated `copilot` CLI
+#   defaultModel: gpt-5.6-luna       # requires an authenticated `copilot` CLI
 #   fallbackModels:                 # first available concrete model is used
-#     - gpt-5-mini
 #     - gpt-5.4-mini
+#     - gpt-5-mini
+#     - gpt-5.4
 #   # Optional: connect to an already-running Copilot CLI server over TCP
 #   # instead of spawning a CLI child per host. Eliminates the one-time
 #   # (multi-second) CLI startup latency. Format: "host:port" / "port".
@@ -339,7 +340,7 @@ wikipedia:
 
 reasoning:
   timeoutMs: 1200000 # reasoning-loop timeout (0 = disabled)
-  copilotModel: claude-sonnet-5 # override default Copilot reasoning model
+  copilotModel: gpt-5.6-sol # override default Copilot reasoning model
 
 # ╔═══════════════════════════════════════════════════════════════════╗
 # ║  Embedding provider                                              ║

--- a/ts/docs/overview/command-reference.md
+++ b/ts/docs/overview/command-reference.md
@@ -1186,7 +1186,7 @@ Usage: `@config execution reasoning [<engine>]`
 
 - &lt;engine&gt; - (optional) Reasoning engine to use (claude, copilot, or none). Omit to show the current engine. (type: string)
 
-## @config execution reasoningModel - Set the Copilot reasoning model (e.g. claude-opus-4.8). Omit to show the current value.
+## @config execution reasoningModel - Set the Copilot reasoning model (e.g. gpt-5.6-sol). Omit to show the current value.
 
 Usage: `@config execution reasoningModel [<model>]`
 

--- a/ts/packages/aiclient/src/copilotModelDefaults.ts
+++ b/ts/packages/aiclient/src/copilotModelDefaults.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
+export const DEFAULT_COPILOT_MODEL = "gpt-5.6-luna";
 
 export const DEFAULT_COPILOT_FALLBACK_MODELS: readonly string[] = [
-    "gpt-5-mini",
     "gpt-5.4-mini",
+    "gpt-5-mini",
+    "gpt-5.4",
 ];

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -372,14 +372,21 @@ function isConcreteAvailableModel(model: ModelInfo): boolean {
     return model.id !== "auto" && model.policy?.state !== "disabled";
 }
 
-function versionedFamily(
-    modelId: string,
-): { family: string; version: number[] } | undefined {
-    const match = /^(.*?)-(\d+(?:\.\d+)*)$/.exec(modelId);
+type VersionedModelId = {
+    family: string;
+    version: number[];
+    tier: string | undefined;
+};
+
+function versionedFamily(modelId: string): VersionedModelId | undefined {
+    const match = /^(.*?)-(\d+(?:\.\d+)*)(?:-([a-z][a-z0-9.-]*))?$/i.exec(
+        modelId,
+    );
     if (match === null) return undefined;
     return {
         family: match[1],
         version: match[2].split(".").map(Number),
+        tier: match[3]?.toLowerCase(),
     };
 }
 
@@ -390,6 +397,56 @@ function compareVersionsDescending(a: number[], b: number[]): number {
         if (difference !== 0) return difference;
     }
     return 0;
+}
+
+function modelTierClass(tier: string | undefined): number | undefined {
+    switch (tier) {
+        case undefined:
+        case "sol":
+            return 3;
+        case "terra":
+        case "mini":
+            return 2;
+        case "luna":
+        case "nano":
+            return 1;
+        default:
+            return undefined;
+    }
+}
+
+function compareFamilyCandidates(
+    a: { model: ModelInfo; parsed: VersionedModelId },
+    b: { model: ModelInfo; parsed: VersionedModelId },
+    requested: VersionedModelId,
+): number {
+    const aExactTier = a.parsed.tier === requested.tier;
+    const bExactTier = b.parsed.tier === requested.tier;
+    if (aExactTier !== bExactTier) return aExactTier ? -1 : 1;
+
+    const requestedClass = modelTierClass(requested.tier);
+    const aClass = modelTierClass(a.parsed.tier);
+    const bClass = modelTierClass(b.parsed.tier);
+    if (requestedClass !== undefined) {
+        const aDistance =
+            aClass === undefined
+                ? Number.POSITIVE_INFINITY
+                : Math.abs(requestedClass - aClass);
+        const bDistance =
+            bClass === undefined
+                ? Number.POSITIVE_INFINITY
+                : Math.abs(requestedClass - bClass);
+        if (aDistance !== bDistance) return aDistance - bDistance;
+        if (aClass !== bClass) return (aClass ?? 0) - (bClass ?? 0);
+    }
+
+    const versionOrder = compareVersionsDescending(
+        a.parsed.version,
+        b.parsed.version,
+    );
+    return versionOrder !== 0
+        ? versionOrder
+        : a.model.id.localeCompare(b.model.id);
 }
 
 export function selectCopilotModel(
@@ -413,19 +470,17 @@ export function selectCopilotModel(
         const familyModels = available
             .map((model) => ({
                 model,
-                version: versionedFamily(model.id),
+                parsed: versionedFamily(model.id),
             }))
             .filter(
                 (
                     candidate,
                 ): candidate is {
                     model: ModelInfo;
-                    version: { family: string; version: number[] };
-                } => candidate.version?.family === requestedFamily.family,
+                    parsed: VersionedModelId;
+                } => candidate.parsed?.family === requestedFamily.family,
             )
-            .sort((a, b) =>
-                compareVersionsDescending(a.version.version, b.version.version),
-            );
+            .sort((a, b) => compareFamilyCandidates(a, b, requestedFamily));
         if (familyModels.length > 0) return familyModels[0].model;
     }
 

--- a/ts/packages/aiclient/src/copilotModels.ts
+++ b/ts/packages/aiclient/src/copilotModels.ts
@@ -378,16 +378,36 @@ type VersionedModelId = {
     tier: string | undefined;
 };
 
+function parseNumericVersion(segment: string): number[] | undefined {
+    const components = segment.split(".");
+    const version: number[] = [];
+    for (const component of components) {
+        if (component.length === 0) return undefined;
+        for (let i = 0; i < component.length; i++) {
+            const code = component.charCodeAt(i);
+            if (code < 48 || code > 57) return undefined;
+        }
+        const value = Number(component);
+        if (!Number.isSafeInteger(value)) return undefined;
+        version.push(value);
+    }
+    return version;
+}
+
 function versionedFamily(modelId: string): VersionedModelId | undefined {
-    const match = /^(.*?)-(\d+(?:\.\d+)*)(?:-([a-z][a-z0-9.-]*))?$/i.exec(
-        modelId,
-    );
-    if (match === null) return undefined;
-    return {
-        family: match[1],
-        version: match[2].split(".").map(Number),
-        tier: match[3]?.toLowerCase(),
-    };
+    const segments = modelId.split("-");
+    for (let i = 1; i < segments.length; i++) {
+        const version = parseNumericVersion(segments[i]);
+        if (version === undefined) continue;
+        const family = segments.slice(0, i).join("-");
+        if (family.length === 0) return undefined;
+        const tier = segments
+            .slice(i + 1)
+            .join("-")
+            .toLowerCase();
+        return { family, version, tier: tier.length === 0 ? undefined : tier };
+    }
+    return undefined;
 }
 
 function compareVersionsDescending(a: number[], b: number[]): number {

--- a/ts/packages/aiclient/src/providerMode.ts
+++ b/ts/packages/aiclient/src/providerMode.ts
@@ -72,12 +72,12 @@ export function usesProviderDefault(canonical: string): boolean {
  */
 const COPILOT_MAP: Record<CanonicalName, string> = {
     DEFAULT: DEFAULT_COPILOT_MODEL,
-    GPT_35_TURBO: "gpt-5-mini",
-    GPT_4_O: "gpt-5.4",
-    GPT_5: DEFAULT_COPILOT_MODEL,
-    GPT_5_MINI: "gpt-5-mini",
-    GPT_5_NANO: "gpt-5-mini",
-    GPT_V: "gpt-5.4",
+    GPT_35_TURBO: "gpt-5.6-luna",
+    GPT_4_O: "gpt-5.6-sol",
+    GPT_5: "gpt-5.6-sol",
+    GPT_5_MINI: "gpt-5.6-terra",
+    GPT_5_NANO: "gpt-5.6-luna",
+    GPT_V: "gpt-5.6-sol",
 };
 
 const OLLAMA_MAP: Record<CanonicalName, string> = {

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -234,6 +234,16 @@ describe("selectCopilotModel", () => {
         expect(selected?.id).toBe("a-model");
     });
 
+    test("handles long malformed model ids without family matching", () => {
+        const requested = "-0-a".repeat(10_000);
+        const selected = selectCopilotModel(
+            requested,
+            [],
+            [makeModel("z-model"), makeModel("a-model")],
+        );
+        expect(selected?.id).toBe("a-model");
+    });
+
     test("returns undefined when no concrete model is enabled", () => {
         const selected = selectCopilotModel(
             "claude-haiku-4.5",

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -19,9 +19,9 @@ function makeSettings(): CopilotApiSettings {
         provider: "copilot",
         modelType: ModelType.Chat,
         endpoint: "copilot-cli",
-        modelName: "claude-haiku-4.5",
+        modelName: "gpt-5.6-luna",
         disableInfiniteSessions: true,
-        fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
+        fallbackModels: ["gpt-5.4-mini", "gpt-5-mini", "gpt-5.4"],
         maxRetryAttempts: 0,
         retryPauseMs: 1,
         timeout: 5_000,
@@ -31,7 +31,7 @@ function makeSettings(): CopilotApiSettings {
 function makeEndpoint(overrides?: Partial<CopilotEndpoint>): CopilotEndpoint {
     return {
         url: "https://api.example/chat/completions",
-        model: "claude-haiku-4.5",
+        model: "gpt-5.6-luna",
         headers: {
             Authorization: "******",
             "Copilot-Integration-Id": "copilot-developer-cli",
@@ -199,6 +199,32 @@ describe("selectCopilotModel", () => {
         expect(selected?.id).toBe("claude-sonnet-6");
     });
 
+    test("uses the newest available model in the requested tier", () => {
+        const selected = selectCopilotModel(
+            "gpt-5.6-sol",
+            [],
+            [
+                makeModel("gpt-5.5-sol"),
+                makeModel("gpt-5.7-sol"),
+                makeModel("gpt-6-astra"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5.7-sol");
+    });
+
+    test("uses the nearest general tier before a specialized model", () => {
+        const selected = selectCopilotModel(
+            "gpt-5.6-sol",
+            [],
+            [
+                makeModel("gpt-6-astra"),
+                makeModel("gpt-5.6-luna"),
+                makeModel("gpt-5.6-terra"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5.6-terra");
+    });
+
     test("uses a deterministic concrete model as the final fallback", () => {
         const selected = selectCopilotModel(
             "missing-model",
@@ -255,7 +281,7 @@ describe("createCopilotTransportModel", () => {
         const headers = fetchArgs[0].init.headers as Record<string, string>;
         expect(headers.Authorization).toBe("******");
         const body = JSON.parse(fetchArgs[0].init.body as string);
-        expect(body.model).toBe("claude-haiku-4.5");
+        expect(body.model).toBe("gpt-5.6-luna");
         expect(body.temperature).toBe(0);
         expect(body.messages).toEqual([
             { role: "user", content: "what time is it" },

--- a/ts/packages/aiclient/test/copilotTransport.spec.ts
+++ b/ts/packages/aiclient/test/copilotTransport.spec.ts
@@ -142,48 +142,49 @@ const CAPI_OK = {
 describe("selectCopilotModel", () => {
     test("uses the requested model when it is available", () => {
         const selected = selectCopilotModel(
-            "claude-haiku-4.5",
-            ["gpt-5-mini"],
-            [makeModel("gpt-5-mini"), makeModel("claude-haiku-4.5")],
+            "gpt-5.6-luna",
+            ["gpt-5.4-mini"],
+            [makeModel("gpt-5.4-mini"), makeModel("gpt-5.6-luna")],
         );
-        expect(selected?.id).toBe("claude-haiku-4.5");
+        expect(selected?.id).toBe("gpt-5.6-luna");
     });
 
     test("uses the first configured concrete fallback", () => {
         const selected = selectCopilotModel(
-            "claude-haiku-4.5",
-            ["auto", "gpt-5-mini", "gpt-5.4-mini"],
+            "gpt-5.6-luna",
+            ["auto", "gpt-5.4-mini", "gpt-5-mini", "gpt-5.4"],
             [
                 makeModel("auto"),
+                makeModel("gpt-5.4-mini"),
                 makeModel("gpt-5-mini"),
-                makeModel("gpt-5.4-mini"),
-            ],
-        );
-        expect(selected?.id).toBe("gpt-5-mini");
-    });
-
-    test("skips disabled fallback models", () => {
-        const selected = selectCopilotModel(
-            "claude-haiku-4.5",
-            ["gpt-5-mini", "gpt-5.4-mini"],
-            [
-                makeModel("gpt-5-mini", { policy: "disabled" }),
-                makeModel("gpt-5.4-mini"),
+                makeModel("gpt-5.4"),
             ],
         );
         expect(selected?.id).toBe("gpt-5.4-mini");
     });
 
-    test("allows fallback models without an explicit policy decision", () => {
+    test("skips disabled fallback models", () => {
         const selected = selectCopilotModel(
-            "claude-haiku-4.5",
-            ["gpt-5-mini", "gpt-5.4-mini"],
+            "gpt-5.6-luna",
+            ["gpt-5.4-mini", "gpt-5-mini"],
             [
-                makeModel("gpt-5-mini", { policy: "unconfigured" }),
-                makeModel("gpt-5.4-mini"),
+                makeModel("gpt-5.4-mini", { policy: "disabled" }),
+                makeModel("gpt-5-mini"),
             ],
         );
         expect(selected?.id).toBe("gpt-5-mini");
+    });
+
+    test("allows fallback models without an explicit policy decision", () => {
+        const selected = selectCopilotModel(
+            "gpt-5.6-luna",
+            ["gpt-5.4-mini", "gpt-5-mini"],
+            [
+                makeModel("gpt-5.4-mini", { policy: "unconfigured" }),
+                makeModel("gpt-5-mini"),
+            ],
+        );
+        expect(selected?.id).toBe("gpt-5.4-mini");
     });
 
     test("uses the newest available model in the requested family", () => {
@@ -246,11 +247,11 @@ describe("selectCopilotModel", () => {
 
     test("returns undefined when no concrete model is enabled", () => {
         const selected = selectCopilotModel(
-            "claude-haiku-4.5",
-            ["gpt-5-mini"],
+            "gpt-5.6-luna",
+            ["gpt-5.4-mini"],
             [
                 makeModel("auto"),
-                makeModel("gpt-5-mini", { policy: "disabled" }),
+                makeModel("gpt-5.4-mini", { policy: "disabled" }),
             ],
         );
         expect(selected).toBeUndefined();

--- a/ts/packages/aiclient/test/providerMode.spec.ts
+++ b/ts/packages/aiclient/test/providerMode.spec.ts
@@ -9,13 +9,19 @@ describe("Copilot provider mode", () => {
         expect(usesProviderDefault("unknown-model-alias")).toBe(true);
     });
 
-    test("maps canonical translation models to Haiku 4.5", () => {
-        expect(resolveTarget("copilot", "DEFAULT")).toBe("claude-haiku-4.5");
-        expect(resolveTarget("copilot", "GPT_5")).toBe("claude-haiku-4.5");
+    test.each([
+        ["DEFAULT", "gpt-5.6-luna"],
+        ["GPT_35_TURBO", "gpt-5.6-luna"],
+        ["GPT_4_O", "gpt-5.6-sol"],
+        ["GPT_5", "gpt-5.6-sol"],
+        ["GPT_5_MINI", "gpt-5.6-terra"],
+        ["GPT_5_NANO", "gpt-5.6-luna"],
+        ["GPT_V", "gpt-5.6-sol"],
+    ])("maps %s to %s", (canonical, expected) => {
+        expect(resolveTarget("copilot", canonical)).toBe(expected);
     });
 
     test("keeps explicit canonical model mappings", () => {
         expect(usesProviderDefault("GPT_4_O")).toBe(false);
-        expect(resolveTarget("copilot", "GPT_4_O")).toBe("gpt-5.4");
     });
 });

--- a/ts/packages/config/test/flatten.spec.ts
+++ b/ts/packages/config/test/flatten.spec.ts
@@ -54,13 +54,13 @@ describe("flatten", () => {
     test("flattens Copilot fallback models as a JSON array", () => {
         const out = flatten({
             copilot: {
-                defaultModel: "claude-haiku-4.5",
-                fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
+                defaultModel: "gpt-5.6-luna",
+                fallbackModels: ["gpt-5.4-mini", "gpt-5-mini", "gpt-5.4"],
             },
         });
         expect(out).toEqual({
-            COPILOT_DEFAULT_MODEL: "claude-haiku-4.5",
-            COPILOT_FALLBACK_MODELS: '["gpt-5-mini","gpt-5.4-mini"]',
+            COPILOT_DEFAULT_MODEL: "gpt-5.6-luna",
+            COPILOT_FALLBACK_MODELS: '["gpt-5.4-mini","gpt-5-mini","gpt-5.4"]',
         });
     });
 

--- a/ts/packages/config/test/runtime.build.spec.ts
+++ b/ts/packages/config/test/runtime.build.spec.ts
@@ -57,22 +57,23 @@ describe("authModeFromString", () => {
 describe("buildConfig: Copilot", () => {
     test("parses fallback models from the flattened JSON array", () => {
         const config = buildConfig({
-            COPILOT_DEFAULT_MODEL: "claude-haiku-4.5",
-            COPILOT_FALLBACK_MODELS: '["gpt-5-mini","gpt-5.4-mini"]',
+            COPILOT_DEFAULT_MODEL: "gpt-5.6-luna",
+            COPILOT_FALLBACK_MODELS: '["gpt-5.4-mini","gpt-5-mini","gpt-5.4"]',
         });
         expect(config.copilot).toEqual({
-            defaultModel: "claude-haiku-4.5",
-            fallbackModels: ["gpt-5-mini", "gpt-5.4-mini"],
+            defaultModel: "gpt-5.6-luna",
+            fallbackModels: ["gpt-5.4-mini", "gpt-5-mini", "gpt-5.4"],
         });
     });
 
     test("accepts comma-separated fallback models from the environment", () => {
         const config = buildConfig({
-            COPILOT_FALLBACK_MODELS: "gpt-5-mini, gpt-5.4-mini",
+            COPILOT_FALLBACK_MODELS: "gpt-5.4-mini, gpt-5-mini, gpt-5.4",
         });
         expect(config.copilot?.fallbackModels).toEqual([
-            "gpt-5-mini",
             "gpt-5.4-mini",
+            "gpt-5-mini",
+            "gpt-5.4",
         ]);
     });
 });

--- a/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
+++ b/ts/packages/dispatcher/dispatcher/src/context/system/handlers/configCommandHandlers.ts
@@ -1818,7 +1818,7 @@ class ConfigExecutionReasoningCommandHandler implements CommandHandler {
 
 class ConfigExecutionReasoningModelCommandHandler implements CommandHandler {
     public readonly description =
-        "Set the Copilot reasoning model (e.g. claude-opus-4.8). Omit to show the current value.";
+        "Set the Copilot reasoning model (e.g. gpt-5.6-sol). Omit to show the current value.";
     public readonly parameters = {
         args: {
             model: {

--- a/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
+++ b/ts/packages/dispatcher/dispatcher/src/reasoning/copilot.ts
@@ -178,7 +178,7 @@ async function sendMessageAndWaitWithCancellation(
     }
 }
 
-const FALLBACK_MODEL = "claude-opus-4.8";
+const FALLBACK_MODEL = "gpt-5.6-sol";
 
 // Default reasoning effort when COPILOT_REASONING_EFFORT is unset/invalid.
 // "high" makes the model more likely to actually run verification tool calls
@@ -214,16 +214,22 @@ export function resolveReasoningTimeoutMs(): number {
         : Math.min(parsed, MAX_SETTIMEOUT_MS);
 }
 
+export function resolveCopilotReasoningModel(
+    configured: string | undefined,
+    environment: string | undefined = process.env.COPILOT_REASONING_MODEL,
+): string {
+    return configured?.trim() || environment?.trim() || FALLBACK_MODEL;
+}
+
 function resolveModel(context: ActionContext<CommandHandlerContext>): string {
     // Live @config override wins, then the COPILOT_REASONING_MODEL env var
     // (from config.yaml), then the built-in fallback.
     const configured =
         context.sessionContext.agentContext.session.getConfig().execution
             .reasoningModel;
-    return (
-        configured?.trim() ||
-        process.env.COPILOT_REASONING_MODEL?.trim() ||
-        FALLBACK_MODEL
+    return resolveCopilotReasoningModel(
+        configured,
+        process.env.COPILOT_REASONING_MODEL,
     );
 }
 

--- a/ts/packages/dispatcher/dispatcher/test/otelReasoningSpan.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/otelReasoningSpan.spec.ts
@@ -75,7 +75,7 @@ describe("wrapReasoningSpan", () => {
 
         await runInReasoningSpan(context, async () => undefined, {
             genAiSystem: "github_copilot",
-            genAiRequestModel: "claude-opus-4.8",
+            genAiRequestModel: "gpt-5.6-sol",
         });
 
         const span = getOnlySpan(manager, "typeagent.reasoning");
@@ -87,7 +87,7 @@ describe("wrapReasoningSpan", () => {
         );
         expect(span.attributes["typeagent.trace.id"]).toBe("trace-production");
         expect(span.attributes["gen_ai.system"]).toBe("github_copilot");
-        expect(span.attributes["gen_ai.request.model"]).toBe("claude-opus-4.8");
+        expect(span.attributes["gen_ai.request.model"]).toBe("gpt-5.6-sol");
     });
 
     it("creates a child of the active request span", async () => {

--- a/ts/packages/dispatcher/dispatcher/test/reasoningTimeout.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/reasoningTimeout.spec.ts
@@ -14,14 +14,14 @@ const MAX_SETTIMEOUT_MS = 2_147_483_647;
 
 describe("resolveCopilotReasoningModel", () => {
     it("uses the configured model before the environment", () => {
-        expect(
-            resolveCopilotReasoningModel("gpt-6-astra", "claude-opus-4.8"),
-        ).toBe("gpt-6-astra");
+        expect(resolveCopilotReasoningModel("gpt-6-astra", "gpt-5.5")).toBe(
+            "gpt-6-astra",
+        );
     });
 
     it("uses the environment model when no live override is configured", () => {
-        expect(resolveCopilotReasoningModel(undefined, "claude-opus-5")).toBe(
-            "claude-opus-5",
+        expect(resolveCopilotReasoningModel(undefined, "gpt-5.5")).toBe(
+            "gpt-5.5",
         );
     });
 

--- a/ts/packages/dispatcher/dispatcher/test/reasoningTimeout.spec.ts
+++ b/ts/packages/dispatcher/dispatcher/test/reasoningTimeout.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import {
+    resolveCopilotReasoningModel,
     resolveReasoningTimeoutMs,
     sendAndWaitWithCancellation,
 } from "../src/reasoning/copilot.js";
@@ -10,6 +11,26 @@ import type { CopilotSession } from "@github/copilot-sdk";
 const ENV_KEY = "TYPEAGENT_REASONING_TIMEOUT_MS";
 const DEFAULT_MS = 20 * 60 * 1000;
 const MAX_SETTIMEOUT_MS = 2_147_483_647;
+
+describe("resolveCopilotReasoningModel", () => {
+    it("uses the configured model before the environment", () => {
+        expect(
+            resolveCopilotReasoningModel("gpt-6-astra", "claude-opus-4.8"),
+        ).toBe("gpt-6-astra");
+    });
+
+    it("uses the environment model when no live override is configured", () => {
+        expect(resolveCopilotReasoningModel(undefined, "claude-opus-5")).toBe(
+            "claude-opus-5",
+        );
+    });
+
+    it("defaults to GPT-5.6 Sol", () => {
+        expect(resolveCopilotReasoningModel(undefined, undefined)).toBe(
+            "gpt-5.6-sol",
+        );
+    });
+});
 
 describe("resolveReasoningTimeoutMs", () => {
     let saved: string | undefined;

--- a/ts/tools/scripts/generate-selfhost-config.mjs
+++ b/ts/tools/scripts/generate-selfhost-config.mjs
@@ -35,7 +35,7 @@
  *   --force                     Overwrite an existing config.local.yaml.
  *   --ollama-host <url>         Ollama base URL (default http://localhost:11434).
  *   --chat-model <name>         Ollama chat model (default llama3.2).
- *   --copilot-model <name>      Copilot chat model (default claude-haiku-4.5).
+ *   --copilot-model <name>      Copilot chat model (default gpt-5.6-luna).
  *   --embedding <mode>          local (default) | ollama | openai | none.
  *   --embedding-endpoint <url>  Embedding endpoint (openai mode; full path).
  *   --embedding-model <name>    Embedding model name.
@@ -53,8 +53,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
 const DEFAULT_OLLAMA_CHAT_MODEL = "llama3.2";
-const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
-const DEFAULT_COPILOT_FALLBACK_MODELS = ["gpt-5-mini", "gpt-5.4-mini"];
+const DEFAULT_COPILOT_MODEL = "gpt-5.6-luna";
+const DEFAULT_COPILOT_FALLBACK_MODELS = [
+    "gpt-5.4-mini",
+    "gpt-5-mini",
+    "gpt-5.4",
+];
 const DEFAULT_LOCAL_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
 

--- a/ts/tools/scripts/install-typeagent.sh
+++ b/ts/tools/scripts/install-typeagent.sh
@@ -54,7 +54,7 @@ Options:
   --embedding <mode>                 Embedding source for ollama/copilot: local (default), ollama, openai, none
   --ollama-host <url>                Ollama base URL (default: http://localhost:11434)
   --chat-model <name>                Ollama chat model (default: llama3.2)
-  --copilot-model <name>             Copilot chat model (default: claude-haiku-4.5)
+  --copilot-model <name>             Copilot chat model (default: gpt-5.6-luna)
   --embedding-endpoint <url>         Embedding endpoint (openai embedding mode; full path)
   --embedding-model <name>           Embedding model name
   --openai-key <key>                 API key for openai embedding mode

--- a/ts/tools/scripts/packageOptionalAgents.mjs
+++ b/ts/tools/scripts/packageOptionalAgents.mjs
@@ -74,6 +74,7 @@ function writeRuntimeInstallWorkspace(directory) {
         '  "@azure/msal-node-runtime": true',
         "  better-sqlite3: true",
         "  keytar: true",
+        "  koffi: true",
         "  onnxruntime-node: true",
         "  puppeteer: false",
         "  sharp: true",

--- a/ts/tools/scripts/setModelProvider.mjs
+++ b/ts/tools/scripts/setModelProvider.mjs
@@ -31,7 +31,7 @@
  *   --provider <mode>            copilot | ollama | aisystems (required unless --restore).
  *   --embedding <mode>           local | ollama | openai | none | azure (default: local
  *                                for copilot/ollama; azure for aisystems).
- *   --copilot-model <name>       Copilot chat model (default claude-haiku-4.5).
+ *   --copilot-model <name>       Copilot chat model (default gpt-5.6-luna).
  *   --ollama-host <url>          Ollama base URL (default http://localhost:11434).
  *   --chat-model <name>          Ollama chat model (default llama3.2).
  *   --embedding-endpoint <url>   Embedding endpoint (openai mode; full path).
@@ -57,8 +57,12 @@ const yaml = require("js-yaml");
 
 const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
 const DEFAULT_OLLAMA_CHAT_MODEL = "llama3.2";
-const DEFAULT_COPILOT_MODEL = "claude-haiku-4.5";
-const DEFAULT_COPILOT_FALLBACK_MODELS = ["gpt-5-mini", "gpt-5.4-mini"];
+const DEFAULT_COPILOT_MODEL = "gpt-5.6-luna";
+const DEFAULT_COPILOT_FALLBACK_MODELS = [
+    "gpt-5.4-mini",
+    "gpt-5-mini",
+    "gpt-5.4",
+];
 const DEFAULT_LOCAL_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
 


### PR DESCRIPTION
Switch Copilot chat and reasoning defaults to GPT-5.6 models, refresh fallback lists and docs, and improve model selection to prefer matching or nearby GPT tier variants.