### PR TITLE
Document Copilot fast actions and macros

### DIFF
--- a/ts/docs/plans/copilot-fastActions/PLAN.md
+++ b/ts/docs/plans/copilot-fastActions/PLAN.md
@@ -10,10 +10,10 @@ Copilot fast actions let TypeAgent reuse a known procedure instead of asking
 the Copilot model to plan the same work again. The area contains two related
 mechanisms:
 
-| Mechanism | Entry point | Fast path | Learning or adaptation |
-| --- | --- | --- | --- |
-| Dev actions | Copilot `userPromptSubmitted` hook in dev mode | A registered PowerShell namespace action or dynamic flow handles the prompt | PowerShell-specific reasoning may reuse, create, or repair a flow |
-| Tool-composed macros | `typeagent-macros` MCP tools | An approved replayable macro invokes its MCP steps in order | An explicit trace creates a draft; agent-guided execution may submit a new draft |
+| Mechanism            | Entry point                                    | Fast path                                                                   | Learning or adaptation                                                           |
+| -------------------- | ---------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Dev actions          | Copilot `userPromptSubmitted` hook in dev mode | A registered PowerShell namespace action or dynamic flow handles the prompt | PowerShell-specific reasoning may reuse, create, or repair a flow                |
+| Tool-composed macros | `typeagent-macros` MCP tools                   | An approved replayable macro invokes its MCP steps in order                 | An explicit trace creates a draft; agent-guided execution may submit a new draft |
 
 Both mechanisms store reusable procedures, but they have different routing,
 approval, execution, and platform rules. Macros are tools available alongside
@@ -44,15 +44,15 @@ and provider-specific flow formats, see
 
 ## Terminology
 
-| Term | Meaning |
-| --- | --- |
-| Dev action | A PowerShell-family action offered first refusal in Copilot dev mode |
-| Static namespace action | A committed, typed PowerShell action implemented in a `powershell.*` namespace |
-| Dynamic PowerShell flow | A persisted PowerShell recipe with generated schema and grammar |
-| Tool-composed macro | A versioned procedure induced from one explicitly recorded Copilot tool trace |
-| Deterministic replay | TypeAgent executes a fixed, validated sequence of replayable MCP calls |
-| Agent-guided execution | The Copilot macro runner executes the whole procedure through the live tool and permission surface |
-| Automatic selection | `run_macro` chooses replay or agent handoff from the approved macro's execution class |
+| Term                    | Meaning                                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| Dev action              | A PowerShell-family action offered first refusal in Copilot dev mode                               |
+| Static namespace action | A committed, typed PowerShell action implemented in a `powershell.*` namespace                     |
+| Dynamic PowerShell flow | A persisted PowerShell recipe with generated schema and grammar                                    |
+| Tool-composed macro     | A versioned procedure induced from one explicitly recorded Copilot tool trace                      |
+| Deterministic replay    | TypeAgent executes a fixed, validated sequence of replayable MCP calls                             |
+| Agent-guided execution  | The Copilot macro runner executes the whole procedure through the live tool and permission surface |
+| Automatic selection     | `run_macro` chooses replay or agent handoff from the approved macro's execution class              |
 
 ## System map
 
@@ -205,15 +205,15 @@ It does not mutate or approve the source version.
 
 ## Execution selection
 
-| Condition | Result |
-| --- | --- |
-| Registered PowerShell action or flow matches in dev mode | TypeAgent executes it and handles the prompt |
-| No direct PowerShell match, request is suitable | Bounded reasoning may reuse, create, or repair a flow |
-| Request is not suitable for PowerShell | TypeAgent returns not handled and Copilot continues |
-| Approved macro contains only replayable MCP steps | TypeAgent preflights and replays it |
-| Macro contains an agent-required step | TypeAgent returns a runner launch payload |
-| Macro version is draft or disabled | Execution is rejected |
-| A tool schema changed after approval | Replay fails before step one with `schemaDrift` |
+| Condition                                                | Result                                                |
+| -------------------------------------------------------- | ----------------------------------------------------- |
+| Registered PowerShell action or flow matches in dev mode | TypeAgent executes it and handles the prompt          |
+| No direct PowerShell match, request is suitable          | Bounded reasoning may reuse, create, or repair a flow |
+| Request is not suitable for PowerShell                   | TypeAgent returns not handled and Copilot continues   |
+| Approved macro contains only replayable MCP steps        | TypeAgent preflights and replays it                   |
+| Macro contains an agent-required step                    | TypeAgent returns a runner launch payload             |
+| Macro version is draft or disabled                       | Execution is rejected                                 |
+| A tool schema changed after approval                     | Replay fails before step one with `schemaDrift`       |
 
 ## Try dev actions
 
@@ -269,12 +269,12 @@ surface and remains model-mediated.
 
 Macro boundaries can be disabled independently:
 
-| Environment variable | Boundary |
-| --- | --- |
-| `TYPEAGENT_MACRO_RECORDING_ENABLED` | Explicit trace recording |
-| `TYPEAGENT_MACRO_INDUCTION_ENABLED` | Draft creation |
-| `TYPEAGENT_MACRO_REPLAY_ENABLED` | Deterministic replay |
-| `TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED` | Agent-runner handoff |
+| Environment variable                    | Boundary                 |
+| --------------------------------------- | ------------------------ |
+| `TYPEAGENT_MACRO_RECORDING_ENABLED`     | Explicit trace recording |
+| `TYPEAGENT_MACRO_INDUCTION_ENABLED`     | Draft creation           |
+| `TYPEAGENT_MACRO_REPLAY_ENABLED`        | Deterministic replay     |
+| `TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED` | Agent-runner handoff     |
 
 ## Storage
 
@@ -313,32 +313,31 @@ agent-server is stopped.
 
 ## Verification
 
-| Behavior | Focused evidence |
-| --- | --- |
-| Dev hook options, platform policy, fallthrough, and cancellation | `packages/copilot-plugin/test/hookDevActions.spec.ts` |
-| Schema-family routing and dispositions | `packages/dispatcher/test/devActionRouting.spec.ts` |
-| Flow transaction, repair, persistence, and namespaces | `packages/agents/powershell/test/actionHandler.spec.ts` |
-| Flow storage | `packages/agents/powershell/test/powerShellStore.spec.ts` |
-| Macro induction and validation | `packages/copilot-macros/test/macroDefinition.spec.ts` |
-| Replay preflight and ordered execution | `packages/copilot-macros/test/deterministicReplay.spec.ts` |
-| Versioning, approval, schema drift, and runs | `packages/copilot-macros/test/macroCatalog.spec.ts` |
-| Macro MCP surface and packaging | `packages/copilot-plugin/test/macroServer.spec.ts`, `pluginArtifact.spec.ts` |
-| Recording RPC integration | `packages/agentServer/server/test/macroRecordingRpc.spec.ts` |
+| Behavior                                                         | Focused evidence                                                             |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Dev hook options, platform policy, fallthrough, and cancellation | `packages/copilot-plugin/test/hookDevActions.spec.ts`                        |
+| Schema-family routing and dispositions                           | `packages/dispatcher/test/devActionRouting.spec.ts`                          |
+| Flow transaction, repair, persistence, and namespaces            | `packages/agents/powershell/test/actionHandler.spec.ts`                      |
+| Flow storage                                                     | `packages/agents/powershell/test/powerShellStore.spec.ts`                    |
+| Macro induction and validation                                   | `packages/copilot-macros/test/macroDefinition.spec.ts`                       |
+| Replay preflight and ordered execution                           | `packages/copilot-macros/test/deterministicReplay.spec.ts`                   |
+| Versioning, approval, schema drift, and runs                     | `packages/copilot-macros/test/macroCatalog.spec.ts`                          |
+| Macro MCP surface and packaging                                  | `packages/copilot-plugin/test/macroServer.spec.ts`, `pluginArtifact.spec.ts` |
+| Recording RPC integration                                        | `packages/agentServer/server/test/macroRecordingRpc.spec.ts`                 |
 
 ## Key files
 
-| Area | Path |
-| --- | --- |
-| Dev-action hook | `packages/copilot-plugin/src/hooks/hook-dev-actions.ts` |
-| Hook routing and recording commands | `packages/copilot-plugin/src/hooks/hook-router.ts` |
-| Macro MCP adapter | `packages/copilot-plugin/src/mcp/macroServer.ts` |
-| Macro contracts | `packages/copilot-macros/src/contracts.ts` |
-| Induction and validation | `packages/copilot-macros/src/macroDefinition.ts` |
-| Macro lifecycle and persistence | `packages/copilot-macros/src/macroManager.ts` |
-| Deterministic replay | `packages/copilot-macros/src/deterministicReplay.ts` |
-| MCP replay host | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts` |
-| PowerShell action and flow lifecycle | `packages/agents/powershell/src/actionHandler.mts` |
-| PowerShell store | `packages/agents/powershell/src/store/powerShellStore.mts` |
-| PowerShell script host | `packages/agents/powershell/scripts/scriptHost.ps1` |
-| Capability reasoning profiles | `packages/dispatcher/dispatcher/src/reasoning/reasoningProfile.ts` |
-
+| Area                                 | Path                                                               |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| Dev-action hook                      | `packages/copilot-plugin/src/hooks/hook-dev-actions.ts`            |
+| Hook routing and recording commands  | `packages/copilot-plugin/src/hooks/hook-router.ts`                 |
+| Macro MCP adapter                    | `packages/copilot-plugin/src/mcp/macroServer.ts`                   |
+| Macro contracts                      | `packages/copilot-macros/src/contracts.ts`                         |
+| Induction and validation             | `packages/copilot-macros/src/macroDefinition.ts`                   |
+| Macro lifecycle and persistence      | `packages/copilot-macros/src/macroManager.ts`                      |
+| Deterministic replay                 | `packages/copilot-macros/src/deterministicReplay.ts`               |
+| MCP replay host                      | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts`           |
+| PowerShell action and flow lifecycle | `packages/agents/powershell/src/actionHandler.mts`                 |
+| PowerShell store                     | `packages/agents/powershell/src/store/powerShellStore.mts`         |
+| PowerShell script host               | `packages/agents/powershell/scripts/scriptHost.ps1`                |
+| Capability reasoning profiles        | `packages/dispatcher/dispatcher/src/reasoning/reasoningProfile.ts` |

--- a/ts/docs/plans/copilot-fastActions/PLAN.md
+++ b/ts/docs/plans/copilot-fastActions/PLAN.md
@@ -1,0 +1,344 @@
+# Copilot fast actions
+
+Status: Implemented, with follow-up work. This document is the source of truth
+for the cross-package design of Copilot dev actions and tool-composed macros.
+Progress and remaining work are tracked in [STATUS.md](./STATUS.md).
+
+## Purpose
+
+Copilot fast actions let TypeAgent reuse a known procedure instead of asking
+the Copilot model to plan the same work again. The area contains two related
+mechanisms:
+
+| Mechanism | Entry point | Fast path | Learning or adaptation |
+| --- | --- | --- | --- |
+| Dev actions | Copilot `userPromptSubmitted` hook in dev mode | A registered PowerShell namespace action or dynamic flow handles the prompt | PowerShell-specific reasoning may reuse, create, or repair a flow |
+| Tool-composed macros | `typeagent-macros` MCP tools | An approved replayable macro invokes its MCP steps in order | An explicit trace creates a draft; agent-guided execution may submit a new draft |
+
+Both mechanisms store reusable procedures, but they have different routing,
+approval, execution, and platform rules. Macros are tools available alongside
+prompt routing; they are not a fourth plugin mode.
+
+For the common TypeAgent workflow lifecycle, dynamic schema and grammar API,
+and provider-specific flow formats, see
+[Workflows](../../architecture/workflows/workflows.md).
+
+## Goals
+
+- Handle known development actions before the Copilot agent loop.
+- Reuse successful procedures without repeated model planning.
+- Return a clean miss when a request does not belong to the active fast-action
+  surface.
+- Make macro recording and approval explicit.
+- Check deterministic macro requirements before invoking the first step.
+- Preserve cancellation, failure, and possible-side-effect information across
+  package boundaries.
+
+## Non-goals
+
+- A unified catalog across PowerShell, WebFlow, TaskFlow, and Excel providers.
+- Deterministic replay of Copilot-native shell or edit tools.
+- General semantic program induction from one recorded interaction.
+- Treating dynamic PowerShell policy metadata as a security sandbox.
+- A separate plugin routing mode for macros.
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| Dev action | A PowerShell-family action offered first refusal in Copilot dev mode |
+| Static namespace action | A committed, typed PowerShell action implemented in a `powershell.*` namespace |
+| Dynamic PowerShell flow | A persisted PowerShell recipe with generated schema and grammar |
+| Tool-composed macro | A versioned procedure induced from one explicitly recorded Copilot tool trace |
+| Deterministic replay | TypeAgent executes a fixed, validated sequence of replayable MCP calls |
+| Agent-guided execution | The Copilot macro runner executes the whole procedure through the live tool and permission surface |
+| Automatic selection | `run_macro` chooses replay or agent handoff from the approved macro's execution class |
+
+## System map
+
+```text
+User prompt
+  |
+  +-> dev-mode hook
+  |     +-> registered PowerShell action/flow -> handled result
+  |     +-> PowerShell capability reasoning -> reuse/create/repair/decline
+  |     +-> not suitable -> Copilot continues
+  |
+  +-> Copilot tool use
+        +-> explicit recording -> trace -> draft -> approval
+        +-> approved replayable macro -> full preflight -> MCP replay
+        +-> agent-required macro -> bounded Copilot runner handoff
+```
+
+Dev actions can intercept the root prompt. Tool-composed macros are invoked
+through MCP tools after Copilot selects or is asked to use them.
+
+## Dev-action routing
+
+`@typeagent mode dev` selects the dev-action hook. On Windows, the hook submits
+the original prompt with the PowerShell schema family active.
+
+Ordinary prompts use:
+
+```ts
+{
+    activeSchemaFamilies: ["powershell"],
+    noReasoning: false,
+    reasoningProfile: "powershellCapabilityFallback",
+}
+```
+
+The dispatcher tries registered grammar and translation first. A static
+namespace action or active flow can therefore complete without a Copilot model
+turn. If no direct action fits, the PowerShell capability profile may:
+
+- use an existing static action or flow;
+- add a validated grammar pattern to an existing flow;
+- create and test a new flow;
+- repair one stale flow once; or
+- report that the request is not suitable for PowerShell.
+
+A typed `notSuitable` outcome maps to a not-handled disposition, allowing
+Copilot to process the original prompt. Once TypeAgent accepts work, failures
+remain handled so Copilot does not repeat a potentially state-changing action.
+
+Recording directives such as `learn:` use the `powershellFlowRecording`
+profile. On non-Windows platforms, ordinary dev requests fall through and
+explicit PowerShell recording requests return a visible unsupported-platform
+message.
+
+Cancellation after submission propagates through agent-server and dispatcher
+request cancellation to the PowerShell child process. Mutating static actions
+request confirmation; the unattended plugin client selects the default-deny
+choice.
+
+## PowerShell actions and flows
+
+### Static namespace actions
+
+Committed namespace handlers cover files, processes, system, services,
+network, data, and archives. Each namespace owns an exhaustive action map.
+A shared factory applies confirmation, execution, cancellation, failure
+conversion, and display behavior.
+
+### Dynamic flow lifecycle
+
+Dynamic flows use a pending/test/promote/activate transaction:
+
+1. Search for an existing flow with the proposed action name.
+2. Validate grammar patterns.
+3. Save a pending recipe.
+4. Execute that recipe once.
+5. Delete the pending recipe on failure or cancellation.
+6. Promote the same recipe after success.
+7. Reload the dynamic schema and grammar.
+8. Remove the promoted flow if activation fails.
+
+Same-name mutations are serialized within one agent-server process. A promoted
+flow persists in instance storage and is available after restart. Repair is
+bounded to one attempt per request and is not attempted for policy denial,
+cancellation, unsafe requests, or failures that may have produced partial side
+effects.
+
+## Tool-composed macro lifecycle
+
+### Capture
+
+`@typeagent macro record` arms exactly one eligible Copilot interaction. The
+plugin claims the recording before the turn, associates tool calls by ID, and
+finalizes a redacted trace after the turn completes. Recording is explicit and
+expires if the armed interaction is not claimed in time.
+
+### Induction
+
+`create_macro_from_trace` creates draft version 1. Current induction can:
+
+- replace prompt-mentioned string leaves with inputs;
+- create secret inputs for redacted leaves;
+- bind a later argument to an exact value found in an earlier result; and
+- infer result-type and result-path postconditions.
+
+It does not infer arbitrary semantics, loops, branches, or a generalized
+program from one example.
+
+Calls that identify an MCP server are classified as `replayable`. Calls
+without one are `agentRequired`.
+
+### Validation and approval
+
+Drafts cannot run. Validation checks macro structure, bindings, trace
+provenance, and execution classes. Approval is explicit and creates a new,
+immutable approved version. When a replay host is configured, approval also
+records the current schema fingerprint for each replayable tool.
+
+```text
+captured trace -> draft v1 -> validation -> approval -> approved v2
+```
+
+### Deterministic replay
+
+Before step one, replay checks the entire macro:
+
+- the version is approved and replayable;
+- every required input exists and has the expected type;
+- every input reference is bound;
+- every tool is available; and
+- recorded schema fingerprints still match.
+
+A failed preflight, including `schemaDrift`, invokes no steps. After preflight,
+steps run in order. Arguments may include literals, caller inputs, or values
+from prior step results. Postconditions check result types and required paths.
+Cancellation and timeout stop the run and are recorded in the sanitized run
+record.
+
+### Agent-guided execution
+
+If the macro is `agentRequired`, or the caller requests the `agent`
+preference, `run_macro` returns an `AgentRunnerLaunchPayload`. The
+`typeagent-macro-runner` executes the whole macro through Copilot's live tools
+and permission surface. Replay never executes a prefix before handing off the
+remainder.
+
+A successful adaptation may call `submit_macro_candidate`. Agent-server checks
+the handoff provenance and execution budgets before saving a separate draft.
+It does not mutate or approve the source version.
+
+## Execution selection
+
+| Condition | Result |
+| --- | --- |
+| Registered PowerShell action or flow matches in dev mode | TypeAgent executes it and handles the prompt |
+| No direct PowerShell match, request is suitable | Bounded reasoning may reuse, create, or repair a flow |
+| Request is not suitable for PowerShell | TypeAgent returns not handled and Copilot continues |
+| Approved macro contains only replayable MCP steps | TypeAgent preflights and replays it |
+| Macro contains an agent-required step | TypeAgent returns a runner launch payload |
+| Macro version is draft or disabled | Execution is rejected |
+| A tool schema changed after approval | Replay fails before step one with `schemaDrift` |
+
+## Try dev actions
+
+Dev actions require Windows, a running agent-server, and the PowerShell agent.
+
+```text
+@typeagent mode dev
+show top 5 memory hogs
+```
+
+To demonstrate learning with disposable, read-only data:
+
+```text
+learn: show the 3 newest .log files under <PATH>
+@typeagent run list powershell flows
+show the 3 newest .log files under <PATH>
+```
+
+The generated flow name and exact output depend on the configured model. Use
+the name returned by TypeAgent instead of predicting it.
+
+## Try a tool-composed macro
+
+1. Run `@typeagent macro record`.
+2. Complete one successful Copilot turn that uses an MCP tool.
+3. Run `@typeagent macro status` and copy the returned trace ID.
+4. Use `create_macro_from_trace`.
+5. Inspect requirements and call `validate_macro`.
+6. Ask the user to approve the draft, then call `approve_macro`.
+7. Call `run_macro` with the approved macro ID, required inputs, and
+   `preference: "auto"`.
+8. Use `get_macro_run` to inspect persisted, sanitized replay evidence.
+
+Keep the draft-rejection step in tests and demos. It makes the approval
+boundary observable.
+
+## Safety and trust boundaries
+
+Static PowerShell actions contain reviewed scripts. Dynamic flows contain
+generated, imported, edited, or repaired scripts. These paths do not currently
+have the same trust level.
+
+Dynamic scripts run in PowerShell `FullLanguage` mode. Cmdlet lists, path
+validation, module lists, and network flags restrict common command paths, but
+they do not prevent direct .NET filesystem, process, network, reflection, or
+assembly APIs. Treat dynamic flow execution as host code execution, not as a
+security sandbox. See the active FullLanguage issue in codeDocs for the
+mitigation plan.
+
+Macro recording is explicit, drafts cannot run, and deterministic replay
+preflights every step. Agent-guided execution uses Copilot's permission
+surface and remains model-mediated.
+
+Macro boundaries can be disabled independently:
+
+| Environment variable | Boundary |
+| --- | --- |
+| `TYPEAGENT_MACRO_RECORDING_ENABLED` | Explicit trace recording |
+| `TYPEAGENT_MACRO_INDUCTION_ENABLED` | Draft creation |
+| `TYPEAGENT_MACRO_REPLAY_ENABLED` | Deterministic replay |
+| `TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED` | Agent-runner handoff |
+
+## Storage
+
+PowerShell flows live under the PowerShell area of TypeAgent instance storage.
+They include an index, flow metadata, script bodies, generated grammar, and
+pending recipes.
+
+Macros use a separate `copilot-macros/` directory under agent-server instance
+storage:
+
+```text
+copilot-macros/
+  index.json
+  traces/<traceId>.json
+  macros/<macroId>/versions/<version>.json
+  runs/<runId>.json
+  handoffs/<runId>.json
+  metrics.jsonl
+```
+
+Back up these directories before migrations. Restore them only while
+agent-server is stopped.
+
+## Known limitations
+
+- Dev actions are PowerShell-specific and Windows-only.
+- Dynamic PowerShell scripts run in FullLanguage mode.
+- Flow mutation locking does not coordinate separate agent-server processes
+  sharing one storage directory.
+- PowerShell cancellation has no forced process-tree termination fallback.
+- Macro induction from a single trace is deliberately narrow.
+- Native Copilot tools require agent-guided execution.
+- Macro catalog mutation coordination is process-local.
+- Credentialed live end-to-end coverage is not yet a release gate.
+- The macro catalog does not enumerate other TypeAgent workflow providers.
+
+## Verification
+
+| Behavior | Focused evidence |
+| --- | --- |
+| Dev hook options, platform policy, fallthrough, and cancellation | `packages/copilot-plugin/test/hookDevActions.spec.ts` |
+| Schema-family routing and dispositions | `packages/dispatcher/test/devActionRouting.spec.ts` |
+| Flow transaction, repair, persistence, and namespaces | `packages/agents/powershell/test/actionHandler.spec.ts` |
+| Flow storage | `packages/agents/powershell/test/powerShellStore.spec.ts` |
+| Macro induction and validation | `packages/copilot-macros/test/macroDefinition.spec.ts` |
+| Replay preflight and ordered execution | `packages/copilot-macros/test/deterministicReplay.spec.ts` |
+| Versioning, approval, schema drift, and runs | `packages/copilot-macros/test/macroCatalog.spec.ts` |
+| Macro MCP surface and packaging | `packages/copilot-plugin/test/macroServer.spec.ts`, `pluginArtifact.spec.ts` |
+| Recording RPC integration | `packages/agentServer/server/test/macroRecordingRpc.spec.ts` |
+
+## Key files
+
+| Area | Path |
+| --- | --- |
+| Dev-action hook | `packages/copilot-plugin/src/hooks/hook-dev-actions.ts` |
+| Hook routing and recording commands | `packages/copilot-plugin/src/hooks/hook-router.ts` |
+| Macro MCP adapter | `packages/copilot-plugin/src/mcp/macroServer.ts` |
+| Macro contracts | `packages/copilot-macros/src/contracts.ts` |
+| Induction and validation | `packages/copilot-macros/src/macroDefinition.ts` |
+| Macro lifecycle and persistence | `packages/copilot-macros/src/macroManager.ts` |
+| Deterministic replay | `packages/copilot-macros/src/deterministicReplay.ts` |
+| MCP replay host | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts` |
+| PowerShell action and flow lifecycle | `packages/agents/powershell/src/actionHandler.mts` |
+| PowerShell store | `packages/agents/powershell/src/store/powerShellStore.mts` |
+| PowerShell script host | `packages/agents/powershell/scripts/scriptHost.ps1` |
+| Capability reasoning profiles | `packages/dispatcher/dispatcher/src/reasoning/reasoningProfile.ts` |
+

--- a/ts/docs/plans/copilot-fastActions/STATUS.md
+++ b/ts/docs/plans/copilot-fastActions/STATUS.md
@@ -1,0 +1,65 @@
+# Copilot fast actions status
+
+Working tracker for [PLAN.md](./PLAN.md). Keep implementation, documentation,
+and live verification as separate states.
+
+_Last updated: 2026-09-09._
+
+## Implementation status
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Dev-mode PowerShell schema-family routing | done | Static namespaces and dynamic flows receive first refusal |
+| Typed handled and not-handled dispositions | done | `notSuitable` returns the original prompt to Copilot |
+| PowerShell capability fallback | done | Existing-flow preference, synthesis, aliases, and bounded repair |
+| Transactional flow creation | done | Pending, execute once, promote, reload, and rollback |
+| Flow persistence and same-process locking | done | Cross-process storage locking remains open |
+| Explicit macro trace recording | done | One armed interaction per session |
+| Macro induction and validation | done | Narrow deterministic induction from one trace |
+| Immutable macro approval | done | Approval creates a new version |
+| Deterministic MCP replay | done | Full preflight, ordered calls, bindings, and postconditions |
+| Agent-runner handoff | done | Whole-macro handoff with budgets |
+| Adaptation candidate submission | done | Successful adaptations become new drafts |
+| Macro rollout controls | done | Recording, induction, replay, and handoff are independently gated |
+
+## Documentation status
+
+| Item | Status |
+| --- | --- |
+| Cross-package plan | done |
+| Plugin README routing and dev-mode correction | done |
+| Plugin README macro lifecycle and component inventory | done |
+| Macro package README replacement | done |
+| Workflow architecture PowerShell security correction | done |
+| Published architecture page | deferred until plan review |
+
+## Open implementation work
+
+- [ ] Replace FullLanguage dynamic PowerShell execution with an untrusted
+      execution boundary.
+- [ ] Require explicit first-run approval for generated, repaired, edited, and
+      imported dynamic scripts until that boundary exists.
+- [ ] Add storage-level locking for independent agent-server processes.
+- [ ] Add forced process-tree termination after cancellation or timeout.
+- [ ] Make credentialed end-to-end dev-action and macro scenarios a release
+      gate.
+- [ ] Decide whether to build a catalog over other TypeAgent flow providers.
+
+## Documentation follow-up
+
+- [ ] Review the `copilot-fastActions` directory name before more documents
+      link to it.
+- [ ] Promote stable cross-package material into a published architecture page
+      after review.
+- [ ] Add a link from the plugin and macro READMEs to that architecture page.
+- [ ] Recheck security wording when the PowerShell execution boundary changes.
+
+## Validation checklist
+
+- [x] Commands match current hook command parsing.
+- [x] Dev-mode options match `hook-dev-actions.ts`.
+- [x] Macro lifecycle matches `MacroManager`.
+- [x] Replay guarantees match `deterministicReplay.ts`.
+- [x] Package ownership follows the wiki contribution guide.
+- [ ] Build the DocFX site when the plan is promoted into published content.
+

--- a/ts/docs/plans/copilot-fastActions/STATUS.md
+++ b/ts/docs/plans/copilot-fastActions/STATUS.md
@@ -7,31 +7,31 @@ _Last updated: 2026-09-09._
 
 ## Implementation status
 
-| Area | Status | Notes |
-| --- | --- | --- |
-| Dev-mode PowerShell schema-family routing | done | Static namespaces and dynamic flows receive first refusal |
-| Typed handled and not-handled dispositions | done | `notSuitable` returns the original prompt to Copilot |
-| PowerShell capability fallback | done | Existing-flow preference, synthesis, aliases, and bounded repair |
-| Transactional flow creation | done | Pending, execute once, promote, reload, and rollback |
-| Flow persistence and same-process locking | done | Cross-process storage locking remains open |
-| Explicit macro trace recording | done | One armed interaction per session |
-| Macro induction and validation | done | Narrow deterministic induction from one trace |
-| Immutable macro approval | done | Approval creates a new version |
-| Deterministic MCP replay | done | Full preflight, ordered calls, bindings, and postconditions |
-| Agent-runner handoff | done | Whole-macro handoff with budgets |
-| Adaptation candidate submission | done | Successful adaptations become new drafts |
-| Macro rollout controls | done | Recording, induction, replay, and handoff are independently gated |
+| Area                                       | Status | Notes                                                             |
+| ------------------------------------------ | ------ | ----------------------------------------------------------------- |
+| Dev-mode PowerShell schema-family routing  | done   | Static namespaces and dynamic flows receive first refusal         |
+| Typed handled and not-handled dispositions | done   | `notSuitable` returns the original prompt to Copilot              |
+| PowerShell capability fallback             | done   | Existing-flow preference, synthesis, aliases, and bounded repair  |
+| Transactional flow creation                | done   | Pending, execute once, promote, reload, and rollback              |
+| Flow persistence and same-process locking  | done   | Cross-process storage locking remains open                        |
+| Explicit macro trace recording             | done   | One armed interaction per session                                 |
+| Macro induction and validation             | done   | Narrow deterministic induction from one trace                     |
+| Immutable macro approval                   | done   | Approval creates a new version                                    |
+| Deterministic MCP replay                   | done   | Full preflight, ordered calls, bindings, and postconditions       |
+| Agent-runner handoff                       | done   | Whole-macro handoff with budgets                                  |
+| Adaptation candidate submission            | done   | Successful adaptations become new drafts                          |
+| Macro rollout controls                     | done   | Recording, induction, replay, and handoff are independently gated |
 
 ## Documentation status
 
-| Item | Status |
-| --- | --- |
-| Cross-package plan | done |
-| Plugin README routing and dev-mode correction | done |
-| Plugin README macro lifecycle and component inventory | done |
-| Macro package README replacement | done |
-| Workflow architecture PowerShell security correction | done |
-| Published architecture page | deferred until plan review |
+| Item                                                  | Status                     |
+| ----------------------------------------------------- | -------------------------- |
+| Cross-package plan                                    | done                       |
+| Plugin README routing and dev-mode correction         | done                       |
+| Plugin README macro lifecycle and component inventory | done                       |
+| Macro package README replacement                      | done                       |
+| Workflow architecture PowerShell security correction  | done                       |
+| Published architecture page                           | deferred until plan review |
 
 ## Open implementation work
 
@@ -62,4 +62,3 @@ _Last updated: 2026-09-09._
 - [x] Replay guarantees match `deterministicReplay.ts`.
 - [x] Package ownership follows the wiki contribution guide.
 - [ ] Build the DocFX site when the plan is promoted into published content.
-

--- a/ts/packages/copilot-macros/README.md
+++ b/ts/packages/copilot-macros/README.md
@@ -42,17 +42,17 @@ approved version rather than changing the draft in place.
 
 The public contracts in `src/contracts.ts` include:
 
-| Type | Purpose |
-| --- | --- |
-| `RecordedInteractionTrace` | One completed Copilot interaction and its correlated tool calls |
-| `CopilotToolMacro` | A versioned macro definition, inputs, steps, provenance, and state |
-| `MacroInput` | A required or optional caller-supplied value, including secret inputs |
-| `MacroStep` | One captured tool call and its argument expression |
-| `ValueExpression` | A literal, caller input, prior-step result, or template containing bindings |
-| `MacroPostcondition` | A result-type or required-result-path check |
-| `MacroValidationReport` | Errors and warnings produced before approval |
-| `MacroRunRecord` | Sanitized evidence from one deterministic run |
-| `ReplayToolHost` | The host interface for tool inspection and invocation |
+| Type                       | Purpose                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `RecordedInteractionTrace` | One completed Copilot interaction and its correlated tool calls             |
+| `CopilotToolMacro`         | A versioned macro definition, inputs, steps, provenance, and state          |
+| `MacroInput`               | A required or optional caller-supplied value, including secret inputs       |
+| `MacroStep`                | One captured tool call and its argument expression                          |
+| `ValueExpression`          | A literal, caller input, prior-step result, or template containing bindings |
+| `MacroPostcondition`       | A result-type or required-result-path check                                 |
+| `MacroValidationReport`    | Errors and warnings produced before approval                                |
+| `MacroRunRecord`           | Sanitized evidence from one deterministic run                               |
+| `ReplayToolHost`           | The host interface for tool inspection and invocation                       |
 
 Each macro and step has an execution class:
 
@@ -160,14 +160,14 @@ Minimal setup:
 import { MacroManager, type ReplayToolHost } from "@typeagent/copilot-macros";
 
 const replayHost: ReplayToolHost = {
-    async inspectTool(serverName, toolName) {
-        // Return the current descriptor from the host's MCP catalog.
-        return undefined;
-    },
-    async callTool(serverName, toolName, args, signal) {
-        // Invoke the MCP tool and return its structured result.
-        throw new Error("Provide a ReplayToolHost implementation.");
-    },
+  async inspectTool(serverName, toolName) {
+    // Return the current descriptor from the host's MCP catalog.
+    return undefined;
+  },
+  async callTool(serverName, toolName, args, signal) {
+    // Invoke the MCP tool and return its structured result.
+    throw new Error("Provide a ReplayToolHost implementation.");
+  },
 };
 
 const manager = new MacroManager(instanceDirectory, replayHost);
@@ -178,15 +178,15 @@ TypeAgent's concrete MCP replay host lives in
 
 ## Integration points
 
-| Area | Location |
-| --- | --- |
-| Recording and macro RPC contracts | `packages/agentServer/protocol/src/protocol.ts` |
-| Agent-server ownership | `packages/agentServer/server/src/` |
-| MCP adapter | `packages/copilot-plugin/src/mcp/macroServer.ts` |
-| Recording hooks | `packages/copilot-plugin/src/hooks/` |
-| Macro skill | `packages/copilot-plugin/skills/typeagent-macros/SKILL.md` |
-| Macro runner | `packages/copilot-plugin/agents/typeagent-macro-runner.agent.md` |
-| MCP replay host | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts` |
+| Area                              | Location                                                         |
+| --------------------------------- | ---------------------------------------------------------------- |
+| Recording and macro RPC contracts | `packages/agentServer/protocol/src/protocol.ts`                  |
+| Agent-server ownership            | `packages/agentServer/server/src/`                               |
+| MCP adapter                       | `packages/copilot-plugin/src/mcp/macroServer.ts`                 |
+| Recording hooks                   | `packages/copilot-plugin/src/hooks/`                             |
+| Macro skill                       | `packages/copilot-plugin/skills/typeagent-macros/SKILL.md`       |
+| Macro runner                      | `packages/copilot-plugin/agents/typeagent-macro-runner.agent.md` |
+| MCP replay host                   | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts`         |
 
 ## Build and test
 

--- a/ts/packages/copilot-macros/README.md
+++ b/ts/packages/copilot-macros/README.md
@@ -1,6 +1,216 @@
 # @typeagent/copilot-macros
 
-undefined
+`@typeagent/copilot-macros` is the internal engine for TypeAgent
+tool-composed macros. It defines recorded Copilot tool traces, macro
+definitions, validation, immutable lifecycle operations, deterministic MCP
+replay, agent-runner handoff payloads, redaction, and persisted run evidence.
+
+The package does not expose an MCP server or launch Copilot by itself.
+Agent-server owns the `MacroManager` instance and its storage. The Copilot
+plugin exposes the lifecycle through
+[`macroServer.ts`](../copilot-plugin/src/mcp/macroServer.ts), a macro skill, and
+the TypeAgent Macro Runner agent.
+
+For the cross-package request flow and its relationship to PowerShell dev
+actions, see the
+[Copilot fast actions plan](../../docs/plans/copilot-fastActions/PLAN.md).
+
+## Lifecycle
+
+```text
+arm -> claim -> finalize trace
+               |
+               v
+          induce draft v1
+               |
+          validate + review
+               |
+         approve as version 2
+               |
+     replay or agent-runner handoff
+```
+
+Recording is explicit and scoped to one session. Only one recording token can
+be active for a session, and tokens expire if they are not claimed. A finalized
+trace is redacted before it is persisted.
+
+`createMacroFromTrace()` always creates a draft. Draft and disabled versions
+cannot run. `approveMacro()` validates the draft and writes a new immutable
+approved version rather than changing the draft in place.
+
+## Core model
+
+The public contracts in `src/contracts.ts` include:
+
+| Type | Purpose |
+| --- | --- |
+| `RecordedInteractionTrace` | One completed Copilot interaction and its correlated tool calls |
+| `CopilotToolMacro` | A versioned macro definition, inputs, steps, provenance, and state |
+| `MacroInput` | A required or optional caller-supplied value, including secret inputs |
+| `MacroStep` | One captured tool call and its argument expression |
+| `ValueExpression` | A literal, caller input, prior-step result, or template containing bindings |
+| `MacroPostcondition` | A result-type or required-result-path check |
+| `MacroValidationReport` | Errors and warnings produced before approval |
+| `MacroRunRecord` | Sanitized evidence from one deterministic run |
+| `ReplayToolHost` | The host interface for tool inspection and invocation |
+
+Each macro and step has an execution class:
+
+- `replayable`: TypeAgent can inspect and call the named MCP tool.
+- `agentRequired`: the step needs Copilot's live tool and permission surface.
+
+Execution class is selected for the whole macro. A run never replays a prefix
+before handing later steps to the agent.
+
+## Induction boundaries
+
+`induceMacroFromTrace()` performs a narrow, deterministic conversion. It can:
+
+- turn string values that also appear in the recorded prompt into inputs;
+- turn redacted leaves into required secret inputs;
+- bind a later argument to an exact value found in a prior tool result; and
+- infer the result type and up to 50 result paths as postconditions.
+
+It does not infer arbitrary semantic parameters, loops, branches, or a
+generalized program from one example. Calls with an MCP server name are
+classified as replayable. Calls without one are classified as agent-required.
+
+## Validation and approval
+
+Validate a draft before asking the user to approve it. Validation checks macro
+structure, expressions, step ordering, trace provenance, and execution
+classes.
+
+When a replay host is configured, approval inspects every replayable tool and
+records its schema fingerprint. Approval then writes the next version with
+state `approved`. Disabling an approved macro also writes a new version.
+Agent-guided adaptations are saved as separate drafts.
+
+## Deterministic replay
+
+Replay preflights the complete macro before invoking step one:
+
+1. The version must be approved and replayable.
+2. Required inputs must exist and match their recorded value types.
+3. Every referenced input must be bound.
+4. Every tool must be available through the replay host.
+5. Recorded schema fingerprints must match the current tool schemas.
+
+A failed preflight, including `schemaDrift`, invokes no tools. After preflight,
+steps execute in order. Template expressions resolve caller inputs and prior
+step results immediately before each call. Postconditions validate result
+types and required paths.
+
+The caller supplies an `AbortSignal`. `MacroManager` also enforces a bounded
+timeout, records cancellation or failure, and persists a sanitized run record.
+
+## Agent-guided execution and adaptation
+
+If a macro is `agentRequired`, or the caller selects the `agent` preference,
+`MacroManager.runMacro()` returns an `AgentRunnerLaunchPayload`. The payload
+contains the approved macro, supplied inputs, handoff reason, execution
+budgets, and candidate provenance. The package does not launch the runner.
+
+After a successful agent-guided run, `submitMacroCandidate()` can save an
+adapted procedure. It verifies handoff identity, source version, execution
+outcome, and budget use before writing a new draft. It never changes or
+approves the source macro.
+
+## Persistence
+
+`MacroManager` stores data under the supplied agent-server instance directory:
+
+```text
+copilot-macros/
+  index.json
+  traces/<traceId>.json
+  macros/<macroId>/versions/<version>.json
+  runs/<runId>.json
+  handoffs/<runId>.json
+  metrics.jsonl
+```
+
+Version and catalog writes use temporary files and rename where atomic
+replacement is required. Catalog mutations are serialized within one process;
+the package does not provide a cross-process storage lock.
+
+## Privacy and persisted data
+
+Trace persistence redacts values whose keys look like credentials and common
+inline token formats. Persisted run inputs, step results, and final results use
+the same redaction. Large run values are replaced with a bounded preview.
+
+This filtering is defense in depth, not a secret-management boundary. Tool
+outputs may contain sensitive values that do not match the current patterns.
+Callers should limit what they record and which tool results they persist.
+
+## API
+
+The package exports:
+
+- contracts from `contracts.ts`;
+- `inspectReplayTools()`, `replayMacro()`, and `ReplayValidationError`;
+- `induceMacroFromTrace()` and `validateMacro()`;
+- `MacroManager`; and
+- `redactTraceValue()`.
+
+Minimal setup:
+
+```ts
+import { MacroManager, type ReplayToolHost } from "@typeagent/copilot-macros";
+
+const replayHost: ReplayToolHost = {
+    async inspectTool(serverName, toolName) {
+        // Return the current descriptor from the host's MCP catalog.
+        return undefined;
+    },
+    async callTool(serverName, toolName, args, signal) {
+        // Invoke the MCP tool and return its structured result.
+        throw new Error("Provide a ReplayToolHost implementation.");
+    },
+};
+
+const manager = new MacroManager(instanceDirectory, replayHost);
+```
+
+TypeAgent's concrete MCP replay host lives in
+`packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts`.
+
+## Integration points
+
+| Area | Location |
+| --- | --- |
+| Recording and macro RPC contracts | `packages/agentServer/protocol/src/protocol.ts` |
+| Agent-server ownership | `packages/agentServer/server/src/` |
+| MCP adapter | `packages/copilot-plugin/src/mcp/macroServer.ts` |
+| Recording hooks | `packages/copilot-plugin/src/hooks/` |
+| Macro skill | `packages/copilot-plugin/skills/typeagent-macros/SKILL.md` |
+| Macro runner | `packages/copilot-plugin/agents/typeagent-macro-runner.agent.md` |
+| MCP replay host | `packages/defaultAgentProvider/src/mcp/mcpReplayHost.ts` |
+
+## Build and test
+
+From `ts/packages/copilot-macros`:
+
+```bash
+pnpm run build
+pnpm run test
+pnpm run prettier
+```
+
+The focused specs cover definition and validation, deterministic replay,
+catalog lifecycle, approval, persistence, cancellation, schema drift, and
+run-record sanitization.
+
+## Limitations
+
+- Single-trace induction is deliberately narrow.
+- Copilot-native tools require agent-guided execution.
+- This package does not provide a catalog over PowerShell, WebFlow, TaskFlow,
+  or Excel procedures.
+- Catalog mutation coordination is process-local.
+- Pattern-based redaction cannot prove that arbitrary tool output contains no
+  sensitive data.
 
 ## Trademarks
 

--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -543,16 +543,16 @@ Expected output shows server URL and current mode. If TypeAgent is not running, 
 
 ### Common Issues
 
-| Issue                          | Cause                         | Fix                                                            |
-| ------------------------------ | ----------------------------- | -------------------------------------------------------------- |
-| `copilot` not found            | Copilot CLI not installed     | Install GitHub Copilot CLI and verify with `copilot --version` |
-| Dev action falls through | Request was unsuitable, PowerShell is unavailable, or mode is not `dev` | Check `@typeagent status`, Windows platform, agent-server, and the PowerShell agent |
-| TypeAgent connection refused   | Server not running            | Start TypeAgent server (`pnpm run start:agent-server`)         |
-| Hook timeout                   | TypeAgent slow to respond     | Increase `timeout` in `hooks.json` or use MCP mode             |
-| Recording does not complete | The turn is still running or recording failed | Run `@typeagent macro status`; re-arm after a failed or expired recording |
-| Macro will not run | Version is not approved or a feature boundary is disabled | Inspect the macro state and the macro flags shown by `@typeagent status` |
-| Replay fails before step one | Required input, tool, or approved schema no longer matches | Inspect requirements and the structured replay error; revalidate or create a reviewed draft |
-| SQLite experimental warning    | Node 24 feature               | Normal — can be suppressed with `--no-experimental-warnings`   |
+| Issue                        | Cause                                                                   | Fix                                                                                         |
+| ---------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `copilot` not found          | Copilot CLI not installed                                               | Install GitHub Copilot CLI and verify with `copilot --version`                              |
+| Dev action falls through     | Request was unsuitable, PowerShell is unavailable, or mode is not `dev` | Check `@typeagent status`, Windows platform, agent-server, and the PowerShell agent         |
+| TypeAgent connection refused | Server not running                                                      | Start TypeAgent server (`pnpm run start:agent-server`)                                      |
+| Hook timeout                 | TypeAgent slow to respond                                               | Increase `timeout` in `hooks.json` or use MCP mode                                          |
+| Recording does not complete  | The turn is still running or recording failed                           | Run `@typeagent macro status`; re-arm after a failed or expired recording                   |
+| Macro will not run           | Version is not approved or a feature boundary is disabled               | Inspect the macro state and the macro flags shown by `@typeagent status`                    |
+| Replay fails before step one | Required input, tool, or approved schema no longer matches              | Inspect requirements and the structured replay error; revalidate or create a reviewed draft |
+| SQLite experimental warning  | Node 24 feature                                                         | Normal — can be suppressed with `--no-experimental-warnings`                                |
 
 ---
 

--- a/ts/packages/copilot-plugin/README.md
+++ b/ts/packages/copilot-plugin/README.md
@@ -1,20 +1,28 @@
 # TypeAgent Plugin for GitHub Copilot CLI
 
-This plugin integrates TypeAgent with GitHub Copilot CLI, enabling action requests (calendar, email, music, browser automation, etc.) to be routed to TypeAgent before the Copilot LLM.
+This plugin connects GitHub Copilot CLI to TypeAgent. It can route prompts to
+TypeAgent, expose TypeAgent through MCP, give registered PowerShell actions
+first refusal, and capture successful tool sequences as reusable macros.
 
 ## How It Works
 
-```
-User Input → copilot
-    ↓
-userPromptSubmitted hook (hook-router.js)
-    ↓
-Question word? → Fall through to Copilot LLM
-Action request?
-    ├── direct mode → Connect to TypeAgent ws://localhost:8999
-    │     → Recognized action? → Return response, skip LLM
-    │     → Unknown action? → Fall through to Copilot
-    └── mcp mode → Inject directive, LLM calls typeagent-processCommand tool
+```text
+User prompt
+  |
+  +-> direct: TypeAgent dispatcher -> handled response or fallthrough
+  |
+  +-> mcp: Copilot calls typeagent-processCommand
+  |
+  +-> dev: registered PowerShell action/flow
+  |           -> handled response
+  |         or PowerShell capability fallback
+  |           -> reuse/create/repair or fall through as not suitable
+  |
+  +-> bypass: Copilot handles the prompt
+
+Registered alongside routing (calls are disabled in bypass mode):
+  typeagent-workspace MCP tools
+  typeagent-macros MCP tools -> replay or macro-runner handoff
 ```
 
 The hook output fields `handled`, `responseContent`, and `handledBy` are supported in current Copilot CLI behavior, allowing the hook to skip the agentic loop entirely when TypeAgent handles a request. For local runtime debugging against the runtime repo, use `pnpm copilot:dev`.
@@ -159,7 +167,7 @@ The `--plugin-dir` flag loads the plugin from a local directory. On first launch
 > @typeagent run list the playlists
 ```
 
-### Step 5: Verify Verification in Copilot CLI
+### Step 5: Verify the Plugin in Copilot CLI
 
 Check that the plugin loaded:
 
@@ -182,6 +190,38 @@ Agent-guided adaptations may be saved only through
 budgets, and macro structure, then creates a new draft. It never mutates or
 promotes the approved version.
 
+Macros are not a plugin routing mode. They are a tool surface available in
+direct, MCP, and dev modes.
+
+### Record, approve, and run a macro
+
+1. Arm one interaction:
+
+   ```text
+   @typeagent macro record
+   ```
+
+2. Complete one successful Copilot turn that uses an MCP tool.
+3. Retrieve the trace ID:
+
+   ```text
+   @typeagent macro status
+   ```
+
+4. Ask Copilot to use `create_macro_from_trace`, then inspect the draft,
+   retrieve its requirements, and call `validate_macro`.
+5. Review the draft and explicitly call `approve_macro`. A draft cannot run;
+   approval creates a new immutable version.
+6. Call `run_macro` with the approved macro ID, required inputs, and
+   `preference: "auto"`.
+7. Use `get_macro_run` to inspect the sanitized persisted run record.
+
+Replayable macros are preflighted in full before step one. Preflight checks
+approval, required inputs, tool availability, and tool-schema fingerprints.
+Macros containing Copilot-native tools use the macro runner for the whole
+procedure. TypeAgent never replays a prefix and hands only the remainder to
+the agent.
+
 ### Rollout Controls
 
 Each macro boundary is enabled by default and can be disabled independently:
@@ -194,8 +234,8 @@ Each macro boundary is enabled by default and can be disabled independently:
 | `TYPEAGENT_MACRO_AGENT_HANDOFF_ENABLED` | Agent-runner handoff       |
 
 Set a variable to `0`, `false`, or `off` before starting Copilot to disable
-that boundary. `@typeagent status` reports the effective settings. These flags
-do not change direct, MCP, dev, or PowerShell mode selection.
+that boundary. These flags do not change direct, MCP, dev, or PowerShell mode
+selection. Restart Copilot after changing them.
 
 ### Recovery And Rollback
 
@@ -308,10 +348,15 @@ The hook injects a directive into the prompt context, instructing the LLM to cal
 
 ### Dev Mode
 
-The hook asks TypeAgent to handle PowerShell actions first. Ordinary requests
-are translated against the active `powershell` schema family, including static
-`powershell.*` namespaces and registered dynamic flows, with reasoning disabled.
-A miss falls through to Copilot without running TypeAgent reasoning.
+Dev mode is supported on Windows. The hook asks TypeAgent to handle the
+PowerShell schema family first, including static `powershell.*` namespaces and
+registered dynamic flows.
+
+Ordinary requests use the `powershellCapabilityFallback` reasoning profile
+after a grammar or translation miss. That bounded fallback can reuse an
+existing flow, add a grammar pattern, create and test a new flow, repair one
+stale flow once, or report that the request is not suitable for PowerShell. A
+typed `notSuitable` result falls through to Copilot with the original prompt.
 
 Recording directives such as `learn:`, `record`, and `dev: learn:` are sent to
 the configured TypeAgent reasoning engine with a PowerShell flow recording
@@ -326,8 +371,28 @@ with its normal tool set.
 
 - **Pros:** Reuses deterministic development actions without taking over normal
   Copilot coding requests
-- **Cons:** Requires an agent-server version that supports request-scoped schema
-  selection and command dispositions
+- **Cons:** Requires Windows, the PowerShell agent, and an agent-server version
+  that supports request-scoped schema selection and command dispositions
+
+Try a registered action:
+
+```text
+> @typeagent mode dev
+> show top 5 memory hogs
+```
+
+To demonstrate flow creation, use a disposable read-only task:
+
+```text
+> learn: show the 3 newest .log files under <PATH>
+> @typeagent run list powershell flows
+> show the 3 newest .log files under <PATH>
+```
+
+The generated name and output can vary with the configured model. Dynamic
+PowerShell scripts currently run in FullLanguage mode. Cmdlet and path policy
+metadata does not prevent direct .NET access, so do not treat generated or
+imported flows as securely sandboxed.
 
 **Switch modes:**
 
@@ -424,17 +489,21 @@ The hooks therefore behave as follows:
 - `preToolUse` keeps its existing PowerShell guidance policy.
 
 The workspace MCP server is local to the plugin and does not require
-agent-server. Agent-server continues to receive bounded tool/turn history from
-the hooks. Macro catalog, validation, promotion, and D1 orchestration remain
-agent-server responsibilities when those provider components are added.
+agent-server. Agent-server receives bounded tool and turn history from the
+hooks and owns macro recording state, catalog management, validation,
+immutable approval, replay orchestration, handoff records, and persisted run
+evidence.
 
 ### Agents (`agents/`)
 
 - `typeagent.agent.md` — Sub-agent that delegates action requests to TypeAgent via MCP tools
+- `typeagent-macro-runner.agent.md` — Executes an entire agent-required macro
+  through Copilot's live tools and permissions
 
 ### Skills (`skills/`)
 
 - `typeagent-setup/` — Interactive skill to configure integration mode and server connection
+- `typeagent-macros/` — Discovers, validates, runs, and adapts TypeAgent macros
 
 ---
 
@@ -477,9 +546,12 @@ Expected output shows server URL and current mode. If TypeAgent is not running, 
 | Issue                          | Cause                         | Fix                                                            |
 | ------------------------------ | ----------------------------- | -------------------------------------------------------------- |
 | `copilot` not found            | Copilot CLI not installed     | Install GitHub Copilot CLI and verify with `copilot --version` |
-| Action not routed to TypeAgent | Prompt detected as a question | Rephrase: use imperative ("schedule...", "send...", "play...") |
+| Dev action falls through | Request was unsuitable, PowerShell is unavailable, or mode is not `dev` | Check `@typeagent status`, Windows platform, agent-server, and the PowerShell agent |
 | TypeAgent connection refused   | Server not running            | Start TypeAgent server (`pnpm run start:agent-server`)         |
 | Hook timeout                   | TypeAgent slow to respond     | Increase `timeout` in `hooks.json` or use MCP mode             |
+| Recording does not complete | The turn is still running or recording failed | Run `@typeagent macro status`; re-arm after a failed or expired recording |
+| Macro will not run | Version is not approved or a feature boundary is disabled | Inspect the macro state and the macro flags shown by `@typeagent status` |
+| Replay fails before step one | Required input, tool, or approved schema no longer matches | Inspect requirements and the structured replay error; revalidate or create a reviewed draft |
 | SQLite experimental warning    | Node 24 feature               | Normal — can be suppressed with `--no-experimental-warnings`   |
 
 ---
@@ -494,7 +566,11 @@ The key runtime hook behavior change was in:
 
 This allows any `userPromptSubmitted` hook to fully handle a request and return a response without the LLM being invoked.
 
-See the [investigation document](D:\repos\codeDocs\TypeAgent\forAgent\investigations\active\2026-04-06_copilot-cli-typeagent-integration.md) for full architectural analysis.
+See the repository's
+[Copilot fast actions plan](../../docs/plans/copilot-fastActions/PLAN.md) for
+the cross-package design and
+[workflow architecture](../../docs/architecture/workflows/workflows.md) for
+TypeAgent's common flow model.
 
 ## Trademarks
 


### PR DESCRIPTION
Add cross-package planning and status documentation for dev actions and tool-composed macros, and expand the Copilot plugin and macro package READMEs with lifecycle, routing, replay, approval, storage, and security guidance.